### PR TITLE
fix: remove VM upgrade version check for AKS

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -223,8 +223,11 @@ func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, az armh
 					uc.Logger.Infof("Master VM name: %s, orchestrator: %s (MasterVMs)\n", *vm.Name, vmOrchestratorTypeAndVersion)
 					*uc.MasterVMs = append(*uc.MasterVMs, vm)
 				} else {
-					if err := uc.upgradable(vmOrchestratorTypeAndVersion); err != nil && !uc.DataModel.Properties.IsHostedMasterProfile() {
-						return err
+					// skip the agent VM upgrade validation for managed clusters as it only applies to aks-engine version support
+					if !uc.DataModel.Properties.IsHostedMasterProfile() {
+						if err := uc.upgradable(vmOrchestratorTypeAndVersion); err != nil {
+							return err
+						}
 					}
 					uc.addVMToAgentPool(vm, true)
 				}

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -223,7 +223,7 @@ func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, az armh
 					uc.Logger.Infof("Master VM name: %s, orchestrator: %s (MasterVMs)\n", *vm.Name, vmOrchestratorTypeAndVersion)
 					*uc.MasterVMs = append(*uc.MasterVMs, vm)
 				} else {
-					if err := uc.upgradable(vmOrchestratorTypeAndVersion); err != nil {
+					if err := uc.upgradable(vmOrchestratorTypeAndVersion); err != nil && !uc.DataModel.Properties.IsHostedMasterProfile() {
 						return err
 					}
 					uc.addVMToAgentPool(vm, true)


### PR DESCRIPTION

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The upgradable() function in upgrade checks if a node is upgradable by checking if its current version is contained in a list of upgrade versions. The list of upgrade versions is determined using the list of supported Kubernetes version for aks-engine. However, this does not apply to hosted master clusters (AKS) that have their own list of supported versions and perform upgrade validation already. This allows distinct version support for AKS (as long as the versions supported in aks-engine are a superset).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #235

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
