### PR TITLE
test: print pod logs when errors occur

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -615,8 +615,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						pods, err := pod.GetAllByPrefix("metrics-server", "kube-system")
 						Expect(err).NotTo(HaveOccurred())
 						for _, p := range pods {
-							err = p.Logs()
-							Expect(err).NotTo(HaveOccurred())
+							p.Logs()
 						}
 						log.Println(string(out))
 					}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -612,10 +612,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					}
 					if i > 28 {
 						log.Printf("Error while running kubectl top nodes:%s\n", err)
-						pods, err := pod.GetAllByPrefix("metrics-server", "kube-system")
-						Expect(err).NotTo(HaveOccurred())
-						for _, p := range pods {
-							p.Logs()
+						pods, _ := pod.GetAllByPrefix("metrics-server", "kube-system")
+						if pods != nil {
+							for _, p := range pods {
+								p.Logs()
+							}
 						}
 						log.Println(string(out))
 					}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -612,6 +612,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					}
 					if i > 28 {
 						log.Printf("Error while running kubectl top nodes:%s\n", err)
+						p, err := pod.Get("metrics-server", "kube-system")
+						Expect(err).NotTo(HaveOccurred())
+						err = p.Logs()
+						Expect(err).NotTo(HaveOccurred())
 						log.Println(string(out))
 					}
 				}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -612,10 +612,12 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					}
 					if i > 28 {
 						log.Printf("Error while running kubectl top nodes:%s\n", err)
-						p, err := pod.Get("metrics-server", "kube-system")
+						pods, err := pod.GetAllByPrefix("metrics-server", "kube-system")
 						Expect(err).NotTo(HaveOccurred())
-						err = p.Logs()
-						Expect(err).NotTo(HaveOccurred())
+						for _, p := range pods {
+							err = p.Logs()
+							Expect(err).NotTo(HaveOccurred())
+						}
 						log.Println(string(out))
 					}
 				}

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -59,6 +59,7 @@ type Container struct {
 	Ports     []Port    `json:"ports"`
 	Env       []EnvVar  `json:"env"`
 	Resources Resources `json:"resources"`
+	Name      string    `json:"name"`
 }
 
 // TerminatedContainerState shows terminated state of a container
@@ -770,6 +771,19 @@ func (p *Pod) ValidateHostPort(check string, attempts int, sleep time.Duration, 
 		time.Sleep(sleep)
 	}
 	return false
+}
+
+// Logs will get logs from all containers in a pod
+func (p *Pod) Logs() error {
+	for _, container := range p.Spec.Containers {
+		cmd := exec.Command("kubectl", "logs", p.Metadata.Name, "-c", container.Name, "-n", p.Metadata.Namespace)
+		out, err := util.RunAndLogCommand(cmd)
+		log.Printf("\n%s\n", string(out))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ValidateAzureFile will keep retrying the check if azure file is mounted in Pod

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -493,6 +493,15 @@ func WaitOnReady(podPrefix, namespace string, successesNeeded int, sleep, durati
 	for {
 		select {
 		case err := <-errCh:
+			pods, _ := GetAllByPrefix(podPrefix, namespace)
+			if pods != nil {
+				for _, p := range pods {
+					e := p.Logs()
+					if e != nil {
+						log.Printf("Unable to print pod logs for pod %s", p.Metadata.Name)
+					}
+				}
+			}
 			return false, err
 		case ready := <-readyCh:
 			return ready, nil


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

To help debug flakes (e.g., `kubectl top nodes`), we should be printing out the pod logs when errors occur)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
