### PR TITLE
feat(cilium): Create bpffs mount on every node as cilium (almost) requires it

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -130,6 +130,27 @@ write_files:
     }
 {{end}}
 
+{{if HasCiliumNetworkPlugin }}
+- path: /etc/systemd/system/sys-fs-bpf.mount
+  permissions: "0644"
+  owner: root
+  content: |
+    [Unit]
+    Description=Cilium BPF mounts
+    Documentation=http://docs.cilium.io/
+    DefaultDependencies=no
+    Before=local-fs.target umount.target
+    After=swap.target
+
+    [Mount]
+    What=bpffs
+    Where=/sys/fs/bpf
+    Type=bpf
+
+    [Install]
+    WantedBy=multi-user.target
+{{end}}
+
 {{if IsNSeriesSKU .}}
 - path: /etc/systemd/system/nvidia-modprobe.service
   permissions: "0644"

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -202,6 +202,11 @@ configureCNI() {
         fi
         /sbin/ebtables -t nat --list
     fi
+    if [[ "${NETWORK_PLUGIN}" = "cilium" ]]; then
+        systemctl enable sys-fs-bpf.mount
+        systemctl restart sys-fs-bpf.mount
+        REBOOTREQUIRED=true
+    fi
 }
 
 setKubeletOpts () {

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -133,6 +133,27 @@ write_files:
     }
 {{end}}
 
+{{if eq .OrchestratorProfile.KubernetesConfig.NetworkPlugin "cilium"}}
+- path: /etc/systemd/system/sys-fs-bpf.mount
+  permissions: "0644"
+  owner: root
+  content: |
+    [Unit]
+    Description=Cilium BPF mounts
+    Documentation=http://docs.cilium.io/
+    DefaultDependencies=no
+    Before=local-fs.target umount.target
+    After=swap.target
+
+    [Mount]
+    What=bpffs
+    Where=/sys/fs/bpf
+    Type=bpf
+
+    [Install]
+    WantedBy=multi-user.target
+{{end}}
+
 - path: /etc/kubernetes/certs/ca.crt
   permissions: "0644"
   encoding: base64

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -814,6 +814,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"HasCustomSearchDomain": func() bool {
 			return cs.Properties.LinuxProfile.HasSearchDomain()
 		},
+		"HasCiliumNetworkPlugin": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin == "cilium"
+		},
 		"HasCustomNodesDNS": func() bool {
 			return cs.Properties.LinuxProfile.HasCustomNodesDNS()
 		},


### PR DESCRIPTION
This PR allows for the creation of a new systemd unit to auto-mount the bpffs (almost) required by the Cilium project (http://docs.cilium.io/en/latest/kubernetes/configuration/?highlight=bpffs#mounting-bpffs-with-systemd). After creating the unit the REBOOT_REQUIRED flag is set to ensure mounting occurs (had some trouble with only enable/restarting the mount).

Reason for this PR is to allow the cilium daemonset to work properly out of the box. More steps are needed to create a 100% experience the first time but this is a step towards that goal.

