### PR TITLE
test: NetworkPolicy E2E tests cleanup for soak

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -896,11 +896,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.HasNetworkPolicy("calico") || eng.HasNetworkPolicy("azure") || eng.HasNetworkPolicy("cilium") {
 				nsClientOne, nsClientTwo, nsServer := "client-one", "client-two", "server"
 				By("Creating namespaces")
-				_, err := namespace.Create(nsClientOne)
+				namespaceClientOne, err := namespace.CreateIfNotExist(nsClientOne)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = namespace.Create(nsClientTwo)
+				namespaceClientTwo, err := namespace.CreateIfNotExist(nsClientTwo)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = namespace.Create(nsServer)
+				namespaceServer, err := namespace.CreateIfNotExist(nsServer)
 				Expect(err).NotTo(HaveOccurred())
 				By("Creating client and server nginx deployments")
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -1001,6 +1001,12 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				err = clientTwoDeploy.Delete(deleteResourceRetries)
 				Expect(err).NotTo(HaveOccurred())
 				err = serverDeploy.Delete(deleteResourceRetries)
+				Expect(err).NotTo(HaveOccurred())
+				err = namespaceClientOne.Delete()
+				Expect(err).NotTo(HaveOccurred())
+				err = namespaceClientTwo.Delete()
+				Expect(err).NotTo(HaveOccurred())
+				err = namespaceServer.Delete()
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("Calico or Azure network policy was not provisioned for this Cluster Definition")

--- a/test/e2e/kubernetes/namespace/namespace.go
+++ b/test/e2e/kubernetes/namespace/namespace.go
@@ -35,6 +35,15 @@ func Create(name string) (*Namespace, error) {
 	return Get(name)
 }
 
+// CreateIfNotExist a namespace with the given name if it doesn't exist already
+func CreateIfNotExist(name string) (*Namespace, error) {
+	n, err := Get(name)
+	if err != nil {
+		return Create(name)
+	}
+	return n, nil
+}
+
 // Get returns a namespace for with a given name
 func Get(name string) (*Namespace, error) {
 	cmd := exec.Command("kubectl", "get", "namespace", name, "-o", "json")


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Calico and Azure NetworkPolicy-backed clusters aren't able to be E2E-tested in long-running scenarios (soak/upgrade/scale) because the test was not implemented to be re-used in the same cluster across multiple runs.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
