### PR TITLE
fix: set heapster Deployment to EnsureExists to prevent heapster-nann…

### DIFF
--- a/parts/k8s/containeraddons/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-heapster-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 ---
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/parts/k8s/containeraddons/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-heapster-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 ---
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -91,7 +91,7 @@ metadata:
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
…y-induced pod thrashing

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

aks-engine currently delivers a heapster implementation (for clusters < 1.13) that configures the `Deployment` addon to `Reconcile`, in order to enforce k8s runtime updates to configuration changes from heapster. In practice, folks are experiencing the the `heapster-nanny`container is inducing regular reconciliations (read: kill/recreate) of the `heapster` pod.

This sets the `Deployment` to `EnsureExists` instead, which we expect to fix the above symptom; and will require manual reconciliation (read: `kubectl delete pod <heapster pod id>`) in order to apply changes to the addon spec.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #275

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
