### PR TITLE
chore: increase auto-generated cert expiration to 30 years

### DIFF
--- a/pkg/helpers/pki.go
+++ b/pkg/helpers/pki.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// ValidityDuration specifies the duration an TLS certificate is valid
-	ValidityDuration = time.Hour * 24 * 365 * 2
+	ValidityDuration = time.Hour * 24 * 365 * 30
 	// PkiKeySize is the size in bytes of the PKI key
 	PkiKeySize = 4096
 )


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

For folks not submitting their own certificates, let's increase the expiration of the auto-generated certs we provide for them. In practice, expired certs render a cluster 100% inoperable.

@qike-ms @thomas1206 @jwilder @sauryadas @seanmck FYI

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
