### PR TITLE
fix: primary scale set name

### DIFF
--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -202,7 +202,7 @@
 {{end}}
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
 {{if AnyAgentUsesVirtualMachineScaleSets}}
-    "primaryScaleSetName": "[concat(parameters('orchestratorName'), '-{{ (index .AgentPoolProfiles 0).Name }}-',parameters('nameSuffix'), '-vmss')]",
+    "primaryScaleSetName": "[variables('{{ (index .AgentPoolProfiles 0).Name }}VMNamePrefix')]",
     "primaryAvailabilitySetName": "",
     "vmType": "vmss",
 {{else}}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
VM Scale Set name used is incorrect for Windows agent pool, cluster auto scaler fails.

https://github.com/Azure/acs-engine/issues/4055


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #209 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Tested on Azure. Creating Windows agent pool with "availabilityProfile": "VirtualMachineScaleSets"
