### PR TITLE
E2E: retry node count test

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -141,9 +141,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should have have the appropriate node count", func() {
 			var nodeList *node.List
+			var err error
 			// Allow ten mins for node count to converge, in the case where we're running this test immediately after a scale operation
 			for i := 0; i < 60; i++ {
-				nodeList, err := node.Get()
+				nodeList, err = node.Get()
 				if err != nil {
 					log.Printf("Error while getting nodes: %s\n", err)
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: When we run E2E tests immediately after a scale operation, the node could might still be converging towards the goal state, so we want to be able to tolerate that temporary inconsistency.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
E2E: retry node count test
```
