### PR TITLE
disable heapster for kubernetes versions > 1.13

### DIFF
--- a/parts/k8s/containeraddons/1.6/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/1.6/kubernetesmasteraddons-heapster-deployment.yaml
@@ -95,7 +95,7 @@ spec:
         operator: Exists
       serviceAccountName: heapster
       containers:
-      - image: <img>
+      - image: {{ContainerImage "heapster"}}
         imagePullPolicy: IfNotPresent
         command:
         - "/heapster"
@@ -108,7 +108,7 @@ spec:
           limits:
             cpu: 80m
             memory: 140Mi
-      - image: <imgNanny>
+      - image: {{ContainerImage "heapster-nanny"}}
         imagePullPolicy: IfNotPresent
         command:
         - "/pod_nanny"

--- a/parts/k8s/containeraddons/1.7/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/1.7/kubernetesmasteraddons-heapster-deployment.yaml
@@ -95,7 +95,7 @@ spec:
         operator: Exists
       serviceAccountName: heapster
       containers:
-      - image: <img>
+      - image: {{ContainerImage "heapster"}}
         imagePullPolicy: IfNotPresent
         command:
         - "/heapster"
@@ -108,7 +108,7 @@ spec:
           limits:
             cpu: 80m
             memory: 140Mi
-      - image: <imgNanny>
+      - image: {{ContainerImage "heapster-nanny"}}
         imagePullPolicy: IfNotPresent
         command:
         - "/pod_nanny"

--- a/parts/k8s/containeraddons/1.8/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/1.8/kubernetesmasteraddons-heapster-deployment.yaml
@@ -95,7 +95,7 @@ spec:
         operator: Exists
       serviceAccountName: heapster
       containers:
-      - image: <img>
+      - image: {{ContainerImage "heapster"}}
         imagePullPolicy: IfNotPresent
         command:
         - "/heapster"
@@ -108,7 +108,7 @@ spec:
           limits:
             cpu: 80m
             memory: 140Mi
-      - image: <imgNanny>
+      - image: {{ContainerImage "heapster-nanny"}}
         imagePullPolicy: IfNotPresent
         command:
         - "/pod_nanny"

--- a/parts/k8s/containeraddons/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-heapster-deployment.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: <img>
+        - image: {{ContainerImage "heapster"}}
           imagePullPolicy: IfNotPresent
           name: heapster
           resources:
@@ -126,7 +126,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: <imgNanny>
+        - image: {{ContainerImage "heapster-nanny"}}
           imagePullPolicy: IfNotPresent
           name: heapster-nanny
           resources:

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -304,7 +304,6 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
 {{else}}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesKubeDNSSpec"}}|g; s|<imgMasq>|{{WrapAsParameter "kubernetesDNSMasqSpec"}}|g; s|<imgSidecar>|{{WrapAsParameter "kubernetesDNSSidecarSpec"}}|g; s|<domain>|{{WrapAsParameter "kubernetesKubeletClusterDomain"}}|g; s|<clustIP>|{{WrapAsParameter "kubeDNSServiceIP"}}|g" $KUBEDNS
 {{end}}
-    sed -i "s|<img>|{{WrapAsParameter "kubernetesHeapsterSpec"}}|g; s|<imgNanny>|{{WrapAsParameter "kubernetesAddonResizerSpec"}}|g" /etc/kubernetes/addons/kube-heapster-deployment.yaml
 
 {{if AdminGroupID }}
     sed -i "s|<gID>|{{WrapAsParameter "aadAdminGroupId"}}|g" "/etc/kubernetes/addons/aad-default-admin-group-rbac.yaml"

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -216,12 +216,6 @@
       },
       "type": "string"
     },
-    "kubernetesAddonResizerSpec": {
-      "metadata": {
-        "description": "The container spec for addon-resizer."
-      },
-      "type": "string"
-    },
     "enableAggregatedAPIs": {
       "metadata": {
         "description": "Enable aggregated API on master nodes"
@@ -240,12 +234,6 @@
     "kubernetesDNSSidecarSpec": {
       "metadata": {
         "description": "The container spec for k8s-dns-sidecar-amd64."
-      },
-      "type": "string"
-    },
-    "kubernetesHeapsterSpec": {
-      "metadata": {
-        "description": "The container spec for heapster."
       },
       "type": "string"
     },

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -15,6 +15,21 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 	cloudSpecConfig := cs.GetCloudSpecConfig()
 	k8sComponents := K8sComponentsByVersionMap[o.OrchestratorVersion]
 	specConfig := cloudSpecConfig.KubernetesSpecConfig
+	defaultsHeapsterAddonsConfig := KubernetesAddon{
+		Name:    DefaultHeapsterAddonName,
+		Enabled: helpers.PointerToBool(DefaultHeapsterAddonEnabled),
+		Containers: []KubernetesContainerSpec{
+			{
+				Name:  DefaultHeapsterAddonName,
+				Image: specConfig.KubernetesImageBase + k8sComponents["heapster"],
+			},
+			{
+				Name:  "heapster-nanny",
+				Image: specConfig.KubernetesImageBase + k8sComponents["addonresizer"],
+			},
+		},
+	}
+
 	defaultTillerAddonsConfig := KubernetesAddon{
 		Name:    DefaultTillerAddonName,
 		Enabled: helpers.PointerToBool(DefaultTillerAddonEnabled),
@@ -249,6 +264,7 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 	}
 
 	defaultAddons := []KubernetesAddon{
+		defaultsHeapsterAddonsConfig,
 		defaultTillerAddonsConfig,
 		defaultACIConnectorAddonsConfig,
 		defaultClusterAutoscalerAddonsConfig,

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -111,6 +111,8 @@ const (
 const publicAgentPoolSuffix = "-public"
 
 const (
+	// DefaultHeapsterAddonEnabled determines the acs-engine provided default for enabling heapster addon
+	DefaultHeapsterAddonEnabled = true
 	// DefaultTillerAddonEnabled determines the aks-engine provided default for enabling tiller addon
 	DefaultTillerAddonEnabled = true
 	// DefaultAADPodIdentityAddonEnabled determines the aks-engine provided default for enabling aad-pod-identity addon
@@ -149,6 +151,8 @@ const (
 	DefaultDNSAutoscalerAddonEnabled = false
 	// IPMasqAgentAddonEnabled enables the ip-masq-agent addon
 	IPMasqAgentAddonEnabled = true
+	// DefaultHeapsterAddonName is the name of the heapster addon
+	DefaultHeapsterAddonName = "heapster"
 	// DefaultTillerAddonName is the name of the tiller addon deployment
 	DefaultTillerAddonName = "tiller"
 	// DefaultAADPodIdentityAddonName is the name of the aad-pod-identity addon deployment

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -185,7 +185,7 @@ func TestAddonsIndexByName(t *testing.T) {
 }
 
 func TestAssignDefaultAddonImages(t *testing.T) {
-	addonNameMap := map[string]string{
+	addonContainerMap := map[string]string{
 		DefaultTillerAddonName:             "gcr.io/kubernetes-helm/tiller:v2.11.0",
 		DefaultACIConnectorAddonName:       "microsoft/virtual-kubelet:latest",
 		DefaultClusterAutoscalerAddonName:  "k8s.gcr.io/cluster-autoscaler:v1.2.2",
@@ -200,10 +200,11 @@ func TestAssignDefaultAddonImages(t *testing.T) {
 		IPMASQAgentAddonName:               "k8s.gcr.io/ip-masq-agent-amd64:v2.0.0",
 		AzureCNINetworkMonitoringAddonName: "containernetworking/networkmonitor:v0.0.4",
 		DefaultDNSAutoscalerAddonName:      "k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.1",
+		DefaultHeapsterAddonName:           "k8s.gcr.io/heapster-amd64:v1.5.1",
 	}
 
 	var addons []KubernetesAddon
-	for addonName := range addonNameMap {
+	for addonName := range addonContainerMap {
 		containerName := addonName
 		if addonName == ContainerMonitoringAddonName {
 			containerName = "omsagent"
@@ -231,7 +232,7 @@ func TestAssignDefaultAddonImages(t *testing.T) {
 	modifiedAddons := mockCS.Properties.OrchestratorProfile.KubernetesConfig.Addons
 
 	for _, addon := range modifiedAddons {
-		expected := addonNameMap[addon.Name]
+		expected := addonContainerMap[addon.Name]
 		actual := addon.Containers[0].Image
 		if actual != expected {
 			t.Errorf("expected setDefaults to set Image %s in addon %s, but got %s", expected, addon.Name, actual)

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -21,6 +21,12 @@ type kubernetesFeatureSetting struct {
 
 func kubernetesContainerAddonSettingsInit(profile *api.Properties) map[string]kubernetesFeatureSetting {
 	return map[string]kubernetesFeatureSetting{
+		DefaultHeapsterAddonName: {
+			"kubernetesmasteraddons-heapster-deployment.yaml",
+			"kube-heapster-deployment.yaml",
+			!common.IsKubernetesVersionGe(profile.OrchestratorProfile.OrchestratorVersion, "1.12.0"),
+			profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultKubeHeapsterDeploymentAddonName),
+		},
 		DefaultMetricsServerAddonName: {
 			"kubernetesmasteraddons-metrics-server-deployment.yaml",
 			"kube-metrics-server-deployment.yaml",
@@ -119,13 +125,6 @@ func kubernetesContainerAddonSettingsInit(profile *api.Properties) map[string]ku
 
 func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSetting {
 	return []kubernetesFeatureSetting{
-		{
-
-			"kubernetesmasteraddons-heapster-deployment.yaml",
-			"kube-heapster-deployment.yaml",
-			true,
-			profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultKubeHeapsterDeploymentAddonName),
-		},
 		{
 			"kubernetesmasteraddons-kube-dns-deployment.yaml",
 			"kube-dns-deployment.yaml",
@@ -329,6 +328,11 @@ func buildConfigString(configString, destinationFile, destinationPath string) st
 }
 
 func getCustomScriptFromFile(sourceFile, sourcePath, version string) string {
+	customDataFilePath := getCustomDataFilePath(sourceFile, sourcePath, version)
+	return getBase64CustomScript(customDataFilePath)
+}
+
+func getCustomDataFilePath(sourceFile, sourcePath, version string) string {
 	sourceFileFullPath := sourcePath + "/" + sourceFile
 	sourceFileFullPathVersioned := sourcePath + "/" + version + "/" + sourceFile
 
@@ -337,5 +341,5 @@ func getCustomScriptFromFile(sourceFile, sourcePath, version string) string {
 	if err == nil {
 		sourceFileFullPath = sourceFileFullPathVersioned
 	}
-	return getBase64CustomScript(sourceFileFullPath)
+	return sourceFileFullPath
 }

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -24,7 +24,7 @@ func kubernetesContainerAddonSettingsInit(profile *api.Properties) map[string]ku
 		DefaultHeapsterAddonName: {
 			"kubernetesmasteraddons-heapster-deployment.yaml",
 			"kube-heapster-deployment.yaml",
-			!common.IsKubernetesVersionGe(profile.OrchestratorProfile.OrchestratorVersion, "1.12.0"),
+			!common.IsKubernetesVersionGe(profile.OrchestratorProfile.OrchestratorVersion, "1.13.0"),
 			profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultKubeHeapsterDeploymentAddonName),
 		},
 		DefaultMetricsServerAddonName: {

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -73,6 +73,8 @@ const (
 	DefaultGeneratorCode = "acsengine"
 	// DefaultReschedulerAddonName is the name of the rescheduler addon deployment
 	DefaultReschedulerAddonName = "rescheduler"
+	// DefaultHeapsterAddonName is the name of the heapster addon deployment
+	DefaultHeapsterAddonName = "heapster"
 	// DefaultMetricsServerAddonName is the name of the kubernetes Metrics server addon deployment
 	DefaultMetricsServerAddonName = "metrics-server"
 	// NVIDIADevicePluginAddonName is the name of the kubernetes NVIDIA Device Plugin daemon set

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -717,9 +717,11 @@ func getContainerAddonsString(properties *api.Properties, sourcePath string) str
 			if setting.rawScript != "" {
 				input = setting.rawScript
 			} else {
-				addon := properties.OrchestratorProfile.KubernetesConfig.GetAddonByName(addonName)
+				orchProfile := properties.OrchestratorProfile
+				versions := strings.Split(orchProfile.OrchestratorVersion, ".")
+				addon := orchProfile.KubernetesConfig.GetAddonByName(addonName)
 				templ := template.New("addon resolver template").Funcs(getAddonFuncMap(addon))
-				addonFile := sourcePath + "/" + setting.sourceFile
+				addonFile := getCustomDataFilePath(setting.sourceFile, sourcePath, versions[0]+"."+versions[1])
 				addonFileBytes, err := Asset(addonFile)
 				if err != nil {
 					return ""

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -46,12 +46,10 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 			addValue(parametersMap, "kubeDNSServiceIP", kubernetesConfig.DNSServiceIP)
 			addValue(parametersMap, "kubernetesHyperkubeSpec", kubernetesHyperkubeSpec)
 			addValue(parametersMap, "kubernetesAddonManagerSpec", kubernetesImageBase+k8sComponents["addonmanager"])
-			addValue(parametersMap, "kubernetesAddonResizerSpec", kubernetesImageBase+k8sComponents["addonresizer"])
 			if orchestratorProfile.NeedsExecHealthz() {
 				addValue(parametersMap, "kubernetesExecHealthzSpec", kubernetesImageBase+k8sComponents["exechealthz"])
 			}
 			addValue(parametersMap, "kubernetesDNSSidecarSpec", kubernetesImageBase+k8sComponents["k8s-dns-sidecar"])
-			addValue(parametersMap, "kubernetesHeapsterSpec", kubernetesImageBase+k8sComponents["heapster"])
 			if kubernetesConfig.IsAADPodIdentityEnabled() {
 				aadPodIdentityAddon := kubernetesConfig.GetAddonByName(DefaultAADPodIdentityAddonName)
 				aadIndex := aadPodIdentityAddon.GetAddonContainersIndexByName(DefaultAADPodIdentityAddonName)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should have core kube-system componentry running", func() {
 			coreComponents := []string{"kube-proxy", "kube-addon-manager", "kube-apiserver", "kube-controller-manager", "kube-scheduler"}
-			if !common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.12.0") {
+			if !common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.13.0") {
 				coreComponents = append(coreComponents, "heapster")
 			}
 			for _, componentName := range coreComponents {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -171,7 +171,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have core kube-system componentry running", func() {
-			for _, componentName := range []string{"kube-proxy", "heapster", "kube-addon-manager", "kube-apiserver", "kube-controller-manager", "kube-scheduler"} {
+			coreComponents := []string{"kube-proxy", "kube-addon-manager", "kube-apiserver", "kube-controller-manager", "kube-scheduler"}
+			if !common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.12.0") {
+				coreComponents = append(coreComponents, "heapster")
+			}
+			for _, componentName := range coreComponents {
 				By(fmt.Sprintf("Ensuring that %s is Running", componentName))
 				running, err := pod.WaitOnReady(componentName, "kube-system", 3, 1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixes #126 

This PR does two things

    Disable Heapster for k8s clusters with version 1.13.0 or greater. As per this document , https://github.com/kubernetes/heapster/blob/master/docs/deprecation.md

    Remove sed statements to apply heapster configurations and use the new addon pre-render flow instead.
