### PR TITLE
fix: add missing container images in VHD

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -144,7 +144,7 @@ done
 
 BLOBFUSE_FLEXVOLUME_VERSIONS="1.0.7"
 for BLOBFUSE_FLEXVOLUME_VERSION in ${BLOBFUSE_FLEXVOLUME_VERSIONS}; do
-    pullContainerImage "docker" "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:v${BLOBFUSE_FLEXVOLUME_VERSION}"
+    pullContainerImage "docker" "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:${BLOBFUSE_FLEXVOLUME_VERSION}"
 done
 
 IP_MASQ_AGENT_VERSIONS="2.0.0"

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -87,7 +87,7 @@ for PAUSE_VERSION in ${PAUSE_VERSIONS}; do
     pullContainerImage "docker" "k8s.gcr.io/pause-amd64:${PAUSE_VERSION}"
 done
 
-TILLER_VERSIONS="2.8.1"
+TILLER_VERSIONS="2.8.1 2.11.0"
 for TILLER_VERSION in ${TILLER_VERSIONS}; do
     pullContainerImage "docker" "gcr.io/kubernetes-helm/tiller:v${TILLER_VERSION}"
 done
@@ -140,6 +140,11 @@ done
 KV_FLEXVOLUME_VERSIONS="0.0.5"
 for KV_FLEXVOLUME_VERSION in ${KV_FLEXVOLUME_VERSIONS}; do
     pullContainerImage "docker" "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v${KV_FLEXVOLUME_VERSION}"
+done
+
+BLOBFUSE-FLEXVOLUME_VERSIONS="1.0.7"
+for FLEXVOLUME_VERSIONS in ${FLEXVOLUME_VERSIONS}; do
+    pullContainerImage "docker" "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:v${FLEXVOLUME_VERSIONS}"
 done
 
 IP_MASQ_AGENT_VERSIONS="2.0.0"

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -142,9 +142,9 @@ for KV_FLEXVOLUME_VERSION in ${KV_FLEXVOLUME_VERSIONS}; do
     pullContainerImage "docker" "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v${KV_FLEXVOLUME_VERSION}"
 done
 
-BLOBFUSE-FLEXVOLUME_VERSIONS="1.0.7"
-for FLEXVOLUME_VERSIONS in ${FLEXVOLUME_VERSIONS}; do
-    pullContainerImage "docker" "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:v${FLEXVOLUME_VERSIONS}"
+BLOBFUSE_FLEXVOLUME_VERSIONS="1.0.7"
+for BLOBFUSE_FLEXVOLUME_VERSION in ${BLOBFUSE_FLEXVOLUME_VERSIONS}; do
+    pullContainerImage "docker" "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:v${BLOBFUSE_FLEXVOLUME_VERSION}"
 done
 
 IP_MASQ_AGENT_VERSIONS="2.0.0"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Noticed that Tiller 2.11.0 and blobfuse-flexvolume addon container images were missing from the VHD install script. This PR adds them.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
