### PR TITLE
test: enable multiple subnets per agent pool

### DIFF
--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -226,21 +226,19 @@ func (a *Account) CreateDeployment(name string, e *engine.Engine) error {
 }
 
 // CreateVnet will create a vnet in a resource group
-func (a *Account) CreateVnet(vnet, addressPrefixes, subnetName, subnetPrefix string) error {
+func (a *Account) CreateVnet(vnet, addressPrefixes string) error {
 	var cmd *exec.Cmd
 	if a.TimeoutCommands {
 		cmd = exec.Command("timeout", "60", "az", "network", "vnet", "create", "-g",
-			a.ResourceGroup.Name, "-n", vnet, "--address-prefixes", addressPrefixes,
-			"--subnet-name", subnetName, "--subnet-prefix", subnetPrefix)
+			a.ResourceGroup.Name, "-n", vnet, "--address-prefixes", addressPrefixes)
 	} else {
 		cmd = exec.Command("az", "network", "vnet", "create", "-g",
-			a.ResourceGroup.Name, "-n", vnet, "--address-prefixes", addressPrefixes,
-			"--subnet-name", subnetName, "--subnet-prefix", subnetPrefix)
+			a.ResourceGroup.Name, "-n", vnet, "--address-prefixes", addressPrefixes)
 	}
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Printf("Error while trying to create vnet with the following command:\n az network vnet create -g %s -n %s --address-prefixes %s --subnet-name %s --subnet-prefix %s \n Output:%s\n", a.ResourceGroup.Name, vnet, addressPrefixes, subnetName, subnetPrefix, out)
+		log.Printf("Error while trying to create vnet with the following command:\n az network vnet create -g %s -n %s --address-prefixes %s\n Output:%s\n", a.ResourceGroup.Name, vnet, addressPrefixes, out)
 		return err
 	}
 	return nil

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -79,7 +79,7 @@ func ParseConfig(cwd, clusterDefinition, name string) (*Config, error) {
 
 // Build takes a template path and will inject values based on provided environment variables
 // it will then serialize the structs back into json and save it to outputPath
-func Build(cfg *config.Config, masterSubnetID string, agentSubnetID string, isVMSS bool) (*Engine, error) {
+func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, isVMSS bool) (*Engine, error) {
 	config, err := ParseConfig(cfg.CurrentWorkingDir, cfg.ClusterDefinition, cfg.Name)
 	if err != nil {
 		log.Printf("Error while trying to build Engine Configuration:%s\n", err)
@@ -139,14 +139,14 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetID string, isVM
 	if config.CreateVNET {
 		if isVMSS {
 			prop.MasterProfile.VnetSubnetID = masterSubnetID
-			prop.MasterProfile.AgentVnetSubnetID = agentSubnetID
+			prop.MasterProfile.AgentVnetSubnetID = agentSubnetIDs[0]
 			for _, p := range prop.AgentPoolProfiles {
-				p.VnetSubnetID = agentSubnetID
+				p.VnetSubnetID = agentSubnetIDs[0]
 			}
 		} else {
 			prop.MasterProfile.VnetSubnetID = masterSubnetID
-			for _, p := range prop.AgentPoolProfiles {
-				p.VnetSubnetID = masterSubnetID
+			for i, p := range prop.AgentPoolProfiles {
+				p.VnetSubnetID = agentSubnetIDs[i]
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

In practice, lots of folks segment their vnet into subnets per agent pool. The purpose of this PR is to add that configuration pattern to "custom VNET" scenarios automatically, to ensure that this known working operational scenario does not decay into an edge case over time due to lack of test coverage.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
