### PR TITLE
Add toggle for switching ip-masq-agent logic for AKS.

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -224,7 +224,7 @@ AGENT_ARTIFACTS_CONFIG_PLACEHOLDER
 {{if not EnablePodSecurityPolicy}}
     sed -i "s|apparmor_parser|d|g" "/etc/systemd/system/kubelet.service"
 {{end}}
-{{if IsHostedMaster}}
+{{if IsHostedMasterIPMasqAgentDisabled}}
     {{if IsAzureCNI}}
     iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsParameter "vnetCidr"}} -j MASQUERADE
     {{end}}

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -67,8 +67,8 @@ func (cs *ContainerService) setKubeletConfig() {
 		"--image-pull-progress-deadline":    "30m",
 	}
 
-	// AKS overrides
-	if cs.Properties.IsHostedMasterProfile() {
+	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS
+	if cs.Properties.IsHostedMasterIPMasqAgentDisabled() {
 		defaultKubeletConfig["--non-masquerade-cidr"] = cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet
 	}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -488,6 +488,7 @@ type AgentPoolProfile struct {
 	EnableAutoScaling                   *bool                `json:"enableAutoScaling,omitempty"`
 	AvailabilityZones                   []string             `json:"availabilityZones,omitempty"`
 	SinglePlacementGroup                *bool                `json:"singlePlacementGroup,omitempty"`
+	VnetCidrs                           []string             `json:"vnetCidrs,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role
@@ -567,6 +568,7 @@ type HostedMasterProfile struct {
 	Subnet string `json:"subnet"`
 	// ApiServerWhiteListRange is a comma delimited CIDR which is whitelisted to AKS
 	APIServerWhiteListRange *string `json:"apiServerWhiteListRange"`
+	IPMasqAgent             bool    `json:"ipMasqAgent"`
 }
 
 // AuthenticatorType represents the authenticator type the cluster was
@@ -803,6 +805,11 @@ func (p *Properties) GetPrimaryScaleSetName() string {
 // IsHostedMasterProfile returns true if the cluster has a hosted master
 func (p *Properties) IsHostedMasterProfile() bool {
 	return p.HostedMasterProfile != nil
+}
+
+// IsHostedMasterIPMasqAgentDisabled returns true if the cluster has a hosted master and IpMasqAgent is disabled
+func (p *Properties) IsHostedMasterIPMasqAgentDisabled() bool {
+	return p.HostedMasterProfile != nil && !p.HostedMasterProfile.IPMasqAgent
 }
 
 // GetVNetResourceGroupName returns the virtual network resource group name of the cluster

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -209,6 +209,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"IsHostedMaster": func() bool {
 			return cs.Properties.IsHostedMasterProfile()
 		},
+		"IsHostedMasterIPMasqAgentDisabled": func() bool {
+			return cs.Properties.IsHostedMasterIPMasqAgentDisabled()
+		},
 		"IsDCOS19": func() bool {
 			return cs.Properties.OrchestratorProfile.OrchestratorType == api.DCOS &&
 				(cs.Properties.OrchestratorProfile.OrchestratorVersion == common.DCOSVersion1Dot9Dot0 ||


### PR DESCRIPTION
Add toggle for switching ip-masq-agent logic for AKS. This way, the AKS-engine code can be checked in first. Later when AKS turn on the toggle, it should activate this feature.