### PR TITLE
set publicIPAllocationMethod as static for master node

### DIFF
--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -238,11 +238,7 @@
     "dnsSettings": {
       "domainNameLabel": "[variables('masterFqdnPrefix')]"
     },
-    {{ if eq LoadBalancerSku "Standard"}}
     "publicIPAllocationMethod": "Static"
-    {{else}}
-    "publicIPAllocationMethod": "Dynamic"
-    {{end}}
   },
   "sku": {
       "name": "[variables('loadBalancerSku')]"

--- a/pkg/engine/transform/transformtestfiles/k8s_agent_upgrade_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_agent_upgrade_template.json
@@ -1882,7 +1882,7 @@
         "dnsSettings": {
           "domainNameLabel": "[variables('masterFqdnPrefix')]"
         },
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Static"
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_master_upgrade_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_master_upgrade_template.json
@@ -2057,7 +2057,7 @@
         "dnsSettings": {
           "domainNameLabel": "[variables('masterFqdnPrefix')]"
         },
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Static"
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_scale_template.json
@@ -2064,7 +2064,7 @@
         "dnsSettings": {
           "domainNameLabel": "[variables('masterFqdnPrefix')]"
         },
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Static"
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_template.json
@@ -2148,7 +2148,7 @@
         "dnsSettings": {
           "domainNameLabel": "[variables('masterFqdnPrefix')]"
         },
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Static"
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_vnet_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_vnet_scale_template.json
@@ -2009,7 +2009,7 @@
         "dnsSettings": {
           "domainNameLabel": "[variables('masterFqdnPrefix')]"
         },
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Static"
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_vnet_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_vnet_template.json
@@ -2059,7 +2059,7 @@
         "dnsSettings": {
           "domainNameLabel": "[variables('masterFqdnPrefix')]"
         },
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Static"
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This PR sets `publicIPAllocationMethod` as static for master node, this is for doing AKS whitelist feature which requires all master nodes uses static public ip.

cc @feiskyer @ritazh 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
set `publicIPAllocationMethod` as static for master node