### PR TITLE
fix: Add ILB for vmss masters

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -394,7 +394,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
   {{if IsMasterVirtualMachineScaleSets}}
     MASTER_VM_NAME=$(hostname)
     MASTER_VM_NAME_BASE=$(hostname | sed "s/.$//")
-    MASTER_FIRSTADDR={{WrapAsVariable "kubernetesAPIServerIP"}}
+    MASTER_FIRSTADDR={{WrapAsVariable "masterFirstAddr"}}
     MASTER_INDEX=$(hostname | tail -c 2)
     PRIVATE_IP=$(hostname -I | cut -d" " -f1)
     MASTER_COUNT={{WrapAsVariable "masterCount"}}

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -394,7 +394,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
   {{if IsMasterVirtualMachineScaleSets}}
     MASTER_VM_NAME=$(hostname)
     MASTER_VM_NAME_BASE=$(hostname | sed "s/.$//")
-    MASTER_FIRSTADDR={{WrapAsVariable "masterFirstAddr"}}
+    MASTER_FIRSTADDR={{WrapAsParameter "firstConsecutiveStaticIP"}}
     MASTER_INDEX=$(hostname | tail -c 2)
     PRIVATE_IP=$(hostname -I | cut -d" " -f1)
     MASTER_COUNT={{WrapAsVariable "masterCount"}}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -244,7 +244,7 @@
         "masterInternalLbIPConfigID": "[concat(variables('masterInternalLbID'),'/frontendIPConfigurations/', variables('masterInternalLbIPConfigName'))]",
         "masterInternalLbIPOffset": {{GetDefaultInternalLbStaticIPOffset}},
         {{if IsMasterVirtualMachineScaleSets}}
-        "kubernetesAPIServerIP": "[parameters('firstConsecutiveStaticIP')]",
+        "kubernetesAPIServerIP": "[concat(variables('masterFirstAddrOctets')[0],'.',variables('masterFirstAddrOctets')[1],'.255.', variables('masterInternalLbIPOffset'))]",
         {{else}}
         "kubernetesAPIServerIP": "[concat(variables('masterFirstAddrPrefix'), add(variables('masterInternalLbIPOffset'), int(variables('masterFirstAddrOctet4'))))]",
         {{end}}
@@ -252,6 +252,7 @@
       "kubernetesAPIServerIP": "[parameters('firstConsecutiveStaticIP')]",
     {{end}}
     "masterLbBackendPoolName": "[concat(parameters('orchestratorName'), '-master-pool-', parameters('nameSuffix'))]",
+    "masterFirstAddr": "[parameters('firstConsecutiveStaticIP')]",
     "masterFirstAddrComment": "these MasterFirstAddrComment are used to place multiple masters consecutively in the address space",
     "masterFirstAddrOctets": "[split(parameters('firstConsecutiveStaticIP'),'.')]",
     "masterFirstAddrOctet4": "[variables('masterFirstAddrOctets')[3]]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -252,7 +252,6 @@
       "kubernetesAPIServerIP": "[parameters('firstConsecutiveStaticIP')]",
     {{end}}
     "masterLbBackendPoolName": "[concat(parameters('orchestratorName'), '-master-pool-', parameters('nameSuffix'))]",
-    "masterFirstAddr": "[parameters('firstConsecutiveStaticIP')]",
     "masterFirstAddrComment": "these MasterFirstAddrComment are used to place multiple masters consecutively in the address space",
     "masterFirstAddrOctets": "[split(parameters('firstConsecutiveStaticIP'),'.')]",
     "masterFirstAddrOctet4": "[variables('masterFirstAddrOctets')[3]]",

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -37,6 +37,8 @@ const (
 	MinIPAddressCount = 1
 	// MaxIPAddressCount specifies the maximum number of IP addresses per network interface
 	MaxIPAddressCount = 256
+	// address relative to the first consecutive Kubernetes static IP
+	DefaultInternalLbStaticIPOffset = 10
 )
 
 // Availability profiles

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -531,9 +531,14 @@ func (p *Properties) setDefaultCerts() (bool, []net.IP, error) {
 	}
 
 	ips := []net.IP{firstMasterIP, localhostIP}
-	// Add the Internal Loadbalancer IP which is always at at p known offset from the firstMasterIP
-	ips = append(ips, net.IP{firstMasterIP[0], firstMasterIP[1], firstMasterIP[2], firstMasterIP[3] + byte(DefaultInternalLbStaticIPOffset)})
+
 	// Include the Internal load balancer as well
+	if p.MasterProfile.IsVirtualMachineScaleSets() {
+		ips = append(ips, net.IP{firstMasterIP[0], firstMasterIP[1], byte(255), byte(DefaultInternalLbStaticIPOffset)})
+	} else {
+		// Add the Internal Loadbalancer IP which is always at p known offset from the firstMasterIP
+		ips = append(ips, net.IP{firstMasterIP[0], firstMasterIP[1], firstMasterIP[2], firstMasterIP[3] + byte(DefaultInternalLbStaticIPOffset)})
+	}
 
 	var offsetMultiplier int
 	if p.MasterProfile.IsVirtualMachineScaleSets() {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1246,6 +1246,71 @@ func TestSetCertDefaults(t *testing.T) {
 				Secret:   "bazSecret",
 			},
 			MasterProfile: &MasterProfile{
+				Count:     3,
+				DNSPrefix: "myprefix1",
+				VMSize:    "Standard_DS2_v2",
+			},
+			OrchestratorProfile: &OrchestratorProfile{
+				OrchestratorType:    Kubernetes,
+				OrchestratorVersion: "1.10.2",
+				KubernetesConfig: &KubernetesConfig{
+					NetworkPlugin: "azure",
+				},
+			},
+		},
+	}
+
+	cs.setOrchestratorDefaults(false)
+	cs.Properties.setMasterProfileDefaults(false)
+	result, ips, err := cs.Properties.setDefaultCerts()
+
+	if !result {
+		t.Error("expected setDefaultCerts to return true")
+	}
+
+	if err != nil {
+		t.Errorf("unexpected error thrown while executing setDefaultCerts %s", err.Error())
+	}
+
+	if ips == nil {
+		t.Error("expected setDefaultCerts to create a list of IPs")
+	} else {
+
+		if len(ips) != cs.Properties.MasterProfile.Count+3 {
+			t.Errorf("expected length of IPs from setDefaultCerts %d, actual length %d", cs.Properties.MasterProfile.Count+3, len(ips))
+		}
+
+		firstMasterIP := net.ParseIP(cs.Properties.MasterProfile.FirstConsecutiveStaticIP).To4()
+		offsetMultiplier := 1
+		addr := binary.BigEndian.Uint32(firstMasterIP)
+		expectedNewAddr := getNewAddr(addr, cs.Properties.MasterProfile.Count-1, offsetMultiplier)
+		actualLastIPAddr := binary.BigEndian.Uint32(ips[len(ips)-2])
+		if actualLastIPAddr != expectedNewAddr {
+			expectedLastIP := make(net.IP, 4)
+			binary.BigEndian.PutUint32(expectedLastIP, expectedNewAddr)
+			t.Errorf("expected last IP of master vm from setDefaultCerts %d, actual %d", expectedLastIP, ips[len(ips)-2])
+		}
+
+		if cs.Properties.MasterProfile.Count > 1 {
+			expectedILBIP := net.IP{firstMasterIP[0], firstMasterIP[1], firstMasterIP[2], firstMasterIP[3] + byte(DefaultInternalLbStaticIPOffset)}
+			actualILBIPAddr := binary.BigEndian.Uint32(ips[2])
+			expectedILBIPAddr := binary.BigEndian.Uint32(expectedILBIP)
+
+			if actualILBIPAddr != expectedILBIPAddr {
+				t.Errorf("expected IP of master ILB from setDefaultCerts %d, actual %d", expectedILBIP, ips[2])
+			}
+		}
+	}
+}
+
+func TestSetCertDefaultsVMSS(t *testing.T) {
+	cs := &ContainerService{
+		Properties: &Properties{
+			ServicePrincipalProfile: &ServicePrincipalProfile{
+				ClientID: "barClientID",
+				Secret:   "bazSecret",
+			},
+			MasterProfile: &MasterProfile{
 				Count:               3,
 				DNSPrefix:           "myprefix1",
 				VMSize:              "Standard_DS2_v2",
@@ -1282,12 +1347,7 @@ func TestSetCertDefaults(t *testing.T) {
 		}
 
 		firstMasterIP := net.ParseIP(cs.Properties.MasterProfile.FirstConsecutiveStaticIP).To4()
-		var offsetMultiplier int
-		if cs.Properties.MasterProfile.IsVirtualMachineScaleSets() {
-			offsetMultiplier = cs.Properties.MasterProfile.IPAddressCount
-		} else {
-			offsetMultiplier = 1
-		}
+		offsetMultiplier := cs.Properties.MasterProfile.IPAddressCount
 		addr := binary.BigEndian.Uint32(firstMasterIP)
 		expectedNewAddr := getNewAddr(addr, cs.Properties.MasterProfile.Count-1, offsetMultiplier)
 		actualLastIPAddr := binary.BigEndian.Uint32(ips[len(ips)-2])
@@ -1296,8 +1356,17 @@ func TestSetCertDefaults(t *testing.T) {
 			binary.BigEndian.PutUint32(expectedLastIP, expectedNewAddr)
 			t.Errorf("expected last IP of master vm from setDefaultCerts %d, actual %d", expectedLastIP, ips[len(ips)-2])
 		}
-	}
 
+		if cs.Properties.MasterProfile.Count > 1 {
+			expectedILBIP := net.IP{firstMasterIP[0], firstMasterIP[1], byte(255), byte(DefaultInternalLbStaticIPOffset)}
+			actualILBIPAddr := binary.BigEndian.Uint32(ips[2])
+			expectedILBIPAddr := binary.BigEndian.Uint32(expectedILBIP)
+
+			if actualILBIPAddr != expectedILBIPAddr {
+				t.Errorf("expected IP of master ILB from setDefaultCerts %d, actual %d", expectedILBIP, ips[2])
+			}
+		}
+	}
 }
 
 func getMockBaseContainerService(orchestratorVersion string) ContainerService {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -622,7 +622,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					if i > 28 {
 						log.Printf("Error while running kubectl top nodes:%s\n", err)
 						pods, _ := pod.GetAllByPrefix("metrics-server", "kube-system")
-						if pods != nil {
+						if len(pods) != 0 {
 							for _, p := range pods {
 								p.Logs()
 							}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -191,6 +192,25 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
 			}
+		})
+
+		It("should have the correct IP address for the apiserver", func() {
+			pods, err := pod.GetAllByPrefix("kube-apiserver", "kube-system")
+			Expect(err).NotTo(HaveOccurred())
+			By("Ensuring that the correct IP address has been applied to the apiserver")
+			expectedIPAddress := eng.ExpandedDefinition.Properties.MasterProfile.FirstConsecutiveStaticIP
+			if eng.ExpandedDefinition.Properties.MasterProfile.Count > 1 {
+				firstMasterIP := net.ParseIP(eng.ExpandedDefinition.Properties.MasterProfile.FirstConsecutiveStaticIP).To4()
+				expectedIP := net.IP{firstMasterIP[0], firstMasterIP[1], firstMasterIP[2], firstMasterIP[3] + byte(common.DefaultInternalLbStaticIPOffset)}
+				if eng.ExpandedDefinition.Properties.MasterProfile.IsVirtualMachineScaleSets() {
+					expectedIP = net.IP{firstMasterIP[0], firstMasterIP[1], byte(255), byte(common.DefaultInternalLbStaticIPOffset)}
+				}
+				expectedIPAddress = expectedIP.String()
+			}
+
+			actualIPAddress, err := pods[0].Spec.Containers[0].GetArg("--advertise-address")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actualIPAddress).To(Equal(expectedIPAddress))
 		})
 
 		It("should have addons running", func() {

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -60,6 +60,7 @@ type Container struct {
 	Env       []EnvVar  `json:"env"`
 	Resources Resources `json:"resources"`
 	Name      string    `json:"name"`
+	Args      []string  `json:"args"`
 }
 
 // TerminatedContainerState shows terminated state of a container
@@ -904,6 +905,17 @@ func (c *Container) GetEnvironmentVariable(varName string) (string, error) {
 		}
 	}
 	return "", errors.New("environment variable not found")
+}
+
+// GetArg returns an arg's value from a container within a pod
+func (c *Container) GetArg(argKey string) (string, error) {
+	for _, argvar := range c.Args {
+		if strings.Contains(argvar, argKey) {
+			value := strings.SplitAfter(argvar, "=")[1]
+			return value, nil
+		}
+	}
+	return "", errors.New("container argument not found")
 }
 
 // getCPURequests returns an the CPU Requests value from a container within a pod

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -494,7 +494,7 @@ func WaitOnReady(podPrefix, namespace string, successesNeeded int, sleep, durati
 		select {
 		case err := <-errCh:
 			pods, _ := GetAllByPrefix(podPrefix, namespace)
-			if pods != nil {
+			if len(pods) != 0 {
 				for _, p := range pods {
 					e := p.Logs()
 					if e != nil {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
- Add internal loadbalancer for masters when `availabilityProfile` is `VirtualMachineScaleSets` and `MasterProfile.Count > 1`
- New internal IP assigned to `kubernetesAPIServerIP` derived from `"[concat(variables('masterFirstAddrOctets')[0],'.',variables('masterFirstAddrOctets')[1],'.255.', variables('masterInternalLbIPOffset'))]"` e.g. `10.240.255.10`
- Add master node's primary IP to ILB's backend pool

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #304 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
- Also fixes few style issues in e2e