### PR TITLE
do not parse azure-cni monitor manifests if addon is disabled in the apimodel

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -131,6 +131,8 @@ const (
 	DefaultDashboardAddonEnabled = true
 	// DefaultReschedulerAddonEnabled determines the aks-engine provided default for enabling kubernetes-rescheduler addon
 	DefaultReschedulerAddonEnabled = false
+	// DefaultAzureCNIMonitoringAddonEnabled determines the aks-engine provided default for enabling azurecni-network monitoring addon
+	DefaultAzureCNIMonitoringAddonEnabled = true
 	// DefaultRBACEnabled determines the aks-engine provided default for enabling kubernetes RBAC
 	DefaultRBACEnabled = true
 	// DefaultUseInstanceMetadata determines the aks-engine provided default for enabling Azure cloudprovider instance metadata service

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1222,6 +1222,11 @@ func (o *OrchestratorProfile) IsMetricsServerEnabled() bool {
 		common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0"))
 }
 
+// IsAzureCNIMonitoringEnabled checks if the azure cni monitoring addon is enabled
+func (k *KubernetesConfig) IsAzureCNIMonitoringEnabled() bool {
+	return k.isAddonEnabled(AzureCNINetworkMonitoringAddonName, DefaultAzureCNIMonitoringAddonEnabled)
+}
+
 // IsContainerMonitoringEnabled checks if the container monitoring addon is enabled
 func (k *KubernetesConfig) IsContainerMonitoringEnabled() bool {
 	return k.isAddonEnabled(ContainerMonitoringAddonName, DefaultContainerMonitoringAddonEnabled)

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -109,7 +109,7 @@ func kubernetesContainerAddonSettingsInit(profile *api.Properties) map[string]ku
 		DefaultAzureCNINetworkMonitorAddonName: {
 			"azure-cni-networkmonitor.yaml",
 			"azure-cni-networkmonitor.yaml",
-			profile.OrchestratorProfile.IsAzureCNI(),
+			profile.OrchestratorProfile.IsAzureCNI() && profile.OrchestratorProfile.KubernetesConfig.IsAzureCNIMonitoringEnabled(),
 			profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureCNINetworkMonitorAddonName),
 		},
 		DefaultDNSAutoscalerAddonName: {


### PR DESCRIPTION
Partially addresses #160 