### PR TITLE
feat: add exec_with_retry to windows build script

### DIFF
--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
 set -eo pipefail
 
+exec_with_retry() {
+
+      local retry=0
+      local max_retries=$1
+      local cmd=${@:2}
+      local exit_code=0
+
+      while [[ ${retry} -lt ${max_retries} ]]; do
+          eval $cmd || exit_code=$?
+          if [[ ${exit_code} -eq 0 ]]; then
+              return ${exit_code}
+          fi
+          let retry=retry+1
+     done
+     if [[ ! ${exit_code} -eq 0 ]]; then
+          echo "Failed to execute command: $cmd with exit_code: ${exit_code}"
+          return ${exit_code}
+    fi
+}
+
 fetch_k8s() {
 	git clone https://github.com/Azure/kubernetes ${GOPATH}/src/k8s.io/kubernetes || true
 	cd $KUBEPATH
@@ -299,7 +319,7 @@ download_nssm() {
 	NSSM_VERSION=2.24
 	NSSM_URL=https://nssm.cc/release/nssm-${NSSM_VERSION}.zip
 	echo "downloading nssm ..."
-	curl ${NSSM_URL} -o /tmp/nssm-${NSSM_VERSION}.zip
+	exec_with_retry 5 "curl --fail ${NSSM_URL} -o /tmp/nssm-${NSSM_VERSION}.zip"
 	unzip -q -d /tmp /tmp/nssm-${NSSM_VERSION}.zip
 	cp /tmp/nssm-${NSSM_VERSION}/win64/nssm.exe ${DIST_DIR}
 	chmod 775 ${DIST_DIR}/nssm.exe
@@ -311,8 +331,8 @@ download_wincni() {
 	WINSDN_URL=https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/
 	WINCNI_EXE=cni/wincni.exe
 	HNS_PSM1=hns.psm1
-	curl -L ${WINSDN_URL}${WINCNI_EXE} -o ${DIST_DIR}/${WINCNI_EXE}
-	curl -L ${WINSDN_URL}${HNS_PSM1} -o ${DIST_DIR}/${HNS_PSM1}
+	exec_with_retry 5 "curl --fail -L ${WINSDN_URL}${WINCNI_EXE} -o ${DIST_DIR}/${WINCNI_EXE}"
+	exec_with_retry 5 "curl --fail -L ${WINSDN_URL}${HNS_PSM1} -o ${DIST_DIR}/${HNS_PSM1}"
 }
 
 create_zip() {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

In the upstream e2e CI for windows, that is using this build script,
we have noticed downloading nssm tends tofail.
Add exec_with_retry function to wrap curl commands.

