### PR TITLE
fix: add a ClusterName property and use it for resources names

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -139,6 +139,7 @@
       {
         "creationSource" : "[concat(parameters('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
         "resourceNameSuffix" : "[parameters('nameSuffix')]",
+        "clusterName" : "['{{GetClusterName}}']",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "acsengineVersion" : "[parameters('acsengineVersion')]",
         "poolName" : "{{.Name}}"
@@ -322,4 +323,3 @@
       }
     }
     {{end}}
-  

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -104,7 +104,7 @@
         },
         "osProfile": {
           "adminUsername": "[parameters('linuxAdminUsername')]",
-          "computerNamePrefix": "[variables('{{.Name}}VMNamePrefix')]",
+          "computerNamePrefix": "[concat(variables('{{.Name}}VMNamePrefix'), '-')]",
           {{GetKubernetesAgentCustomData .}}
           "linuxConfiguration": {
               "disablePasswordAuthentication": true,

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -9,7 +9,7 @@
 {{end}}
 {{if .IsAvailabilitySets}}
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
-    "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', parameters('nameSuffix'))]",
+    "{{.Name}}AvailabilitySet": "[concat('{{GetClusterName}}', '-{{.Name}}-availabilityset')]",
 {{else}}
     {{if .IsLowPriorityScaleSet}}
     "{{.Name}}ScaleSetPriority": "[parameters('{{.Name}}ScaleSetPriority')]",

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -329,7 +329,7 @@
 {{ end }}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -412,7 +412,7 @@
   {{end}}
         ],
         "location": "[variables('location')]",
-        "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+        "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic')]",
         "properties": {
           "ipConfigurations": [
             {
@@ -703,7 +703,7 @@
        "apiVersion": "[variables('apiVersionKeyVault')]",
        "location": "[variables('location')]",
        {{ if UseManagedIdentity}}
-       "dependsOn": 
+       "dependsOn":
        [
        {{if UserAssignedIDEnabled}}
        "[variables('userAssignedIDReference')]"
@@ -806,7 +806,7 @@
         "name": "vmLoopNode"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic')]"
         {{if not .MasterProfile.HasAvailabilityZones}}
         ,"[concat('Microsoft.Compute/availabilitySets/',variables('masterAvailabilitySet'))]"
         {{end}}
@@ -817,6 +817,7 @@
       "tags":
       {
         "creationSource" : "[concat(parameters('generatorCode'), '-', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
+        "clusterName" : "['{{GetClusterName}}']",
         "resourceNameSuffix" : "[parameters('nameSuffix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "acsengineVersion" : "[parameters('acsengineVersion')]",
@@ -853,7 +854,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'),'nic-', copyIndex(variables('masterOffset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic'))]"
             }
           ]
         },
@@ -906,8 +907,8 @@
           "osDisk": {
             "caching": "ReadWrite"
             ,"createOption": "FromImage"
-{{if .MasterProfile.IsStorageAccount}}
             ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-osdisk')]"
+{{if .MasterProfile.IsStorageAccount}}
             ,"vhd": {
               "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-osdisk.vhd')]"
             }

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -96,7 +96,7 @@
          "[parameters('location')]"
     ],
     "location": "[variables('locations')[mod(add(2,length(parameters('location'))),add(1,length(parameters('location'))))]]",
-    "masterAvailabilitySet": "[concat('master-availabilityset-', parameters('nameSuffix'))]",
+    "masterAvailabilitySet": "[concat('{{GetClusterName}}', '-master-availabilityset')]",
     "resourceGroup": "[resourceGroup().name]",
     "truncatedResourceGroup": "[take(replace(replace(resourceGroup().name, '(', '-'), ')', '-'), 63)]",
     "labelResourceGroup": "[if(or(or(endsWith(variables('truncatedResourceGroup'), '-'), endsWith(variables('truncatedResourceGroup'), '_')), endsWith(variables('truncatedResourceGroup'), '.')), concat(take(variables('truncatedResourceGroup'), 62), 'z'), variables('truncatedResourceGroup'))]",
@@ -162,10 +162,10 @@
     "virtualNetworkName": "[split(variables('vnetSubnetID'), '/')[variables('vnetNameResourceSegmentIndex')]]",
     "virtualNetworkResourceGroupName": "[split(variables('vnetSubnetID'), '/')[variables('vnetResourceGroupNameResourceSegmentIndex')]]",
   {{else}}
-    "subnetName": "[concat(parameters('orchestratorName'), '-subnet')]",
+    "subnetName": "[concat('{{GetClusterName}}', '-subnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]",
+    "virtualNetworkName": "[concat('{{GetClusterName}}', '-vnet')]",
     "virtualNetworkResourceGroupName": "",
   {{end}}
 {{else}}
@@ -185,10 +185,10 @@
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/subnetagent')]",
     "vnetSubnetIDMaster": "[concat(variables('vnetID'),'/subnets/subnetmaster')]",
     {{else}}
-    "subnetName": "[concat(parameters('orchestratorName'), '-subnet')]",
+    "subnetName": "[concat('{{GetClusterName}}', '-subnet')]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
     {{end}}
-    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]",
+    "virtualNetworkName": "[concat('{{GetClusterName}}', '-vnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "virtualNetworkResourceGroupName": "''",
   {{end}}
@@ -200,17 +200,17 @@
 {{end}}
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
 {{if AnyAgentUsesVirtualMachineScaleSets}}
-    "primaryScaleSetName": "[concat(parameters('orchestratorName'), '-{{ (index .AgentPoolProfiles 0).Name }}-',parameters('nameSuffix'), '-vmss')]",
+    "primaryScaleSetName": "[concat('{{GetClusterName}}', '-{{ (index .AgentPoolProfiles 0).Name }}-vmss')]",
     "primaryAvailabilitySetName": "",
     "vmType": "vmss",
 {{else}}
-    "primaryAvailabilitySetName": "[concat('{{ (index .AgentPoolProfiles 0).Name }}-availabilitySet-',parameters('nameSuffix'))]",
+    "primaryAvailabilitySetName": "[concat('{{GetClusterName}}', '-{{ (index .AgentPoolProfiles 0).Name }}-availabilityset')]",
     "primaryScaleSetName": "",
     "vmType": "standard",
 {{end}}
 {{if IsHostedMaster }}
     "kubernetesAPIServerIP": "[parameters('kubernetesEndpoint')]",
-    "agentNamePrefix": "[concat(parameters('orchestratorName'), '-agentpool-', parameters('nameSuffix'), '-')]",
+    "agentNamePrefix": "[concat('{{GetClusterName}}', '-agentpool-', parameters('nameSuffix'), '-')]",
 {{else}}
     {{if IsPrivateCluster}}
       "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",
@@ -228,17 +228,17 @@
           {{end}}
         {{end}}
     {{else}}
-        "masterPublicIPAddressName": "[concat(parameters('orchestratorName'), '-master-ip-', variables('masterFqdnPrefix'), '-', parameters('nameSuffix'))]",
+        "masterPublicIPAddressName": "[concat('{{GetClusterName}}', '-master-ip-', variables('masterFqdnPrefix'))]",
         "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",
         "masterLbIPConfigID": "[concat(variables('masterLbID'),'/frontendIPConfigurations/', variables('masterLbIPConfigName'))]",
-        "masterLbIPConfigName": "[concat(parameters('orchestratorName'), '-master-lbFrontEnd-', parameters('nameSuffix'))]",
-        "masterLbName": "[concat(parameters('orchestratorName'), '-master-lb-', parameters('nameSuffix'))]",
+        "masterLbIPConfigName": "[concat('{{GetClusterName}}', '-master-lbFrontEnd-', parameters('nameSuffix'))]",
+        "masterLbName": "[concat('{{GetClusterName}}', '-master-lb')]",
         "kubeconfigServer": "[concat('https://', variables('masterFqdnPrefix'), '.', variables('location'), '.', parameters('fqdnEndpointSuffix'))]",
     {{end}}
       {{if gt .MasterProfile.Count 1}}
-        "masterInternalLbName": "[concat(parameters('orchestratorName'), '-master-internal-lb-', parameters('nameSuffix'))]",
+        "masterInternalLbName": "[concat('{{GetClusterName}}', '-master-internal-lb')]",
         "masterInternalLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterInternalLbName'))]",
-        "masterInternalLbIPConfigName": "[concat(parameters('orchestratorName'), '-master-internal-lbFrontEnd-', parameters('nameSuffix'))]",
+        "masterInternalLbIPConfigName": "[concat('{{GetClusterName}}', '-master-internal-lb-frontend')]",
         "masterInternalLbIPConfigID": "[concat(variables('masterInternalLbID'),'/frontendIPConfigurations/', variables('masterInternalLbIPConfigName'))]",
         "masterInternalLbIPOffset": {{GetDefaultInternalLbStaticIPOffset}},
         {{if IsMasterVirtualMachineScaleSets}}
@@ -249,7 +249,7 @@
     {{else}}
       "kubernetesAPIServerIP": "[parameters('firstConsecutiveStaticIP')]",
     {{end}}
-    "masterLbBackendPoolName": "[concat(parameters('orchestratorName'), '-master-pool-', parameters('nameSuffix'))]",
+    "masterLbBackendPoolName": "[concat('{{GetClusterName}}', '-master-pool-', parameters('nameSuffix'))]",
     "masterFirstAddrComment": "these MasterFirstAddrComment are used to place multiple masters consecutively in the address space",
     "masterFirstAddrOctets": "[split(parameters('firstConsecutiveStaticIP'),'.')]",
     "masterFirstAddrOctet4": "[variables('masterFirstAddrOctets')[3]]",

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -1,3 +1,10 @@
+    "clusterName": {
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the cluster which will prefix all resources name."
+      },
+      "type": "string"
+    },
     "linuxAdminUsername": {
       "metadata": {
         "description": "User name for the Linux Virtual Machines (SSH or Password)."

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -434,6 +434,7 @@ func convertPropertiesToV20170701(api *Properties, p *v20170701.Properties) {
 }
 
 func convertPropertiesToVLabs(api *Properties, vlabsProps *vlabs.Properties) {
+	vlabsProps.ClusterName = api.ClusterName
 	vlabsProps.ProvisioningState = vlabs.ProvisioningState(api.ProvisioningState)
 	if api.OrchestratorProfile != nil {
 		vlabsProps.OrchestratorProfile = &vlabs.OrchestratorProfile{}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -350,6 +350,7 @@ func convertV20170701Properties(v20170701 *v20170701.Properties, api *Properties
 }
 
 func convertVLabsProperties(vlabs *vlabs.Properties, api *Properties, isUpdate bool) {
+	api.ClusterName = vlabs.ClusterName
 	api.ProvisioningState = ProvisioningState(vlabs.ProvisioningState)
 	if vlabs.OrchestratorProfile != nil {
 		api.OrchestratorProfile = &OrchestratorProfile{}

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -35,6 +35,7 @@ type ContainerService struct {
 
 // Properties represents the AKS cluster definition
 type Properties struct {
+	ClusterName             string                   `json:"clusterName,omitempty"`
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
 	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty" validate:"required"`
 	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty" validate:"required"`

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -12,8 +12,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/to"
-
 	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
@@ -21,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	azStorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 )
@@ -371,14 +370,14 @@ func (mc *MockAKSEngineClient) ListVirtualMachines(ctx context.Context, resource
 		}, errors.New("ListVirtualMachines failed")
 	}
 
-	vm1Name := "k8s-agentpool1-12345678-0"
+	vm1Name := "k8s-12345678-agentpool1-0"
 
 	creationSourceString := "creationSource"
 	orchestratorString := "orchestrator"
 	resourceNameSuffixString := "resourceNameSuffix"
 	poolnameString := "poolName"
 
-	creationSource := "acsengine-k8s-agentpool1-12345678-0"
+	creationSource := "acsengine-k8s-12345678-agentpool1-0"
 	orchestrator := "Kubernetes:1.7.9"
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
@@ -439,14 +438,14 @@ func (mc *MockAKSEngineClient) GetVirtualMachine(ctx context.Context, resourceGr
 		return compute.VirtualMachine{}, errors.New("GetVirtualMachine failed")
 	}
 
-	vm1Name := "k8s-agentpool1-12345678-0"
+	vm1Name := "k8s-12345678-agentpool1-0"
 
 	creationSourceString := "creationSource"
 	orchestratorString := "orchestrator"
 	resourceNameSuffixString := "resourceNameSuffix"
 	poolnameString := "poolName"
 
-	creationSource := "acsengine-k8s-agentpool1-12345678-0"
+	creationSource := "acsengine-k8s-12345678-agentpool1-0"
 	orchestrator := "Kubernetes:1.7.9"
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
@@ -542,7 +541,7 @@ func (mc *MockAKSEngineClient) DeleteNetworkInterface(ctx context.Context, resou
 }
 
 var validOSDiskResourceName = "https://00k71r4u927seqiagnt0.blob.core.windows.net/osdisk/k8s-agentpool1-12345678-0-osdisk.vhd"
-var validNicResourceName = "/subscriptions/DEC923E3-1EF1-4745-9516-37906D56DEC4/resourceGroups/acsK8sTest/providers/Microsoft.Network/networkInterfaces/k8s-agent-12345678-nic-0"
+var validNicResourceName = "/subscriptions/DEC923E3-1EF1-4745-9516-37906D56DEC4/resourceGroups/acsK8sTest/providers/Microsoft.Network/networkInterfaces/k8s-12345678-agent-nic-0"
 
 // Active Directory
 // Mocks

--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -17,17 +17,17 @@ import (
 
 const (
 	// TODO: merge with the RP code
-	k8sLinuxVMNamingFormat         = "^[0-9a-zA-Z]{3}-(.+)-([0-9a-fA-F]{8})-{0,2}([0-9]+)$"
-	k8sLinuxVMAgentPoolNameIndex   = 1
-	k8sLinuxVMAgentClusterIDIndex  = 2
+	k8sLinuxVMNamingFormat         = "^[0-9a-zA-Z]{3}-([0-9a-fA-F]{8})-(.+)-([0-9]+)$"
+	k8sLinuxVMAgentPoolNameIndex   = 2
+	k8sLinuxVMAgentClusterIDIndex  = 1
 	k8sLinuxVMAgentIndexArrayIndex = 3
 
 	// here there are 2 capture groups
 	//  the first is the agent pool name, which can contain -s
 	//  the second group is the Cluster ID for the cluster
-	vmssNamingFormat       = "^[0-9a-zA-Z]+-(.+)-([0-9a-fA-F]{8})-vmss$"
-	vmssAgentPoolNameIndex = 1
-	vmssClusterIDIndex     = 2
+	vmssNamingFormat       = "^[0-9a-zA-Z]+-([0-9a-fA-F]{8})-(.+)-vmss$"
+	vmssAgentPoolNameIndex = 2
+	vmssClusterIDIndex     = 1
 
 	k8sWindowsOldVMNamingFormat = "^([a-fA-F0-9]{5})([0-9a-zA-Z]{3})([9])([a-zA-Z0-9]{3,5})$"
 	k8sWindowsVMNamingFormat    = "^([a-fA-F0-9]{4})([0-9a-zA-Z]{3})([0-9]{3,8})$"
@@ -73,7 +73,7 @@ func SplitBlobURI(URI string) (string, string, string, error) {
 	return accountName, containerName, blobPath, nil
 }
 
-// K8sLinuxVMNameParts returns parts of Linux VM name e.g: k8s-agentpool1-11290731-0
+// K8sLinuxVMNameParts returns parts of Linux VM name e.g: k8s-11290731-agentpool1-0
 func K8sLinuxVMNameParts(vmName string) (poolIdentifier, nameSuffix string, agentIndex int, err error) {
 	vmNameParts := vmnameLinuxRegexp.FindStringSubmatch(vmName)
 	if len(vmNameParts) != 4 {
@@ -89,7 +89,7 @@ func K8sLinuxVMNameParts(vmName string) (poolIdentifier, nameSuffix string, agen
 	return vmNameParts[k8sLinuxVMAgentPoolNameIndex], vmNameParts[k8sLinuxVMAgentClusterIDIndex], vmNum, nil
 }
 
-// VmssNameParts returns parts of Linux VM name e.g: k8s-agentpool1-11290731-0
+// VmssNameParts returns parts of Linux VM name e.g: k8s-11129073-agentpool1-0
 func VmssNameParts(vmssName string) (poolIdentifier, nameSuffix string, err error) {
 	vmssNameParts := vmssnameRegexp.FindStringSubmatch(vmssName)
 	if len(vmssNameParts) != 3 {

--- a/pkg/armhelpers/utils/util_test.go
+++ b/pkg/armhelpers/utils/util_test.go
@@ -41,7 +41,7 @@ func Test_LinuxVMNameParts(t *testing.T) {
 	}
 
 	for _, el := range data {
-		vmName := fmt.Sprintf("k8s-%s-%s-%d", el.poolIdentifier, el.nameSuffix, el.agentIndex)
+		vmName := fmt.Sprintf("k8s-%s-%s-%d", el.nameSuffix, el.poolIdentifier, el.agentIndex)
 		poolIdentifier, nameSuffix, agentIndex, err := K8sLinuxVMNameParts(vmName)
 		if poolIdentifier != el.poolIdentifier {
 			t.Fatalf("incorrect poolIdentifier. expected=%s actual=%s", el.poolIdentifier, poolIdentifier)
@@ -68,7 +68,7 @@ func Test_VmssNameParts(t *testing.T) {
 	}
 
 	for _, el := range data {
-		vmssName := fmt.Sprintf("swarmm-%s-%s-vmss", el.poolIdentifier, el.nameSuffix)
+		vmssName := fmt.Sprintf("swarmm-%s-%s-vmss", el.nameSuffix, el.poolIdentifier)
 		poolIdentifier, nameSuffix, err := VmssNameParts(vmssName)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -116,7 +116,7 @@ func Test_WindowsVMNameParts(t *testing.T) {
 func Test_GetVMNameIndexLinux(t *testing.T) {
 	expectedAgentIndex := 65
 
-	agentIndex, err := GetVMNameIndex(compute.Linux, "k8s-agentpool1-38988164-65")
+	agentIndex, err := GetVMNameIndex(compute.Linux, "k8s-38988164-agentpool1-65")
 
 	if agentIndex != expectedAgentIndex {
 		t.Fatalf("incorrect agentIndex. expected=%d actual=%d", expectedAgentIndex, agentIndex)
@@ -175,7 +175,7 @@ func Test_GetK8sVMName(t *testing.T) {
 		expected                   string
 		expectedErr                bool
 	}{
-		{properties: p, agentPoolIndex: 0, agentIndex: 2, expected: "aks-linux1-28513887-2", expectedErr: false},
+		{properties: p, agentPoolIndex: 0, agentIndex: 2, expected: "aks-28513887-linux1-2", expectedErr: false},
 		{properties: p, agentPoolIndex: 1, agentIndex: 1, expected: "2851aks011", expectedErr: false},
 		{properties: p, agentPoolIndex: 3, agentIndex: 0, expected: "", expectedErr: true},
 	} {

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -23,6 +23,7 @@ func getParameters(cs *api.ContainerService, generatorCode string, acsengineVers
 	addValue(parametersMap, "acsengineVersion", acsengineVersion)
 
 	// Master Parameters
+	addValue(parametersMap, "clusterName", cs.Properties.ClusterName)
 	addValue(parametersMap, "location", location)
 
 	// Identify Master distro

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -14,12 +14,11 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Azure/go-autorest/autorest/to"
-
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/aks-engine/pkg/i18n"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -877,6 +876,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"GetMasterVMPrefix": func() string {
 			return cs.Properties.GetMasterVMPrefix()
+		},
+		"GetClusterName": func() string {
+			return cs.Properties.GetClusterName()
 		},
 		"GetRouteTableName": func() string {
 			return cs.Properties.GetRouteTableName()

--- a/pkg/engine/transform/transformtestfiles/k8s_agent_upgrade_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_agent_upgrade_template.json
@@ -1312,7 +1312,7 @@
     "useInstanceMetadata": "false",
     "useManagedIdentityExtension": "false",
     "username": "[parameters('linuxAdminUsername')]",
-    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]",
+    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet')]",
     "vmSizesMap": {
       "Standard_A0": {
         "storageAccountType": "Standard_LRS"

--- a/pkg/engine/transform/transformtestfiles/k8s_master_upgrade_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_master_upgrade_template.json
@@ -1312,7 +1312,7 @@
     "useInstanceMetadata": "false",
     "useManagedIdentityExtension": "false",
     "username": "[parameters('linuxAdminUsername')]",
-    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]",
+    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet')]",
     "vmSizesMap": {
       "Standard_A0": {
         "storageAccountType": "Standard_LRS"

--- a/pkg/engine/transform/transformtestfiles/k8s_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_scale_template.json
@@ -1312,7 +1312,7 @@
     "useInstanceMetadata": "false",
     "useManagedIdentityExtension": "false",
     "username": "[parameters('linuxAdminUsername')]",
-    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]",
+    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet')]",
     "vmSizesMap": {
       "Standard_A0": {
         "storageAccountType": "Standard_LRS"

--- a/pkg/engine/transform/transformtestfiles/k8s_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_template.json
@@ -1312,7 +1312,7 @@
     "useInstanceMetadata": "false",
     "useManagedIdentityExtension": "false",
     "username": "[parameters('linuxAdminUsername')]",
-    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]",
+    "virtualNetworkName": "[concat(parameters('orchestratorName'), '-vnet')]",
     "vmSizesMap": {
       "Standard_A0": {
         "storageAccountType": "Standard_LRS"

--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Azure/aks-engine/test/e2e/engine"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/util"
-
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -212,7 +211,8 @@ func (a *Account) CreateDeployment(name string, e *engine.Engine) error {
 		"--name", d.Name,
 		"--resource-group", a.ResourceGroup.Name,
 		"--template-file", e.Config.GeneratedTemplatePath,
-		"--parameters", e.Config.GeneratedParametersPath)
+		"--parameters", e.Config.GeneratedParametersPath,
+		"--verbose", "--debug")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 		ClusterDefinition:  csInput,
 		ExpandedDefinition: csGenerated,
 	}
-	masterNodes, err := node.GetByPrefix("k8s-master")
+	masterNodes, err := node.GetByPrefix("k8s-\\d+-master")
 	Expect(err).NotTo(HaveOccurred())
 	masterName := masterNodes[0].Metadata.Name
 	if strings.Contains(masterName, "vmss") {


### PR DESCRIPTION
**What this PR does / why we need it**:

Rebase a branch we used at my company to fix the name of the resources.

It adds a property `clusterName` which is used to prefix the name of all Azure resources, e.g. : `clusterName = k8s-prod` -> `k8s-prod-master-0, k8s-prod-master-1 ... etc`

If no  `clusterName` is provided the prefix of the resources falls back to `(k8s|aks)-<clusterId>`.

**Which issue this PR fixes** : fixes #56

**Special notes for your reviewer**:


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add a clusterName property which is used to prefix all Azure resources. 
```
