### PR TITLE
fix: Fail deployCmd when orchestrator version is invalid

### DIFF
--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -208,7 +208,12 @@ func (a *Apiloader) LoadContainerService(
 		if e := containerService.Properties.Validate(isUpdate); validate && e != nil {
 			return nil, e
 		}
-		unversioned := ConvertVLabsContainerService(containerService, isUpdate)
+
+		var unversioned *ContainerService
+		var err error
+		if unversioned, err = ConvertVLabsContainerService(containerService, isUpdate); err != nil {
+			return nil, err
+		}
 		if curOrchVersion != "" &&
 			(containerService.Properties.OrchestratorProfile == nil ||
 				(containerService.Properties.OrchestratorProfile.OrchestratorVersion == "" &&

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -605,7 +605,7 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 		}
 		setVlabsKubernetesDefaults(vp, api)
 
-		//HACK : this validation should be done as part of the main validation, but deploy does it only after loading the container.
+		// TODO (hack): this validation should be done as part of the main validation, but deploy does it only after loading the container.
 		if err := vp.ValidateOrchestratorProfile(isUpdate); err != nil {
 			return err
 		}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -103,7 +103,7 @@ func ConvertV20170701ContainerService(v20170701 *v20170701.ContainerService, isU
 }
 
 // ConvertVLabsContainerService converts a vlabs ContainerService to an unversioned ContainerService
-func ConvertVLabsContainerService(vlabs *vlabs.ContainerService, isUpdate bool) *ContainerService {
+func ConvertVLabsContainerService(vlabs *vlabs.ContainerService, isUpdate bool) (*ContainerService, error) {
 	c := &ContainerService{}
 	c.ID = vlabs.ID
 	c.Location = helpers.NormalizeAzureRegion(vlabs.Location)
@@ -118,8 +118,10 @@ func ConvertVLabsContainerService(vlabs *vlabs.ContainerService, isUpdate bool) 
 	}
 	c.Type = vlabs.Type
 	c.Properties = &Properties{}
-	convertVLabsProperties(vlabs.Properties, c.Properties, isUpdate)
-	return c
+	if err := convertVLabsProperties(vlabs.Properties, c.Properties, isUpdate); err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 // convertV20160930ResourcePurchasePlan converts a v20160930 ResourcePurchasePlan to an unversioned ResourcePurchasePlan
@@ -350,11 +352,13 @@ func convertV20170701Properties(v20170701 *v20170701.Properties, api *Properties
 	}
 }
 
-func convertVLabsProperties(vlabs *vlabs.Properties, api *Properties, isUpdate bool) {
+func convertVLabsProperties(vlabs *vlabs.Properties, api *Properties, isUpdate bool) error {
 	api.ProvisioningState = ProvisioningState(vlabs.ProvisioningState)
 	if vlabs.OrchestratorProfile != nil {
 		api.OrchestratorProfile = &OrchestratorProfile{}
-		convertVLabsOrchestratorProfile(vlabs, api.OrchestratorProfile, isUpdate)
+		if err := convertVLabsOrchestratorProfile(vlabs, api.OrchestratorProfile, isUpdate); err != nil {
+			return err
+		}
 	}
 	if vlabs.MasterProfile != nil {
 		api.MasterProfile = &MasterProfile{}
@@ -409,6 +413,8 @@ func convertVLabsProperties(vlabs *vlabs.Properties, api *Properties, isUpdate b
 		api.CustomCloudProfile = &CustomCloudProfile{}
 		convertVLabsCustomCloudProfile(vlabs.CustomCloudProfile, api.CustomCloudProfile)
 	}
+
+	return nil
 }
 
 func convertVLabsFeatureFlags(vlabs *vlabs.FeatureFlags, api *FeatureFlags) {
@@ -588,7 +594,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 	}
 }
 
-func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProfile, isUpdate bool) {
+func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProfile, isUpdate bool) error {
 	vlabscs := vp.OrchestratorProfile
 	api.OrchestratorType = vlabscs.OrchestratorType
 	switch api.OrchestratorType {
@@ -598,12 +604,19 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 			convertVLabsKubernetesConfig(vlabscs.KubernetesConfig, api.KubernetesConfig)
 		}
 		setVlabsKubernetesDefaults(vp, api)
+
+		//HACK : this validation should be done as part of the main validation, but deploy does it only after loading the container.
+		if err := vp.ValidateOrchestratorProfile(isUpdate); err != nil {
+			return err
+		}
+
 		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(
 			vlabscs.OrchestratorType,
 			vlabscs.OrchestratorRelease,
 			vlabscs.OrchestratorVersion,
 			isUpdate,
 			vp.HasWindows())
+
 	case DCOS:
 		if vlabscs.DcosConfig != nil {
 			api.DcosConfig = &DcosConfig{}
@@ -616,6 +629,8 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 			isUpdate,
 			false)
 	}
+
+	return nil
 }
 
 func convertVLabsDcosConfig(vlabs *vlabs.DcosConfig, api *DcosConfig) {

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -117,7 +117,10 @@ func TestOrchestratorVersion(t *testing.T) {
 			},
 		},
 	}
-	cs = ConvertVLabsContainerService(vlabscs, false)
+	cs, err := ConvertVLabsContainerService(vlabscs, false)
+	if err != nil {
+		t.Fatalf("Failed to convert ContainerService, error: %s", err)
+	}
 	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.GetDefaultKubernetesVersion(false) {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
@@ -130,10 +133,45 @@ func TestOrchestratorVersion(t *testing.T) {
 			},
 		},
 	}
-	cs = ConvertVLabsContainerService(vlabscs, false)
+	cs, err = ConvertVLabsContainerService(vlabscs, false)
+	if err != nil {
+		t.Fatalf("Failed to convert ContainerService, error: %s", err)
+	}
 	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.7.15" {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
+}
+
+func TestKubernetesOrchestratorVersionFailWhenInvalid(t *testing.T) {
+	vlabscs := &vlabs.ContainerService{
+		Properties: &vlabs.Properties{
+			OrchestratorProfile: &vlabs.OrchestratorProfile{
+				OrchestratorType:    vlabs.Kubernetes,
+				OrchestratorVersion: "1.10.8",
+			},
+		},
+	}
+
+	_, err := ConvertVLabsContainerService(vlabscs, false)
+	if err == nil {
+		t.Error("1.10.8 is not a valid version and should fail, but didn't")
+	}
+
+	vlabscs.Properties.OrchestratorProfile.OrchestratorRelease = "1.9"
+	vlabscs.Properties.OrchestratorProfile.OrchestratorVersion = "1.10.7"
+	_, err = ConvertVLabsContainerService(vlabscs, false)
+	if err == nil {
+		t.Fatalf("release 1.9 is incoherent with 1.10.7 and should fail, but didn't")
+	}
+
+	vlabscs.Properties.OrchestratorProfile.OrchestratorVersion = "whatever"
+	vlabscs.Properties.OrchestratorProfile.OrchestratorRelease = "1.10.8"
+
+	_, err = ConvertVLabsContainerService(vlabscs, false)
+	if err == nil {
+		t.Fatalf("garbage version string should fail, but didn't")
+	}
+
 }
 
 func TestKubernetesVlabsDefaults(t *testing.T) {

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -318,7 +318,10 @@ func TestCustomCloudProfile(t *testing.T) {
 		},
 	}
 
-	cs := ConvertVLabsContainerService(vlabscs, false)
+	cs, err := ConvertVLabsContainerService(vlabscs, false)
+	if err != nil {
+		t.Fatalf("failed to convert: '%s'", err)
+	}
 	if cs.Properties.CustomCloudProfile.Environment.Name != name {
 		t.Fatalf("incorrect Name, expect: '%s', actual: '%s'", name, cs.Properties.CustomCloudProfile.Environment.Name)
 	}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -113,7 +113,7 @@ func (a *Properties) Validate(isUpdate bool) error {
 	if e := validate.Struct(a); e != nil {
 		return handleValidationErrors(e.(validator.ValidationErrors))
 	}
-	if e := a.validateOrchestratorProfile(isUpdate); e != nil {
+	if e := a.ValidateOrchestratorProfile(isUpdate); e != nil {
 		return e
 	}
 	if e := a.validateMasterProfile(); e != nil {
@@ -162,7 +162,8 @@ func handleValidationErrors(e validator.ValidationErrors) error {
 	return common.HandleValidationErrors(e)
 }
 
-func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
+//ValidateOrchestratorProfile validates the orchestrator profile and the addons dependent on the version of the orchestrator
+func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 	o := a.OrchestratorProfile
 	// On updates we only need to make sure there is a supported patch version for the minor version
 	if !isUpdate {

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -258,7 +258,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 		test := test
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
-			err := test.properties.validateOrchestratorProfile(test.isUpdate)
+			err := test.properties.ValidateOrchestratorProfile(test.isUpdate)
 
 			if test.expectedError == "" && err == nil {
 				return


### PR DESCRIPTION
This PR runs the orchestrator version validation logic when running deploy before it is mistakenly being reset to the default value. This is mostly a workaround until we reach a better solution

**Issue Fixed**:
Fixes #191 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
The fix is implemented with a workaround. Comment in the code describes the root cause/ideal fix.