### PR TITLE
docs fix: deploy.md broken links fix

### DIFF
--- a/docs/tutorials/deploy.md
+++ b/docs/tutorials/deploy.md
@@ -2,7 +2,7 @@
 
 ## Install Prerequisites
 
-All the commands in this guide require both the Azure CLI and `aks-engine`. Follow the [installation instructions to download aks-engine before continuing](../aksengine.md#install-aks-engine) or [compile from source](../aksengine.md#build-from-source).
+All the commands in this guide require both the Azure CLI and `aks-engine`. Follow the [installation instructions to download aks-engine before continuing](./quickstart.md#install) or [compile from source](./quickstart.md#build-aks-engine-from-source).
 
 For installation instructions see [the Azure CLI GitHub repository](https://github.com/Azure/azure-cli#installation) for the latest release.
 


### PR DESCRIPTION
##### Reason for Change:
 
Fixing docs/tutorials/deploy.md broken links. #372  


