### PR TITLE
Add copyright header to source code that isn't Go

### DIFF
--- a/packer/cleanup-vhd.sh
+++ b/packer/cleanup-vhd.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eux
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 ## Cleanup packer SSH key and machine ID generated for this boot
 rm -f /root/.ssh/authorized_keys
 rm -f /home/packer/.ssh/authorized_keys

--- a/packer/feature-flagged.sh
+++ b/packer/feature-flagged.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 function installDockerEngine() {
     DOCKER_REPO="https://apt.dockerproject.org/repo"
     DOCKER_ENGINE_VERSION="1.13.*"

--- a/packer/init-variables.sh
+++ b/packer/init-variables.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 CDIR=$(dirname "${BASH_SOURCE}")
 
 SETTINGS_JSON="${SETTINGS_JSON:-./packer/settings.json}"

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 source /home/packer/provision_installs.sh
 source /home/packer/provision_source.sh
 source /home/packer/feature-flagged.sh

--- a/pkg/engine/testdata/rename.sh
+++ b/pkg/engine/testdata/rename.sh
@@ -1,5 +1,8 @@
 #/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 for f in $(find . -name "*.err"); do
         len=${#f}
 	mv ${f} ${f::len-4};

--- a/pkg/helpers/Get-AzureConstants.py
+++ b/pkg/helpers/Get-AzureConstants.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 import json
 import subprocess
 from time import gmtime, strftime

--- a/scripts/azure-const.sh
+++ b/scripts/azure-const.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 if [ -z "$CLIENT_ID" ]; then
     echo "must provide a CLIENT_ID env var"
     exit 1;

--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 set -eo pipefail
 
 fetch_k8s() {

--- a/scripts/convert-lcg-lcl.sh
+++ b/scripts/convert-lcg-lcl.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 # DON'T RUN. This script requires PythonLocalizerTool which is not published yet.
 # TODO: make PythonLocalizerTool public
 set -eo pipefail

--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 set -eu -o pipefail
 set -x
 

--- a/scripts/update-enus-po.sh
+++ b/scripts/update-enus-po.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 scripts/update-translation.sh -l en_US -p
 
 mv aksengine.po translations/en_US/LC_MESSAGES/aksengine.po

--- a/scripts/update-translation.sh
+++ b/scripts/update-translation.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 GO_SOURCE="pkg/engine/*.go pkg/engine/transform/*.go pkg/api/*.go pkg/operations/*.go pkg/operations/kubernetesupgrade/*.go"
 LANGUAGE="en_US"
 DOMAIN="aksengine"

--- a/scripts/validate-dependencies.sh
+++ b/scripts/validate-dependencies.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 exit_code=0
 
 echo "==> Running dep check <=="

--- a/scripts/validate-generated.sh
+++ b/scripts/validate-generated.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 # TODO: does this script need refactoring post-OpenShift, or can it be deleted?
 echo "No generated files to check!"
 exit 0

--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 function test_linux_deployment() {
   ###### Testing an nginx deployment
   log "Testing deployments"

--- a/test/cluster-tests/kubernetes/test.sh
+++ b/test/cluster-tests/kubernetes/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 ####################################################
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/test/cluster-tests/utils.sh
+++ b/test/cluster-tests/utils.sh
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
 
 function log {
   local message="$1"

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 ####################################################
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 ####################################################
 
 if [ -z "$SERVICE_PRINCIPAL_CLIENT_ID" ]; then

--- a/test/shunit/deploy_template.sh
+++ b/test/shunit/deploy_template.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 source "${HOME}/test/common.sh"
 
 function shunittest_deploy_template {

--- a/test/shunit/generate_template.sh
+++ b/test/shunit/generate_template.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 source "${HOME}/test/common.sh"
 
 function shunittest_generate_template {

--- a/test/shunit/scale_agent_pool.sh
+++ b/test/shunit/scale_agent_pool.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 source "${HOME}/test/common.sh"
 
 function shunittest_scale_agent_pool {

--- a/test/shunit/validate_deployment.sh
+++ b/test/shunit/validate_deployment.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 function shunittest_validate_deployment {
   set -eux -o pipefail
 

--- a/test/step.sh
+++ b/test/step.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends #23 to add headers to shell scripts and the lone Python file in the repository.

(Also gives me a simple PR with which to ensure our CircleCI setup is working.)

**Which issue this PR fixes**:

Refs #12

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add copyright header to source code that isn't Go
```
