### PR TITLE
fix: specify the vm size in error message during acc. networking valid…

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1234,7 +1234,7 @@ func validatePoolOSType(os OSType) error {
 
 func validatePoolAcceleratedNetworking(VMSize string) error {
 	if !helpers.AcceleratedNetworkingSupported(VMSize) {
-		return fmt.Errorf("The AgentPoolProfile.vmsize does not support AgentPoolProfile.acceleratedNetworking")
+		return fmt.Errorf("AgentPoolProfile.vmsize %s does not support AgentPoolProfile.acceleratedNetworking", VMSize)
 	}
 	return nil
 }


### PR DESCRIPTION
When specifying a VM size sku that is not supported by accelerated networking, we get an unhelpful error message.

`"AgentPoolProfile.vmsize does not support AgentPoolProfile.acceleratedNetworking"`

This PR adds the vmsize sku to the message