### PR TITLE
feat: add force parameter to the upgrade command

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -277,6 +277,7 @@ func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 	upgradeCluster.DataModel = uc.containerService
 	upgradeCluster.NameSuffix = uc.nameSuffix
 	upgradeCluster.AgentPoolsToUpgrade = uc.agentPoolsToUpgrade
+	upgradeCluster.Force = uc.force
 
 	kubeConfig, err := engine.GenerateKubeConfig(uc.containerService.Properties, uc.location)
 	if err != nil {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -219,9 +219,9 @@ func (uc *upgradeCmd) validateCurrentLocalState(armTemplateHandle io.Reader) err
 }
 
 func readNameSuffixFromARMTemplate(armTemplateHandle io.Reader) (string, error) {
-	var template *map[string]interface{}
+	var azureDeployTemplate *map[string]interface{}
 	decoder := json.NewDecoder(armTemplateHandle)
-	if err := decoder.Decode(&template); err != nil {
+	if err := decoder.Decode(&azureDeployTemplate); err != nil {
 		return "", err
 	}
 
@@ -234,7 +234,7 @@ func readNameSuffixFromARMTemplate(armTemplateHandle io.Reader) (string, error) 
 		defaultValueKey = "defaultValue"
 	)
 
-	if templateParameters, okType = (*template)[parametersKey].(map[string]interface{}); !okType {
+	if templateParameters, okType = (*azureDeployTemplate)[parametersKey].(map[string]interface{}); !okType {
 		return "", errors.Errorf("error asserting data from key \"%s\" in file %q",
 			parametersKey, "azuredeploy.json")
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -201,7 +201,7 @@ func (uc *upgradeCmd) validateCurrentLocalState(armTemplateHandle io.Reader) err
 	}
 
 	//allows to identify VMs in the resource group that belong to this cluster.
-	if nameSuffix, err := readNameSuffixFromArmTemplate(armTemplateHandle); err == nil {
+	if nameSuffix, err := readNameSuffixFromARMTemplate(armTemplateHandle); err == nil {
 		uc.nameSuffix = nameSuffix
 	} else {
 		return errors.Wrap(err, "Failed to read nameSuffix from azuredeploy.json")
@@ -217,7 +217,7 @@ func (uc *upgradeCmd) validateCurrentLocalState(armTemplateHandle io.Reader) err
 	return nil
 }
 
-func readNameSuffixFromArmTemplate(armTemplateHandle io.Reader) (string, error) {
+func readNameSuffixFromARMTemplate(armTemplateHandle io.Reader) (string, error) {
 	var template *map[string]interface{}
 	decoder := json.NewDecoder(armTemplateHandle)
 	if err := decoder.Decode(&template); err != nil {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -204,7 +204,8 @@ func (uc *upgradeCmd) validateCurrentLocalState(armTemplateHandle io.Reader) err
 	if nameSuffix, err := readNameSuffixFromARMTemplate(armTemplateHandle); err == nil {
 		uc.nameSuffix = nameSuffix
 	} else {
-		return errors.Wrap(err, "Failed to read nameSuffix from azuredeploy.json")
+		templatePath := path.Join(uc.deploymentDirectory, "azuredeploy.json")
+		return errors.Wrapf(err, "Failed to read nameSuffix from %s", templatePath)
 	}
 
 	log.Infoln(fmt.Sprintf("Upgrading cluster with name suffix: %s", uc.nameSuffix))

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -220,7 +220,7 @@ func (uc *upgradeCmd) validateCurrentLocalState(armTemplateHandle io.Reader) err
 func readNameSuffixFromArmTemplate(armTemplateHandle io.Reader) (string, error) {
 	var template *map[string]interface{}
 	decoder := json.NewDecoder(armTemplateHandle)
-	if err := decoder.Decode(&template); err != nil || template == nil {
+	if err := decoder.Decode(&template); err != nil {
 		return "", err
 	}
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -40,6 +40,7 @@ type upgradeCmd struct {
 	upgradeVersion      string
 	location            string
 	timeoutInMinutes    int
+	force               bool
 
 	// derived
 	containerService    *api.ContainerService
@@ -69,6 +70,7 @@ func newUpgradeCmd() *cobra.Command {
 	f.StringVar(&uc.deploymentDirectory, "deployment-dir", "", "the location of the output from `generate` (required)")
 	f.StringVarP(&uc.upgradeVersion, "upgrade-version", "k", "", "desired kubernetes version (required)")
 	f.IntVar(&uc.timeoutInMinutes, "vm-timeout", -1, "how long to wait for each vm to be upgraded in minutes")
+	f.BoolVarP(&uc.force, "force", "f", false, "force upgrading the cluster to desired version. Allows same version upgrades and downgrades.")
 	addAuthFlags(&uc.authArgs, f)
 
 	return upgradeCmd

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -4,104 +4,102 @@
 package cmd
 
 import (
-	. "github.com/onsi/ginkgo"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-var _ = Describe("the upgrade command", func() {
+func TestUpgradeCommandShouldBeValidated(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r := &cobra.Command{}
 
-	It("should create an upgrade command", func() {
-		output := newUpgradeCmd()
+	cases := []struct {
+		uc          *upgradeCmd
+		expectedErr error
+	}{
+		{
+			uc: &upgradeCmd{
+				resourceGroupName:   "",
+				deploymentDirectory: "_output/test",
+				upgradeVersion:      "1.8.9",
+				location:            "centralus",
+				timeoutInMinutes:    60,
+			},
+			expectedErr: errors.New("--resource-group must be specified"),
+		},
+		{
+			uc: &upgradeCmd{
+				resourceGroupName:   "test",
+				deploymentDirectory: "_output/test",
+				upgradeVersion:      "1.8.9",
+				location:            "",
+				timeoutInMinutes:    60,
+			},
+			expectedErr: errors.New("--location must be specified"),
+		},
+		{
+			uc: &upgradeCmd{
+				resourceGroupName:   "test",
+				deploymentDirectory: "_output/test",
+				upgradeVersion:      "",
+				location:            "southcentralus",
+				timeoutInMinutes:    60,
+			},
+			expectedErr: errors.New("--upgrade-version must be specified"),
+		},
+		{
+			uc: &upgradeCmd{
+				resourceGroupName:   "test",
+				deploymentDirectory: "",
+				upgradeVersion:      "1.9.0",
+				location:            "southcentralus",
+				timeoutInMinutes:    60,
+			},
+			expectedErr: errors.New("--deployment-dir must be specified"),
+		},
+		{
+			uc: &upgradeCmd{
+				resourceGroupName:   "test",
+				deploymentDirectory: "",
+				upgradeVersion:      "1.9.0",
+				location:            "southcentralus",
+				timeoutInMinutes:    60,
+			},
+			expectedErr: errors.New("--deployment-dir must be specified"),
+		},
+		{
+			uc: &upgradeCmd{
+				resourceGroupName:   "test",
+				deploymentDirectory: "_output/mydir",
+				upgradeVersion:      "1.9.0",
+				location:            "southcentralus",
+			},
+			expectedErr: nil,
+		},
+	}
 
-		Expect(output.Use).Should(Equal(upgradeName))
-		Expect(output.Short).Should(Equal(upgradeShortDescription))
-		Expect(output.Long).Should(Equal(upgradeLongDescription))
-		Expect(output.Flags().Lookup("location")).NotTo(BeNil())
-		Expect(output.Flags().Lookup("resource-group")).NotTo(BeNil())
-		Expect(output.Flags().Lookup("deployment-dir")).NotTo(BeNil())
-		Expect(output.Flags().Lookup("upgrade-version")).NotTo(BeNil())
-	})
-
-	It("should validate an upgrade command", func() {
-		r := &cobra.Command{}
-
-		cases := []struct {
-			uc          *upgradeCmd
-			expectedErr error
-		}{
-			{
-				uc: &upgradeCmd{
-					resourceGroupName:   "",
-					deploymentDirectory: "_output/test",
-					upgradeVersion:      "1.8.9",
-					location:            "centralus",
-					timeoutInMinutes:    60,
-				},
-				expectedErr: errors.New("--resource-group must be specified"),
-			},
-			{
-				uc: &upgradeCmd{
-					resourceGroupName:   "test",
-					deploymentDirectory: "_output/test",
-					upgradeVersion:      "1.8.9",
-					location:            "",
-					timeoutInMinutes:    60,
-				},
-				expectedErr: errors.New("--location must be specified"),
-			},
-			{
-				uc: &upgradeCmd{
-					resourceGroupName:   "test",
-					deploymentDirectory: "_output/test",
-					upgradeVersion:      "",
-					location:            "southcentralus",
-					timeoutInMinutes:    60,
-				},
-				expectedErr: errors.New("--upgrade-version must be specified"),
-			},
-			{
-				uc: &upgradeCmd{
-					resourceGroupName:   "test",
-					deploymentDirectory: "",
-					upgradeVersion:      "1.9.0",
-					location:            "southcentralus",
-					timeoutInMinutes:    60,
-				},
-				expectedErr: errors.New("--deployment-dir must be specified"),
-			},
-			{
-				uc: &upgradeCmd{
-					resourceGroupName:   "test",
-					deploymentDirectory: "",
-					upgradeVersion:      "1.9.0",
-					location:            "southcentralus",
-					timeoutInMinutes:    60,
-				},
-				expectedErr: errors.New("--deployment-dir must be specified"),
-			},
-			{
-				uc: &upgradeCmd{
-					resourceGroupName:   "test",
-					deploymentDirectory: "_output/mydir",
-					upgradeVersion:      "1.9.0",
-					location:            "southcentralus",
-				},
-				expectedErr: nil,
-			},
+	for _, c := range cases {
+		err := c.uc.validate(r)
+		if c.expectedErr != nil && err != nil {
+			g.Expect(err.Error()).To(Equal(c.expectedErr.Error()))
+		} else {
+			g.Expect(err).To(BeNil())
+			g.Expect(c.expectedErr).To(BeNil())
 		}
+	}
+}
 
-		for _, c := range cases {
-			err := c.uc.validate(r)
-			if c.expectedErr != nil && err != nil {
-				Expect(err.Error()).To(Equal(c.expectedErr.Error()))
-			} else {
-				Expect(err).To(BeNil())
-				Expect(c.expectedErr).To(BeNil())
-			}
-		}
+func TestCreateUpgradeCommandSuccesfully(t *testing.T) {
+	g := NewGomegaWithT(t)
+	output := newUpgradeCmd()
 
-	})
-
-})
+	g.Expect(output.Use).Should(Equal(upgradeName))
+	g.Expect(output.Short).Should(Equal(upgradeShortDescription))
+	g.Expect(output.Long).Should(Equal(upgradeLongDescription))
+	g.Expect(output.Flags().Lookup("location")).NotTo(BeNil())
+	g.Expect(output.Flags().Lookup("resource-group")).NotTo(BeNil())
+	g.Expect(output.Flags().Lookup("deployment-dir")).NotTo(BeNil())
+	g.Expect(output.Flags().Lookup("upgrade-version")).NotTo(BeNil())
+}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/armhelpers"
-	"github.com/gofrs/uuid"
 
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -150,16 +149,4 @@ func TestUpgradeForceSameVersionShouldSucceed(t *testing.T) {
 	upgradeCmd.force = true
 	err := upgradeCmd.validateCurrentLocalState(fakeArmTemplateHandle)
 	g.Expect(err).NotTo(HaveOccurred())
-}
-
-func setupAuthParams(uc *upgradeCmd) {
-	fakeRawSubscriptionID := "6dc93fae-9a76-421f-bbe5-cc6460ea81cb"
-	fakeSubscriptionID, _ := uuid.FromString(fakeRawSubscriptionID)
-	fakeClientID := "b829b379-ca1f-4f1d-91a2-0d26b244680d"
-	fakeClientSecret := "0se43bie-3zs5-303e-aav5-dcf231vb82ds"
-
-	uc.getAuthArgs().SubscriptionID = fakeSubscriptionID
-	uc.getAuthArgs().rawSubscriptionID = fakeRawSubscriptionID
-	uc.getAuthArgs().rawClientID = fakeClientID
-	uc.getAuthArgs().ClientSecret = fakeClientSecret
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -110,7 +110,7 @@ func TestCreateUpgradeCommandSuccesfully(t *testing.T) {
 
 //TODO: Should it fail or should it pass without --force? hmm
 func TestUpgradeShouldFailForSameVersion(t *testing.T) {
-	fakeArmTemplateHandle := strings.NewReader("{\"parameters\" : { \"nameSuffix\" : {\"defaultValue\" : \"test\"}}}")
+	fakeArmTemplateHandle := strings.NewReader(`{"parameters" : { "nameSuffix" : {"defaultValue" : "test"}}}`)
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
 		resourceGroupName:   "rg",
@@ -131,7 +131,7 @@ func TestUpgradeShouldFailForSameVersion(t *testing.T) {
 }
 
 func TestUpgradeForceSameVersionShouldSucceed(t *testing.T) {
-	fakeArmTemplateHandle := strings.NewReader("{\"parameters\" : { \"nameSuffix\" : {\"defaultValue\" : \"test\"}}}")
+	fakeArmTemplateHandle := strings.NewReader(`{"parameters" : { "nameSuffix" : {"defaultValue" : "test"}}}`)
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
 		resourceGroupName:   "rg",

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -110,7 +110,7 @@ func TestCreateUpgradeCommandSuccesfully(t *testing.T) {
 
 //TODO: Should it fail or should it pass without --force? hmm
 func TestUpgradeShouldFailForSameVersion(t *testing.T) {
-	fakeArmTemplateHandle := strings.NewReader(`{"parameters" : { "nameSuffix" : {"defaultValue" : "test"}}}`)
+	fakeARMTemplateHandle := strings.NewReader(`{"parameters" : { "nameSuffix" : {"defaultValue" : "test"}}}`)
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
 		resourceGroupName:   "rg",
@@ -125,13 +125,13 @@ func TestUpgradeShouldFailForSameVersion(t *testing.T) {
 	containerServiceMock := api.CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
-	err := upgradeCmd.validateCurrentLocalState(fakeArmTemplateHandle)
+	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("upgrading from Kubernetes version 1.10.13 to version 1.10.13 is not supported"))
 }
 
 func TestUpgradeForceSameVersionShouldSucceed(t *testing.T) {
-	fakeArmTemplateHandle := strings.NewReader(`{"parameters" : { "nameSuffix" : {"defaultValue" : "test"}}}`)
+	fakeARMTemplateHandle := strings.NewReader(`{"parameters" : { "nameSuffix" : {"defaultValue" : "test"}}}`)
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
 		resourceGroupName:   "rg",
@@ -147,6 +147,6 @@ func TestUpgradeForceSameVersionShouldSucceed(t *testing.T) {
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
 	upgradeCmd.force = true
-	err := upgradeCmd.validateCurrentLocalState(fakeArmTemplateHandle)
+	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
 	g.Expect(err).NotTo(HaveOccurred())
 }

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -25,6 +25,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+const (
+	defaultK8sVersionForFakeVMs = "Kubernetes:1.9.10"
+	//DefaultFakeVMName is the default name assigned to VMs part of FakeListVirtualMachineScaleSetVMsResult and FakeListVirtualMachineResult
+	DefaultFakeVMName = "k8s-agentpool1-12345678-0"
+)
+
 //MockAKSEngineClient is an implementation of AKSEngineClient where all requests error out
 type MockAKSEngineClient struct {
 	FailDeployTemplate                      bool
@@ -48,6 +54,7 @@ type MockAKSEngineClient struct {
 	FailDeleteRoleAssignment                bool
 	MockKubernetesClient                    *MockKubernetesClient
 	FakeListVirtualMachineScaleSetsResult   func() []compute.VirtualMachineScaleSet
+	FakeListVirtualMachineResult            func() []compute.VirtualMachine
 	FakeListVirtualMachineScaleSetVMsResult func() []compute.VirtualMachineScaleSetVM
 }
 
@@ -455,10 +462,14 @@ func (mc *MockAKSEngineClient) ListVirtualMachines(ctx context.Context, resource
 		}, errors.New("ListVirtualMachines failed")
 	}
 
-	vm1 := mc.MakeFakeVirtualMachine()
-
+	if mc.FakeListVirtualMachineResult == nil {
+		mc.FakeListVirtualMachineResult = func() []compute.VirtualMachine {
+			return []compute.VirtualMachine{mc.MakeFakeVirtualMachine(DefaultFakeVMName, defaultK8sVersionForFakeVMs)}
+		}
+	}
+	vms := mc.FakeListVirtualMachineResult()
 	vmr := compute.VirtualMachineListResult{}
-	vmr.Value = &[]compute.VirtualMachine{vm1}
+	vmr.Value = &vms
 
 	return &MockVirtualMachineListResultPage{
 		Fn: func(lastResults compute.VirtualMachineListResult) (compute.VirtualMachineListResult, error) {
@@ -497,7 +508,7 @@ func (mc *MockAKSEngineClient) GetVirtualMachine(ctx context.Context, resourceGr
 	if mc.FailGetVirtualMachine {
 		return compute.VirtualMachine{}, errors.New("GetVirtualMachine failed")
 	}
-	return mc.MakeFakeVirtualMachine(), nil
+	return mc.MakeFakeVirtualMachine(DefaultFakeVMName, defaultK8sVersionForFakeVMs), nil
 }
 
 // MakeFakeVirtualMachineScaleSetVM creates a fake VMSS VM
@@ -551,8 +562,8 @@ func (mc *MockAKSEngineClient) MakeFakeVirtualMachineScaleSetVM(orchestratorTag 
 }
 
 //MakeFakeVirtualMachine returns a fake compute.VirtualMachine
-func (mc *MockAKSEngineClient) MakeFakeVirtualMachine() compute.VirtualMachine {
-	vm1Name := "k8s-agentpool1-12345678-0"
+func (mc *MockAKSEngineClient) MakeFakeVirtualMachine(vmName string, orchestratorVersion string) compute.VirtualMachine {
+	vm1Name := vmName
 
 	creationSourceString := "creationSource"
 	orchestratorString := "orchestrator"
@@ -560,7 +571,7 @@ func (mc *MockAKSEngineClient) MakeFakeVirtualMachine() compute.VirtualMachine {
 	poolnameString := "poolName"
 
 	creationSource := "aksengine-k8s-agentpool1-12345678-0"
-	orchestrator := "Kubernetes:1.9.10"
+	orchestrator := orchestratorVersion
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -86,7 +86,7 @@ func (uc *UpgradeCluster) UpgradeCluster(az armhelpers.AKSEngineClient, kubeConf
 	}
 
 	upgradeVersion := uc.DataModel.Properties.OrchestratorProfile.OrchestratorVersion
-	uc.Logger.Infof("Upgrading to Kubernetes version %s\n", upgradeVersion)
+	uc.Logger.Infof("Upgrading to Kubernetes version %s", upgradeVersion)
 
 	if err := uc.getUpgradeWorkflow(kubeConfig, aksEngineVersion).RunUpgrade(); err != nil {
 		return err

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -147,7 +147,7 @@ func (uc *UpgradeCluster) getClusterNodeStatus(az armhelpers.AKSEngineClient, re
 						uc.Logger.Infof("Skipping VM: %s for upgrade as the orchestrator version could not be determined.", *vm.Name)
 						continue
 					}
-					if currentVersion != goalVersion {
+					if uc.Force || currentVersion != goalVersion {
 						uc.Logger.Infof(
 							"VM %s in VMSS %s has a current version of %s and a desired version of %s. Upgrading this node.",
 							*vm.Name,

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"fmt"
-
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/armhelpers"
 	"github.com/Azure/aks-engine/pkg/i18n"
@@ -215,29 +213,6 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		err := uc.UpgradeCluster(&mockClient, "kubeConfig", TestAKSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("DeleteNetworkInterface failed"))
-	})
-
-	It("Should return error message when failing on ClusterPreflightCheck operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.9.0", 3, 3, false)
-		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
-		}
-
-		mockClient := armhelpers.MockAKSEngineClient{}
-		uc.Client = &mockClient
-
-		uc.ClusterTopology = ClusterTopology{}
-		uc.SubscriptionID = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
-		uc.ResourceGroup = "TestRg"
-		uc.DataModel = cs
-		uc.NameSuffix = "12345678"
-		uc.AgentPoolsToUpgrade = map[string]bool{"agentpool1": true}
-
-		err := uc.UpgradeCluster(&mockClient, "kubeConfig", TestAKSEngineVersion)
-		Expect(err).NotTo(BeNil())
-		fmt.Print("GOT :   ", err.Error())
-		Expect(err.Error()).To(ContainSubstring("Error while querying ARM for resources: 1.9.10 cannot be upgraded to 1.9.0"))
 	})
 
 	It("Should return error message when failing to delete role assignment during upgrade operation", func() {

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -241,7 +241,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		Expect(err.Error()).To(Equal("DeleteRoleAssignmentByID failed"))
 	})
 
-	PIt("Should skip VMSS VMs that are already on desired version", func() {
+	It("Should skip VMSS VMs that are already on desired version", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -241,47 +241,97 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		Expect(err.Error()).To(Equal("DeleteRoleAssignmentByID failed"))
 	})
 
-	It("Should skip VMSS VMs that are already on desired version", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
-		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
-		}
-
-		mockClient := armhelpers.MockAKSEngineClient{}
-		mockClient.FakeListVirtualMachineScaleSetsResult = func() []compute.VirtualMachineScaleSet {
-			scalesetName := "scalesetName"
-			sku := compute.Sku{}
-			location := "eastus"
-			return []compute.VirtualMachineScaleSet{
-				{
-					Name:     &scalesetName,
-					Sku:      &sku,
-					Location: &location,
-				},
+	Context("When upgrading a cluster with VMSS VMs", func() {
+		var cs *api.ContainerService
+		var uc UpgradeCluster
+		var mockClient armhelpers.MockAKSEngineClient
+		BeforeEach(func() {
+			mockClient = armhelpers.MockAKSEngineClient{}
+			cs = api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
+			uc = UpgradeCluster{
+				Translator: &i18n.Translator{},
+				Logger:     log.NewEntry(log.New()),
 			}
-		}
-		mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
-			return []compute.VirtualMachineScaleSetVM{
-				mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.10"),
-				mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.9"),
-				mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.7"),
-				mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.10"),
+			mockClient.FakeListVirtualMachineScaleSetsResult = func() []compute.VirtualMachineScaleSet {
+				scalesetName := "scalesetName"
+				sku := compute.Sku{}
+				location := "eastus"
+				return []compute.VirtualMachineScaleSet{
+					{
+						Name:     &scalesetName,
+						Sku:      &sku,
+						Location: &location,
+					},
+				}
 			}
-		}
-		uc.Client = &mockClient
+			uc.Client = &mockClient
+			uc.ClusterTopology = ClusterTopology{}
+			uc.SubscriptionID = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
+			uc.ResourceGroup = "TestRg"
+			uc.DataModel = cs
+			uc.NameSuffix = "12345678"
+			uc.UpgradeWorkFlow = fakeUpgradeWorkflow{}
+		})
 
-		uc.ClusterTopology = ClusterTopology{}
-		uc.SubscriptionID = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
-		uc.ResourceGroup = "TestRg"
-		uc.DataModel = cs
-		uc.NameSuffix = "12345678"
-		uc.AgentPoolsToUpgrade = map[string]bool{"agentpool1": true}
-		uc.UpgradeWorkFlow = fakeUpgradeWorkflow{}
+		It("Should skip VMs that are already on desired version", func() {
+			mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
+				return []compute.VirtualMachineScaleSetVM{
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.10"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.9"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.7"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.10"),
+				}
+			}
+			uc.Force = false
 
-		err := uc.UpgradeCluster(&mockClient, "kubeConfig", TestAKSEngineVersion)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(uc.AgentPoolScaleSetsToUpgrade[0].VMsToUpgrade).To(HaveLen(2))
+			err := uc.UpgradeCluster(&mockClient, "kubeConfig", TestAKSEngineVersion)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uc.AgentPoolScaleSetsToUpgrade[0].VMsToUpgrade).To(HaveLen(2))
+		})
+
+		It("Should skip VMs that cannot determine version", func() {
+			mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
+				return []compute.VirtualMachineScaleSetVM{
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.7"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:"),
+				}
+			}
+			uc.Force = false
+
+			err := uc.UpgradeCluster(&mockClient, "kubeConfig", TestAKSEngineVersion)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uc.AgentPoolScaleSetsToUpgrade[0].VMsToUpgrade).To(HaveLen(1))
+		})
+
+		It("Should not VMs that cannot determine version when using Force", func() {
+			mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
+				return []compute.VirtualMachineScaleSetVM{
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.7"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:"),
+				}
+			}
+			uc.Force = true
+
+			err := uc.UpgradeCluster(&mockClient, "kubeConfig", TestAKSEngineVersion)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uc.AgentPoolScaleSetsToUpgrade[0].VMsToUpgrade).To(HaveLen(2))
+		})
+
+		It("Should not skip any VMs when using Force", func() {
+			mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
+				return []compute.VirtualMachineScaleSetVM{
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.10"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.9"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.7"),
+					mockClient.MakeFakeVirtualMachineScaleSetVM("Kubernetes:1.9.10"),
+				}
+			}
+			uc.Force = true
+
+			err := uc.UpgradeCluster(&mockClient, "kubeConfig", TestAKSEngineVersion)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uc.AgentPoolScaleSetsToUpgrade[0].VMsToUpgrade).To(HaveLen(4))
+		})
 	})
 
 	It("Should not fail if no managed identity is returned by azure during upgrade operation", func() {


### PR DESCRIPTION
**Is this a request for help?**:  
No

---
**Is this an ISSUE or FEATURE REQUEST?** (choose one):
Feature Proposal

---

**description**:
We want to be able to force the upgrade process on a cluster without changing the kubernetes version. This will ensure that all components of the cluster are healthy and using the latest validated version for a given kubernetes version.

**proposed cli**: 
For an existing kubernetes `1.12.5` cluster, we want the following command to go through each nodes of the cluster and "refresh" them if necessary (update to latest valid version).

```bash
> aks-engine upgrade --force --location westus --resource-group rg --subsctiption $sub --upgrade-version 1.12.5
```

**Open questions**: 
- What should the behavior of the `--force` flag be for a usual next k8s version upgrade?
Same behavior

- What happens for same-version upgrade?
A: Currently, when a node is already on the requested version, the upgrade either fail validation, or the node upgrade ends up being a no-op. `--force` runs the upgrade process on these nodes as well

- Should the --force flag allow other arbitrary upgrade (not valid per our `get-versions` matrix)? 
A : yes, using --force will allow any arbitrary version jump, or even downgrade. You're on your own.

**Related**
implements #522 
https://github.com/Azure/acs-engine/pull/3810