### PR TITLE
feat: add human-readable output option to "get-versions" command

### DIFF
--- a/cmd/get_versions.go
+++ b/cmd/get_versions.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -82,7 +81,7 @@ func (gvc *getVersionsCmd) run(cmd *cobra.Command, args []string) error {
 		}
 		w.Flush()
 	default:
-		return errors.New(fmt.Sprintf("Output format \"%s\" is not supported.", gvc.output))
+		return fmt.Errorf("output format \"%s\" is not supported", gvc.output)
 	}
 
 	return nil

--- a/cmd/get_versions.go
+++ b/cmd/get_versions.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/Azure/aks-engine/pkg/api"
@@ -17,6 +18,10 @@ const (
 	getVersionsName             = "get-versions"
 	getVersionsShortDescription = "Display info about supported Kubernetes versions"
 	getVersionsLongDescription  = "Display supported Kubernetes versions and upgrade versions"
+)
+
+var (
+	getVersionsOutputFormatOptions = []string{"human", "json"}
 )
 
 type getVersionsCmd struct {
@@ -43,7 +48,9 @@ func newGetVersionsCmd() *cobra.Command {
 	gvc.orchestrator = "Kubernetes" // orchestrator is always Kubernetes
 	f.StringVar(&gvc.version, "version", "", "Kubernetes version (optional)")
 	f.BoolVar(&gvc.windows, "windows", false, "Kubernetes cluster with Windows nodes (optional)")
-	f.StringVarP(&gvc.output, "output", "o", "table", "Output format. Allowed values: json, table.")
+	getVersionsCmdDescription := fmt.Sprintf("Output format. Allowed values: %s",
+		strings.Join(getVersionsOutputFormatOptions, ", "))
+	f.StringVarP(&gvc.output, "output", "o", "human", getVersionsCmdDescription)
 
 	return command
 }
@@ -61,7 +68,7 @@ func (gvc *getVersionsCmd) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		fmt.Println(string(data))
-	case "table":
+	case "human":
 		w := tabwriter.NewWriter(os.Stdout, 0, 4, 1, ' ', tabwriter.FilterHTML)
 		fmt.Fprintln(w, "Version\tUpgrades")
 		// iterate in reverse so the newest Kubernetes release is listed first

--- a/cmd/get_versions.go
+++ b/cmd/get_versions.go
@@ -43,7 +43,7 @@ func newGetVersionsCmd() *cobra.Command {
 	gvc.orchestrator = "Kubernetes" // orchestrator is always Kubernetes
 	f.StringVar(&gvc.version, "version", "", "Kubernetes version (optional)")
 	f.BoolVar(&gvc.windows, "windows", false, "Kubernetes cluster with Windows nodes (optional)")
-	f.StringVarP(&gvc.output, "output", "o", "json", "Output format. Allowed values: json, table.")
+	f.StringVarP(&gvc.output, "output", "o", "table", "Output format. Allowed values: json, table.")
 
 	return command
 }

--- a/cmd/get_versions.go
+++ b/cmd/get_versions.go
@@ -20,10 +20,6 @@ const (
 	getVersionsLongDescription  = "Display supported Kubernetes versions and upgrade versions"
 )
 
-var (
-	getVersionsOutputFormatOptions = []string{"human", "json"}
-)
-
 type getVersionsCmd struct {
 	// user input
 	orchestrator string
@@ -49,7 +45,7 @@ func newGetVersionsCmd() *cobra.Command {
 	f.StringVar(&gvc.version, "version", "", "Kubernetes version (optional)")
 	f.BoolVar(&gvc.windows, "windows", false, "Kubernetes cluster with Windows nodes (optional)")
 	getVersionsCmdDescription := fmt.Sprintf("Output format. Allowed values: %s",
-		strings.Join(getVersionsOutputFormatOptions, ", "))
+		strings.Join(outputFormatOptions, ", "))
 	f.StringVarP(&gvc.output, "output", "o", "human", getVersionsCmdDescription)
 
 	return command

--- a/cmd/get_versions_test.go
+++ b/cmd/get_versions_test.go
@@ -18,4 +18,35 @@ var _ = Describe("The get-versions command", func() {
 		Expect(output.Flags().Lookup("orchestrator")).To(BeNil())
 		Expect(output.Flags().Lookup("version")).NotTo(BeNil())
 	})
+
+	It("should support JSON output", func() {
+		command := &getVersionsCmd{
+			orchestrator: "kubernetes",
+			version:      "1.13.3",
+			output:       "json",
+		}
+		err := command.run(nil, nil)
+		Expect(err).To(BeNil())
+	})
+
+	It("should support table output", func() {
+		command := &getVersionsCmd{
+			orchestrator: "kubernetes",
+			version:      "1.13.3",
+			output:       "table",
+		}
+		err := command.run(nil, nil)
+		Expect(err).To(BeNil())
+	})
+
+	It("should error on an invalid output option", func() {
+		command := &getVersionsCmd{
+			orchestrator: "kubernetes",
+			version:      "1.13.3",
+			output:       "yaml",
+		}
+		err := command.run(nil, nil)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("output format \"yaml\" is not supported"))
+	})
 })

--- a/cmd/get_versions_test.go
+++ b/cmd/get_versions_test.go
@@ -29,11 +29,11 @@ var _ = Describe("The get-versions command", func() {
 		Expect(err).To(BeNil())
 	})
 
-	It("should support table output", func() {
+	It("should support human-readable output", func() {
 		command := &getVersionsCmd{
 			orchestrator: "kubernetes",
 			version:      "1.13.3",
-			output:       "table",
+			output:       "human",
 		}
 		err := command.run(nil, nil)
 		Expect(err).To(BeNil())

--- a/cmd/orchestrators.go
+++ b/cmd/orchestrators.go
@@ -4,10 +4,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/Azure/aks-engine/pkg/api"
-	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/spf13/cobra"
 )
 
@@ -17,45 +13,23 @@ const (
 	orchestratorsLongDescription  = "Display supported versions and upgrade versions for each orchestrator"
 )
 
-type orchestratorsCmd struct {
-	// user input
-	orchestrator string
-	version      string
-	windows      bool
-}
-
 func newOrchestratorsCmd() *cobra.Command {
-	oc := orchestratorsCmd{}
+	gvc := getVersionsCmd{}
 
 	command := &cobra.Command{
 		Use:   orchestratorsName,
 		Short: orchestratorsShortDescription,
 		Long:  orchestratorsLongDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return oc.run(cmd, args)
+			return gvc.run(cmd, args)
 		},
 		Hidden: true,
 	}
 
 	f := command.Flags()
-	f.StringVar(&oc.orchestrator, "orchestrator", "", "orchestrator name (optional) ")
-	f.StringVar(&oc.version, "version", "", "orchestrator version (optional)")
-	f.BoolVar(&oc.windows, "windows", false, "orchestrator platform (optional, applies to Kubernetes only)")
+	f.StringVar(&gvc.orchestrator, "orchestrator", "", "orchestrator name (optional) ")
+	f.StringVar(&gvc.version, "version", "", "orchestrator version (optional)")
+	f.BoolVar(&gvc.windows, "windows", false, "orchestrator platform (optional, applies to Kubernetes only)")
 
 	return command
-}
-
-func (oc *orchestratorsCmd) run(cmd *cobra.Command, args []string) error {
-	orchs, err := api.GetOrchestratorVersionProfileListVLabs(oc.orchestrator, oc.version, oc.windows)
-	if err != nil {
-		return err
-	}
-
-	data, err := helpers.JSONMarshalIndent(orchs, "", "  ", false)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(data))
-	return nil
 }

--- a/cmd/orchestrators.go
+++ b/cmd/orchestrators.go
@@ -30,6 +30,7 @@ func newOrchestratorsCmd() *cobra.Command {
 	f.StringVar(&gvc.orchestrator, "orchestrator", "", "orchestrator name (optional) ")
 	f.StringVar(&gvc.version, "version", "", "orchestrator version (optional)")
 	f.BoolVar(&gvc.windows, "windows", false, "orchestrator platform (optional, applies to Kubernetes only)")
+	gvc.output = "json" // output is always JSON
 
 	return command
 }

--- a/cmd/orchestrators_test.go
+++ b/cmd/orchestrators_test.go
@@ -54,6 +54,7 @@ var _ = Describe("The orchestrators command", func() {
 		command := &getVersionsCmd{
 			orchestrator: "kubernetes",
 			version:      "1.7.14",
+			output:       "json",
 		}
 
 		err := command.run(nil, nil)

--- a/cmd/orchestrators_test.go
+++ b/cmd/orchestrators_test.go
@@ -20,7 +20,7 @@ var _ = Describe("The orchestrators command", func() {
 	})
 
 	It("should fail on unsupported orchestrator", func() {
-		command := &orchestratorsCmd{
+		command := &getVersionsCmd{
 			orchestrator: "unsupported",
 		}
 
@@ -30,7 +30,7 @@ var _ = Describe("The orchestrators command", func() {
 	})
 
 	It("should fail on unprovided orchestrator", func() {
-		command := &orchestratorsCmd{
+		command := &getVersionsCmd{
 			version: "1.1.1",
 		}
 
@@ -40,7 +40,7 @@ var _ = Describe("The orchestrators command", func() {
 	})
 
 	It("should fail on unsupported version", func() {
-		command := &orchestratorsCmd{
+		command := &getVersionsCmd{
 			orchestrator: "kubernetes",
 			version:      "1.1.1",
 		}
@@ -51,7 +51,7 @@ var _ = Describe("The orchestrators command", func() {
 	})
 
 	It("should succeed", func() {
-		command := &orchestratorsCmd{
+		command := &getVersionsCmd{
 			orchestrator: "kubernetes",
 			version:      "1.7.14",
 		}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Azure/aks-engine/pkg/helpers"
 	log "github.com/sirupsen/logrus"
@@ -86,7 +87,8 @@ func newVersionCmd() *cobra.Command {
 		},
 	}
 
-	versionCmdDescription := fmt.Sprintf("Output format to use: %s", outputFormatOptions)
+	versionCmdDescription := fmt.Sprintf("Output format. Allowed values: %s",
+		strings.Join(outputFormatOptions, ", "))
 
 	versionCmd.Flags().StringVarP(&outputFormat, "output", "o", "human", versionCmdDescription)
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -70,7 +70,7 @@ func getVersion(outputType string) string {
 	} else if outputType == "json" {
 		output = getJSONVersion()
 	} else {
-		log.Fatalf("unsupported output format: %s\n", outputFormat)
+		log.Fatalf("output format \"%s\" is not supported", outputFormat)
 	}
 
 	return output


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The `aks-engine get-versions` command added in #448 defaults to JSON output that is hard to read. This adds the `--output=human` argument which acts similarly to `az aks get-versions --output table`:

```sh
$ ./bin/aks-engine get-versions -o human
Version        Upgrades
1.14.0-alpha.1 
1.13.3         1.14.0-alpha.1
1.13.2         1.13.3, 1.14.0-alpha.1
1.12.5         1.13.2, 1.13.3
1.12.4         1.12.5, 1.13.2, 1.13.3
1.11.7         1.12.4, 1.12.5
1.11.6         1.11.7, 1.12.4, 1.12.5
1.10.13        1.11.6, 1.11.7
1.10.12        1.10.13, 1.11.6, 1.11.7
1.9.11         1.10.12, 1.10.13
1.9.10         1.9.11, 1.10.12, 1.10.13
1.6.9          1.9.10, 1.9.11
```


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #520

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Should we make the table output the default?
