### PR TITLE
fix: silence `k` script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/Azure/aks-engine
   docker:
-    - image: quay.io/deis/go-dev:v1.18.4
+    - image: quay.io/deis/go-dev:v1.18.5
   environment:
     GOPATH: /go
 

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -17,7 +17,7 @@ pr:
 resources:
   containers:
   - container: dev1
-    image: quay.io/deis/go-dev:v1.18.4
+    image: quay.io/deis/go-dev:v1.18.5
 
 jobs:
 - job: unit_tests

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GITTAG := $(VERSION_SHORT)
 endif
 
 REPO_PATH := github.com/Azure/$(PROJECT)
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.18.4
+DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.18.5
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_OPTS := --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_VARS}
 DEV_ENV_CMD := docker run ${DEV_ENV_OPTS} ${DEV_ENV_IMAGE}

--- a/docs/community/developer-guide.md
+++ b/docs/community/developer-guide.md
@@ -194,9 +194,9 @@ environment variables to be set:
 * `SUBSCRIPTION_ID`: Azure subscription UUID
 * `TENANT_ID`: Azure tenant UUID
 
-The end-to-end tests also require the [`k`](https://github.com/jakepearson/k)
-script to be in your search $PATH. This ensures that testing uses a `kubectl`
-client that matches the version of the Kubernetes server.
+The end-to-end tests also require the `k` script from the `scripts/` folder in to
+be in your search $PATH. This ensures that testing uses a `kubectl` client that
+matches the version of the Kubernetes server.
 
 ### Debugging
 

--- a/makedev.ps1
+++ b/makedev.ps1
@@ -1,5 +1,5 @@
 $REPO_PATH = "github.com/Azure/aks-engine"
-$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.18.4"
+$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.18.5"
 $DEV_ENV_WORK_DIR = "/go/src/$REPO_PATH"
 
 docker.exe run -it --rm -w $DEV_ENV_WORK_DIR -v `"$($PWD)`":$DEV_ENV_WORK_DIR $DEV_ENV_IMAGE bash

--- a/scripts/k
+++ b/scripts/k
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Downloads and runs the correct version of kubectl just in time.
+# This script is modified from the original source at https://github.com/jakepearson/k
+
+set +x
+
+KX_PATH="$HOME/.kx"
+mkdir -p "$KX_PATH/cache"
+
+case "$OSTYPE" in
+  *arwin*)
+    OS="darwin"
+    ;;
+  *in32* | *indows*)
+    OS="windows"
+    ;;
+  *)
+    OS="linux"
+esac
+
+# Attempt to load the server version from cache
+if [ ! -z "$KUBECONFIG" ]; then
+  if [ "$OS" == "darwin" ]; then
+    KUBECONFIG_HASH=$(echo "$KUBECONFIG" | shasum -a 256 | cut -c1-5)
+  else
+    KUBECONFIG_HASH=$(echo "$KUBECONFIG" | sha256sum | cut -c1-5)
+  fi
+  VERSION_CACHE_FILE="$KX_PATH/cache/$KUBECONFIG_HASH"
+  TARGET_VERSION=$(cat "$VERSION_CACHE_FILE" 2> /dev/null)
+fi
+
+# Get the server version from the server if not cached
+if [ -z "$TARGET_VERSION" ]; then
+  TARGET_VERSION=$(kubectl version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion')
+fi
+
+# Default to kubectl v1.10.12 if TARGET_VERSION was unset and `kubectl version` failed
+if [ "$TARGET_VERSION" == "null" ]; then
+  TARGET_VERSION=v1.10.12
+fi
+
+# Fill the cache if possible
+if [ ! -z "$KUBECONFIG" ]; then
+  echo "$TARGET_VERSION" > "$VERSION_CACHE_FILE"
+fi
+
+TARGET=$KX_PATH/kubectl-$TARGET_VERSION
+
+if [ ! -f $TARGET ]; then
+  cd "$KX_PATH"
+  curl -sLO "https://storage.googleapis.com/kubernetes-release/release/$TARGET_VERSION/bin/$OS/amd64/kubectl"
+  mv $KX_PATH/kubectl $TARGET
+  chmod +x $TARGET
+fi
+
+$TARGET "$@"


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
See https://github.com/deis/docker-go-dev/releases/tag/v1.18.5

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Closes #567

Should fix issues we are seeing in Jenkins E2E upgrade tests. I've already set `${GO_DEV_IMAGE}` to v1.18.5 there and it looks like we are 💚 again.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
