### PR TITLE
fix: update MSI

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -152,7 +152,7 @@ for NGINX_VERSION in ${NGINX_VERSIONS}; do
     pullContainerImage "docker" "nginx:${NGINX_VERSION}"
 done
 
-KMS_PLUGIN_VERSIONS="0.0.7"
+KMS_PLUGIN_VERSIONS="0.0.8"
 for KMS_PLUGIN_VERSION in ${KMS_PLUGIN_VERSIONS}; do
     pullContainerImage "docker" "microsoft/k8s-azure-kms:v${KMS_PLUGIN_VERSION}"
 done

--- a/parts/k8s/artifacts/kubernetesazurekms.service
+++ b/parts/k8s/artifacts/kubernetesazurekms.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/docker run \
   --volume=/etc/kubernetes:/etc/kubernetes \
   --volume=/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
   --volume=/var/lib/waagent:/var/lib/waagent \
-  microsoft/k8s-azure-kms:v0.0.7
+  microsoft/k8s-azure-kms:v0.0.8
 
 [Install]
 WantedBy=multi-user.target

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -224,8 +224,7 @@
       },
       "type": "Microsoft.Compute/virtualMachines"
     },
-    {{if UseManagedIdentity}}
-    {{if (not UserAssignedIDEnabled)}}
+    {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
     {
       "apiVersion": "[variables('apiVersionAuthorization')]",
       "copy": {
@@ -241,49 +240,13 @@
     },
     {{end}}
      {
-       "type": "Microsoft.Compute/virtualMachines/extensions",
-       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/ManagedIdentityExtension')]",
-       "copy": {
-         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
-         "name": "vmLoopNode"
-       },
-       "apiVersion": "[variables('apiVersionCompute')]",
-       "location": "[resourceGroup().location]",
-       {{if UserAssignedIDEnabled}}
-       "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
-        "[concat('Microsoft.Authorization/roleAssignments/',guid(concat(variables('userAssignedID'), 'roleAssignment', resourceGroup().id)))]"
-       ],
-       {{else}}
-       "dependsOn": [
-         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
-         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), 'vmidentity')))]"
-       ],
-       {{end}}
-       "properties": {
-         "publisher": "Microsoft.ManagedIdentity",
-         "type": "ManagedIdentityExtensionForLinux",
-         "typeHandlerVersion": "1.0",
-         "autoUpgradeMinorVersion": true,
-         "settings": {
-           "port": 50343
-         },
-         "protectedSettings": {}
-       }
-     },
-     {{end}}
-     {
       "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
       },
       "dependsOn": [
-        {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/extensions/ManagedIdentityExtension')]"
-        {{else}}
         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
-        {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -146,18 +146,18 @@
       "location": "[variables('location')]",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
       {{if UseManagedIdentity}}
-      {{if UserAssignedIDEnabled}}
+        {{if UserAssignedIDEnabled}}
       "identity": {
         "type": "userAssigned",
         "userAssignedIdentities": {
           "[variables('userAssignedIDReference')]":{}
         }
       },
-      {{else}}
+        {{else}}
       "identity": {
         "type": "systemAssigned"
       },
-      {{end}}
+        {{end}}
       {{end}}
       "properties": {
         "availabilitySet": {

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -226,7 +226,7 @@
     },
     {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
     {
-      "apiVersion": "[variables('apiVersionAuthorization')]",
+      "apiVersion": "[variables('apiVersionAuthorizationSystem')]",
       "copy": {
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -236,7 +236,10 @@
       "properties": {
         "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
         "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset'))), '2017-03-30', 'Full').identity.principalId]"
-      }
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
+      ]
     },
     {{end}}
      {

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -6,7 +6,10 @@
     "properties": {
       "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
       "principalId": "[reference(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix')), '2017-03-30', 'Full').identity.principalId]"
-    }
+    },
+    "dependsOn": [
+      "[concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'))]"
+    ]
   },
 {{end}}
   {

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
   {
-    "apiVersion": "[variables('apiVersionAuthorization')]",
+    "apiVersion": "[variables('apiVersionAuthorizationSystem')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -172,21 +172,6 @@
               }
             }
             {{end}}
-            {{if UseManagedIdentity}}
-            ,{
-              "name": "managedIdentityExtension",
-              "properties": {
-                "publisher": "Microsoft.ManagedIdentity",
-                "type": "ManagedIdentityExtensionForLinux",
-                "typeHandlerVersion": "1.0",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                  "port": 50343
-                },
-                "protectedSettings": {}
-              }
-            }
-            {{end}}
           ]
         }
       }

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -34,18 +34,18 @@
     {{ end }}
     "name": "[variables('{{.Name}}VMNamePrefix')]",
     {{if UseManagedIdentity}}
-    {{if UserAssignedIDEnabled}}
+      {{if UserAssignedIDEnabled}}
     "identity": {
       "type": "userAssigned",
       "userAssignedIdentities": {
         "[variables('userAssignedIDReference')]":{}
       }
     },
-    {{else}}
+      {{else}}
     "identity": {
       "type": "systemAssigned"
     },
-    {{end}}
+      {{end}}
     {{end}}
     "sku": {
       "tier": "Standard",

--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -36,7 +36,7 @@
         "location": "[variables('location')]"
       },
       {
-        "apiVersion": "[variables('apiVersionAuthorization')]",
+        "apiVersion": "[variables('apiVersionAuthorizationUser')]",
         "type": "Microsoft.Authorization/roleAssignments",
         "name": "[guid(concat(variables('userAssignedID'), 'roleAssignment', resourceGroup().id))]",
         "properties": {

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -828,18 +828,18 @@
       "zones": "[split(string(parameters('availabilityZones')[mod(copyIndex(variables('masterOffset')), length(parameters('availabilityZones')))]), ',')]",
       {{end}}
       {{if UseManagedIdentity}}
-      {{if UserAssignedIDEnabled}}
+        {{if UserAssignedIDEnabled}}
       "identity": {
         "type": "userAssigned",
         "userAssignedIdentities": {
           "[variables('userAssignedIDReference')]":{}
         }
       },
-      {{else}}
+        {{else}}
       "identity": {
         "type": "systemAssigned"
       },
-      {{end}}
+        {{end}}
       {{end}}
       "properties": {
         {{if not .MasterProfile.HasAvailabilityZones}}

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -937,34 +937,6 @@
       }
     },
     {{end}}
-     {
-       "type": "Microsoft.Compute/virtualMachines/extensions",
-       "name": "[concat(variables('masterVMNamePrefix'), copyIndex(), '/ManagedIdentityExtension')]",
-       "copy": {
-         "count": "[variables('masterCount')]",
-         "name": "vmLoopNode"
-       },
-       "apiVersion": "[variables('apiVersionCompute')]",
-       "location": "[resourceGroup().location]",
-       "dependsOn": [
-         "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex())]",
-         {{if UserAssignedIDEnabled}}
-         "[concat('Microsoft.Authorization/roleAssignments/',guid(concat(variables('userAssignedID'), 'roleAssignment', resourceGroup().id)))]"
-         {{else}}
-         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(), 'vmidentity')))]"
-         {{end}}
-       ],
-       "properties": {
-         "publisher": "Microsoft.ManagedIdentity",
-         "type": "ManagedIdentityExtensionForLinux",
-         "typeHandlerVersion": "1.0",
-         "autoUpgradeMinorVersion": true,
-         "settings": {
-           "port": 50343
-         },
-         "protectedSettings": {}
-       }
-     },
      {{end}}
     {
       "apiVersion": "[variables('apiVersionCompute')]",
@@ -973,11 +945,7 @@
         "name": "vmLoopNode"
       },
       "dependsOn": [
-        {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '/extensions/ManagedIdentityExtension')]"
-        {{else}}
         "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]"
-        {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -921,10 +921,9 @@
       },
       "type": "Microsoft.Compute/virtualMachines"
     },
-    {{if UseManagedIdentity}}
-    {{if (not UserAssignedIDEnabled)}}
+    {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
     {
-      "apiVersion": "[variables('apiVersionAuthorization')]",
+      "apiVersion": "[variables('apiVersionAuthorizationSystem')]",
       "copy": {
          "count": "[variables('masterCount')]",
          "name": "vmLoopNode"
@@ -937,7 +936,6 @@
       }
     },
     {{end}}
-     {{end}}
     {
       "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
@@ -946,6 +944,9 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]"
+        {{if EnableEncryptionWithExternalKms}}
+        ,"[concat('Microsoft.KeyVault/vaults/', variables('clusterKeyVaultName'))]"
+        {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -477,21 +477,6 @@
         },
         "extensionProfile": {
           "extensions": [
-            {{if UseManagedIdentity}}
-            {
-              "name": "[concat(variables('masterVMNamePrefix'), 'vmss-ManagedIdentityExtension')]",
-              "properties": {
-                "publisher": "Microsoft.ManagedIdentity",
-                "type": "ManagedIdentityExtensionForLinux",
-                "typeHandlerVersion": "1.0",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                  "port": 50343
-                },
-                "protectedSettings": {}
-              }
-            },
-            {{end}}
             {
               "name": "[concat(variables('masterVMNamePrefix'), 'vmssCSE')]",
               "properties": {

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -90,7 +90,8 @@
     "apiVersionKeyVault": "2018-02-14",
     "apiVersionNetwork": "2018-08-01",
     "apiVersionManagedIdentity": "2015-08-31-preview",
-    "apiVersionAuthorization": "2018-09-01-preview",
+    "apiVersionAuthorizationUser": "2018-09-01-preview",
+    "apiVersionAuthorizationSystem": "2018-01-01-preview",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -218,7 +218,7 @@
     },
     {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
     {
-      "apiVersion": "[variables('apiVersionAuthorization')]",
+      "apiVersion": "[variables('apiVersionAuthorizationSystem')]",
       "copy": {
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -154,18 +154,18 @@
       "location": "[variables('location')]",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
       {{if UseManagedIdentity}}
-      {{if UserAssignedIDEnabled}}
+        {{if UserAssignedIDEnabled}}
       "identity": {
         "type": "userAssigned",
         "userAssignedIdentities": {
           "[variables('userAssignedIDReference')]":{}
         }
       },
-      {{else}}
+        {{else}}
       "identity": {
         "type": "systemAssigned"
       },
-      {{end}}
+        {{end}}
       {{end}}
       "properties": {
         "availabilitySet": {

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -228,7 +228,10 @@
       "properties": {
         "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
         "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset'))), '2017-03-30', 'Full').identity.principalId]"
-      }
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
+      ]
     },
      {{end}}
     {

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -154,9 +154,18 @@
       "location": "[variables('location')]",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
       {{if UseManagedIdentity}}
+      {{if UserAssignedIDEnabled}}
+      "identity": {
+        "type": "userAssigned",
+        "userAssignedIdentities": {
+          "[variables('userAssignedIDReference')]":{}
+        }
+      },
+      {{else}}
       "identity": {
         "type": "systemAssigned"
       },
+      {{end}}
       {{end}}
       "properties": {
         "availabilitySet": {
@@ -207,7 +216,7 @@
       },
       "type": "Microsoft.Compute/virtualMachines"
     },
-    {{if UseManagedIdentity}}
+    {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
     {
       "apiVersion": "[variables('apiVersionAuthorization')]",
       "copy": {
@@ -221,30 +230,6 @@
         "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset'))), '2017-03-30', 'Full').identity.principalId]"
       }
     },
-      {
-        "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/ManagedIdentityExtension')]",
-        "copy": {
-          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
-          "name": "vmLoopNode"
-        },
-        "apiVersion": "[variables('apiVersionCompute')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
-          "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), 'vmidentity')))]"
-        ],
-        "properties": {
-          "publisher": "Microsoft.ManagedIdentity",
-          "type": "ManagedIdentityExtensionForWindows",
-          "typeHandlerVersion": "1.0",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "port": 50343
-          },
-          "protectedSettings": {}
-        }
-      },
      {{end}}
     {
       "apiVersion": "[variables('apiVersionCompute')]",
@@ -253,11 +238,7 @@
         "name": "vmLoopNode"
       },
       "dependsOn": [
-        {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/extensions/ManagedIdentityExtension')]"
-        {{else}}
         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
-        {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -6,7 +6,10 @@
     "properties": {
       "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
       "principalId": "[reference(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix')), '2017-03-30', 'Full').identity.principalId]"
-    }
+    },
+    "dependsOn": [
+      "[concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'))]"
+    ]
   },
 {{end}}
   {

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
   {
-    "apiVersion": "[variables('apiVersionAuthorization')]",
+    "apiVersion": "[variables('apiVersionAuthorizationSystem')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -34,18 +34,18 @@
     {{ end }}
     "name": "[variables('{{.Name}}VMNamePrefix')]",
     {{if UseManagedIdentity}}
-    {{if UserAssignedIDEnabled}}
+      {{if UserAssignedIDEnabled}}
     "identity": {
       "type": "userAssigned",
       "userAssignedIdentities": {
         "[variables('userAssignedIDReference')]":{}
       }
     },
-    {{else}}
+      {{else}}
     "identity": {
       "type": "systemAssigned"
     },
-    {{end}}
+      {{end}}
     {{end}}
     "sku": {
       "tier": "Standard",

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -1,4 +1,4 @@
-{{if UseManagedIdentity}}
+{{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
   {
     "apiVersion": "[variables('apiVersionAuthorization')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
@@ -31,9 +31,18 @@
     {{ end }}
     "name": "[variables('{{.Name}}VMNamePrefix')]",
     {{if UseManagedIdentity}}
+    {{if UserAssignedIDEnabled}}
+    "identity": {
+      "type": "userAssigned",
+      "userAssignedIdentities": {
+        "[variables('userAssignedIDReference')]":{}
+      }
+    },
+    {{else}}
     "identity": {
       "type": "systemAssigned"
     },
+    {{end}}
     {{end}}
     "sku": {
       "tier": "Standard",
@@ -129,21 +138,6 @@
                 "typeHandlerVersion": "1.0",
                 "autoUpgradeMinorVersion": true,
                 "settings": {}
-              }
-            }
-            {{end}}
-            {{if UseManagedIdentity}}
-            ,{
-              "name": "managedIdentityExtension",
-              "properties": {
-                "publisher": "Microsoft.ManagedIdentity",
-                "type": "ManagedIdentityExtensionForWindows",
-                "typeHandlerVersion": "1.0",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                  "port": 50343
-                },
-                "protectedSettings": {}
               }
             }
             {{end}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews

-->

**What this PR does / why we need it**:
- Remove MSI Extension since it will be deprecated in Jan 2019 and it is not available in sovereign clouds
- Create separate apiVersionAuthorization to support both user assigned and system assigned identity for clouds that do not have the latest apis: `apiVersionAuthorizationUser` and `apiVersionAuthorizationSystem`
- Add VMs to dependsOn for each role assignment if it's system assigned identity
- Bump version of kms plugin to support instance metadata service identity endpoint 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #175

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update MSI to remove MSI extension and add support for older api versions of role assignment
```
