### PR TITLE
update Calico network policy examples docs

### DIFF
--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -7,11 +7,11 @@ There are 2 different Network Policy options :
 
 ## Calico
 
-Before enabling Calico policy for the AKS-engine cluster, you must first decide which network plugin to use for the cluster: Azure or Kubenet. 
+Before enabling Calico policy for the AKS-Engine cluster, you must first decide which network plugin to use for the cluster: Azure or Kubenet. 
 The difference between Azure and Kubenet lies in the way IP addresses get allocated; Azure uses Azure-native IPs while Kubenet does static IP assignment based on the node's pod CIDR.
 If you're not sure which one to go with, we recommend going with Azure.
 
-The kubernetes-calico deployment template enables Calico networking and policies for the AKS-engine cluster via `"networkPolicy": "calico"` being present inside the `kubernetesConfig`.
+The kubernetes-calico deployment template enables Calico networking and policies for the AKS-Engine cluster via `"networkPolicy": "calico"` being present inside the `kubernetesConfig`.
 
 ```json
   "properties": {
@@ -35,10 +35,10 @@ Once the template has been successfully deployed, following the [simple policy t
 
 > Note: `ping` (ICMP) traffic is blocked on the cluster by default.  Wherever `ping` is used in any tutorial substitute testing access with something like `wget -q --timeout=5 google.com -O -` instead.
 
-### Update guidance for clusters deployed by aks-engine releases prior to 0.17.0
+### Update guidance for clusters deployed by AKS-Engine releases prior to 0.17.0
 Clusters deployed with calico networkPolicy enabled prior to `0.17.0` had calico `2.6.3` deployed, and a daemonset with an `updateStrategy` of `Ondelete`.
 
-aks-engine releases starting with 0.17.0 now produce an addon manifest for calico in `/etc/kubernetes/addons/calico-daemonset.yaml` contaning calico 3.1.x, and an `updateStrategy` of `RollingUpdate`. Due to breaking changes introduced by calico 3, one must first migrate through calico `2.6.5` or a later 2.6.x release in order to migrate to calico 3.1.x. as described in the [calico kubernetes upgrade documentation](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/). The aks-engine manifest for calico uses the [kubernetes API datastore, policy-only setup](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade#upgrading-an-installation-that-uses-the-kubernetes-api-datastore).
+AKS-Engine releases starting with 0.17.0 now produce an addon manifest for calico in `/etc/kubernetes/addons/calico-daemonset.yaml` contaning calico 3.1.x, and an `updateStrategy` of `RollingUpdate`. Due to breaking changes introduced by calico 3, one must first migrate through calico `2.6.5` or a later 2.6.x release in order to migrate to calico 3.1.x. as described in the [calico kubernetes upgrade documentation](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/). The AKS-Engine manifest for calico uses the [kubernetes API datastore, policy-only setup](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade#upgrading-an-installation-that-uses-the-kubernetes-api-datastore).
 
 1. To update to `2.6.5+` in preparation of an upgrade to 3.1.x as specified, edit `/etc/kubernetes/addons/calico-daemonset.yaml` on a master node, replacing `calico/node:v3.1.1` with `calico/node:v2.6.10` and `calico/cni:v3.1.1` with `calico/cni:v2.0.6`. Run `kubectl apply -f /etc/kubernetes/addons/calico-daemonset.yaml`.
 
@@ -64,7 +64,7 @@ If you have any customized calico resource manifests, you must also follow the [
 
 ## Cilium
 
-The kubernetes-cilium deployment template enables Cilium networking and policies for the AKS-engine cluster via `"networkPolicy": "cilium"` or `"networkPlugin": "cilium"` being present inside the `kubernetesConfig`.
+The kubernetes-cilium deployment template enables Cilium networking and policies for the AKS-Engine cluster via `"networkPolicy": "cilium"` or `"networkPlugin": "cilium"` being present inside the `kubernetesConfig`.
 
 ```json
   "properties": {

--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Kubernetes Engine - Network Policy
+# Microsoft Azure Container Service Engine - Network Policy
 
 There are 2 different Network Policy options :
 
@@ -7,24 +7,27 @@ There are 2 different Network Policy options :
 
 ## Calico
 
-The kubernetes-calico deployment template enables Calico networking and policies for the AKS Engine cluster via `"networkPolicy": "calico"` being present inside the `kubernetesConfig`.
+Before enabling Calico policy for the ACS-engine cluster, you must first decide which network plugin to use for the cluster: Azure or Kubenet. 
+The difference between Azure and Kubenet lies in the way IP addresses get allocated; Azure uses Azure-native IPs while Kubenet does static IP assignment based on the node's pod CIDR.
+If you're not sure which one to go with, we recommend going with Azure.
+
+The kubernetes-calico deployment template enables Calico networking and policies for the ACS-engine cluster via `"networkPolicy": "calico"` being present inside the `kubernetesConfig`.
 
 ```json
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "networkPolicy": "calico"
+        "networkPolicy": "calico",
+        "networkPlugin": "azure|kubenet"
       }
 ```
 
-This template will deploy the [v3.1 release](https://docs.projectcalico.org/v3.1/releases/) of [Kubernetes Datastore Install](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/other) version of calico with the "Calico for policy" with user-supplied networking which supports kubernetes ingress policies.
-
-> Note: The Typha service and deployment is installed on the cluster, but effectively disabled using the default settings of deployment replicas set to 0 and Typha service name not configured.  Typha is recommended to be enabled when scaling to 50+ nodes on the cluster to reduce the load on the Kubernetes API server.  If this functionality is desired to be configurable via the API model, please file an issue on Github requesting this feature be added.  Otherwise, this can be manually changed via modifying and applying changes with the `/etc/kubernetes/addons/calico-daemonset.yaml` file on every master node in the cluster.
+This template will deploy the [Kubernetes Datastore backed version of Calico](https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/other) with user-supplied networking which supports kubernetes ingress policies.
 
 If deploying on a K8s 1.8 or later cluster, then egress policies are also supported!
 
-To understand how to deploy this template, please read the baseline [Kubernetes](../../docs/kubernetes.md) document, and use the example **kubernetes-calico.json** file in this folder as an api model reference.
+To understand how to deploy this template, please read the baseline [Kubernetes](../../docs/kubernetes.md) document, and use the appropriate **kubernetes-calico-[azure|kubenet].json** example file in this folder as an api model reference.
 
 ### Post installation
 
@@ -32,10 +35,10 @@ Once the template has been successfully deployed, following the [simple policy t
 
 > Note: `ping` (ICMP) traffic is blocked on the cluster by default.  Wherever `ping` is used in any tutorial substitute testing access with something like `wget -q --timeout=5 google.com -O -` instead.
 
-### Update guidance for clusters deployed by aks-engine releases prior to 0.17.0
+### Update guidance for clusters deployed by acs-engine releases prior to 0.17.0
 Clusters deployed with calico networkPolicy enabled prior to `0.17.0` had calico `2.6.3` deployed, and a daemonset with an `updateStrategy` of `Ondelete`.
 
-aks-engine releases starting with 0.17.0 now produce an addon manifest for calico in `/etc/kubernetes/addons/calico-daemonset.yaml` contaning calico 3.1.x, and an `updateStrategy` of `RollingUpdate`. Due to breaking changes introduced by calico 3, one must first migrate through calico `2.6.5` or a later 2.6.x release in order to migrate to calico 3.1.x. as described in the [calico kubernetes upgrade documentation](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/). The aks-engine manifest for calico uses the [kubernetes API datastore, policy-only setup](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade#upgrading-an-installation-that-uses-the-kubernetes-api-datastore).
+acs-engine releases starting with 0.17.0 now produce an addon manifest for calico in `/etc/kubernetes/addons/calico-daemonset.yaml` contaning calico 3.1.x, and an `updateStrategy` of `RollingUpdate`. Due to breaking changes introduced by calico 3, one must first migrate through calico `2.6.5` or a later 2.6.x release in order to migrate to calico 3.1.x. as described in the [calico kubernetes upgrade documentation](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/). The acs-engine manifest for calico uses the [kubernetes API datastore, policy-only setup](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade#upgrading-an-installation-that-uses-the-kubernetes-api-datastore).
 
 1. To update to `2.6.5+` in preparation of an upgrade to 3.1.x as specified, edit `/etc/kubernetes/addons/calico-daemonset.yaml` on a master node, replacing `calico/node:v3.1.1` with `calico/node:v2.6.10` and `calico/cni:v3.1.1` with `calico/cni:v2.0.6`. Run `kubectl apply -f /etc/kubernetes/addons/calico-daemonset.yaml`.
 
@@ -61,7 +64,7 @@ If you have any customized calico resource manifests, you must also follow the [
 
 ## Cilium
 
-The kubernetes-cilium deployment template enables Cilium networking and policies for the AKS Engine cluster via `"networkPolicy": "cilium"` or `"networkPlugin": "cilium"` being present inside the `kubernetesConfig`.
+The kubernetes-cilium deployment template enables Cilium networking and policies for the ACS-engine cluster via `"networkPolicy": "cilium"` or `"networkPlugin": "cilium"` being present inside the `kubernetesConfig`.
 
 ```json
   "properties": {
@@ -91,6 +94,6 @@ The kubernetes-cilium deployment template enables Cilium networking and policies
 
 ### Post installation
 
-Once the template has been successfully deployed, following the [deploy the demo application](http://cilium.readthedocs.io/en/latest/gettingstarted/minikube/#step-2-deploy-the-demo-application) tutorial will provide a good foundation for how to do L3/4 policy as well as more advanced Layer 7 inspection and routing. If you have [Istio](https://istio.io) you can try this [tutorial](http://cilium.readthedocs.io/en/latest/gettingstarted/istio/) where cilium is used to side by side with Istio to enforce security policies in a Kubernetes deployment.
+Once the template has been successfully deployed, following the [deploy the demo application](http://cilium.readthedocs.io/en/latest/gettingstarted/minikube/#step-2-deploy-the-demo-application) tutorial will provide a good foundation for how to do L3/4 policy as well as more advanced Layer 7 inspection and routing. If you have [Istio](https://istio.io) you can try this [tutorial](http://cilium.readthedocs.io/en/latest/gettingstarted/istio/) where cilium is used to side by side with Istio to enforce security policies in a Kubernetes deployment. 
 
 For the latest documentation on Cilium (including BPF and XDP reference guides), please refer to [this](http://cilium.readthedocs.io/en/latest/)

--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Container Service Engine - Network Policy
+# Microsoft Azure Kubernetes Engine - Network Policy
 
 There are 2 different Network Policy options :
 
@@ -7,11 +7,11 @@ There are 2 different Network Policy options :
 
 ## Calico
 
-Before enabling Calico policy for the ACS-engine cluster, you must first decide which network plugin to use for the cluster: Azure or Kubenet. 
+Before enabling Calico policy for the AKS-engine cluster, you must first decide which network plugin to use for the cluster: Azure or Kubenet. 
 The difference between Azure and Kubenet lies in the way IP addresses get allocated; Azure uses Azure-native IPs while Kubenet does static IP assignment based on the node's pod CIDR.
 If you're not sure which one to go with, we recommend going with Azure.
 
-The kubernetes-calico deployment template enables Calico networking and policies for the ACS-engine cluster via `"networkPolicy": "calico"` being present inside the `kubernetesConfig`.
+The kubernetes-calico deployment template enables Calico networking and policies for the AKS-engine cluster via `"networkPolicy": "calico"` being present inside the `kubernetesConfig`.
 
 ```json
   "properties": {
@@ -35,10 +35,10 @@ Once the template has been successfully deployed, following the [simple policy t
 
 > Note: `ping` (ICMP) traffic is blocked on the cluster by default.  Wherever `ping` is used in any tutorial substitute testing access with something like `wget -q --timeout=5 google.com -O -` instead.
 
-### Update guidance for clusters deployed by acs-engine releases prior to 0.17.0
+### Update guidance for clusters deployed by aks-engine releases prior to 0.17.0
 Clusters deployed with calico networkPolicy enabled prior to `0.17.0` had calico `2.6.3` deployed, and a daemonset with an `updateStrategy` of `Ondelete`.
 
-acs-engine releases starting with 0.17.0 now produce an addon manifest for calico in `/etc/kubernetes/addons/calico-daemonset.yaml` contaning calico 3.1.x, and an `updateStrategy` of `RollingUpdate`. Due to breaking changes introduced by calico 3, one must first migrate through calico `2.6.5` or a later 2.6.x release in order to migrate to calico 3.1.x. as described in the [calico kubernetes upgrade documentation](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/). The acs-engine manifest for calico uses the [kubernetes API datastore, policy-only setup](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade#upgrading-an-installation-that-uses-the-kubernetes-api-datastore).
+aks-engine releases starting with 0.17.0 now produce an addon manifest for calico in `/etc/kubernetes/addons/calico-daemonset.yaml` contaning calico 3.1.x, and an `updateStrategy` of `RollingUpdate`. Due to breaking changes introduced by calico 3, one must first migrate through calico `2.6.5` or a later 2.6.x release in order to migrate to calico 3.1.x. as described in the [calico kubernetes upgrade documentation](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/). The aks-engine manifest for calico uses the [kubernetes API datastore, policy-only setup](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade#upgrading-an-installation-that-uses-the-kubernetes-api-datastore).
 
 1. To update to `2.6.5+` in preparation of an upgrade to 3.1.x as specified, edit `/etc/kubernetes/addons/calico-daemonset.yaml` on a master node, replacing `calico/node:v3.1.1` with `calico/node:v2.6.10` and `calico/cni:v3.1.1` with `calico/cni:v2.0.6`. Run `kubectl apply -f /etc/kubernetes/addons/calico-daemonset.yaml`.
 
@@ -64,7 +64,7 @@ If you have any customized calico resource manifests, you must also follow the [
 
 ## Cilium
 
-The kubernetes-cilium deployment template enables Cilium networking and policies for the ACS-engine cluster via `"networkPolicy": "cilium"` or `"networkPlugin": "cilium"` being present inside the `kubernetesConfig`.
+The kubernetes-cilium deployment template enables Cilium networking and policies for the AKS-engine cluster via `"networkPolicy": "cilium"` or `"networkPlugin": "cilium"` being present inside the `kubernetesConfig`.
 
 ```json
   "properties": {

--- a/examples/networkpolicy/kubernetes-calico-azure.json
+++ b/examples/networkpolicy/kubernetes-calico-azure.json
@@ -4,7 +4,8 @@
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "networkPolicy": "calico"
+        "networkPolicy": "calico",
+        "networkPlugin": "azure"
       }
     },
     "masterProfile": {

--- a/examples/networkpolicy/kubernetes-calico-kubenet.json
+++ b/examples/networkpolicy/kubernetes-calico-kubenet.json
@@ -1,0 +1,39 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPolicy": "calico",
+        "networkPlugin": "kubenet"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_DS2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_DS2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
updates documentation around how to configure Calico policy on the acs-engine deploy