### PR TITLE
fix: Enable billing extension for AzureChinaCloud

### DIFF
--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -394,7 +394,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"UseAksExtension": func() bool {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return cloudSpecConfig.CloudName == api.AzurePublicCloud
+			return cloudSpecConfig.CloudName == api.AzurePublicCloud || cloudSpecConfig.CloudName == api.AzureChinaCloud
 		},
 		"IsMooncake": func() bool {
 			cloudSpecConfig := cs.GetCloudSpecConfig()


### PR DESCRIPTION
**Reason for Change**:
Enable billing extension for AzureChinaCloud
Compute.AKS-Engine.Linux.Billing & Compute.AKS.Linux.Billing are deployed in mooncake.

Moved from https://github.com/Azure/acs-engine/pull/4144


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
