### PR TITLE
fix: remove extra \n in log messages

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -86,7 +86,7 @@ func (uc *UpgradeCluster) UpgradeCluster(az armhelpers.AKSEngineClient, kubeConf
 
 	var upgrader UpgradeWorkFlow
 	upgradeVersion := uc.DataModel.Properties.OrchestratorProfile.OrchestratorVersion
-	uc.Logger.Infof("Upgrading to Kubernetes version %s\n", upgradeVersion)
+	uc.Logger.Infof("Upgrading to Kubernetes version %s", upgradeVersion)
 	u := &Upgrader{}
 	u.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, aksEngineVersion)
 	upgrader = u
@@ -95,7 +95,7 @@ func (uc *UpgradeCluster) UpgradeCluster(az armhelpers.AKSEngineClient, kubeConf
 		return err
 	}
 
-	uc.Logger.Infof("Cluster upgraded successfully to Kubernetes version %s\n", upgradeVersion)
+	uc.Logger.Infof("Cluster upgraded successfully to Kubernetes version %s", upgradeVersion)
 	return nil
 }
 
@@ -166,7 +166,7 @@ func (uc *UpgradeCluster) getClusterNodeStatus(az armhelpers.AKSEngineClient, re
 		for _, vm := range vmListPage.Values() {
 			// Windows VMs contain a substring of the name suffix
 			if !strings.Contains(*(vm.Name), uc.NameSuffix) && !strings.Contains(*(vm.Name), uc.NameSuffix[:4]+"k8s") {
-				uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s\n",
+				uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s",
 					*vm.Name, uc.NameSuffix)
 				continue
 			}
@@ -187,14 +187,14 @@ func (uc *UpgradeCluster) getClusterNodeStatus(az armhelpers.AKSEngineClient, re
 			// If the current version is different than the desired version then we add the VM to the list of VMs to upgrade.
 			if currentVersion != goalVersion {
 				if strings.Contains(*(vm.Name), MasterVMNamePrefix) {
-					uc.Logger.Infof("Master VM name: %s, orchestrator: %s (MasterVMs)\n", *vm.Name, currentVersion)
+					uc.Logger.Infof("Master VM name: %s, orchestrator: %s (MasterVMs)", *vm.Name, currentVersion)
 					*uc.MasterVMs = append(*uc.MasterVMs, vm)
 				} else {
 					uc.addVMToAgentPool(vm, true)
 				}
 			} else if currentVersion == goalVersion {
 				if strings.Contains(*(vm.Name), MasterVMNamePrefix) {
-					uc.Logger.Infof("Master VM name: %s, orchestrator: %s (UpgradedMasterVMs)\n", *vm.Name, currentVersion)
+					uc.Logger.Infof("Master VM name: %s, orchestrator: %s (UpgradedMasterVMs)", *vm.Name, currentVersion)
 					*uc.UpgradedMasterVMs = append(*uc.UpgradedMasterVMs, vm)
 				} else {
 					uc.addVMToAgentPool(vm, false)
@@ -297,7 +297,7 @@ func (uc *UpgradeCluster) addVMToAgentPool(vm compute.VirtualMachine, isUpgradab
 	if vm.StorageProfile.OsDisk.OsType == compute.Windows {
 		poolPrefix, _, _, _, err = utils.WindowsVMNameParts(*vm.Name)
 		if !strings.Contains(uc.NameSuffix, poolPrefix) {
-			uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s\n",
+			uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s",
 				*vm.Name, uc.NameSuffix)
 			return nil
 		}
@@ -318,7 +318,7 @@ func (uc *UpgradeCluster) addVMToAgentPool(vm compute.VirtualMachine, isUpgradab
 		}
 
 		if !strings.EqualFold(uc.NameSuffix, poolPrefix) {
-			uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s\n",
+			uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s",
 				*vm.Name, uc.NameSuffix)
 			return nil
 		}
@@ -334,11 +334,11 @@ func (uc *UpgradeCluster) addVMToAgentPool(vm compute.VirtualMachine, isUpgradab
 		orchestrator = *vm.Tags["orchestrator"]
 	}
 	if isUpgradableVM {
-		uc.Logger.Infof("Adding Agent VM: %s, orchestrator: %s to pool: %s (AgentVMs)\n",
+		uc.Logger.Infof("Adding Agent VM: %s, orchestrator: %s to pool: %s (AgentVMs)",
 			*vm.Name, orchestrator, poolIdentifier)
 		*uc.AgentPools[poolIdentifier].AgentVMs = append(*uc.AgentPools[poolIdentifier].AgentVMs, vm)
 	} else {
-		uc.Logger.Infof("Adding Agent VM: %s, orchestrator: %s to pool: %s (UpgradedAgentVMs)\n",
+		uc.Logger.Infof("Adding Agent VM: %s, orchestrator: %s to pool: %s (UpgradedAgentVMs)",
 			*vm.Name, orchestrator, poolIdentifier)
 		*uc.AgentPools[poolIdentifier].UpgradedAgentVMs = append(*uc.AgentPools[poolIdentifier].UpgradedAgentVMs, vm)
 	}

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -48,11 +48,11 @@ func (kmn *UpgradeMasterNode) CreateNode(ctx context.Context, poolName string, m
 
 	templateVariables["masterOffset"] = masterNo
 	masterOffsetVar := templateVariables["masterOffset"]
-	kmn.logger.Infof("Master offset: %v\n", masterOffsetVar)
+	kmn.logger.Infof("Master offset: %v", masterOffsetVar)
 
 	templateVariables["masterCount"] = masterNo + 1
 	masterOffset := templateVariables["masterCount"]
-	kmn.logger.Infof("Master pool set count to: %v temporarily during upgrade...\n", masterOffset)
+	kmn.logger.Infof("Master pool set count to: %v temporarily during upgrade...", masterOffset)
 
 	// Debug function - keep commented out
 	// WriteTemplate(kmn.Translator, kmn.UpgradeContainerService, kmn.TemplateMap, kmn.ParametersMap)
@@ -94,7 +94,7 @@ func (kmn *UpgradeMasterNode) Validate(vmName *string) error {
 		for {
 			masterNode, err := client.GetNode(*vmName)
 			if err != nil {
-				kmn.logger.Infof("Master VM: %s status error: %v\n", *vmName, err)
+				kmn.logger.Infof("Master VM: %s status error: %v", *vmName, err)
 				time.Sleep(time.Second * 5)
 			} else if isNodeReady(masterNode) {
 				kmn.logger.Infof("Master VM: %s is ready", *vmName)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
To fix some ugly trailing `\n` when I run `aks-engine upgrade`. Like:
```
time="2019-02-25T17:18:03+08:00" level=info msg="Upgrading to Kubernetes version 1.13.3\n"
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
