### PR TITLE
docker-health monitor doesn't work

### DIFF
--- a/parts/k8s/health-monitor.sh
+++ b/parts/k8s/health-monitor.sh
@@ -6,7 +6,7 @@
 set -o nounset
 set -o pipefail
 
-container_runtime_monitoring {
+container_runtime_monitoring() {
   local -r max_attempts=5
   local attempt=1
   local -r crictl="${KUBE_HOME}/bin/crictl"
@@ -38,7 +38,7 @@ container_runtime_monitoring {
   done
 }
 
-kubelet_monitoring {
+kubelet_monitoring() {
   echo "Wait for 2 minutes for kubelet to be functional"
   sleep 120
   local -r max_seconds=10


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: If you define a bash function omitting the `function` keyword, you need `()`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
bash needs params for function definition
```
