### PR TITLE
test: only check top nodes if RBAC is enabled

### DIFF
--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -73,7 +73,7 @@ func (cs *ContainerService) setControllerManagerConfig() {
 		o.KubernetesConfig.ControllerManagerConfig[key] = val
 	}
 
-	if *o.KubernetesConfig.EnableRbac {
+	if o.KubernetesConfig.IsRBACEnabled() {
 		o.KubernetesConfig.ControllerManagerConfig["--use-service-account-credentials"] = "true"
 	}
 }

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -196,7 +196,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpdate bool) {
 			a.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(DefaultRBACEnabled)
 		}
 
-		if to.Bool(a.OrchestratorProfile.KubernetesConfig.EnableRbac) {
+		if a.OrchestratorProfile.KubernetesConfig.IsRBACEnabled() {
 			if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0") {
 				// TODO make EnableAggregatedAPIs a pointer to bool so that a user can opt out of it
 				a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/aks-engine/pkg/api/v20170701"
 	"github.com/Azure/aks-engine/pkg/api/vlabs"
 	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/blang/semver"
 )
 
@@ -1278,6 +1279,14 @@ func (k *KubernetesConfig) IsDashboardEnabled() bool {
 // IsIPMasqAgentEnabled checks if the ip-masq-agent addon is enabled
 func (k *KubernetesConfig) IsIPMasqAgentEnabled() bool {
 	return k.isAddonEnabled(IPMASQAgentAddonName, IPMasqAgentAddonEnabled)
+}
+
+// IsRBACEnabled checks if RBAC is enabled
+func (k *KubernetesConfig) IsRBACEnabled() bool {
+	if k.EnableRbac != nil {
+		return to.Bool(k.EnableRbac)
+	}
+	return false
 }
 
 // IsNSeriesSKU returns true if the agent pool contains an N-series (NVIDIA GPU) VM

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 )
 
@@ -689,4 +690,12 @@ func (o *OrchestratorProfile) IsSwarmMode() bool {
 func (k *KubernetesConfig) RequiresDocker() bool {
 	runtime := strings.ToLower(k.ContainerRuntime)
 	return runtime == "docker" || runtime == ""
+}
+
+// IsRBACEnabled checks if RBAC is enabled
+func (k *KubernetesConfig) IsRBACEnabled() bool {
+	if k.EnableRbac != nil {
+		return to.Bool(k.EnableRbac)
+	}
+	return false
 }

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -228,10 +228,8 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 							minVersion.String(), version)
 					}
 
-					if o.KubernetesConfig.EnableRbac != nil {
-						if !*o.KubernetesConfig.EnableRbac {
-							return errors.New("enableAggregatedAPIs requires the enableRbac feature as a prerequisite")
-						}
+					if o.KubernetesConfig.IsRBACEnabled() {
+						return errors.New("enableAggregatedAPIs requires the enableRbac feature as a prerequisite")
 					}
 				}
 
@@ -260,7 +258,7 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 				}
 
 				if to.Bool(o.KubernetesConfig.EnablePodSecurityPolicy) {
-					if !to.Bool(o.KubernetesConfig.EnableRbac) {
+					if !o.KubernetesConfig.IsRBACEnabled() {
 						return errors.Errorf("enablePodSecurityPolicy requires the enableRbac feature as a prerequisite")
 					}
 					minVersion, err := semver.Make("1.8.0")

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -228,7 +228,7 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 							minVersion.String(), version)
 					}
 
-					if o.KubernetesConfig.IsRBACEnabled() {
+					if !o.KubernetesConfig.IsRBACEnabled() {
 						return errors.New("enableAggregatedAPIs requires the enableRbac feature as a prerequisite")
 					}
 				}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -593,21 +593,23 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should be able to get nodes metrics", func() {
-			success := false
-			for i := 0; i < 30; i++ {
-				cmd := exec.Command("kubectl", "top", "nodes")
-				util.PrintCommand(cmd)
-				out, err := cmd.CombinedOutput()
-				if err == nil {
-					success = true
-					break
+			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.IsRBACEnabled() {
+				success := false
+				for i := 0; i < 30; i++ {
+					cmd := exec.Command("kubectl", "top", "nodes")
+					util.PrintCommand(cmd)
+					out, err := cmd.CombinedOutput()
+					if err == nil {
+						success = true
+						break
+					}
+					if i > 28 {
+						log.Printf("Error while running kubectl top nodes:%s\n", err)
+						log.Println(string(out))
+					}
 				}
-				if i > 28 {
-					log.Printf("Error while running kubectl top nodes:%s\n", err)
-					log.Println(string(out))
-				}
+				Expect(success).To(BeTrue())
 			}
-			Expect(success).To(BeTrue())
 		})
 
 		It("should be able to autoscale", func() {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

Only checks `kubectl top nodes` if RBAC is enabled. Also includes the convenience addition of a `IsRBACEnabled` method.

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

If RBAC is not enabled on the cluster, kubectl top nodes checks are likely to fail. We first observed this yesterday when our tests upgrade to version 1.10 of kubectl.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
