### PR TITLE
feat: add localhost and 127.0.0.1 to certificates

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -522,13 +522,15 @@ func (p *Properties) setDefaultCerts() (bool, []net.IP, error) {
 	}
 
 	masterExtraFQDNs := append(azureProdFQDNs, p.MasterProfile.SubjectAltNames...)
+	masterExtraFQDNs = append(masterExtraFQDNs, "localhost")
 	firstMasterIP := net.ParseIP(p.MasterProfile.FirstConsecutiveStaticIP).To4()
+	localhostIP := net.ParseIP("127.0.0.1").To4()
 
 	if firstMasterIP == nil {
 		return false, nil, errors.Errorf("MasterProfile.FirstConsecutiveStaticIP '%s' is an invalid IP address", p.MasterProfile.FirstConsecutiveStaticIP)
 	}
 
-	ips := []net.IP{firstMasterIP}
+	ips := []net.IP{firstMasterIP, localhostIP}
 	// Add the Internal Loadbalancer IP which is always at at p known offset from the firstMasterIP
 	ips = append(ips, net.IP{firstMasterIP[0], firstMasterIP[1], firstMasterIP[2], firstMasterIP[3] + byte(DefaultInternalLbStaticIPOffset)})
 	// Include the Internal load balancer as well

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1277,8 +1277,8 @@ func TestSetCertDefaults(t *testing.T) {
 		t.Error("expected setDefaultCerts to create a list of IPs")
 	} else {
 
-		if len(ips) != cs.Properties.MasterProfile.Count+2 {
-			t.Errorf("expected length of IPs from setDefaultCerts %d, actual length %d", cs.Properties.MasterProfile.Count+2, len(ips))
+		if len(ips) != cs.Properties.MasterProfile.Count+3 {
+			t.Errorf("expected length of IPs from setDefaultCerts %d, actual length %d", cs.Properties.MasterProfile.Count+3, len(ips))
 		}
 
 		firstMasterIP := net.ParseIP(cs.Properties.MasterProfile.FirstConsecutiveStaticIP).To4()

--- a/pkg/helpers/pki.go
+++ b/pkg/helpers/pki.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -77,7 +76,6 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 	var group errgroup.Group
 
 	var err error
-	var mu sync.Mutex
 	caCertificate, err = pemToCertificate(caPair.CertificatePem)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
@@ -107,20 +105,12 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 	})
 
 	group.Go(func() (err error) {
-		ip := net.ParseIP("127.0.0.1").To4()
-		mu.Lock()
-		peerIPs := append(extraIPs, ip)
-		mu.Unlock()
-		etcdServerCertificate, etcdServerPrivateKey, err = createCertificate("etcdserver", caCertificate, caPrivateKey, true, true, nil, peerIPs, nil)
+		etcdServerCertificate, etcdServerPrivateKey, err = createCertificate("etcdserver", caCertificate, caPrivateKey, true, true, nil, extraIPs, nil)
 		return err
 	})
 
 	group.Go(func() (err error) {
-		ip := net.ParseIP("127.0.0.1").To4()
-		mu.Lock()
-		peerIPs := append(extraIPs, ip)
-		mu.Unlock()
-		etcdClientCertificate, etcdClientPrivateKey, err = createCertificate("etcdclient", caCertificate, caPrivateKey, true, false, nil, peerIPs, nil)
+		etcdClientCertificate, etcdClientPrivateKey, err = createCertificate("etcdclient", caCertificate, caPrivateKey, true, false, nil, extraIPs, nil)
 		return err
 	})
 
@@ -128,11 +118,7 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 	for i := 0; i < masterCount; i++ {
 		i := i
 		group.Go(func() (err error) {
-			ip := net.ParseIP("127.0.0.1").To4()
-			mu.Lock()
-			peerIPs := append(extraIPs, ip)
-			mu.Unlock()
-			etcdPeerCertificate, etcdPeerPrivateKey, err := createCertificate("etcdpeer", caCertificate, caPrivateKey, true, false, nil, peerIPs, nil)
+			etcdPeerCertificate, etcdPeerPrivateKey, err := createCertificate("etcdpeer", caCertificate, caPrivateKey, true, false, nil, extraIPs, nil)
 			etcdPeerCertPairs[i] = &PkiKeyCertPair{CertificatePem: string(certificateToPem(etcdPeerCertificate.Raw)), PrivateKeyPem: string(privateKeyToPem(etcdPeerPrivateKey))}
 			return err
 		})


### PR DESCRIPTION
**Reason for Change**:

There are some cases where we have pods on master nodes who needs to communicate with the API server (e.g.: cluster-autoscaler) but it cannot use the `kubernetes.default` service cause it will intermittently fail due to the fact that, if the request is forwarded by the service to the apiserver on the **same node** as it originated from, the request will never come back due to `Martian source` network error.

The way around that is to use host network and send request to localhost:443 but localhost is currently not part of the default domains in the certificates generated.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
