### PR TITLE
fix: use correct OS Type in description text

### DIFF
--- a/parts/agentparams.t
+++ b/parts/agentparams.t
@@ -59,21 +59,21 @@
     "{{.Name}}osImageName": {
       "defaultValue": "",
       "metadata": {
-        "description": "Name of a Linux OS image. Needs to be used in conjuction with osImageResourceGroup."
+        "description": "Name of a {{.OSType}} OS image. Needs to be used in conjuction with osImageResourceGroup."
       },
       "type": "string"
     },
     "{{.Name}}osImageResourceGroup": {
       "defaultValue": "",
       "metadata": {
-        "description": "Resource group of a Linux OS image. Needs to be used in conjuction with osImageName."
+        "description": "Resource group of a {{.OSType}} OS image. Needs to be used in conjuction with osImageName."
       },
       "type": "string"
     },
     "{{.Name}}osImageOffer": {
       "defaultValue": "UbuntuServer",
       "metadata": {
-        "description": "Linux OS image type."
+        "description": "{{.OSType}} OS image type."
       },
       "type": "string"
     },

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -260,7 +260,7 @@
     {{if UseAksExtension}}
     ,{
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/computeAksLinuxBilling')]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/computeAksWindowsBilling')]",
       "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -133,7 +133,7 @@
             }
             {{if UseAksExtension}}
             ,{
-              "name": "[concat(variables('{{.Name}}VMNamePrefix'), '-computeAksLinuxBilling')]",
+              "name": "[concat(variables('{{.Name}}VMNamePrefix'), '-computeAksWindowsBilling')]",
               "location": "[variables('location')]",
               "properties": {
                 "publisher": "Microsoft.AKS",

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -45,7 +45,7 @@
     "agentWindowsVersion": {
       "defaultValue": "latest",
       "metadata": {
-        "description": "Version of the Windows Server 2016 OS image to use for the agent virtual machines."
+        "description": "Version of the Windows Server OS image to use for the agent virtual machines."
       },
       "type": "string"
     },


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Cleanup text.
Windows pool description was showing "Linux OS image"

Extension profile "Compute.AKS-Engine.Windows.Billing" was named '-computeAksLinuxBilling'


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
