### PR TITLE
fix: use kube-system namespace instead of flex, kv

### DIFF
--- a/parts/k8s/containeraddons/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
@@ -1,15 +1,8 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: flex
-  labels:
-    kubernetes.io/cluster-service: "true"
----
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: blobfuse-flexvol-installer
-  namespace: flex
+  namespace: kube-system
   labels:
     k8s-app: blobfuse
     kubernetes.io/cluster-service: "true"

--- a/parts/k8s/containeraddons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -2,22 +2,22 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    app: keyvault-flexvolume-installer
+    app: keyvault-flexvolume
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
-  name: keyvault-flexvolume-installer
+  name: keyvault-flexvolume
   namespace: kube-system
 spec:
   template:
     metadata:
       labels:
-        app: keyvault-flexvolume-installer
+        app: keyvault-flexvolume
         kubernetes.io/cluster-service: "true"
         addonmanager.kubernetes.io/mode: EnsureExists
     spec:
       tolerations:
       containers:
-      - name: keyvault-flexvolume-installer
+      - name: keyvault-flexvolume
         image: {{ContainerImage "keyvault-flexvolume"}}
         imagePullPolicy: IfNotPresent
         resources:

--- a/parts/k8s/containeraddons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -2,22 +2,22 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    app: keyvault-flexvolume
+    app: keyvault-flexvolume-installer
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
-  name: keyvault-flexvolume
+  name: keyvault-flexvolume-installer
   namespace: kube-system
 spec:
   template:
     metadata:
       labels:
-        app: keyvault-flexvolume
+        app: keyvault-flexvolume-installer
         kubernetes.io/cluster-service: "true"
         addonmanager.kubernetes.io/mode: EnsureExists
     spec:
       tolerations:
       containers:
-      - name: keyvault-flexvolume
+      - name: keyvault-flexvolume-installer
         image: {{ContainerImage "keyvault-flexvolume"}}
         imagePullPolicy: IfNotPresent
         resources:

--- a/parts/k8s/containeraddons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -1,11 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
-  name: kv
----
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -14,7 +6,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
   name: keyvault-flexvolume
-  namespace: kv
+  namespace: kube-system
 spec:
   template:
     metadata:

--- a/parts/k8s/containeraddons/kubernetesmasteraddons-smb-flexvolume-installer.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-smb-flexvolume-installer.yaml
@@ -1,15 +1,8 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: flex
-  labels:
-    kubernetes.io/cluster-service: "true"
----
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: smb-flexvol-installer
-  namespace: flex
+  namespace: kube-system
   labels:
     k8s-app: smb
     kubernetes.io/cluster-service: "true"

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -184,10 +184,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have addons running", func() {
-			for _, addonName := range []string{"tiller", "aci-connector", "cluster-autoscaler", "blobfuse-flexvolume-installer", "smb-flexvolume-installer", "keyvault-flexvolume-installer", "kubernetes-dashboard", "rescheduler", "metrics-server", "nvidia-device-plugin", "container-monitoring", "azure-cni-networkmonitor", "azure-npm-daemonset", "ip-masq-agent"} {
+			for _, addonName := range []string{"tiller", "aci-connector", "cluster-autoscaler", "blobfuse-flexvolume", "smb-flexvolume", "keyvault-flexvolume", "kubernetes-dashboard", "rescheduler", "metrics-server", "nvidia-device-plugin", "container-monitoring", "azure-cni-networkmonitor", "azure-npm-daemonset", "ip-masq-agent"} {
 				var addonPods = []string{addonName}
 				var addonNamespace = "kube-system"
 				switch addonName {
+				case "blobfuse-flexvolume":
+					addonPods = []string{"blobfuse-flexvol-installer"}
+				case "smb-flexvolume":
+					addonPods = []string{"smb-flexvol-installer"}
 				case "container-monitoring":
 					addonPods = []string{"omsagent"}
 				case "azure-npm-daemonset":

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -184,14 +184,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have addons running", func() {
-			for _, addonName := range []string{"tiller", "aci-connector", "cluster-autoscaler", "blobfuse-flexvolume", "smb-flexvolume", "keyvault-flexvolume", "kubernetes-dashboard", "rescheduler", "metrics-server", "nvidia-device-plugin", "container-monitoring", "azure-cni-networkmonitor", "azure-npm-daemonset", "ip-masq-agent"} {
+			for _, addonName := range []string{"tiller", "aci-connector", "cluster-autoscaler", "blobfuse-flexvolume-installer", "smb-flexvolume-installer", "keyvault-flexvolume-installer", "kubernetes-dashboard", "rescheduler", "metrics-server", "nvidia-device-plugin", "container-monitoring", "azure-cni-networkmonitor", "azure-npm-daemonset", "ip-masq-agent"} {
 				var addonPods = []string{addonName}
 				var addonNamespace = "kube-system"
 				switch addonName {
-				case "blobfuse-flexvolume":
-					addonPods = []string{"blobfuse-flexvol-installer"}
-				case "smb-flexvolume":
-					addonPods = []string{"smb-flexvol-installer"}
 				case "container-monitoring":
 					addonPods = []string{"omsagent"}
 				case "azure-npm-daemonset":

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -190,14 +190,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				switch addonName {
 				case "blobfuse-flexvolume":
 					addonPods = []string{"blobfuse-flexvol-installer"}
-					addonNamespace = "flex"
 				case "smb-flexvolume":
 					addonPods = []string{"smb-flexvol-installer"}
-					addonNamespace = "flex"
 				case "container-monitoring":
 					addonPods = []string{"omsagent"}
-				case "keyvault-flexvolume":
-					addonNamespace = "kv"
 				case "azure-npm-daemonset":
 					addonPods = []string{"azure-npm"}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews

-->

**What this PR does / why we need it**:
use kube-system namespace instead of flex, kv:
When enableRbac and enablePodSecurityPolicy are both set to true, default pod security policies are created. The restrictive policy is applied to all pods that either don't have a service account with a role binding to a less restrictive policy or a policy bound to the namespace. This results in pods in the kv and flex namespaces being unable to start.

I decided to use kube-system for all flexvolume drivers since those daemonsets only installs the flexvol driver like what other daemonset in kube-system namespace does, e.g. network-monitor, switch to use kube-system makes the maintanance more easily.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #195

**Special notes for your reviewer**:


**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
use kube-system namespace instead of flex, kv
```

@danbunnell @ritazh

/kind bug
