### PR TITLE
fix: Rename acsengineVersion tag to aksEngineVersion

### DIFF
--- a/docs/kubernetes/deploy.md
+++ b/docs/kubernetes/deploy.md
@@ -166,7 +166,7 @@ az vm show -g <resource group of cluster> -n <name of Master or agent VM> --quer
 
 ```json
 {
-  "acsengineVersion": "v0.15.0",
+  "aksEngineVersion": "v0.15.0",
   "creationSource": "acsengine-k8s-master-22116803-0",
   "orchestrator": "Kubernetes:1.9.5",
   "poolName": "master",

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -140,7 +140,7 @@
         "creationSource" : "[concat(parameters('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
         "resourceNameSuffix" : "[parameters('nameSuffix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
-        "acsengineVersion" : "[parameters('acsengineVersion')]",
+        "aksEngineVersion" : "[parameters('aksEngineVersion')]",
         "poolName" : "{{.Name}}"
       },
       "location": "[variables('location')]",

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -819,7 +819,7 @@
         "creationSource" : "[concat(parameters('generatorCode'), '-', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
         "resourceNameSuffix" : "[parameters('nameSuffix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
-        "acsengineVersion" : "[parameters('acsengineVersion')]",
+        "aksEngineVersion" : "[parameters('aksEngineVersion')]",
         "poolName" : "master"
       },
       "location": "[variables('location')]",

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -344,7 +344,7 @@
       "creationSource": "[concat(parameters('generatorCode'), '-', variables('masterVMNamePrefix'), 'vmss')]",
       "resourceNameSuffix": "[parameters('nameSuffix')]",
       "orchestrator": "[variables('orchestratorNameVersionTag')]",
-      "acsengineVersion" : "[parameters('acsengineVersion')]",
+      "aksEngineVersion" : "[parameters('aksEngineVersion')]",
       "poolName": "master"
     },
     "location": "[variables('location')]",

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -148,7 +148,7 @@
         "creationSource" : "[concat(parameters('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
         "resourceNameSuffix" : "[variables('winResourceNamePrefix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
-        "acsengineVersion" : "[parameters('acsengineVersion')]",
+        "aksEngineVersion" : "[parameters('aksEngineVersion')]",
         "poolName" : "{{.Name}}"
       },
       "location": "[variables('location')]",

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -10,7 +10,7 @@
       },
       "type": "string"
     },
-    "acsengineVersion": {
+    "aksEngineVersion": {
       "metadata": {
         "description": "Contains details of the aks-engine version which was used to provision the cluster"
       },

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -13,14 +13,14 @@ import (
 	"github.com/Azure/aks-engine/pkg/helpers"
 )
 
-func getParameters(cs *api.ContainerService, generatorCode string, acsengineVersion string) (paramsMap, error) {
+func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVersion string) (paramsMap, error) {
 	properties := cs.Properties
 	location := cs.Location
 	parametersMap := paramsMap{}
 	cloudSpecConfig := cs.GetCloudSpecConfig()
 
 	// acsengine Parameters
-	addValue(parametersMap, "acsengineVersion", acsengineVersion)
+	addValue(parametersMap, "aksEngineVersion", aksEngineVersion)
 
 	// Master Parameters
 	addValue(parametersMap, "location", location)

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -43,7 +43,7 @@ func InitializeTemplateGenerator(ctx Context) (*TemplateGenerator, error) {
 }
 
 // GenerateTemplate generates the template from the API Model
-func (t *TemplateGenerator) GenerateTemplate(containerService *api.ContainerService, generatorCode string, acsengineVersion string) (templateRaw string, parametersRaw string, err error) {
+func (t *TemplateGenerator) GenerateTemplate(containerService *api.ContainerService, generatorCode string, aksEngineVersion string) (templateRaw string, parametersRaw string, err error) {
 	// named return values are used in order to set err in case of a panic
 	templateRaw = ""
 	parametersRaw = ""
@@ -100,7 +100,7 @@ func (t *TemplateGenerator) GenerateTemplate(containerService *api.ContainerServ
 	templateRaw = b.String()
 
 	var parametersMap paramsMap
-	if parametersMap, err = getParameters(containerService, generatorCode, acsengineVersion); err != nil {
+	if parametersMap, err = getParameters(containerService, generatorCode, aksEngineVersion); err != nil {
 		return templateRaw, parametersRaw, err
 	}
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -78,7 +78,7 @@ const MasterPoolName = "master"
 
 // UpgradeCluster runs the workflow to upgrade a Kubernetes cluster.
 func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, az armhelpers.AKSEngineClient, kubeConfig, resourceGroup string,
-	cs *api.ContainerService, nameSuffix string, agentPoolsToUpgrade []string, acsengineVersion string) error {
+	cs *api.ContainerService, nameSuffix string, agentPoolsToUpgrade []string, aksEngineVersion string) error {
 	uc.ClusterTopology = ClusterTopology{}
 	uc.SubscriptionID = subscriptionID.String()
 	uc.ResourceGroup = resourceGroup
@@ -104,17 +104,17 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, az armhelpers
 	switch {
 	case strings.HasPrefix(upgradeVersion, "1.6."):
 		upgrader16 := &Kubernetes16upgrader{}
-		upgrader16.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, acsengineVersion)
+		upgrader16.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, aksEngineVersion)
 		upgrader = upgrader16
 
 	case strings.HasPrefix(upgradeVersion, "1.7."):
 		upgrader17 := &Kubernetes17upgrader{}
-		upgrader17.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, acsengineVersion)
+		upgrader17.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, aksEngineVersion)
 		upgrader = upgrader17
 
 	case strings.HasPrefix(upgradeVersion, "1.8."):
 		upgrader18 := &Kubernetes18upgrader{}
-		upgrader18.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, acsengineVersion)
+		upgrader18.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, aksEngineVersion)
 		upgrader = upgrader18
 
 	case strings.HasPrefix(upgradeVersion, "1.9."),
@@ -123,7 +123,7 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, az armhelpers
 		strings.HasPrefix(upgradeVersion, "1.12."),
 		strings.HasPrefix(upgradeVersion, "1.13."):
 		u := &Upgrader{}
-		u.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, acsengineVersion)
+		u.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, aksEngineVersion)
 		upgrader = u
 
 	default:

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -47,14 +47,14 @@ type vmInfo struct {
 }
 
 // Init initializes an upgrader struct
-func (ku *Upgrader) Init(translator *i18n.Translator, logger *logrus.Entry, clusterTopology ClusterTopology, client armhelpers.AKSEngineClient, kubeConfig string, stepTimeout *time.Duration, acsEngineVersion string) {
+func (ku *Upgrader) Init(translator *i18n.Translator, logger *logrus.Entry, clusterTopology ClusterTopology, client armhelpers.AKSEngineClient, kubeConfig string, stepTimeout *time.Duration, aksEngineVersion string) {
 	ku.Translator = translator
 	ku.logger = logger
 	ku.ClusterTopology = clusterTopology
 	ku.Client = client
 	ku.kubeConfig = kubeConfig
 	ku.stepTimeout = stepTimeout
-	ku.AKSEngineVersion = acsEngineVersion
+	ku.AKSEngineVersion = aksEngineVersion
 }
 
 // RunUpgrade runs the upgrade pipeline
@@ -524,7 +524,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 	return nil
 }
 
-func (ku *Upgrader) generateUpgradeTemplate(upgradeContainerService *api.ContainerService, acsengineVersion string) (map[string]interface{}, map[string]interface{}, error) {
+func (ku *Upgrader) generateUpgradeTemplate(upgradeContainerService *api.ContainerService, aksEngineVersion string) (map[string]interface{}, map[string]interface{}, error) {
 	var err error
 	ctx := engine.Context{
 		Translator: ku.Translator,
@@ -542,7 +542,7 @@ func (ku *Upgrader) generateUpgradeTemplate(upgradeContainerService *api.Contain
 
 	var templateJSON string
 	var parametersJSON string
-	if templateJSON, parametersJSON, err = templateGenerator.GenerateTemplate(upgradeContainerService, engine.DefaultGeneratorCode, acsengineVersion); err != nil {
+	if templateJSON, parametersJSON, err = templateGenerator.GenerateTemplate(upgradeContainerService, engine.DefaultGeneratorCode, aksEngineVersion); err != nil {
 		return nil, nil, ku.Translator.Errorf("error generating upgrade template: %s", err.Error())
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This is a leftover "acs-engine" to "aks-engine" transition item. The tag that is added to every VM deployed with aks-engine is now "aksEngineVersion" instead of "acsengineVersion". Also changed variables in the code that referred to acsengineVersion.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
