### PR TITLE
docs: update default value of smb-flexvolume in clusterdefinitions.md

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -81,7 +81,7 @@ To learn more about supported orchestrators and versions, run the orchestrators 
 | [nvidia-device-plugin](../../examples/addons/nvidia-device-plugin/README.md) | true if using a Kubernetes cluster (v1.10+) with an N-series agent pool               | 1                   | Delivers the Kubernetes NVIDIA device plugin component. See https://github.com/NVIDIA/k8s-device-plugin for more info |
 | container-monitoring                       | false               | 1                   | Delivers the Kubernetes container monitoring component |
 | [blobfuse-flexvolume](https://github.com/Azure/kubernetes-volume-drivers/tree/master/flexvolume/blobfuse)                        | true               | as many as linux agent nodes                   | Access virtual filesystem backed by the Azure Blob storage |
-| [smb-flexvolume](https://github.com/Azure/kubernetes-volume-drivers/tree/master/flexvolume/smb)                        | true               | as many as linux agent nodes                   | Access SMB server by using CIFS/SMB protocol |
+| [smb-flexvolume](https://github.com/Azure/kubernetes-volume-drivers/tree/master/flexvolume/smb)                        | false               | as many as linux agent nodes                   | Access SMB server by using CIFS/SMB protocol |
 | [keyvault-flexvolume](../../examples/addons/keyvault-flexvolume/README.md)                        | true               | as many as linux agent nodes                   | Access secrets, keys, and certs in Azure Key Vault from pods |
 | [aad-pod-identity](../../examples/addons/aad-pod-identity/README.md)                        | false               | 1 + 1 on each linux agent nodes | Assign Azure Active Directory Identities to Kubernetes applications |
 


### PR DESCRIPTION
**Reason for Change**:
update default value of smb-flexvolume in clusterdefinitions.md to false, make it consistent with actual behavior.

**Issue Fixed**:
Fixes #322 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
