### PR TITLE
Add "Scaling" constant to provisioning states

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -198,6 +198,8 @@ const (
 	Creating ProvisioningState = "Creating"
 	// Updating means an existing ContainerService resource is being updated
 	Updating ProvisioningState = "Updating"
+	// Scaling means an existing ContainerService resource is being scaled only
+	Scaling ProvisioningState = "Scaling"
 	// Failed means resource is in failed state
 	Failed ProvisioningState = "Failed"
 	// Succeeded means resource created succeeded during last create/update


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a 'Scaling' constant to track a provisioning state where nodes are being scaled up or down. Matches a local modification expected by AKS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add "Scaling" constant to provisioning states
```
