### PR TITLE
using the correct apiVersion Private Cluster NICs

### DIFF
--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -396,7 +396,7 @@
     },
 {{else}}
       {
-        "apiVersion": "[variables('apiVersionCompute')]",
+        "apiVersion": "[variables('apiVersionNetwork')]",
         "copy": {
           "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
           "name": "nicLoopNode"


### PR DESCRIPTION
All network ARM resources must use `apiVersionNetwork` 