### PR TITLE
fix: remove invalid parameter location from vmss extension profiles

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -165,7 +165,6 @@
             {{if UseAksExtension}}
             ,{
               "name": "[concat(variables('{{.Name}}VMNamePrefix'), '-computeAksLinuxBilling')]",
-              "location": "[variables('location')]",
               "properties": {
                 "publisher": "Microsoft.AKS",
                 "type": "Compute.AKS-Engine.Linux.Billing",

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -570,7 +570,6 @@
             {{if UseAksExtension}}
             ,{
               "name": "[concat(variables('masterVMNamePrefix'), 'vmss-computeAksLinuxBilling')]",
-              "location": "[variables('location')]",
               "properties": {
                 "publisher": "Microsoft.AKS",
                 "type": "Compute.AKS-Engine.Linux.Billing",

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -134,7 +134,6 @@
             {{if UseAksExtension}}
             ,{
               "name": "[concat(variables('{{.Name}}VMNamePrefix'), '-computeAksWindowsBilling')]",
-              "location": "[variables('location')]",
               "properties": {
                 "publisher": "Microsoft.AKS",
                 "type": "Compute.AKS-Engine.Windows.Billing",


### PR DESCRIPTION
location is not a valid parameter  in VMSS extension profiles. Extension profiles are a field within the VMSS object and the VMSS object specifies the location :)