### PR TITLE
chore: add commit message categories to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,20 @@ And read this for faster PR reviews: https://github.com/kubernetes/community/blo
 
 **Requirements**:
 <!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
+
 - [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
+  <!-- Common commit types:
+        build: Build 🏭
+        chore: Maintenance 🔧
+        ci: Continuous Integration 💜
+        docs: Documentation 📘
+        feat: Features 🌈
+        fix: Bug Fixes 🐞
+        perf: Performance Improvements 🚀
+        refactor: Code Refactoring 💎
+        revert: Revert Change ◀️
+        style: Code Style 🎶
+        test: Testing 💚 -->
 - [ ] includes documentation
 - [ ] adds unit tests
 - [ ] tested upgrade from previous version


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
When opening a PR I like to have a visual of all the different commit types available, especially for the ones that aren't as obvious as "fix" and "feat". The list I added is a comment so it won't show in PR descriptions, just in the template when someone creates a PR.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
