### PR TITLE
fix: Explicitly use overlay2 storage driver while creation of vhd, by defa…

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -15,6 +15,7 @@ installDeps
 if [[ ${FEATURE_FLAGS} == *"docker-engine"* ]]; then
     DOCKER_ENGINE_REPO="https://apt.dockerproject.org/repo"
     installDockerEngine
+    overrideDockerEngineStorageDriver
     installGPUDrivers
 else
     MOBY_VERSION="3.0.4"

--- a/parts/k8s/kubernetesinstalls.sh
+++ b/parts/k8s/kubernetesinstalls.sh
@@ -128,6 +128,27 @@ installDockerEngine() {
     fi
 }
 
+overrideDockerEngineStorageDriver() {
+    echo "stopping docker engine"
+    sudo systemctl stop docker
+    cat << EOF > /tmp/daemon.json 
+{
+    "storage-driver": "overlay2",
+    "live-restore": true,
+    "log-driver": "json-file",
+    "log-opts":  {
+        "max-size": "50m",
+        "max-file": "5"
+    }
+}
+EOF
+    sudo mv /tmp/daemon.json /etc/docker/daemon.json
+    echo "cleaning up aufs storage"
+    sudo rm -rf /var/lib/docker/aufs
+    echo "starting docker engine with overlay2 driver"
+    sudo systemctl start docker
+}
+
 installKataContainersRuntime() {
     # TODO incorporate this into packer CI so that it is pre-baked into the VHD image
     echo "Adding Kata Containers repository key..."


### PR DESCRIPTION
…ult docker uses aufs

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
By default docker uses aufs storage driver, hence while creation of vhd, the container images are always downloaded to wrong partition /var/lib/docker/aufs while we start docker with overlay2 storage driver after creation of vm. Configure docker engine to use overlay2 after installation during vhd creation.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
