### PR TITLE
chore: Add agentpool resource(used for agentpool level operations) and UT

### DIFF
--- a/pkg/api/mocks.go
+++ b/pkg/api/mocks.go
@@ -8,6 +8,22 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// CreateMockAgentPoolProfile creates a mock AgentPoolResource for testing
+func CreateMockAgentPoolProfile(agentPoolName, orchestratorVersion string, provisioningState ProvisioningState, agentCount int) *AgentPoolResource {
+	agentPoolResource := AgentPoolResource{}
+	agentPoolResource.ID = uuid.NewV4().String()
+	agentPoolResource.Location = "westus2"
+	agentPoolResource.Name = agentPoolName
+
+	agentPoolResource.Properties = &AgentPoolProfile{}
+	// AgentPoolProfile needs to be remain same, so the name is repeated inside.
+	agentPoolResource.Properties.Name = agentPoolName
+	agentPoolResource.Properties.Count = agentCount
+	agentPoolResource.Properties.OrchestratorVersion = orchestratorVersion
+	agentPoolResource.Properties.ProvisioningState = provisioningState
+	return &agentPoolResource
+}
+
 // CreateMockContainerService returns a mock container service for testing purposes
 func CreateMockContainerService(containerServiceName, orchestratorVersion string, masterCount, agentCount int, certs bool) *ContainerService {
 	cs := ContainerService{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -57,6 +57,19 @@ type ContainerService struct {
 	Properties *Properties `json:"properties,omitempty"`
 }
 
+// AgentPoolResource complies with the ARM model of
+// agentpool resource definition in a JSON template.
+type AgentPoolResource struct {
+	ID       string                `json:"id"`
+	Location string                `json:"location"`
+	Name     string                `json:"name"`
+	Plan     *ResourcePurchasePlan `json:"plan,omitempty"`
+	Tags     map[string]string     `json:"tags"`
+	Type     string                `json:"type"`
+
+	Properties *AgentPoolProfile `json:"properties,omitempty"`
+}
+
 // Properties represents the AKS cluster definition
 type Properties struct {
 	ClusterID               string

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2665,6 +2665,24 @@ func TestContainerService_GetAzureProdFQDN(t *testing.T) {
 	}
 }
 
+func TestAgentPoolResource(t *testing.T) {
+	expectedName := "TestAgentPool"
+	expectedVersion := "1.13.0"
+	expectedCount := 100
+
+	agentPoolResource := CreateMockAgentPoolProfile(expectedName, expectedVersion, Succeeded, expectedCount)
+
+	gotName := agentPoolResource.Properties.Name
+	gotVervsion := agentPoolResource.Properties.OrchestratorVersion
+	gotCount := agentPoolResource.Properties.Count
+
+	if gotName != expectedName || gotVervsion != expectedVersion || gotCount != expectedCount {
+		t.Fatalf("Expected values - name: %s, version: %s, count: %d. Got - name: %s, version: %s, count: %d", expectedName, expectedVersion, expectedCount,
+			gotName, gotVervsion, gotCount)
+	}
+
+}
+
 func TestKubernetesConfig_RequiresDocker(t *testing.T) {
 	// k8sConfig with empty runtime string
 	k := &KubernetesConfig{


### PR DESCRIPTION
Add agentpool resource(used for agentpool level operations) and UT

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Agentpool resource definition is required for operating on agentpool as a resource. This is in preparation to the AKS multiagentpool work. There is no usage in aks-engine yet. AgentPoolProfile  is used to represent the agentpool in a cluster. This is included in the AgentPoolResource as its properties field. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: