### PR TITLE
fix: remove IP address network configuration race condition for maste…

### DIFF
--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -372,7 +372,7 @@
                     ]
                 }
           {{end}}
-          {{if or $MasterProfile.IsCustomVNET IsOpenShift}}
+          {{if $MasterProfile.IsCustomVNET}}
                   ,"networkSecurityGroup": {
                     "id": "[variables('nsgID')]"
                   }

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -403,8 +403,7 @@
 {{if not $MasterProfile.IsCustomVNET}}
         "[variables('vnetID')]",
 {{end}}
-{{end}}
-        {{ range $seq2 := loop 0 (subtract $MasterProfile.Count 1) }}
+        {{ range $seq2 := loop 0 (subtract $Context.MasterProfile.Count 1) }}
         {{/* key bit to make sure that ALL the static ips are allocated BEFORE dynamic address assignment */}}
         {{ if gt $seq2 0}} , {{ end }}
         "[concat(variables('masterVMNamePrefix'), 'nic-{{$seq2}}')]"

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -1,3 +1,4 @@
+{{ $Context := . }}
 {{if HasCosmosEtcd }}
    {
      "apiVersion": "[variables('apiVersionCosmos')]",
@@ -308,77 +309,122 @@
       },
       "type": "Microsoft.Network/loadBalancers/inboundNatRules"
     },
+    {{/* allocate all static ips separately and BEFORE dynamic ips */}}
+      {{range $seq := loop 0 (subtract .MasterProfile.Count 1) }}
+         {{ $MasterProfile := $Context.MasterProfile }}
+        {
+          "apiVersion": "[variables('apiVersionNetwork')]",
+          "dependsOn": [
+            "[variables('nsgID')]"
+            {{if not $MasterProfile.IsCustomVNET}}
+            ,"[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),'{{$seq}}')]"
+            {{ end }}
+
+            ,"[variables('masterLbID')]"
+            {{if gt $MasterProfile.Count 1}}
+               ,"[variables('masterInternalLbID')]"
+            {{ end }}
+
+          ],
+          "location": "[variables('location')]",
+          "name": "[concat(variables('masterVMNamePrefix'), 'nic-{{$seq}}')]",
+          "properties": {
+            "ipConfigurations": [
+              {
+                "name": "ipconfig{{add $seq 1}}",
+                "properties": {
+                  {{/* the 1st static ip is primary and gets set for the balancer*/}}
+                  "loadBalancerBackendAddressPools": [
+                    {
+                      "id": "[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
+                    }
+                    {{if gt $MasterProfile.Count 1}}
+                    ,{
+                      "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
+                    }
+                    {{end}}
+                  ],
+                  "loadBalancerInboundNatRules": [
+                    {{if not $MasterProfile.IsCustomVNET}}
+                    {
+                      "id": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),'{{$seq}}')]"
+                    }
+                    {{ end }}
+                  ],
+                  "primary": true,
+                  "privateIPAddress": "[variables('masterPrivateIpAddrs')[{{$seq}}]]",
+                  "privateIPAllocationMethod": "Static",
+                  "subnet": {
+                    "id": "[variables('vnetSubnetID')]"
+                  }
+                }
+              }
+            ]
+
+          {{if not IsAzureCNI}}
+                  ,
+                      "enableIPForwarding": true
+          {{end}}
+          {{if HasCustomNodesDNS}}
+           ,"dnsSettings": {
+                    "dnsServers": [
+                        "[variables('dnsServer')]"
+                    ]
+                }
+          {{end}}
+          {{if or $MasterProfile.IsCustomVNET IsOpenShift}}
+                  ,"networkSecurityGroup": {
+                    "id": "[variables('nsgID')]"
+                  }
+          {{end}}
+            }
+          ,"type": "Microsoft.Network/networkInterfaces"
+        },
+    {{ end }}
+
+    {{/* the dynamic nics get created AFTER the static addresses are allocated azure cni case else there is a race condition */}}
+    {{if IsAzureCNI}}
+        {{ range $seq := loop 0 (subtract (subtract .MasterProfile.IPAddressCount .MasterProfile.Count) 1) }}
+        {{ $MasterProfile := $Context.MasterProfile }}
+        {{ $nicId := (add $MasterProfile.Count $seq)}}
     {
       "apiVersion": "[variables('apiVersionNetwork')]",
-      "copy": {
-        "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
-        "name": "nicLoopNode"
-      },
       "dependsOn": [
-{{if .MasterProfile.IsCustomVNET}}
+{{if $MasterProfile.IsCustomVNET}}
         "[variables('nsgID')]",
 {{else}}
         "[variables('vnetID')]",
 {{end}}
-        "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"
-{{if gt .MasterProfile.Count 1}}
-        ,"[variables('masterInternalLbName')]"
-{{end}}
 {{ if HasCosmosEtcd }}
-        ,"[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmosAccountName'))]"
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmosAccountName'))]",
 {{ end }}
+{{else}}
+        "[variables('nsgID')]",
+{{if not $MasterProfile.IsCustomVNET}}
+        "[variables('vnetID')]",
+{{end}}
+{{end}}
+        {{ range $seq2 := loop 0 (subtract $MasterProfile.Count 1) }}
+        {{/* key bit to make sure that ALL the static ips are allocated BEFORE dynamic address assignment */}}
+        {{ if gt $seq2 0}} , {{ end }}
+        "[concat(variables('masterVMNamePrefix'), 'nic-{{$seq2}}')]"
+        {{ end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterVMNamePrefix'), 'nic-{{ $nicId}}')]",
       "properties": {
         "ipConfigurations": [
           {
-            "name": "ipconfig1",
+            "name": "ipconfig{{ $nicId }}",
             "properties": {
-              "loadBalancerBackendAddressPools": [
-                {
-                  "id": "[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
-                }
-{{if gt .MasterProfile.Count 1}}
-                ,
-                {
-                   "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
-                }
-{{end}}
-              ],
-              "loadBalancerInboundNatRules": [
-                {
-                  "id": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"
-                }
-              ],
-              "privateIPAddress": "[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]",
               "primary": true,
-              "privateIPAllocationMethod": "Static",
-              "subnet": {
-                "id": "[variables('vnetSubnetID')]"
-              }
-            }
-          }
-{{if IsAzureCNI}}
-          {{range $seq := loop 2 .MasterProfile.IPAddressCount}}
-          ,
-          {
-            "name": "ipconfig{{$seq}}",
-            "properties": {
-              "primary": false,
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
                 "id": "[variables('vnetSubnetID')]"
               }
             }
           }
-          {{end}}
-{{end}}
         ]
-{{if not IsAzureCNI}}
-        ,
-        "enableIPForwarding": true
-{{end}}
 {{if HasCustomNodesDNS}}
  ,"dnsSettings": {
           "dnsServers": [
@@ -386,7 +432,7 @@
           ]
       }
 {{end}}
-{{if .MasterProfile.IsCustomVNET}}
+{{if $MasterProfile.IsCustomVNET}}
         ,"networkSecurityGroup": {
           "id": "[variables('nsgID')]"
         }
@@ -394,6 +440,8 @@
       },
       "type": "Microsoft.Network/networkInterfaces"
     },
+    {{ end }} {{/* range $MasterProfile.Count */}}
+    {{ end }} {{/*IsAzureCNI */}}
 {{else}}
       {
         "apiVersion": "[variables('apiVersionNetwork')]",
@@ -419,11 +467,9 @@
               "name": "ipconfig1",
               "properties": {
                 "loadBalancerBackendAddressPools": [
-  {{if gt .MasterProfile.Count 1}}
                   {
                     "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
                   }
-  {{end}}
                 ],
                 "loadBalancerInboundNatRules": [
                 ],

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -311,7 +311,7 @@
     },
     {{/* allocate all static ips separately and BEFORE dynamic ips */}}
       {{range $seq := loop 0 (subtract .MasterProfile.Count 1) }}
-         {{ $MasterProfile := $Context.MasterProfile }}
+        {{ $MasterProfile := $Context.MasterProfile }}
         {
           "apiVersion": "[variables('apiVersionNetwork')]",
           "dependsOn": [
@@ -398,11 +398,6 @@
 {{ if HasCosmosEtcd }}
         "[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmosAccountName'))]",
 {{ end }}
-{{else}}
-        "[variables('nsgID')]",
-{{if not $MasterProfile.IsCustomVNET}}
-        "[variables('vnetID')]",
-{{end}}
         {{ range $seq2 := loop 0 (subtract $Context.MasterProfile.Count 1) }}
         {{/* key bit to make sure that ALL the static ips are allocated BEFORE dynamic address assignment */}}
         {{ if gt $seq2 0}} , {{ end }}

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -944,6 +944,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"subtract": func(a, b int) int {
 			return a - b
 		},
+		"add": func(a, b int) int {
+			return a + b
+		},
 		"IsCustomVNET": func() bool {
 			return cs.Properties.AreAgentProfilesCustomVNET()
 		},


### PR DESCRIPTION
…r nodes so using standard azure dependencies

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

**PR copied over from https://github.com/Azure/acs-engine/pull/3755**

In @fortescue 's words:

Case handled:  AzureCNI/Custom Vnet

[There is a documented race condition](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/features.md) whereby it is impossible to ensure that master ip addresses are allocated serially as REQUIRED by k8 bootstrap scripts.  I hit this problem every time i.e. the cluster fails to start. 

This PR guarantees the 'MasterCount' ip addresses are allocated serially beginning with *firstConsecutiveStaticIP* **before** dynamic ip allocation begins. 

The generated dynamic ips stanza are made dependent on the static ip (masterCount) stanzas.
  
To implement this, both the static and dynamic ips are in separate arm stanzas.
The static network interfaces reference the lb and intlb(for masterCount> 1) as before.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Strike 
```
If possible, assign to the firstConsecutiveStaticIP configuration property an IP address that is near the "end" of the available IP address space in the desired subnet.
For example, if the desired subnet is a /24, choose the "239" address in that network space
```
And change to: 
```Ensure that firstConsecutiveStaticIP + (masterCount-1) ip addresses are free within the master subnet as required by k8 installation scripts.```  