### PR TITLE
remove pb6 series vms from the list of accelerated networking support…

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -142,8 +142,7 @@ func AcceleratedNetworkingSupported(sku string) bool {
 		"Standard_L8s_v2", "Standard_L16s_v2", "Standard_L32s_v2", "Standard_L64s_v2", "Standard_L96s_v2",
 		"SQLGL", "SQLGLCore", "Standard_D4_v3", "Standard_D4s_v3", "Standard_D2_v2", "Standard_DS2_v2",
 		"Standard_E4_v3", "Standard_E4s_v3", "Standard_F2", "Standard_F2s", "Standard_F4s_v2",
-		"Standard_D11_v2", "Standard_DS11_v2", "AZAP_Performance_ComputeV17C", "Standard_PB6s",
-		"Standard_PB12s", "Standard_PB24s":
+		"Standard_D11_v2", "Standard_DS11_v2", "AZAP_Performance_ComputeV17C":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Currently, it is known that PB series VMs have no accelerated Networking support.

We are forced to use/edit these static lists as we have no api from Azure to retrieve VM Skus and their properties :(