### PR TITLE
stop defaulting to westcentralus as a regional option for E2E

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -151,7 +151,7 @@ func (c *Config) IsKubernetes() bool {
 func (c *Config) SetRandomRegion() {
 	var regions []string
 	if c.Regions == nil || len(c.Regions) == 0 {
-		regions = []string{"eastus", "southcentralus", "westcentralus", "southeastasia", "westus2", "westeurope"}
+		regions = []string{"eastus", "southcentralus", "southeastasia", "westus2", "westeurope"}
 	} else {
 		regions = c.Regions
 	}

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -28,13 +28,13 @@ func TestSetRandomRegion(t *testing.T) {
 			config: Config{
 				Regions: []string{},
 			},
-			expected: []string{"eastus", "southcentralus", "westcentralus", "southeastasia", "westus2", "westeurope"},
+			expected: []string{"eastus", "southcentralus", "southeastasia", "westus2", "westeurope"},
 		},
 		{
 			config: Config{
 				Regions: nil,
 			},
-			expected: []string{"eastus", "southcentralus", "westcentralus", "southeastasia", "westus2", "westeurope"},
+			expected: []string{"eastus", "southcentralus", "southeastasia", "westus2", "westeurope"},
 		},
 		{
 			config: Config{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews

-->

**What this PR does / why we need it**: This canary-ish region has more trouble than other ones, let's stop using it in the blessed default list.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
stop defaulting to westcentralus as a regional option for E2E
```
