### PR TITLE
fix: name windows aks billing extension correctly for hosted master profile

### DIFF
--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -272,7 +272,7 @@
       ],
       "properties": {
         "publisher": "Microsoft.AKS",
-        "type": "Compute.AKS-Engine.Windows.Billing",
+        "type": {{if IsHostedMaster}}"Compute.AKS.Windows.Billing"{{else}}"Compute.AKS-Engine.Windows.Billing"{{end}},
         "typeHandlerVersion": "1.0",
         "autoUpgradeMinorVersion": true,
         "settings": {


### PR DESCRIPTION
Naming should be symmetrical with that of linux cases.