### PR TITLE
fix: standardize upgrade cordon-drain timeout

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -21,7 +21,7 @@ import (
 const (
 	interval           = time.Second * 1
 	retry              = time.Second * 5
-	cordonDrainTimeout = time.Minute * 10
+	cordonDrainTimeout = time.Minute * 1
 )
 
 // Compiler to verify QueueMessageProcessor implements OperationsProcessor

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	interval = time.Second * 1
-	retry    = time.Second * 5
+	interval           = time.Second * 1
+	retry              = time.Second * 5
+	cordonDrainTimeout = time.Minute * 10
 )
 
 // Compiler to verify QueueMessageProcessor implements OperationsProcessor
@@ -59,7 +60,7 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 	}
 	// Cordon and drain the node
 	if drain {
-		err := operations.SafelyDrainNodeWithClient(client, kan.logger, *vmName, time.Minute)
+		err := operations.SafelyDrainNodeWithClient(client, kan.logger, *vmName, cordonDrainTimeout)
 		if err != nil {
 			kan.logger.Warningf("Error draining agent VM %s. Proceeding with deletion. Error: %v", *vmName, err)
 			// Proceed with deletion anyways

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -483,7 +483,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 				client,
 				ku.logger,
 				vmToUpgrade.Name,
-				time.Minute,
+				cordonDrainTimeout,
 			)
 			if err != nil {
 				ku.logger.Errorf("Error draining VM in VMSS: %v", err)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Enable future maintenance of cordon/drain timeout by making it a discrete const.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
