### PR TITLE
enable ipvs + samples

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -67,6 +67,8 @@ To learn more about supported orchestrators and versions, run the orchestrators 
 | azureCNIURLLinux                | no       | Deploy a private build of Azure CNI on Linux nodes. This should be a full path to the .tar.gz |
 | azureCNIURLWindows              | no       | Deploy a private build of Azure CNI on Windows nodes. This should be a full path to the .tar.gz |
 | maximumLoadBalancerRuleCount    | no       | Maximum allowed LoadBalancer Rule Count is the limit enforced by Azure Load balancer. Default is 250 |
+| kubeProxyMode    | no       | kube-proxy --proxy-mode value, either "iptables" or "ipvs". Default is "iptables". See https://kubernetes.io/blog/2018/07/09/ipvs-based-in-cluster-load-balancing-deep-dive/ for further reference. |
+
 
 #### addons
 

--- a/examples/ipvs/kubernetes-msi.json
+++ b/examples/ipvs/kubernetes-msi.json
@@ -1,0 +1,37 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.7",
+      "kubernetesConfig": {
+        "useManagedIdentity": true,
+				"kubeProxyMode" : "ipvs"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "linuxpool1",
+        "count": 2,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ]
+	},
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    }
+  }
+}

--- a/examples/ipvs/kubernetes-msi.json
+++ b/examples/ipvs/kubernetes-msi.json
@@ -6,7 +6,7 @@
       "orchestratorRelease": "1.7",
       "kubernetesConfig": {
         "useManagedIdentity": true,
-				"kubeProxyMode" : "ipvs"
+        "kubeProxyMode" : "ipvs"
       }
     },
     "masterProfile": {

--- a/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         - --kubeconfig=/var/lib/kubelet/kubeconfig
         - --cluster-cidr=<CIDR>
         - --feature-gates=ExperimentalCriticalPodAnnotation=true
-        - --proxy-mode=<KUBE-PROXY-MODE>
+        - --proxy-mode=<kubeProxyMode>
         image: <img>
         imagePullPolicy: IfNotPresent
         name: kube-proxy

--- a/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -26,6 +26,7 @@ spec:
         - --kubeconfig=/var/lib/kubelet/kubeconfig
         - --cluster-cidr=<CIDR>
         - --feature-gates=ExperimentalCriticalPodAnnotation=true
+        - --proxy-mode=<KUBE-PROXY-MODE>
         image: <img>
         imagePullPolicy: IfNotPresent
         name: kube-proxy
@@ -46,6 +47,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: iptableslock
+        - mountPath: /lib/modules/
+          name: kernelmodules
+          readOnly: true
       hostNetwork: true
       volumes:
       - hostPath:
@@ -60,5 +64,8 @@ spec:
       - hostPath:
           path: /run/xtables.lock
         name: iptableslock
+      - hostPath:
+          path: /lib/modules/
+        name: kernelmodules
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -295,7 +295,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<advertiseAddr>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" $a
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}|g" /etc/kubernetes/manifests/kube-controller-manager.yaml
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.SchedulerConfig}}|g" /etc/kubernetes/manifests/kube-scheduler.yaml
-    sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+    sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<KUBE-PROXY-MODE>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     KUBEDNS=/etc/kubernetes/addons/kube-dns-deployment.yaml
 {{if NeedsKubeDNSWithExecHealthz}}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesKubeDNSSpec"}}|g; s|<imgMasq>|{{WrapAsParameter "kubernetesDNSMasqSpec"}}|g; s|<imgHealthz>|{{WrapAsParameter "kubernetesExecHealthzSpec"}}|g; s|<imgSidecar>|{{WrapAsParameter "kubernetesDNSSidecarSpec"}}|g; s|<domain>|{{WrapAsParameter "kubernetesKubeletClusterDomain"}}|g; s|<clustIP>|{{WrapAsParameter "kubeDNSServiceIP"}}|g" $KUBEDNS

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -295,7 +295,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<advertiseAddr>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" $a
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}|g" /etc/kubernetes/manifests/kube-controller-manager.yaml
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.SchedulerConfig}}|g" /etc/kubernetes/manifests/kube-scheduler.yaml
-    sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<KUBE-PROXY-MODE>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+    sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     KUBEDNS=/etc/kubernetes/addons/kube-dns-deployment.yaml
 {{if NeedsKubeDNSWithExecHealthz}}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesKubeDNSSpec"}}|g; s|<imgMasq>|{{WrapAsParameter "kubernetesDNSMasqSpec"}}|g; s|<imgHealthz>|{{WrapAsParameter "kubernetesExecHealthzSpec"}}|g; s|<imgSidecar>|{{WrapAsParameter "kubernetesDNSSidecarSpec"}}|g; s|<domain>|{{WrapAsParameter "kubernetesKubeletClusterDomain"}}|g; s|<clustIP>|{{WrapAsParameter "kubeDNSServiceIP"}}|g" $KUBEDNS

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -387,6 +387,8 @@ const (
 	DefaultKubernetesSchedulerEnableProfiling = "false"
 	// DefaultNonMasqueradeCIDR is the default --non-masquerade-cidr value for kubelet
 	DefaultNonMasqueradeCIDR = "0.0.0.0/0"
+	// DefaultKubeProxyMode is the default KubeProxyMode value
+	DefaultKubeProxyMode KubeProxyMode = KubeProxyModeIPTables
 )
 
 const (

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -692,58 +692,59 @@ func convertDcosConfigToVLabs(api *DcosConfig, vl *vlabs.DcosConfig) {
 	}
 }
 
-func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.KubernetesConfig) {
-	vlabs.KubernetesImageBase = api.KubernetesImageBase
-	vlabs.ClusterSubnet = api.ClusterSubnet
-	vlabs.DNSServiceIP = api.DNSServiceIP
-	vlabs.ServiceCidr = api.ServiceCIDR
-	vlabs.NetworkPolicy = api.NetworkPolicy
-	vlabs.NetworkPlugin = api.NetworkPlugin
-	vlabs.MaxPods = api.MaxPods
-	vlabs.DockerBridgeSubnet = api.DockerBridgeSubnet
-	vlabs.CloudProviderBackoff = api.CloudProviderBackoff
-	vlabs.CloudProviderBackoffDuration = api.CloudProviderBackoffDuration
-	vlabs.CloudProviderBackoffExponent = api.CloudProviderBackoffExponent
-	vlabs.CloudProviderBackoffJitter = api.CloudProviderBackoffJitter
-	vlabs.CloudProviderBackoffRetries = api.CloudProviderBackoffRetries
-	vlabs.CloudProviderRateLimit = api.CloudProviderRateLimit
-	vlabs.CloudProviderRateLimitBucket = api.CloudProviderRateLimitBucket
-	vlabs.CloudProviderRateLimitQPS = api.CloudProviderRateLimitQPS
-	vlabs.UseManagedIdentity = api.UseManagedIdentity
-	vlabs.UserAssignedID = api.UserAssignedID
-	vlabs.UserAssignedClientID = api.UserAssignedClientID
-	vlabs.CustomHyperkubeImage = api.CustomHyperkubeImage
-	vlabs.CustomCcmImage = api.CustomCcmImage
-	vlabs.UseCloudControllerManager = api.UseCloudControllerManager
-	vlabs.CustomWindowsPackageURL = api.CustomWindowsPackageURL
-	vlabs.WindowsNodeBinariesURL = api.WindowsNodeBinariesURL
-	vlabs.UseInstanceMetadata = api.UseInstanceMetadata
-	vlabs.LoadBalancerSku = api.LoadBalancerSku
-	vlabs.ExcludeMasterFromStandardLB = api.ExcludeMasterFromStandardLB
-	vlabs.EnableRbac = api.EnableRbac
-	vlabs.EnableSecureKubelet = api.EnableSecureKubelet
-	vlabs.EnableAggregatedAPIs = api.EnableAggregatedAPIs
-	vlabs.EnableDataEncryptionAtRest = api.EnableDataEncryptionAtRest
-	vlabs.EnableEncryptionWithExternalKms = api.EnableEncryptionWithExternalKms
-	vlabs.EnablePodSecurityPolicy = api.EnablePodSecurityPolicy
-	vlabs.GCHighThreshold = api.GCHighThreshold
-	vlabs.GCLowThreshold = api.GCLowThreshold
-	vlabs.EtcdVersion = api.EtcdVersion
-	vlabs.EtcdDiskSizeGB = api.EtcdDiskSizeGB
-	vlabs.EtcdEncryptionKey = api.EtcdEncryptionKey
-	vlabs.AzureCNIVersion = api.AzureCNIVersion
-	vlabs.AzureCNIURLLinux = api.AzureCNIURLLinux
-	vlabs.AzureCNIURLWindows = api.AzureCNIURLWindows
-	vlabs.KeyVaultSku = api.KeyVaultSku
-	vlabs.MaximumLoadBalancerRuleCount = api.MaximumLoadBalancerRuleCount
-	convertAddonsToVlabs(api, vlabs)
-	convertKubeletConfigToVlabs(api, vlabs)
-	convertControllerManagerConfigToVlabs(api, vlabs)
-	convertCloudControllerManagerConfigToVlabs(api, vlabs)
-	convertAPIServerConfigToVlabs(api, vlabs)
-	convertSchedulerConfigToVlabs(api, vlabs)
-	convertPrivateClusterToVlabs(api, vlabs)
-	convertPodSecurityPolicyConfigToVlabs(api, vlabs)
+func convertKubernetesConfigToVLabs(apiCfg *KubernetesConfig, vlabsCfg *vlabs.KubernetesConfig) {
+	vlabsCfg.KubernetesImageBase = apiCfg.KubernetesImageBase
+	vlabsCfg.ClusterSubnet = apiCfg.ClusterSubnet
+	vlabsCfg.DNSServiceIP = apiCfg.DNSServiceIP
+	vlabsCfg.ServiceCidr = apiCfg.ServiceCIDR
+	vlabsCfg.NetworkPolicy = apiCfg.NetworkPolicy
+	vlabsCfg.NetworkPlugin = apiCfg.NetworkPlugin
+	vlabsCfg.MaxPods = apiCfg.MaxPods
+	vlabsCfg.DockerBridgeSubnet = apiCfg.DockerBridgeSubnet
+	vlabsCfg.CloudProviderBackoff = apiCfg.CloudProviderBackoff
+	vlabsCfg.CloudProviderBackoffDuration = apiCfg.CloudProviderBackoffDuration
+	vlabsCfg.CloudProviderBackoffExponent = apiCfg.CloudProviderBackoffExponent
+	vlabsCfg.CloudProviderBackoffJitter = apiCfg.CloudProviderBackoffJitter
+	vlabsCfg.CloudProviderBackoffRetries = apiCfg.CloudProviderBackoffRetries
+	vlabsCfg.CloudProviderRateLimit = apiCfg.CloudProviderRateLimit
+	vlabsCfg.CloudProviderRateLimitBucket = apiCfg.CloudProviderRateLimitBucket
+	vlabsCfg.CloudProviderRateLimitQPS = apiCfg.CloudProviderRateLimitQPS
+	vlabsCfg.UseManagedIdentity = apiCfg.UseManagedIdentity
+	vlabsCfg.UserAssignedID = apiCfg.UserAssignedID
+	vlabsCfg.UserAssignedClientID = apiCfg.UserAssignedClientID
+	vlabsCfg.CustomHyperkubeImage = apiCfg.CustomHyperkubeImage
+	vlabsCfg.CustomCcmImage = apiCfg.CustomCcmImage
+	vlabsCfg.UseCloudControllerManager = apiCfg.UseCloudControllerManager
+	vlabsCfg.CustomWindowsPackageURL = apiCfg.CustomWindowsPackageURL
+	vlabsCfg.WindowsNodeBinariesURL = apiCfg.WindowsNodeBinariesURL
+	vlabsCfg.UseInstanceMetadata = apiCfg.UseInstanceMetadata
+	vlabsCfg.LoadBalancerSku = apiCfg.LoadBalancerSku
+	vlabsCfg.ExcludeMasterFromStandardLB = apiCfg.ExcludeMasterFromStandardLB
+	vlabsCfg.EnableRbac = apiCfg.EnableRbac
+	vlabsCfg.EnableSecureKubelet = apiCfg.EnableSecureKubelet
+	vlabsCfg.EnableAggregatedAPIs = apiCfg.EnableAggregatedAPIs
+	vlabsCfg.EnableDataEncryptionAtRest = apiCfg.EnableDataEncryptionAtRest
+	vlabsCfg.EnableEncryptionWithExternalKms = apiCfg.EnableEncryptionWithExternalKms
+	vlabsCfg.EnablePodSecurityPolicy = apiCfg.EnablePodSecurityPolicy
+	vlabsCfg.GCHighThreshold = apiCfg.GCHighThreshold
+	vlabsCfg.GCLowThreshold = apiCfg.GCLowThreshold
+	vlabsCfg.EtcdVersion = apiCfg.EtcdVersion
+	vlabsCfg.EtcdDiskSizeGB = apiCfg.EtcdDiskSizeGB
+	vlabsCfg.EtcdEncryptionKey = apiCfg.EtcdEncryptionKey
+	vlabsCfg.AzureCNIVersion = apiCfg.AzureCNIVersion
+	vlabsCfg.AzureCNIURLLinux = apiCfg.AzureCNIURLLinux
+	vlabsCfg.AzureCNIURLWindows = apiCfg.AzureCNIURLWindows
+	vlabsCfg.KeyVaultSku = apiCfg.KeyVaultSku
+	vlabsCfg.MaximumLoadBalancerRuleCount = apiCfg.MaximumLoadBalancerRuleCount
+	vlabsCfg.ProxyMode = vlabs.KubeProxyMode(apiCfg.ProxyMode)
+	convertAddonsToVlabs(apiCfg, vlabsCfg)
+	convertKubeletConfigToVlabs(apiCfg, vlabsCfg)
+	convertControllerManagerConfigToVlabs(apiCfg, vlabsCfg)
+	convertCloudControllerManagerConfigToVlabs(apiCfg, vlabsCfg)
+	convertAPIServerConfigToVlabs(apiCfg, vlabsCfg)
+	convertSchedulerConfigToVlabs(apiCfg, vlabsCfg)
+	convertPrivateClusterToVlabs(apiCfg, vlabsCfg)
+	convertPodSecurityPolicyConfigToVlabs(apiCfg, vlabsCfg)
 }
 
 func convertKubeletConfigToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -685,6 +685,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.AzureCNIURLWindows = vlabs.AzureCNIURLWindows
 	api.KeyVaultSku = vlabs.KeyVaultSku
 	api.MaximumLoadBalancerRuleCount = vlabs.MaximumLoadBalancerRuleCount
+	api.ProxyMode = KubeProxyMode(vlabs.ProxyMode)
 	convertAddonsToAPI(vlabs, api)
 	convertKubeletConfigToAPI(vlabs, api)
 	convertControllerManagerConfigToAPI(vlabs, api)

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -230,8 +230,8 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpdate bool) {
 		if a.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount == 0 {
 			a.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount = DefaultMaximumLoadBalancerRuleCount
 		}
-		if "" == a.OrchestratorProfile.KubernetesConfig.ProxyMode {
-			a.OrchestratorProfile.KubernetesConfig.ProxyMode = KubeProxyModeIPTables
+		if a.OrchestratorProfile.KubernetesConfig.ProxyMode == "" {
+			a.OrchestratorProfile.KubernetesConfig.ProxyMode = DefaultKubeProxyMode
 		}
 
 		// Configure addons

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -231,7 +231,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpdate bool) {
 			a.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount = DefaultMaximumLoadBalancerRuleCount
 		}
 		if "" == a.OrchestratorProfile.KubernetesConfig.ProxyMode {
-			a.OrchestratorProfile.KubernetesConfig.ProxyMode = KubeProxyModeIpTables
+			a.OrchestratorProfile.KubernetesConfig.ProxyMode = KubeProxyModeIPTables
 		}
 
 		// Configure addons

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -230,6 +230,9 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpdate bool) {
 		if a.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount == 0 {
 			a.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount = DefaultMaximumLoadBalancerRuleCount
 		}
+		if "" == a.OrchestratorProfile.KubernetesConfig.ProxyMode {
+			a.OrchestratorProfile.KubernetesConfig.ProxyMode = KubeProxyModeIpTables
+		}
 
 		// Configure addons
 		cs.setAddonsConfig(isUpdate)

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1369,6 +1369,31 @@ func TestSetCertDefaultsVMSS(t *testing.T) {
 	}
 }
 
+func TestProxyModeDefaults(t *testing.T) {
+	// Test that default is what we expect
+	mockCS := getMockBaseContainerService("1.10.12")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	properties.MasterProfile.Count = 1
+	mockCS.setOrchestratorDefaults(true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.ProxyMode != DefaultKubeProxyMode {
+		t.Fatalf("ProxyMode string not the expected default value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.ProxyMode, DefaultKubeProxyMode)
+	}
+
+	// Test that default assignment flow doesn't overwrite a user-provided config
+	mockCS = getMockBaseContainerService("1.10.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	properties.OrchestratorProfile.KubernetesConfig.ProxyMode = KubeProxyModeIPVS
+	properties.MasterProfile.Count = 1
+	mockCS.setOrchestratorDefaults(true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.ProxyMode != KubeProxyModeIPVS {
+		t.Fatalf("ProxyMode string not the expected default value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.ProxyMode, KubeProxyModeIPVS)
+	}
+}
+
 func getMockBaseContainerService(orchestratorVersion string) ContainerService {
 	mockAPIProperties := getMockAPIProperties(orchestratorVersion)
 	return ContainerService{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -313,7 +313,7 @@ type KubeProxyMode string
 
 // We currently support ipvs and iptables
 const (
-	KubeProxyModeIpTables KubeProxyMode = "iptables"
+	KubeProxyModeIPTables KubeProxyMode = "iptables"
 	KubeProxyModeIPVS     KubeProxyMode = "ipvs"
 )
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -317,6 +317,9 @@ const (
 	KubeProxyModeIPVS     KubeProxyMode = "ipvs"
 )
 
+// DefaultKubeProxyMode is the default KubeProxyMode value
+const DefaultKubeProxyMode KubeProxyMode = KubeProxyModeIPTables
+
 // KubernetesConfig contains the Kubernetes config structure, containing
 // Kubernetes specific configuration
 type KubernetesConfig struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -308,6 +308,15 @@ type KubernetesConfigDeprecated struct {
 	CtrlMgrRouteReconciliationPeriod string `json:"ctrlMgrRouteReconciliationPeriod,omitempty"`
 }
 
+// KubeProxyMode is for iptables and ipvs (and future others)
+type KubeProxyMode string
+
+// We currently support ipvs and iptables
+const (
+	KubeProxyModeIpTables KubeProxyMode = "iptables"
+	KubeProxyModeIPVS     KubeProxyMode = "ipvs"
+)
+
 // KubernetesConfig contains the Kubernetes config structure, containing
 // Kubernetes specific configuration
 type KubernetesConfig struct {
@@ -370,6 +379,7 @@ type KubernetesConfig struct {
 	AzureCNIURLWindows               string            `json:"azureCNIURLWindows,omitempty"`
 	KeyVaultSku                      string            `json:"keyVaultSku,omitempty"`
 	MaximumLoadBalancerRuleCount     int               `json:"maximumLoadBalancerRuleCount,omitempty"`
+	ProxyMode                        KubeProxyMode     `json:"kubeProxyMode,omitempty"`
 }
 
 // CustomFile has source as the full absolute source path to a file and dest

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -313,12 +313,11 @@ type KubeProxyMode string
 
 // We currently support ipvs and iptables
 const (
+	// KubeProxyModeIPTables is used to set the kube-proxy to iptables mode
 	KubeProxyModeIPTables KubeProxyMode = "iptables"
-	KubeProxyModeIPVS     KubeProxyMode = "ipvs"
+	// KubeProxyModeIPVS is used to set the kube-proxy to ipvs mode
+	KubeProxyModeIPVS KubeProxyMode = "ipvs"
 )
-
-// DefaultKubeProxyMode is the default KubeProxyMode value
-const DefaultKubeProxyMode KubeProxyMode = KubeProxyModeIPTables
 
 // KubernetesConfig contains the Kubernetes config structure, containing
 // Kubernetes specific configuration

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -262,6 +262,15 @@ type PrivateJumpboxProfile struct {
 	StorageProfile string `json:"storageProfile,omitempty"`
 }
 
+// KubeProxyMode is for iptables and ipvs (and future others)
+type KubeProxyMode string
+
+// We currently support ipvs and iptables
+const (
+	KubeProxyModeIpTables KubeProxyMode = "iptables"
+	KubeProxyModeIPVS     KubeProxyMode = "ipvs"
+)
+
 // KubernetesConfig contains the Kubernetes config structure, containing
 // Kubernetes specific configuration
 type KubernetesConfig struct {
@@ -318,6 +327,7 @@ type KubernetesConfig struct {
 	AzureCNIURLWindows              string            `json:"azureCNIURLWindows,omitempty"`
 	KeyVaultSku                     string            `json:"keyVaultSku,omitempty"`
 	MaximumLoadBalancerRuleCount    int               `json:"maximumLoadBalancerRuleCount,omitempty"`
+	ProxyMode                       KubeProxyMode     `json:"kubeProxyMode,omitempty"`
 }
 
 // CustomFile has source as the full absolute source path to a file and dest

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -267,7 +267,7 @@ type KubeProxyMode string
 
 // We currently support ipvs and iptables
 const (
-	KubeProxyModeIpTables KubeProxyMode = "iptables"
+	KubeProxyModeIPTables KubeProxyMode = "iptables"
 	KubeProxyModeIPVS     KubeProxyMode = "ipvs"
 )
 

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -292,8 +292,8 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 				if o.KubernetesConfig.MaximumLoadBalancerRuleCount < 0 {
 					return errors.New("maximumLoadBalancerRuleCount shouldn't be less than 0")
 				}
-				if "" != o.KubernetesConfig.ProxyMode && KubeProxyModeIpTables != o.KubernetesConfig.ProxyMode && KubeProxyModeIPVS != o.KubernetesConfig.ProxyMode {
-					return errors.Errorf("Invalid KubeProxyMode %v. Allowed modes are %v and %v", o.KubernetesConfig.ProxyMode, KubeProxyModeIpTables, KubeProxyModeIPVS)
+				if "" != o.KubernetesConfig.ProxyMode && KubeProxyModeIPTables != o.KubernetesConfig.ProxyMode && KubeProxyModeIPVS != o.KubernetesConfig.ProxyMode {
+					return errors.Errorf("Invalid KubeProxyMode %v. Allowed modes are %v and %v", o.KubernetesConfig.ProxyMode, KubeProxyModeIPTables, KubeProxyModeIPVS)
 				}
 			}
 		default:

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -292,6 +292,9 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 				if o.KubernetesConfig.MaximumLoadBalancerRuleCount < 0 {
 					return errors.New("maximumLoadBalancerRuleCount shouldn't be less than 0")
 				}
+				if "" != o.KubernetesConfig.ProxyMode && KubeProxyModeIpTables != o.KubernetesConfig.ProxyMode && KubeProxyModeIPVS != o.KubernetesConfig.ProxyMode {
+					return errors.Errorf("Invalid KubeProxyMode %v. Allowed modes are %v and %v", o.KubernetesConfig.ProxyMode, KubeProxyModeIpTables, KubeProxyModeIPVS)
+				}
 			}
 		default:
 			return errors.Errorf("OrchestratorProfile has unknown orchestrator: %s", o.OrchestratorType)

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -292,9 +292,6 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 				if o.KubernetesConfig.MaximumLoadBalancerRuleCount < 0 {
 					return errors.New("maximumLoadBalancerRuleCount shouldn't be less than 0")
 				}
-				if "" != o.KubernetesConfig.ProxyMode && KubeProxyModeIPTables != o.KubernetesConfig.ProxyMode && KubeProxyModeIPVS != o.KubernetesConfig.ProxyMode {
-					return errors.Errorf("Invalid KubeProxyMode %v. Allowed modes are %v and %v", o.KubernetesConfig.ProxyMode, KubeProxyModeIPTables, KubeProxyModeIPVS)
-				}
 			}
 		default:
 			return errors.Errorf("OrchestratorProfile has unknown orchestrator: %s", o.OrchestratorType)
@@ -1074,6 +1071,10 @@ func (k *KubernetesConfig) Validate(k8sVersion string, hasWindows bool) error {
 		if firstServiceIP.Equal(dnsIP) {
 			return errors.Errorf("OrchestratorProfile.KubernetesConfig.DNSServiceIP '%s' cannot be the first IP of ServiceCidr '%s'", k.DNSServiceIP, k.ServiceCidr)
 		}
+	}
+
+	if k.ProxyMode != "" && k.ProxyMode != KubeProxyModeIPTables && k.ProxyMode != KubeProxyModeIPVS {
+		return errors.Errorf("Invalid KubeProxyMode %v. Allowed modes are %v and %v", k.ProxyMode, KubeProxyModeIPTables, KubeProxyModeIPVS)
 	}
 
 	// Validate that we have a valid etcd version

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -468,6 +468,32 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 		if err := c.Validate(k8sVersion, false); err == nil {
 			t.Error("should error when ClusterSubnet has a mask of 24 bits or higher")
 		}
+
+		c = KubernetesConfig{
+			ProxyMode: KubeProxyMode("invalid"),
+		}
+
+		if err := c.Validate(k8sVersion, false); err == nil {
+			t.Error("should error when ProxyMode has an invalid string value")
+		}
+
+		for _, validProxyModeValue := range []KubeProxyMode{KubeProxyModeIPTables, KubeProxyModeIPVS} {
+			c = KubernetesConfig{
+				ProxyMode: KubeProxyMode(validProxyModeValue),
+			}
+
+			if err := c.Validate(k8sVersion, false); err != nil {
+				t.Error("should error when ProxyMode has a valid string value")
+			}
+
+			c = KubernetesConfig{
+				ProxyMode: KubeProxyMode(validProxyModeValue),
+			}
+
+			if err := c.Validate(k8sVersion, false); err != nil {
+				t.Error("should error when ProxyMode has a valid string value")
+			}
+		}
 	}
 
 	// Tests that apply to 1.6 and later releases


### PR DESCRIPTION
**Reason for Change**:
adds ipvs support to clusters created by `aks-engine`. The default mode is still iptabales, the user have to opt-in via setting `KuberentesConfig.kubeProxyMode = "ipvs"` in api-model

**Issue Fixed**:
 > I do believe there was a long standing feature request on acs-engine, maybe we lost it in the move? (I could be wrong)

Fixes #344 