### PR TITLE
fix(cilium): Allow the daemonset to deploy regardless of node status.

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-cilium-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-cilium-daemonset.yaml
@@ -108,6 +108,9 @@ spec:
           effect: NoSchedule
         - key: CriticalAddonsOnly
           operator: Exists
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: Exists
       containers:
       - image: cilium/cilium:stable
         imagePullPolicy: Always


### PR DESCRIPTION
When a cluster is bootstrapped with cilium nodes do not become ready because of a missing CNI plugin which is installed by this daemonset. Allow it to schedule pods on non-ready nodes actually fixes the CNI configuration and the nodes turn into a Ready state.

