### PR TITLE
Add support for Kubernetes 1.13.1

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -101,7 +101,7 @@ for K8S_DNS_SIDECAR_VERSION in ${K8S_DNS_SIDECAR_VERSIONS}; do
     pullContainerImage "docker" "k8s.gcr.io/k8s-dns-sidecar-amd64:${K8S_DNS_SIDECAR_VERSION}"
 done
 
-CORE_DNS_VERSIONS="1.2.2"
+CORE_DNS_VERSIONS="1.2.6 1.2.2"
 for CORE_DNS_VERSION in ${CORE_DNS_VERSIONS}; do
     pullContainerImage "docker" "k8s.gcr.io/coredns:${CORE_DNS_VERSION}"
 done

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -71,7 +71,7 @@ for KUBE_DNS_VERSION in ${KUBE_DNS_VERSIONS}; do
     pullContainerImage "docker" "k8s.gcr.io/k8s-dns-kube-dns-amd64:${KUBE_DNS_VERSION}"
 done
 
-KUBE_ADDON_MANAGER_VERSIONS="8.8 8.7 8.6"
+KUBE_ADDON_MANAGER_VERSIONS="8.9 8.8 8.7 8.6"
 for KUBE_ADDON_MANAGER_VERSION in ${KUBE_ADDON_MANAGER_VERSIONS}; do
     pullContainerImage "docker" "k8s.gcr.io/kube-addon-manager-amd64:v${KUBE_ADDON_MANAGER_VERSION}"
 done

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -154,7 +154,7 @@ done
 pullContainerImage "docker" "busybox"
 
 # TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
-K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.4 1.11.5 1.12.1 1.12.2"
+K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.4 1.11.5 1.12.1 1.12.2 1.13.0"
 
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -92,8 +92,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.0":         false,
 	"1.12.1":         true,
 	"1.12.2":         true,
-	"1.13.0-alpha.1": true,
-	"1.13.0-alpha.2": true,
+	"1.13.0":         true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -92,7 +92,8 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.0":         false,
 	"1.12.1":         true,
 	"1.12.2":         true,
-	"1.13.0":         false,
+	"1.13.0-alpha.1": false,
+	"1.13.0-alpha.2": false,
 	"1.13.1":         true,
 }
 

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -92,7 +92,8 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.0":         false,
 	"1.12.1":         true,
 	"1.12.2":         true,
-	"1.13.0":         true,
+	"1.13.0":         false,
+	"1.13.1":         true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -22,7 +22,7 @@ var k8sComponentVersions = map[string]map[string]string{
 		"metrics-server":                   "metrics-server-amd64:v0.2.1",
 		"coredns":                          "coredns:1.2.2",
 		"kube-dns":                         "k8s-dns-kube-dns-amd64:1.14.13",
-		"addon-manager":                    "kube-addon-manager-amd64:v8.8",
+		"addon-manager":                    "kube-addon-manager-amd64:v8.9",
 		"dnsmasq":                          "k8s-dns-dnsmasq-nanny-amd64:1.14.10",
 		"pause":                            "pause-amd64:3.1",
 		"tiller":                           "tiller:v2.11.0",

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -20,7 +20,7 @@ var k8sComponentVersions = map[string]map[string]string{
 		"addon-resizer":                    "addon-resizer:1.8.1",
 		"heapster":                         "heapster-amd64:v1.5.3",
 		"metrics-server":                   "metrics-server-amd64:v0.2.1",
-		"coredns":                          "coredns:1.2.2",
+		"coredns":                          "coredns:1.2.6",
 		"kube-dns":                         "k8s-dns-kube-dns-amd64:1.14.13",
 		"addon-manager":                    "kube-addon-manager-amd64:v8.9",
 		"dnsmasq":                          "k8s-dns-dnsmasq-nanny-amd64:1.14.10",


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/releases/tag/v1.13.0

Refs #73 and kubernetes/kubernetes#71736

fixes #140

TODO:

- [x] upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
Add support for Kubernetes 1.13.0
```
