### PR TITLE
docs: Update kubernetes-developers.md

### DIFF
--- a/docs/topics/kubernetes-developers.md
+++ b/docs/topics/kubernetes-developers.md
@@ -43,4 +43,18 @@ For VERSION, we recommend that you provide a value which would help you identify
 }
 ```
 
+* AKS Engine uses the `aks-ubuntu-1604` image for the master and Linux agents. This image contains prebuilt versions of kubelet and kubectl, thus the provision scripts will not copy the desired kubelet binary ( and kubectl ) from the custom hyperkube image. In order to get over this limitation it is required to specify `ubuntu` for the master and Linux agents in "masterProfile" and each agent pool under `agentPoolProfiles`.
+
+```
+"masterProfile": {
+    "distro": "ubuntu"
+}
+
+"agentPoolProfiles": [
+    {
+        "distro": "ubuntu"
+    }
+]
+```
+
 * Run `./bin/aks-engine deploy --api-model the_json_file_you_just_edited.json ...` [as normal](deploy.md).


### PR DESCRIPTION
Update kubernetes-developers.md to reflect the fact that "distro" needs to be set for master and agent nodes in order to get the kubelet from the custom hyperkube image passed.

Addresses issue: https://github.com/Azure/aks-engine/issues/342

