### PR TITLE
chore: per-agent pool k8s versions and provisioning state

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -486,6 +486,7 @@ type AgentPoolProfile struct {
 	DNSPrefix                           string               `json:"dnsPrefix,omitempty"`
 	OSType                              OSType               `json:"osType,omitempty"`
 	Ports                               []int                `json:"ports,omitempty"`
+	ProvisioningState                   ProvisioningState    `json:"provisioningState,omitempty"`
 	AvailabilityProfile                 string               `json:"availabilityProfile"`
 	ScaleSetPriority                    string               `json:"scaleSetPriority,omitempty"`
 	ScaleSetEvictionPolicy              string               `json:"scaleSetEvictionPolicy,omitempty"`
@@ -503,6 +504,7 @@ type AgentPoolProfile struct {
 	PreprovisionExtension               *Extension           `json:"preProvisionExtension"`
 	Extensions                          []Extension          `json:"extensions"`
 	KubernetesConfig                    *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
+	KubernetesVersion                   string               `json:"kubernetesVersion"`
 	ImageRef                            *ImageReference      `json:"imageReference,omitempty"`
 	MaxCount                            *int                 `json:"maxCount,omitempty"`
 	MinCount                            *int                 `json:"minCount,omitempty"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -504,7 +504,7 @@ type AgentPoolProfile struct {
 	PreprovisionExtension               *Extension           `json:"preProvisionExtension"`
 	Extensions                          []Extension          `json:"extensions"`
 	KubernetesConfig                    *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
-	KubernetesVersion                   string               `json:"kubernetesVersion"`
+	OrchestratorVersion                 string               `json:"orchestratorVersion"`
 	ImageRef                            *ImageReference      `json:"imageReference,omitempty"`
 	MaxCount                            *int                 `json:"maxCount,omitempty"`
 	MinCount                            *int                 `json:"minCount,omitempty"`

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -504,6 +504,42 @@ func TestAvailabilityProfile(t *testing.T) {
 	}
 }
 
+func TestPerAgentPoolVersionAndState(t *testing.T) {
+	cases := []struct {
+		ap              AgentPoolProfile
+		expectedVersion string
+		expectedState   ProvisioningState
+	}{
+		{
+			ap: AgentPoolProfile{
+				Name:                "agentpool1",
+				OrchestratorVersion: "1.12.0",
+				ProvisioningState:   Creating,
+			},
+			expectedVersion: "1.12.0",
+			expectedState:   Creating,
+		},
+		{
+			ap: AgentPoolProfile{
+				Name:                "agentpool2",
+				OrchestratorVersion: "",
+				ProvisioningState:   "",
+			},
+			expectedVersion: "",
+			expectedState:   "",
+		},
+	}
+
+	for _, c := range cases {
+		if c.ap.OrchestratorVersion != c.expectedVersion {
+			t.Fatalf("Orchestrator profile mismatch. Expected: %s. Got: %s.", c.expectedVersion, c.ap.OrchestratorVersion)
+		}
+		if c.ap.ProvisioningState != c.expectedState {
+			t.Fatalf("Provisioning state mismatch. Expected: %s. Got: %s.", c.expectedState, c.ap.ProvisioningState)
+		}
+	}
+}
+
 func TestIsCustomVNET(t *testing.T) {
 	cases := []struct {
 		p              Properties

--- a/pkg/armhelpers/compute.go
+++ b/pkg/armhelpers/compute.go
@@ -60,6 +60,19 @@ func (az *AzureClient) DeleteVirtualMachineScaleSetVM(ctx context.Context, resou
 	return err
 }
 
+// DeleteVirtualMachineScaleSet deletes an entire VM Scale Set.
+func (az *AzureClient) DeleteVirtualMachineScaleSet(ctx context.Context, resourceGroup, vmssName string) error {
+	future, err := az.virtualMachineScaleSetsClient.Delete(ctx, resourceGroup, vmssName)
+	if err != nil {
+		return err
+	}
+	if err = future.WaitForCompletionRef(ctx, az.virtualMachineScaleSetsClient.Client); err != nil {
+		return err
+	}
+	_, err = future.Result(az.virtualMachineScaleSetsClient)
+	return err
+}
+
 // SetVirtualMachineScaleSetCapacity sets the VMSS capacity
 func (az *AzureClient) SetVirtualMachineScaleSetCapacity(ctx context.Context, resourceGroup, virtualMachineScaleSet string, sku compute.Sku, location string) error {
 	future, err := az.virtualMachineScaleSetsClient.CreateOrUpdate(


### PR DESCRIPTION
- Add per agentpool level kubernetes version and provisioning state.
- Add calls to delete an entire vmss.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Required work towards multi agentpool operations.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
These will start getting used by AKS multi agent pool work initially and then used in aks-engine multi agentpool operations - like delete, scale, upgrade.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: