### PR TITLE
feat: add anti affinity to coredns deployment

### DIFF
--- a/parts/k8s/addons/coredns.yaml
+++ b/parts/k8s/addons/coredns.yaml
@@ -100,6 +100,27 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: docker/default
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: kubernetes.io/hostname
+            weight: 5
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/master


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Improve resilience of the coredns service with anti-affinity.

Those will try to spread coredns pods across `failure-domain zones` and `nodes` at scheduling.

See:

https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
