### PR TITLE
feat: enable configurable --enforce-node-allocatable

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -272,6 +272,7 @@ Below is a list of kubelet options that aks-engine will configure by default:
 | "--pod-max-pids"                    | "100" (need to activate the feature in --feature-gates=SupportPodPidsLimit=true)                                                                              |
 | "--image-pull-progress-deadline"    | "30m"                                                                                                                                                         |
 | "--feature-gates"                   | No default (can be a comma-separated list). On agent nodes `Accelerators=true` will be applied in the `--feature-gates` option for k8s versions before 1.11.0 |
+| "--enforce-node-allocatable"        | "pods" |
 
 Below is a list of kubelet options that are _not_ currently user-configurable, either because a higher order configuration vector is available that enforces kubelet configuration, or because a static configuration is required to build a functional cluster:
 
@@ -283,7 +284,6 @@ Below is a list of kubelet options that are _not_ currently user-configurable, e
 | "--network-plugin"                           | "cni"                                            |
 | "--node-labels"                              | (based on Azure node metadata)                   |
 | "--cgroups-per-qos"                          | "true"                                           |
-| "--enforce-node-allocatable"                 | "pods"                                           |
 | "--kubeconfig"                               | "/var/lib/kubelet/kubeconfig"                    |
 | "--register-node" (master nodes only)        | "true"                                           |
 | "--register-with-taints" (master nodes only) | "node-role.kubernetes.io/master=true:NoSchedule" |

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -23,7 +23,6 @@ func (cs *ContainerService) setKubeletConfig() {
 		"--pod-manifest-path":           "/etc/kubernetes/manifests",
 		"--cluster-dns":                 o.KubernetesConfig.DNSServiceIP,
 		"--cgroups-per-qos":             "true",
-		"--enforce-node-allocatable":    "pods",
 		"--kubeconfig":                  "/var/lib/kubelet/kubeconfig",
 		"--keep-terminated-pod-volumes": "false",
 	}
@@ -66,6 +65,7 @@ func (cs *ContainerService) setKubeletConfig() {
 		"--cadvisor-port":                   DefaultKubeletCadvisorPort,
 		"--pod-max-pids":                    strconv.Itoa(DefaultKubeletPodMaxPIDs),
 		"--image-pull-progress-deadline":    "30m",
+		"--enforce-node-allocatable":        "pods",
 	}
 
 	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -291,3 +291,28 @@ func TestKubeletIPMasqAgentEnabledOrDisabled(t *testing.T) {
 			k["--non-masquerade-cidr"], DefaultNonMasqueradeCIDR)
 	}
 }
+
+func TestEnforceNodeAllocatable(t *testing.T) {
+	// Validate default
+	cs := CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.setKubeletConfig()
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--enforce-node-allocatable"] != "pods" {
+		t.Fatalf("got unexpected '--enforce-node-allocatable' kubelet config value %s, the expected value is %s",
+			k["--enforce-node-allocatable"], "pods")
+	}
+
+	// Validate that --enforce-node-allocatable is overridable
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		KubeletConfig: map[string]string{
+			"--enforce-node-allocatable": "kube-reserved/system-reserved",
+		},
+	}
+	cs.setKubeletConfig()
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--enforce-node-allocatable"] != "kube-reserved/system-reserved" {
+		t.Fatalf("got unexpected '--enforce-node-allocatable' kubelet config value %s, the expected value is %s",
+			k["--enforce-node-allocatable"], "kube-reserved/system-reserved")
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Enable configurable `--enforce-node-allocatable` kubelet flag to unblock scenarios such as described in #507.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #507 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: