### PR TITLE
change azure disk cachingMode to ReadOnly

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes.yaml
@@ -10,7 +10,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Standard_LRS
-  cachingmode: None
+  cachingmode: ReadOnly
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -23,7 +23,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Premium_LRS
-  cachingmode: None
+  cachingmode: ReadOnly
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -36,7 +36,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Standard_LRS
-  cachingmode: None
+  cachingmode: ReadOnly
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
 provisioner: kubernetes.io/azure-disk
 parameters:
-  cachingmode: None
+  cachingmode: ReadOnly
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -20,7 +20,7 @@ metadata:
 provisioner: kubernetes.io/azure-disk
 parameters:
   storageaccounttype: Premium_LRS
-  cachingmode: None
+  cachingmode: ReadOnly
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -32,7 +32,7 @@ metadata:
 provisioner: kubernetes.io/azure-disk
 parameters:
   storageaccounttype: Standard_LRS
-  cachingmode: None
+  cachingmode: ReadOnly
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews

-->

**What this PR does / why we need it**:
The default value `None` would lead to slow perf. And according to below doc: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage-performance#disk-caching

default host cache should be `ReadOnly`, the reason why we use “cachingMode: None” by default in k8s is that there is a critical disk bug due to this cachingMode setting(`ReadOnly` & `ReadWrite`) which would lead to disk i/o error, and this issue has been fixed in the middle of this year by azure disk team. 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
For more details, refer to https://github.com/kubernetes/kubernetes/pull/72229

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
change azure disk cachingMode to ReadOnly
```
