### PR TITLE
fix: increase vm upgrade timeout to 20 mins

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -35,7 +35,7 @@ type Upgrader struct {
 type vmStatus int
 
 const (
-	defaultTimeout            = time.Minute * 10
+	defaultTimeout            = time.Minute * 20
 	vmStatusUpgraded vmStatus = iota
 	vmStatusNotUpgraded
 	vmStatusIgnored


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This change is aks-engine only, does not affect AKS (reviewer to validate).

Our 99th percentile 3 node cluster measurement is tracking at 13 mins, so 10 min timeout is probably too low in the real world.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
increase vm upgrade timeout to 20 mins
```
