### PR TITLE
chore: add support for Kubernetes 1.13.2

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -160,7 +160,7 @@ done
 pullContainerImage "docker" "busybox"
 
 # TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
-K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.9 1.10.12 1.11.5 1.11.6 1.12.2 1.12.4 1.13.1"
+K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.9 1.10.12 1.11.5 1.11.6 1.12.2 1.12.4 1.13.1 1.13.2"
 
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -98,6 +98,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.13.0-alpha.1": false,
 	"1.13.0-alpha.2": false,
 	"1.13.1":         true,
+	"1.13.2":         true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
See the [v1.13.2 changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#changelog-since-v1131) and https://github.com/kubernetes/kubernetes/releases/tag/v1.13.2

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Several Azure-specific fixes in this patch release--some may correlate to aks-engine issues...


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

- [x] Windows support file `v1.13.2-1int.zip` uploaded to wink8s blob in acsmirror storage account.
