### PR TITLE
test: use "k" script to fetch the right kubectl just-in-time

### DIFF
--- a/docs/community/developer-guide.md
+++ b/docs/community/developer-guide.md
@@ -194,6 +194,10 @@ environment variables to be set:
 * `SUBSCRIPTION_ID`: Azure subscription UUID
 * `TENANT_ID`: Azure tenant UUID
 
+The end-to-end tests also require the [`k`](https://github.com/jakepearson/k)
+script to be your the search $PATH. This ensures that testing uses a `kubectl`
+client that matches the version of the Kubernetes server.
+
 ### Debugging
 
 For aks-engine code debugging you can use [Delve](https://github.com/derekparker/delve) debugger.

--- a/docs/community/developer-guide.md
+++ b/docs/community/developer-guide.md
@@ -195,7 +195,7 @@ environment variables to be set:
 * `TENANT_ID`: Azure tenant UUID
 
 The end-to-end tests also require the [`k`](https://github.com/jakepearson/k)
-script to be your the search $PATH. This ensures that testing uses a `kubectl`
+script to be in your search $PATH. This ensures that testing uses a `kubectl`
 client that matches the version of the Kubernetes server.
 
 ### Debugging

--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -1,7 +1,7 @@
 function test_linux_deployment() {
   ###### Testing an nginx deployment
   log "Testing deployments"
-  kubectl create namespace ${namespace}
+  k create namespace ${namespace}
 
   NGINX="docker.io/library/nginx:latest"
   IMAGE="${NGINX}" # default to the library image unless we're in TEST_ACR mode
@@ -17,28 +17,28 @@ function test_linux_deployment() {
     docker push "${IMAGE}"
   fi
 
-  kubectl run --image="${IMAGE}" nginx --namespace=${namespace} --overrides='{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
+  k run --image="${IMAGE}" nginx --namespace=${namespace} --overrides='{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
   count=12
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    running=$(kubectl get pods --namespace=${namespace} | grep nginx | grep Running | wc | awk '{print $1}')
+    running=$(k get pods --namespace=${namespace} | grep nginx | grep Running | wc | awk '{print $1}')
     if (( ${running} == 1 )); then break; fi
       sleep 5; count=$((count-1))
   done
   if (( ${running} != 1 )); then
     log "K8S-Linux: gave up waiting for deployment"
-    kubectl get all --namespace=${namespace}
+    k get all --namespace=${namespace}
     exit 1
   fi
 
-  kubectl expose deployments/nginx --type=LoadBalancer --namespace=${namespace} --port=80
+  k expose deployments/nginx --type=LoadBalancer --namespace=${namespace} --port=80
 
   log "Checking Service External IP"
   count=60
   external_ip=""
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    external_ip=$(kubectl get svc --namespace ${namespace} nginx --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}" || echo "")
+    external_ip=$(k get svc --namespace ${namespace} nginx --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}" || echo "")
     [[ ! -z "${external_ip}" ]] && break
     sleep 10; count=$((count-1))
   done
@@ -70,17 +70,17 @@ function test_windows_deployment() {
   log "Testing Windows deployments"
 
   log "Creating simpleweb service"
-  kubectl apply -f "$DIR/simpleweb-windows.yaml"
+  k apply -f "$DIR/simpleweb-windows.yaml"
   count=90
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    running=$(kubectl get pods --namespace=default | grep win-webserver | grep Running | wc | awk '{print $1}')
+    running=$(k get pods --namespace=default | grep win-webserver | grep Running | wc | awk '{print $1}')
     if (( ${running} == 1 )); then break; fi
     sleep 10; count=$((count-1))
   done
   if (( ${running} != 1 )); then
     log "K8S-Windows: gave up waiting for deployment"
-    kubectl get all --namespace=default
+    k get all --namespace=default
     exit 1
   fi
 
@@ -89,7 +89,7 @@ function test_windows_deployment() {
   external_ip=""
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    external_ip=$(kubectl get svc --namespace default win-webserver --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}" || echo "")
+    external_ip=$(k get svc --namespace default win-webserver --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}" || echo "")
     [[ ! -z "${external_ip}" ]] && break
     sleep 10; count=$((count-1))
   done
@@ -119,7 +119,7 @@ function test_windows_deployment() {
   count=10
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    winpodname=$(kubectl get pods --namespace=default | grep win-webserver | awk '{print $1}')
+    winpodname=$(k get pods --namespace=default | grep win-webserver | awk '{print $1}')
     [[ ! -z "${winpodname}" ]] && break
     sleep 10; count=$((count-1))
   done
@@ -133,7 +133,7 @@ function test_windows_deployment() {
   success="y" # disabled while outbound connection bug is present
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    query=$(kubectl exec $winpodname -- powershell nslookup www.bing.com)
+    query=$(k exec $winpodname -- powershell nslookup www.bing.com)
     if [[ $(echo ${query} | grep "DNS request timed out" | wc -l) == 0 ]] && [[ $(echo ${query} | grep "UnKnown" | wc -l) == 0 ]]; then
       success="y"
       break
@@ -149,9 +149,9 @@ function test_windows_deployment() {
   while (( $count > 0 )); do
     log "  ... counting down $count"
     # curl without getting status first and see the response. getting status sometimes has the problem to hang
-    # and it doesn't repro when running kubectl from the node
-    kubectl exec $winpodname -- powershell iwr -UseBasicParsing -TimeoutSec 60 www.bing.com
-    statuscode=$(kubectl exec $winpodname -- powershell iwr -UseBasicParsing -TimeoutSec 60 www.bing.com | grep StatusCode)
+    # and it doesn't repro when running k from the node
+    k exec $winpodname -- powershell iwr -UseBasicParsing -TimeoutSec 60 www.bing.com
+    statuscode=$(k exec $winpodname -- powershell iwr -UseBasicParsing -TimeoutSec 60 www.bing.com | grep StatusCode)
     if [[ ${statuscode} != "" ]] && [[ $(echo ${statuscode} | grep 200 | awk '{print $3}' | tr -d '\r') -eq "200" ]]; then
       log "got 200 status code"
       log "${statuscode}"
@@ -159,19 +159,19 @@ function test_windows_deployment() {
       break
     fi
     log "curl failed, retrying..."
-    ipconfig=$(kubectl exec $winpodname -- powershell ipconfig /all)
+    ipconfig=$(k exec $winpodname -- powershell ipconfig /all)
     log "$ipconfig"
     # TODO: reduce sleep time when outbound connection delay is fixed
     sleep 100; count=$((count-1))
   done
   set -e
   if [[ "${success}" != "y" ]]; then
-    nslookup=$(kubectl exec $winpodname -- powershell nslookup www.bing.com)
+    nslookup=$(k exec $winpodname -- powershell nslookup www.bing.com)
     log "$nslookup"
     log "getting the last 50 events to check timeout failure"
-    hdr=$(kubectl get events | head -n 1)
+    hdr=$(k get events | head -n 1)
     log "$hdr"
-    evt=$(kubectl get events | tail -n 50)
+    evt=$(k get events | tail -n 50)
     log "$evt"
     log "K8S-Windows: failed to get outbound internet connection inside simpleweb container"
     exit 1

--- a/test/cluster-tests/kubernetes/test.sh
+++ b/test/cluster-tests/kubernetes/test.sh
@@ -43,10 +43,10 @@ log "Running test in namespace: ${namespace}"
 trap teardown EXIT
 
 function teardown {
-  kubectl get all --all-namespaces || echo "teardown error"
-  kubectl get nodes || echo "teardown error"
-  kubectl get namespaces || echo "teardown error"
-  kubectl delete namespaces ${namespace} || echo "teardown error"
+  k get all --all-namespaces || echo "teardown error"
+  k get nodes || echo "teardown error"
+  k get namespaces || echo "teardown error"
+  k delete namespaces ${namespace} || echo "teardown error"
 }
 
 # TODO: cleanup the loops more
@@ -67,7 +67,7 @@ function check_node_count() {
   count=120
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    node_count=$(kubectl get nodes --no-headers | grep -v NotReady | grep Ready | wc | awk '{print $1}')
+    node_count=$(k get nodes --no-headers | grep -v NotReady | grep Ready | wc | awk '{print $1}')
     if (( ${node_count} == ${EXPECTED_NODE_COUNT} )); then break; fi
     sleep 5; count=$((count-1))
   done
@@ -79,7 +79,7 @@ function check_node_count() {
 check_node_count
 
 ###### Validate Kubernetes version
-kubernetes_version=$(kubectl version --short)
+kubernetes_version=$(k version --short)
 DASHBOARD_PORT=80
 if [[ ${kubernetes_version} == *"Server Version: v1.9."* ]]; then
   DASHBOARD_PORT=443
@@ -98,7 +98,7 @@ log "Checking containers being created"
 count=60
 while (( $count > 0 )); do
   log "  ... counting down $count"
-  creating_count=$(kubectl get nodes --no-headers | grep 'CreatingContainer' | wc | awk '{print $1}')
+  creating_count=$(k get nodes --no-headers | grep 'CreatingContainer' | wc | awk '{print $1}')
   if (( ${creating_count} == 0 )); then break; fi
   sleep 5; count=$((count-1))
 done
@@ -118,7 +118,7 @@ log "Checking $pods"
 count=60
 while (( $count > 0 )); do
   for pod in $pods; do
-    running=$(kubectl get pods --all-namespaces | grep $pod | grep Running | wc -l)
+    running=$(k get pods --all-namespaces | grep $pod | grep Running | wc -l)
     if (( $running > 0 )); then
       log "... $pod is Running"
       pods=$(echo $pods | sed -e "s/ *$pod */ /")
@@ -139,7 +139,7 @@ log "Checking Kube-DNS"
 count=60
 while (( $count > 0 )); do
   log "  ... counting down $count"
-  running=$(kubectl get pods --namespace=kube-system | grep kube-dns | grep Running | wc | awk '{print $1}')
+  running=$(k get pods --namespace=kube-system | grep kube-dns | grep Running | wc | awk '{print $1}')
   if (( ${running} == ${EXPECTED_DNS} )); then break; fi
   sleep 5; count=$((count-1))
 done
@@ -153,7 +153,7 @@ if (( ${EXPECTED_DASHBOARD} != 0 )); then
   count=60
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    running=$(kubectl get pods --namespace=kube-system | grep kubernetes-dashboard | grep Running | wc | awk '{print $1}')
+    running=$(k get pods --namespace=kube-system | grep kubernetes-dashboard | grep Running | wc | awk '{print $1}')
     if (( ${running} == ${EXPECTED_DASHBOARD} )); then break; fi
     sleep 5; count=$((count-1))
   done
@@ -169,7 +169,7 @@ log "Checking Kube-Proxys"
 count=60
 while (( $count > 0 )); do
   log "  ... counting down $count"
-  running=$(kubectl get pods --namespace=kube-system | grep kube-proxy | grep Running | wc | awk '{print $1}')
+  running=$(k get pods --namespace=kube-system | grep kube-proxy | grep Running | wc | awk '{print $1}')
   if (( ${running} == ${KUBE_PROXY_COUNT} )); then break; fi
   sleep 5; count=$((count-1))
 done
@@ -180,11 +180,11 @@ fi
 if ! [ $EXPECTED_WINDOWS_AGENTS -gt 0 ] ; then
   if (( ${EXPECTED_DASHBOARD} != 0 )); then
     # get master public hostname
-    master=$(kubectl config view | grep server | cut -f 3- -d "/" | tr -d " ")
+    master=$(k config view | grep server | cut -f 3- -d "/" | tr -d " ")
     # get dashboard port
-    port=$(kubectl get svc --namespace=kube-system | grep dashboard | awk '{print $4}' | sed -n 's/^'${DASHBOARD_PORT}':\(.*\)\/TCP$/\1/p')
+    port=$(k get svc --namespace=kube-system | grep dashboard | awk '{print $4}' | sed -n 's/^'${DASHBOARD_PORT}':\(.*\)\/TCP$/\1/p')
     # get internal IPs of the nodes
-    ips=$(kubectl get nodes --all-namespaces -o yaml | grep -B 1 InternalIP | grep address | awk '{print $3}')
+    ips=$(k get nodes --all-namespaces -o yaml | grep -B 1 InternalIP | grep address | awk '{print $3}')
 
     for ip in $ips; do
       log "Probing IP address ${ip}"

--- a/test/common.sh
+++ b/test/common.sh
@@ -87,7 +87,7 @@ function set_azure_account() {
 	[[ ! -z "${TENANT_ID:-}" ]] || (echo "Must specify TENANT_ID" && exit -1)
 	[[ ! -z "${SERVICE_PRINCIPAL_CLIENT_ID:-}" ]] || (echo "Must specify SERVICE_PRINCIPAL_CLIENT_ID" && exit -1)
 	[[ ! -z "${SERVICE_PRINCIPAL_CLIENT_SECRET:-}" ]] || (echo "Must specify SERVICE_PRINCIPAL_CLIENT_SECRET" && exit -1)
-	which kubectl || (echo "kubectl must be on PATH" && exit -1)
+	which k || (echo "k must be on PATH" && exit -1)
 	which az || (echo "az must be on PATH" && exit -1)
 
 	# Login to Azure-Cli
@@ -116,7 +116,7 @@ function deploy_template() {
 	[[ ! -z "${RESOURCE_GROUP:-}" ]] || (echo "Must specify RESOURCE_GROUP" && exit -1)
 	[[ ! -z "${OUTPUT:-}" ]] || (echo "Must specify OUTPUT" && exit -1)
 
-	which kubectl || (echo "kubectl must be on PATH" && exit -1)
+	which k || (echo "k must be on PATH" && exit -1)
 	which az || (echo "az must be on PATH" && exit -1)
 
 	create_resource_group

--- a/test/e2e/kubernetes/config.go
+++ b/test/e2e/kubernetes/config.go
@@ -30,7 +30,7 @@ type ClusterInfo struct {
 
 // GetConfig returns a Config value representing the current kubeconfig
 func GetConfig() (*Config, error) {
-	cmd := exec.Command("kubectl", "config", "view", "-o", "json")
+	cmd := exec.Command("k", "config", "view", "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -67,9 +67,9 @@ func CreateLinuxDeploy(image, name, namespace, miscOpts string) (*Deployment, er
 	var cmd *exec.Cmd
 	overrides := `{ "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}`
 	if miscOpts != "" {
-		cmd = exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--overrides", overrides, miscOpts)
+		cmd = exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--overrides", overrides, miscOpts)
 	} else {
-		cmd = exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--overrides", overrides)
+		cmd = exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--overrides", overrides)
 	}
 	out, err := util.RunAndLogCommand(cmd)
 	if err != nil {
@@ -98,7 +98,7 @@ func CreateLinuxDeployIfNotExist(image, name, namespace, miscOpts string) (*Depl
 // --overrides=' "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
 func RunLinuxDeploy(image, name, namespace, command string, replicas int) (*Deployment, error) {
 	overrides := `{ "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}`
-	cmd := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--replicas", strconv.Itoa(replicas), "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command)
+	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--replicas", strconv.Itoa(replicas), "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command)
 	out, err := util.RunAndLogCommand(cmd)
 	if err != nil {
 		log.Printf("Error trying to deploy %s [%s] in namespace %s:%s\n", name, image, namespace, string(out))
@@ -115,7 +115,7 @@ func RunLinuxDeploy(image, name, namespace, command string, replicas int) (*Depl
 // CreateWindowsDeploy will crete a deployment for a given image with a name in a namespace
 func CreateWindowsDeploy(image, name, namespace string, port int, hostport int) (*Deployment, error) {
 	overrides := `{ "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}}}`
-	cmd := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--port", strconv.Itoa(port), "--hostport", strconv.Itoa(hostport), "--overrides", overrides)
+	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--port", strconv.Itoa(port), "--hostport", strconv.Itoa(hostport), "--overrides", overrides)
 	out, err := util.RunAndLogCommand(cmd)
 	if err != nil {
 		log.Printf("Error trying to deploy %s [%s] in namespace %s:%s\n", name, image, namespace, string(out))
@@ -131,7 +131,7 @@ func CreateWindowsDeploy(image, name, namespace string, port int, hostport int) 
 
 // Get returns a deployment from a name and namespace
 func Get(name, namespace string) (*Deployment, error) {
-	cmd := exec.Command("kubectl", "get", "deploy", "-o", "json", "-n", namespace, name)
+	cmd := exec.Command("k", "get", "deploy", "-o", "json", "-n", namespace, name)
 	out, err := util.RunAndLogCommand(cmd)
 	if err != nil {
 		log.Printf("Error while trying to fetch deployment %s in namespace %s:%s\n", name, namespace, string(out))
@@ -151,7 +151,7 @@ func (d *Deployment) Delete(retries int) error {
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {
-		cmd := exec.Command("kubectl", "delete", "deploy", "-n", d.Metadata.Namespace, d.Metadata.Name)
+		cmd := exec.Command("k", "delete", "deploy", "-n", d.Metadata.Namespace, d.Metadata.Name)
 		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
 		if kubectlError != nil {
 			log.Printf("Error while trying to delete deployment %s in namespace %s:%s\n", d.Metadata.Namespace, d.Metadata.Name, string(kubectlOutput))
@@ -166,7 +166,7 @@ func (d *Deployment) Delete(retries int) error {
 
 	if d.Metadata.HasHPA {
 		for i := 0; i < retries; i++ {
-			cmd := exec.Command("kubectl", "delete", "hpa", "-n", d.Metadata.Namespace, d.Metadata.Name)
+			cmd := exec.Command("k", "delete", "hpa", "-n", d.Metadata.Namespace, d.Metadata.Name)
 			kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
 			if kubectlError != nil {
 				log.Printf("Deployment %s has associated HPA but unable to delete in namespace %s:%s\n", d.Metadata.Namespace, d.Metadata.Name, string(kubectlOutput))
@@ -181,7 +181,7 @@ func (d *Deployment) Delete(retries int) error {
 
 // Expose will create a load balancer and expose the deployment on a given port
 func (d *Deployment) Expose(svcType string, targetPort, exposedPort int) error {
-	cmd := exec.Command("kubectl", "expose", "deployment", d.Metadata.Name, "--type", svcType, "-n", d.Metadata.Namespace, "--target-port", strconv.Itoa(targetPort), "--port", strconv.Itoa(exposedPort))
+	cmd := exec.Command("k", "expose", "deployment", d.Metadata.Name, "--type", svcType, "-n", d.Metadata.Namespace, "--target-port", strconv.Itoa(targetPort), "--port", strconv.Itoa(exposedPort))
 	out, err := util.RunAndLogCommand(cmd)
 	if err != nil {
 		log.Printf("Error while trying to expose (%s) target port (%v) for deployment %s in namespace %s on port %v:%s\n", svcType, targetPort, d.Metadata.Name, d.Metadata.Namespace, exposedPort, string(out))
@@ -192,7 +192,7 @@ func (d *Deployment) Expose(svcType string, targetPort, exposedPort int) error {
 
 // ScaleDeployment scales a deployment to n instancees
 func (d *Deployment) ScaleDeployment(n int) error {
-	cmd := exec.Command("kubectl", "scale", fmt.Sprintf("--replicas=%d", n), "deployment", d.Metadata.Name)
+	cmd := exec.Command("k", "scale", fmt.Sprintf("--replicas=%d", n), "deployment", d.Metadata.Name)
 	out, err := util.RunAndLogCommand(cmd)
 	if err != nil {
 		log.Printf("Error while scaling deployment %s to %d pods:%s\n", d.Metadata.Name, n, string(out))
@@ -203,7 +203,7 @@ func (d *Deployment) ScaleDeployment(n int) error {
 
 // CreateDeploymentHPA applies autoscale characteristics to deployment
 func (d *Deployment) CreateDeploymentHPA(cpuPercent, min, max int) error {
-	cmd := exec.Command("kubectl", "autoscale", "deployment", d.Metadata.Name, fmt.Sprintf("--cpu-percent=%d", cpuPercent),
+	cmd := exec.Command("k", "autoscale", "deployment", d.Metadata.Name, fmt.Sprintf("--cpu-percent=%d", cpuPercent),
 		fmt.Sprintf("--min=%d", min), fmt.Sprintf("--max=%d", max))
 	out, err := util.RunAndLogCommand(cmd)
 	if err != nil {

--- a/test/e2e/kubernetes/hpa/hpa.go
+++ b/test/e2e/kubernetes/hpa/hpa.go
@@ -47,7 +47,7 @@ type LoadBalancer struct {
 
 // Get returns the HPA definition specified in a given namespace
 func Get(name, namespace string) (*HPA, error) {
-	cmd := exec.Command("kubectl", "get", "hpa", "-o", "json", "-n", namespace, name)
+	cmd := exec.Command("k", "get", "hpa", "-o", "json", "-n", namespace, name)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -68,7 +68,7 @@ func (h *HPA) Delete(retries int) error {
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {
-		cmd := exec.Command("kubectl", "delete", "hpa", "-n", h.Metadata.Namespace, h.Metadata.Name)
+		cmd := exec.Command("k", "delete", "hpa", "-n", h.Metadata.Namespace, h.Metadata.Name)
 		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
 		if kubectlError != nil {
 			log.Printf("Error while trying to delete service %s in namespace %s:%s\n", h.Metadata.Namespace, h.Metadata.Name, string(kubectlOutput))

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -42,7 +42,7 @@ type Status struct {
 
 // CreateJobFromFile will create a Job from file with a name
 func CreateJobFromFile(filename, name, namespace string) (*Job, error) {
-	cmd := exec.Command("kubectl", "create", "-f", filename)
+	cmd := exec.Command("k", "create", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -59,7 +59,7 @@ func CreateJobFromFile(filename, name, namespace string) (*Job, error) {
 
 // GetAll will return all jobs in a given namespace
 func GetAll(namespace string) (*List, error) {
-	cmd := exec.Command("kubectl", "get", "jobs", "-n", namespace, "-o", "json")
+	cmd := exec.Command("k", "get", "jobs", "-n", namespace, "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -76,7 +76,7 @@ func GetAll(namespace string) (*List, error) {
 
 // Get will return a job with a given name and namespace
 func Get(jobName, namespace string) (*Job, error) {
-	cmd := exec.Command("kubectl", "get", "jobs", jobName, "-n", namespace, "-o", "json")
+	cmd := exec.Command("k", "get", "jobs", jobName, "-n", namespace, "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -168,7 +168,7 @@ func (j *Job) Delete(retries int) error {
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {
-		cmd := exec.Command("kubectl", "delete", "job", "-n", j.Metadata.Namespace, j.Metadata.Name)
+		cmd := exec.Command("k", "delete", "job", "-n", j.Metadata.Namespace, j.Metadata.Name)
 		util.PrintCommand(cmd)
 		kubectlOutput, kubectlError = cmd.CombinedOutput()
 		if kubectlError != nil {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			nodeCount := eng.NodeCount()
 			log.Printf("Checking for %d Ready nodes\n", nodeCount)
 			ready := node.WaitOnReady(nodeCount, 10*time.Second, cfg.Timeout)
-			cmd := exec.Command("kubectl", "get", "nodes", "-o", "wide")
+			cmd := exec.Command("k", "get", "nodes", "-o", "wide")
 			out, _ := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
 			if !ready {
@@ -158,7 +158,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should print all pods", func() {
-			cmd := exec.Command("kubectl", "get", "pods", "--all-namespaces", "-o", "wide")
+			cmd := exec.Command("k", "get", "pods", "--all-namespaces", "-o", "wide")
 			out, err := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
 			if err != nil {
@@ -632,7 +632,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.IsRBACEnabled() {
 				success := false
 				for i := 0; i < 10; i++ {
-					cmd := exec.Command("kubectl", "top", "nodes")
+					cmd := exec.Command("k", "top", "nodes")
 					util.PrintCommand(cmd)
 					out, err := cmd.CombinedOutput()
 					if err == nil {

--- a/test/e2e/kubernetes/namespace/namespace.go
+++ b/test/e2e/kubernetes/namespace/namespace.go
@@ -25,7 +25,7 @@ type Metadata struct {
 
 // Create a namespace with the given name
 func Create(name string) (*Namespace, error) {
-	cmd := exec.Command("kubectl", "create", "namespace", name)
+	cmd := exec.Command("k", "create", "namespace", name)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -46,7 +46,7 @@ func CreateIfNotExist(name string) (*Namespace, error) {
 
 // Get returns a namespace for with a given name
 func Get(name string) (*Namespace, error) {
-	cmd := exec.Command("kubectl", "get", "namespace", name, "-o", "json")
+	cmd := exec.Command("k", "get", "namespace", name, "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -63,7 +63,7 @@ func Get(name string) (*Namespace, error) {
 
 // Delete a namespace
 func (n *Namespace) Delete() error {
-	cmd := exec.Command("kubectl", "delete", "namespace", n.Metadata.Name)
+	cmd := exec.Command("k", "delete", "namespace", n.Metadata.Name)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/kubernetes/networkpolicy/networkpolicy.go
+++ b/test/e2e/kubernetes/networkpolicy/networkpolicy.go
@@ -12,7 +12,7 @@ import (
 
 // CreateNetworkPolicyFromFile will create a NetworkPolicy from file with a name
 func CreateNetworkPolicyFromFile(filename, name, namespace string) error {
-	cmd := exec.Command("kubectl", "create", "-f", filename)
+	cmd := exec.Command("k", "create", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -24,7 +24,7 @@ func CreateNetworkPolicyFromFile(filename, name, namespace string) error {
 
 // DeleteNetworkPolicy will create a NetworkPolicy from file with a name
 func DeleteNetworkPolicy(name, namespace string) error {
-	cmd := exec.Command("kubectl", "delete", "networkpolicy", "-n", namespace, name)
+	cmd := exec.Command("k", "delete", "networkpolicy", "-n", namespace, name)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -126,7 +126,7 @@ func WaitOnReady(nodeCount int, sleep, duration time.Duration) bool {
 
 // Get returns the current nodes for a given kubeconfig
 func Get() (*List, error) {
-	cmd := exec.Command("kubectl", "get", "nodes", "-o", "json")
+	cmd := exec.Command("k", "get", "nodes", "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -143,7 +143,7 @@ func Get() (*List, error) {
 
 // Version get the version of the server
 func Version() (string, error) {
-	cmd := exec.Command("kubectl", "version", "--short")
+	cmd := exec.Command("k", "version", "--short")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/kubernetes/persistentvolume/persistentvolume.go
+++ b/test/e2e/kubernetes/persistentvolume/persistentvolume.go
@@ -69,7 +69,7 @@ type List struct {
 
 // Get returns the current pvs for a given kubeconfig
 func Get() (*List, error) {
-	cmd := exec.Command("kubectl", "get", "pv", "-o", "json")
+	cmd := exec.Command("k", "get", "pv", "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -42,7 +42,7 @@ type Status struct {
 
 // CreatePersistentVolumeClaimsFromFile will create a StorageClass from file with a name
 func CreatePersistentVolumeClaimsFromFile(filename, name, namespace string) (*PersistentVolumeClaims, error) {
-	cmd := exec.Command("kubectl", "apply", "-f", filename)
+	cmd := exec.Command("k", "apply", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -59,7 +59,7 @@ func CreatePersistentVolumeClaimsFromFile(filename, name, namespace string) (*Pe
 
 // Get will return a PersistentVolumeClaims with a given name and namespace
 func Get(pvcName, namespace string) (*PersistentVolumeClaims, error) {
-	cmd := exec.Command("kubectl", "get", "pvc", pvcName, "-n", namespace, "-o", "json")
+	cmd := exec.Command("k", "get", "pvc", pvcName, "-n", namespace, "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -76,7 +76,7 @@ func Get(pvcName, namespace string) (*PersistentVolumeClaims, error) {
 
 // Describe gets the description for the given pvc and namespace.
 func Describe(pvcName, namespace string) error {
-	cmd := exec.Command("kubectl", "describe", "pvc", pvcName, "-n", namespace)
+	cmd := exec.Command("k", "describe", "pvc", pvcName, "-n", namespace)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -92,7 +92,7 @@ func (pvc *PersistentVolumeClaims) Delete(retries int) error {
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {
-		cmd := exec.Command("kubectl", "delete", "pvc", "-n", pvc.Metadata.NameSpace, pvc.Metadata.Name)
+		cmd := exec.Command("k", "delete", "pvc", "-n", pvc.Metadata.NameSpace, pvc.Metadata.Name)
 		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
 		if kubectlError != nil {
 			log.Printf("Error while trying to delete PVC %s in namespace %s:%s\n", pvc.Metadata.Name, pvc.Metadata.NameSpace, string(kubectlOutput))

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -159,7 +159,7 @@ func ReplaceContainerImageFromFile(filename, containerImage string) (string, err
 
 // CreatePodFromFile will create a Pod from file with a name
 func CreatePodFromFile(filename, name, namespace string, sleep, duration time.Duration) (*Pod, error) {
-	cmd := exec.Command("kubectl", "apply", "-f", filename)
+	cmd := exec.Command("k", "apply", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -178,7 +178,7 @@ func CreatePodFromFile(filename, name, namespace string, sleep, duration time.Du
 // --overrides := `"spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}`
 func RunLinuxPod(image, name, namespace, command string, printOutput bool, sleep, duration time.Duration) (*Pod, error) {
 	overrides := `{ "spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}`
-	cmd := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--restart=Never", "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command)
+	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--restart=Never", "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command)
 	var out []byte
 	var err error
 	if printOutput {
@@ -202,7 +202,7 @@ func RunLinuxPod(image, name, namespace, command string, printOutput bool, sleep
 // --overrides := `"spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}`
 func RunWindowsPod(image, name, namespace, command string, printOutput bool, sleep, duration time.Duration) (*Pod, error) {
 	overrides := `{ "spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}`
-	cmd := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--restart=Never", "--overrides", overrides, "--command", "--", "powershell", command)
+	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--restart=Never", "--overrides", overrides, "--command", "--", "powershell", command)
 	var out []byte
 	var err error
 	if printOutput {
@@ -249,7 +249,7 @@ func RunCommandMultipleTimes(podRunnerCmd podRunnerCmd, image, name, command str
 			return successfulAttempts, err
 		}
 		succeeded, _ := p.WaitOnSucceeded(sleep, duration)
-		cmd := exec.Command("kubectl", "logs", podName, "-n", "default")
+		cmd := exec.Command("k", "logs", podName, "-n", "default")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Printf("Unable to get logs from pod %s\n", podName)
@@ -272,7 +272,7 @@ func RunCommandMultipleTimes(podRunnerCmd podRunnerCmd, image, name, command str
 
 // GetAll will return all pods in a given namespace
 func GetAll(namespace string) (*List, error) {
-	cmd := exec.Command("kubectl", "get", "pods", "-n", namespace, "-o", "json")
+	cmd := exec.Command("k", "get", "pods", "-n", namespace, "-o", "json")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("Error getting pod:\n")
@@ -325,7 +325,7 @@ func GetWithRetry(podPrefix, namespace string, sleep, duration time.Duration) (*
 
 // Get will return a pod with a given name and namespace
 func Get(podName, namespace string) (*Pod, error) {
-	cmd := exec.Command("kubectl", "get", "pods", podName, "-n", namespace, "-o", "json")
+	cmd := exec.Command("k", "get", "pods", podName, "-n", namespace, "-o", "json")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("Error getting pod:\n")
@@ -343,7 +343,7 @@ func Get(podName, namespace string) (*Pod, error) {
 
 // GetTerminated will return a pod with a given name and namespace, including terminated pods
 func GetTerminated(podName, namespace string) (*Pod, error) {
-	cmd := exec.Command("kubectl", "get", "pods", podName, "-n", namespace, "-o", "json")
+	cmd := exec.Command("k", "get", "pods", podName, "-n", namespace, "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -561,7 +561,7 @@ func (p *Pod) WaitOnSucceeded(sleep, duration time.Duration) (bool, error) {
 func (p *Pod) Exec(c ...string) ([]byte, error) {
 	execCmd := []string{"exec", p.Metadata.Name, "-n", p.Metadata.Namespace}
 	execCmd = append(execCmd, c...)
-	cmd := exec.Command("kubectl", execCmd...)
+	cmd := exec.Command("k", execCmd...)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -577,7 +577,7 @@ func (p *Pod) Delete(retries int) error {
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {
-		cmd := exec.Command("kubectl", "delete", "po", "-n", p.Metadata.Namespace, p.Metadata.Name)
+		cmd := exec.Command("k", "delete", "po", "-n", p.Metadata.Namespace, p.Metadata.Name)
 		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
 		if kubectlError != nil {
 			log.Printf("Error while trying to delete Pod %s in namespace %s:%s\n", p.Metadata.Namespace, p.Metadata.Name, string(kubectlOutput))
@@ -786,7 +786,7 @@ func (p *Pod) ValidateHostPort(check string, attempts int, sleep time.Duration, 
 // Logs will get logs from all containers in a pod
 func (p *Pod) Logs() error {
 	for _, container := range p.Spec.Containers {
-		cmd := exec.Command("kubectl", "logs", p.Metadata.Name, "-c", container.Name, "-n", p.Metadata.Namespace)
+		cmd := exec.Command("k", "logs", p.Metadata.Name, "-c", container.Name, "-n", p.Metadata.Namespace)
 		out, err := util.RunAndLogCommand(cmd)
 		log.Printf("\n%s\n", string(out))
 		if err != nil {

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -60,7 +60,7 @@ type LoadBalancer struct {
 
 // Get returns the service definition specified in a given namespace
 func Get(name, namespace string) (*Service, error) {
-	cmd := exec.Command("kubectl", "get", "svc", "-o", "json", "-n", namespace, name)
+	cmd := exec.Command("k", "get", "svc", "-o", "json", "-n", namespace, name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("Error getting svc:\n")
@@ -81,7 +81,7 @@ func (s *Service) Delete(retries int) error {
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {
-		cmd := exec.Command("kubectl", "delete", "svc", "-n", s.Metadata.Namespace, s.Metadata.Name)
+		cmd := exec.Command("k", "delete", "svc", "-n", s.Metadata.Namespace, s.Metadata.Name)
 		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
 		if kubectlError != nil {
 			log.Printf("Error while trying to delete service %s in namespace %s:%s\n", s.Metadata.Namespace, s.Metadata.Name, string(kubectlOutput))
@@ -176,7 +176,7 @@ func CreateServiceFromFile(filename, name, namespace string) (*Service, error) {
 		log.Printf("Service %s already exists\n", name)
 		return svc, nil
 	}
-	cmd := exec.Command("kubectl", "create", "-f", filename)
+	cmd := exec.Command("k", "create", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/kubernetes/storageclass/storageclass.go
+++ b/test/e2e/kubernetes/storageclass/storageclass.go
@@ -33,7 +33,7 @@ type Parameters struct {
 
 // CreateStorageClassFromFile will create a StorageClass from file with a name
 func CreateStorageClassFromFile(filename, name string) (*StorageClass, error) {
-	cmd := exec.Command("kubectl", "apply", "-f", filename)
+	cmd := exec.Command("k", "apply", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -50,7 +50,7 @@ func CreateStorageClassFromFile(filename, name string) (*StorageClass, error) {
 
 // Get will return a StorageClass with a given name and namespace
 func Get(scName string) (*StorageClass, error) {
-	cmd := exec.Command("kubectl", "get", "storageclass", scName, "-o", "json")
+	cmd := exec.Command("k", "get", "storageclass", scName, "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -277,7 +277,7 @@ func (cli *CLIProvisioner) waitForNodes() error {
 		if !cli.IsPrivate() {
 			log.Println("Waiting on nodes to go into ready state...")
 			ready := node.WaitOnReady(cli.Engine.NodeCount(), 10*time.Second, cli.Config.Timeout)
-			cmd := exec.Command("kubectl", "get", "nodes", "-o", "wide")
+			cmd := exec.Command("k", "get", "nodes", "-o", "wide")
 			out, _ := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
 			if !ready {

--- a/test/e2e/runner/ginkgo.go
+++ b/test/e2e/runner/ginkgo.go
@@ -52,10 +52,10 @@ func (g *Ginkgo) Run() error {
 	if err != nil {
 		g.Point.RecordTestError()
 		if g.Config.IsKubernetes() {
-			kubectl := exec.Command("kubectl", "get", "all", "--all-namespaces", "-o", "wide")
+			kubectl := exec.Command("k", "get", "all", "--all-namespaces", "-o", "wide")
 			util.PrintCommand(kubectl)
 			kubectl.CombinedOutput()
-			kubectl = exec.Command("kubectl", "get", "nodes", "-o", "wide")
+			kubectl = exec.Command("k", "get", "nodes", "-o", "wide")
 			util.PrintCommand(kubectl)
 			kubectl.CombinedOutput()
 		}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Uses the [`k`](https://github.com/jakepearson/k) script in the [go-dev](https://github.com/deis/docker-go-dev) image to fetch the right version of `kubectl` just-in-time for E2E tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #557
Unblocks #435

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This is just one approach to fixing this recurrent problem: other ideas are welcome. It worked fine for me running E2E tests locally (but requires the `k` script to be in your path of course).
