### PR TITLE
fix: Fix the incorrect computername parameter

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -175,7 +175,7 @@
         },
         "osProfile": {
           "adminUsername": "[parameters('linuxAdminUsername')]",
-          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+          "computerName": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
           {{GetKubernetesAgentCustomData .}}
           "linuxConfiguration": {
               "disablePasswordAuthentication": true,

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -859,7 +859,7 @@
         },
         "osProfile": {
           "adminUsername": "[parameters('linuxAdminUsername')]",
-          "computername": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
+          "computerName": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
           {{GetKubernetesMasterCustomData .}}
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -182,7 +182,7 @@
           ]
         },
         "osProfile": {
-          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+          "computerName": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
           {{GetKubernetesWindowsAgentCustomData .}}
           "adminUsername": "[parameters('windowsAdminUsername')]",
           "adminPassword": "[parameters('windowsAdminPassword')]"


### PR DESCRIPTION
`computername` is the wrong name and it is not recognized by the RP schema. `computerName` should be used instead