### PR TITLE
fix: remove the use of deprecated Next() method

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -299,7 +299,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			return sc.saveAPIModel()
 		}
 	} else {
-		for vmssListPage, err := sc.client.ListVirtualMachineScaleSets(ctx, sc.resourceGroupName); vmssListPage.NotDone(); vmssListPage.Next() {
+		for vmssListPage, err := sc.client.ListVirtualMachineScaleSets(ctx, sc.resourceGroupName); vmssListPage.NotDone(); err = vmssListPage.NextWithContext(ctx) {
 			if err != nil {
 				return errors.Wrap(err, "failed to get vmss list in the resource group")
 			}

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -115,12 +115,12 @@ func (uc *UpgradeCluster) getClusterNodeStatus(az armhelpers.AKSEngineClient, re
 		kubeClient = k
 	}
 
-	for vmScaleSetPage, err := uc.Client.ListVirtualMachineScaleSets(ctx, resourceGroup); vmScaleSetPage.NotDone(); err = vmScaleSetPage.Next() {
+	for vmScaleSetPage, err := uc.Client.ListVirtualMachineScaleSets(ctx, resourceGroup); vmScaleSetPage.NotDone(); err = vmScaleSetPage.NextWithContext(ctx) {
 		if err != nil {
 			return err
 		}
 		for _, vmScaleSet := range vmScaleSetPage.Values() {
-			for vmScaleSetVMsPage, err := uc.Client.ListVirtualMachineScaleSetVMs(ctx, resourceGroup, *vmScaleSet.Name); vmScaleSetVMsPage.NotDone(); err = vmScaleSetVMsPage.Next() {
+			for vmScaleSetVMsPage, err := uc.Client.ListVirtualMachineScaleSetVMs(ctx, resourceGroup, *vmScaleSet.Name); vmScaleSetVMsPage.NotDone(); err = vmScaleSetVMsPage.NextWithContext(ctx) {
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
`Next()` is deprecated and is soon to be removed. `NextWithContext` forces good practices so that we use the existing parent context and not spawn a new one.