### PR TITLE
chore: remove commit check from Azure DevOps pipeline

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -49,7 +49,7 @@ jobs:
   - script: make bootstrap
     displayName: Install dependencies
     workingDirectory: $(modulePath)
-  - script: make validate-commit-msg validate-copyright-headers test-style
+  - script: make validate-copyright-headers test-style
     displayName: Run linting rules
     workingDirectory: $(modulePath)
   - script: make validate-dependencies


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

`make validate-commit-msg` only looks at the most recent non-merge commit, which can be [less than optimal](https://github.com/Azure/aks-engine/pull/237#issuecomment-451593876). This removes that check from our Azure DevOps pipeline.

Instead let's try the probot [semantic pull requests](https://github.com/probot/semantic-pull-requests) GitHub service. I enabled it and will test it with this PR.

![screen shot 2019-01-08 at 10 53 38 am](https://user-images.githubusercontent.com/73019/50849262-b99f5e80-1333-11e9-9c91-d32bc4918633.png)


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
