### PR TITLE
use latest VHD image: k8s 1.11.6, 1.12.4, 1.13.1

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -143,7 +143,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1604-201812",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2018.12.12",
+		ImageVersion:   "2018.12.18",
 	}
 
 	// DefaultAKSDockerEngineOSImageConfig is the AKS image based on Ubuntu 16.04.
@@ -151,7 +151,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1604-docker-engine",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2018.12.12",
+		ImageVersion:   "2018.12.18",
 	}
 
 	//AzureCloudSpec is the default configurations for global azure.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews

-->

**What this PR does / why we need it**: Includes the following additions pre-baked into the image:

- Kubernetes v1.13.1
- Kubernetes v1.12.4
- Kubernetes v1.11.6
- cluster-autoscaler 1.13.1, 1.12.1
- microsoft/k8s-azure-kms v0.0.7

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
use latest VHD image: k8s 1.11.6, 1.12.4, 1.13.1
```