### PR TITLE
kubectl top nodes for metrics-server validation

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -589,11 +589,21 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should be able to get nodes metrics", func() {
-			cmd := exec.Command("kubectl", "top", "nodes")
-			util.PrintCommand(cmd)
-			out, err := cmd.CombinedOutput()
-			log.Printf("%s\n", out)
-			Expect(err).NotTo(HaveOccurred())
+			success := false
+			for i := 0; i < 30; i++ {
+				cmd := exec.Command("kubectl", "top", "nodes")
+				util.PrintCommand(cmd)
+				out, err := cmd.CombinedOutput()
+				if err == nil {
+					success = true
+					break
+				}
+				if i > 28 {
+					log.Printf("Error while running kubectl top nodes:%s\n", err)
+					log.Println(string(out))
+				}
+			}
+			Expect(success).To(BeTrue())
 		})
 
 		It("should be able to autoscale", func() {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -588,6 +588,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		It("should be able to get nodes metrics", func() {
+			cmd := exec.Command("kubectl", "top", "nodes")
+			util.PrintCommand(cmd)
+			out, err := cmd.CombinedOutput()
+			log.Printf("%s\n", out)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("should be able to autoscale", func() {
 			if eng.HasLinuxAgents() && eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
 				// "Pre"-delete the hpa in case a prior delete attempt failed, for long-running cluster scenarios


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds a simple `kubectl top nodes` check as a simple `metrics-server/heapster` validation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #76

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
kubectl top nodes for metrics-server validation
```
