### PR TITLE
fix: do not re-download containerd if pre-downloaded in VHD

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CONTAINERD_DOWNLOAD_URL_BASE="https://storage.googleapis.com/cri-containerd-release/"
+
 source /home/packer/provision_installs.sh
 source /home/packer/provision_source.sh
 
@@ -39,7 +41,7 @@ done
 
 CRI_CONTAINERD_VERSIONS="1.1.5"
 for CRI_CONTAINERD_VERSION in $CRI_CONTAINERD_VERSIONS; do
-    CONTAINERD_DOWNLOAD_URL="https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CRI_CONTAINERD_VERSION}.linux-amd64.tar.gz"
+    CONTAINERD_DOWNLOAD_URL="${CONTAINERD_DOWNLOAD_URL_BASE}cri-containerd-${CRI_CONTAINERD_VERSION}.linux-amd64.tar.gz"
     downloadContainerd
 done
 

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-CONTAINERD_DOWNLOAD_URL_BASE="https://storage.googleapis.com/cri-containerd-release/"
-
 source /home/packer/provision_installs.sh
 source /home/packer/provision_source.sh
 
@@ -39,7 +37,11 @@ for CNI_PLUGIN_VERSION in $CNI_PLUGIN_VERSIONS; do
     downloadCNI
 done
 
-downloadContainerd
+CRI_CONTAINERD_VERSIONS="1.1.5"
+for CRI_CONTAINERD_VERSION in $CRI_CONTAINERD_VERSIONS; do
+    CONTAINERD_DOWNLOAD_URL="https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CRI_CONTAINERD_VERSION}.linux-amd64.tar.gz"
+    downloadContainerd
+done
 
 installImg
 

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -39,7 +39,7 @@ for CNI_PLUGIN_VERSION in $CNI_PLUGIN_VERSIONS; do
     downloadCNI
 done
 
-installContainerd
+downloadContainerd
 
 installImg
 

--- a/parts/k8s/kubernetesinstalls.sh
+++ b/parts/k8s/kubernetesinstalls.sh
@@ -217,16 +217,13 @@ installAzureCNI() {
 }
 
 installContainerd() {
-    containerd --version
-    if [ $? -eq 0 ]; then
-	    echo "containerd is already installed, skipping download"
-	else
+    if [[ ! -f "$CONTAINERD_DOWNLOADS_DIR/${CONTAINERD_TGZ_TMP}" ]]; then
         downloadContainerd
-        tar -xzf "$CONTAINERD_DOWNLOADS_DIR/$CONTAINERD_TGZ_TMP" -C /
-        rm -Rf $CONTAINERD_DOWNLOADS_DIR &
-        sed -i '/\[Service\]/a ExecStartPost=\/sbin\/iptables -P FORWARD ACCEPT' /etc/systemd/system/containerd.service
-        echo "Successfully installed cri-containerd..."
     fi
+    tar -xzf "$CONTAINERD_DOWNLOADS_DIR/$CONTAINERD_TGZ_TMP" -C /
+    rm -Rf $CONTAINERD_DOWNLOADS_DIR &
+    sed -i '/\[Service\]/a ExecStartPost=\/sbin\/iptables -P FORWARD ACCEPT' /etc/systemd/system/containerd.service
+    echo "Successfully installed cri-containerd..."
 }
 
 installImg() {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Follow up on #183: currently if the VHD script installs containerd, which deletes the download directory after it's done. At provisioning time, we check for the downloaded binary and re-download it if it is already present. This is causing containerd to always download, even if it was pre-installed.
Instead, follow the Azure CNI pattern: download containerd in the base image and check for the download at provisioning. Only download again if the version we want is missing. This also will allow us to pre-bake several versions in the future. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
