### PR TITLE
set caching mode of data disks as ReadOnly by default

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -553,6 +553,7 @@ func getDataDisks(a *api.AgentPoolProfile) string {
               "createOption": "Empty",
               "diskSizeGB": "%d",
               "lun": %d,
+              "caching": "ReadOnly",
               "name": "[concat(variables('%sVMNamePrefix'), copyIndex(),'-datadisk%d')]",
               "vhd": {
                 "uri": "[concat('http://',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(),variables('maxVMsPerStorageAccount')),variables('%sStorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(),variables('maxVMsPerStorageAccount')),variables('%sStorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('%sDataAccountName'),'.blob.core.windows.net/vhds/',variables('%sVMNamePrefix'),copyIndex(), '--datadisk%d.vhd')]"
@@ -561,6 +562,7 @@ func getDataDisks(a *api.AgentPoolProfile) string {
 	managedDataDisks := `            {
               "diskSizeGB": "%d",
               "lun": %d,
+              "caching": "ReadOnly",
               "createOption": "Empty"
             }`
 	for i, diskSize := range a.DiskSizesGB {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
change azure disk host cache to ReadOnly
The default value `None` would lead to slow perf. And according to below doc: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage-performance#disk-caching, default host cache should be `ReadOnly`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #418

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
