### PR TITLE
Fix issues in ip-masq yaml render

### DIFF
--- a/parts/k8s/containeraddons/ip-masq-agent.yaml
+++ b/parts/k8s/containeraddons/ip-masq-agent.yaml
@@ -62,7 +62,7 @@ data:
     {{- if ContainerConfig "non-masq-cni-cidr"}}
       - {{ContainerConfig "non-masq-cni-cidr"}}
     masqLinkLocal: true
-    {{else -}}
+    {{else}}
     masqLinkLocal: false
     {{end -}}
     resyncInterval: 60s


### PR DESCRIPTION
Fixing a bug when the YAML is rendered improperly. This can be reproduced when a user supplies a ClusterSubnet