### PR TITLE
refactor: Remove agentpool index usage from function which gets agent VM name

### DIFF
--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -150,12 +150,12 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 }
 
 // GetK8sVMName reconstructs the VM name
-func GetK8sVMName(p *api.Properties, agentPoolIndex, agentIndex int) (string, error) {
-	if len(p.AgentPoolProfiles) > agentPoolIndex {
-		vmPrefix := p.GetAgentVMPrefix(p.AgentPoolProfiles[agentPoolIndex])
-		if vmPrefix != "" {
-			return vmPrefix + strconv.Itoa(agentIndex), nil
-		}
+func GetK8sVMName(p *api.Properties, agentPoolProfile *api.AgentPoolProfile, agentIndex int) (string, error) {
+
+	vmPrefix := p.GetAgentVMPrefix(agentPoolProfile)
+	if vmPrefix != "" {
+		return vmPrefix + strconv.Itoa(agentIndex), nil
 	}
+
 	return "", errors.Errorf("Failed to reconstruct VM Name")
 }

--- a/pkg/armhelpers/utils/util_test.go
+++ b/pkg/armhelpers/utils/util_test.go
@@ -177,9 +177,8 @@ func Test_GetK8sVMName(t *testing.T) {
 	}{
 		{properties: p, agentPoolIndex: 0, agentIndex: 2, expected: "aks-linux1-28513887-2", expectedErr: false},
 		{properties: p, agentPoolIndex: 1, agentIndex: 1, expected: "2851aks011", expectedErr: false},
-		{properties: p, agentPoolIndex: 3, agentIndex: 0, expected: "", expectedErr: true},
 	} {
-		vmName, err := GetK8sVMName(s.properties, s.agentPoolIndex, s.agentIndex)
+		vmName, err := GetK8sVMName(s.properties, p.AgentPoolProfiles[s.agentPoolIndex], s.agentIndex)
 
 		if !s.expectedErr {
 			if err != nil {

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -228,11 +228,12 @@ func (ku *Upgrader) upgradeAgentPools(ctx context.Context) error {
 			return ku.Translator.Errorf("Error generating upgrade template: %s", err.Error())
 		}
 
-		var agentCount, agentPoolIndex int
-		for indx, app := range ku.ClusterTopology.DataModel.Properties.AgentPoolProfiles {
+		var agentCount int
+		var agentPoolProfile *api.AgentPoolProfile
+		for _, app := range ku.ClusterTopology.DataModel.Properties.AgentPoolProfiles {
 			if app.Name == *agentPool.Name {
 				agentCount = app.Count
-				agentPoolIndex = indx
+				agentPoolProfile = app
 				break
 			}
 		}
@@ -315,7 +316,7 @@ func (ku *Upgrader) upgradeAgentPools(ctx context.Context) error {
 		for upgradedCount+toBeUpgradedCount < agentCount {
 			agentIndex := getAvailableIndex(agentVMs)
 
-			vmName, err := utils.GetK8sVMName(ku.DataModel.Properties, agentPoolIndex, agentIndex)
+			vmName, err := utils.GetK8sVMName(ku.DataModel.Properties, agentPoolProfile, agentIndex)
 			if err != nil {
 				ku.logger.Errorf("Error reconstructing agent VM name with index %d: %v", agentIndex, err)
 				return err
@@ -357,7 +358,7 @@ func (ku *Upgrader) upgradeAgentPools(ctx context.Context) error {
 				return err
 			}
 
-			vmName, err := utils.GetK8sVMName(ku.DataModel.Properties, agentPoolIndex, agentIndex)
+			vmName, err := utils.GetK8sVMName(ku.DataModel.Properties, agentPoolProfile, agentIndex)
 			if err != nil {
 				ku.logger.Errorf("Error fetching new VM name: %v", err)
 				return err


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Remove the agentpool index usage from upgrade code path.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Remove agentpool index usage from function which gets agent VM name

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
