### PR TITLE
feat: Azure #402 - Disable windows auto update

### DIFF
--- a/docs/topics/windows-and-kubernetes.md
+++ b/docs/topics/windows-and-kubernetes.md
@@ -61,7 +61,7 @@ If you want to disable automatic Windows updates, you can use the `enableAutomat
             "windowsPublisher": "MicrosoftWindowsServer",
             "windowsOffer": "WindowsServerSemiAnnual",
             "windowsSku": "Datacenter-Core-1809-with-Containers-smalldisk",
-            "enableAutomaticUpdates": "false"
+            "enableAutomaticUpdates": false
      },
 ```
 

--- a/docs/topics/windows-and-kubernetes.md
+++ b/docs/topics/windows-and-kubernetes.md
@@ -50,6 +50,21 @@ You can use the Offer, Publisher and Sku to pick a specific version by adding `w
      },
 ```
 
+### Disabling automatic updates
+
+If you want to disable automatic Windows updates, you can use the `enableAutomaticUpdates` option.
+
+```json
+"windowsProfile": {
+            "adminUsername": "azureuser",
+            "adminPassword": "...",
+            "windowsPublisher": "MicrosoftWindowsServer",
+            "windowsOffer": "WindowsServerSemiAnnual",
+            "windowsSku": "Datacenter-Core-1809-with-Containers-smalldisk",
+            "enableAutomaticUpdates": "false"
+     },
+```
+
 ## More Examples
 
 ### Using Azure Files

--- a/examples/windows/kubernetes-windows-automatic-update.json
+++ b/examples/windows/kubernetes-windows-automatic-update.json
@@ -1,0 +1,40 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes"
+        },
+        "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "",
+            "vmSize": "Standard_D2"
+        },
+        "agentPoolProfiles": [{
+            "name": "windowspool2",
+            "count": 2,
+            "vmSize": "Standard_D2",
+            "availabilityProfile": "AvailabilitySet",
+            "osType": "Windows"
+        }],
+        "windowsProfile": {
+            "adminUsername": "azureuser",
+            "adminPassword": "replacepassword1234$",
+            "windowsPublisher": "MicrosoftWindowsServer",
+            "windowsOffer": "WindowsServerSemiAnnual",
+            "windowsSku": "Datacenter-Core-1803-with-Containers-smalldisk",
+            "enableAutomaticUpdates": "false"
+        },
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [{
+                    "keyData": ""
+                }]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientId": "",
+            "secret": ""
+        }
+    }
+}

--- a/examples/windows/kubernetes-windows-automatic-update.json
+++ b/examples/windows/kubernetes-windows-automatic-update.json
@@ -22,7 +22,7 @@
             "windowsPublisher": "MicrosoftWindowsServer",
             "windowsOffer": "WindowsServerSemiAnnual",
             "windowsSku": "Datacenter-Core-1803-with-Containers-smalldisk",
-            "enableAutomaticUpdates": "false"
+            "enableAutomaticUpdates": false
         },
         "linuxProfile": {
             "adminUsername": "azureuser",

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -185,7 +185,10 @@
           "computerName": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
           {{GetKubernetesWindowsAgentCustomData .}}
           "adminUsername": "[parameters('windowsAdminUsername')]",
-          "adminPassword": "[parameters('windowsAdminPassword')]"
+          "adminPassword": "[parameters('windowsAdminPassword')]",
+          "windowsConfiguration": {
+            "enableAutomaticUpdates": {{WindowsAutomaticUpdateEnabled}}
+          }
         },
         "storageProfile": {
           {{GetDataDisks .}}

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -106,7 +106,10 @@
           "computerNamePrefix": "[variables('{{.Name}}VMNamePrefix')]",
           {{GetKubernetesWindowsAgentCustomData .}}
           "adminUsername": "[parameters('windowsAdminUsername')]",
-          "adminPassword": "[parameters('windowsAdminPassword')]"
+          "adminPassword": "[parameters('windowsAdminPassword')]",
+          "windowsConfiguration": {
+            "enableAutomaticUpdates": {{WindowsAutomaticUpdateEnabled}}
+          }
         },
         "storageProfile": {
           {{GetDataDisks .}}

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -220,6 +220,8 @@ const (
 	// DefaultMaximumLoadBalancerRuleCount determines the default value of maximum allowed loadBalancer rule count according to
 	// https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#load-balancer.
 	DefaultMaximumLoadBalancerRuleCount = 250
+	// DefaultEnableAutomaticUpdates determines the aks-engine provided default for enabling automatic updates
+	DefaultEnableAutomaticUpdates = true
 )
 
 const (

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -611,6 +611,7 @@ func convertWindowsProfileToVLabs(api *WindowsProfile, vlabsProfile *vlabs.Windo
 		vlabsProfile.Secrets = append(vlabsProfile.Secrets, *secret)
 	}
 	vlabsProfile.SSHEnabled = api.SSHEnabled
+	vlabsProfile.EnableAutomaticUpdates = api.EnableAutomaticUpdates
 }
 
 func convertOrchestratorProfileToV20160930(api *OrchestratorProfile, o *v20160930.OrchestratorProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -542,6 +542,7 @@ func convertVLabsWindowsProfile(vlabs *vlabs.WindowsProfile, api *WindowsProfile
 		api.Secrets = append(api.Secrets, *secret)
 	}
 	api.SSHEnabled = vlabs.SSHEnabled
+	api.EnableAutomaticUpdates = vlabs.EnableAutomaticUpdates
 }
 
 func convertV20160930OrchestratorProfile(v20160930 *v20160930.OrchestratorProfile, api *OrchestratorProfile) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -197,16 +197,17 @@ type CustomNodesDNS struct {
 
 // WindowsProfile represents the windows parameters passed to the cluster
 type WindowsProfile struct {
-	AdminUsername         string            `json:"adminUsername"`
-	AdminPassword         string            `json:"adminPassword" conform:"redact"`
-	ImageVersion          string            `json:"imageVersion"`
-	WindowsImageSourceURL string            `json:"windowsImageSourceURL"`
-	WindowsPublisher      string            `json:"windowsPublisher"`
-	WindowsOffer          string            `json:"windowsOffer"`
-	WindowsSku            string            `json:"windowsSku"`
-	WindowsDockerVersion  string            `json:"windowsDockerVersion"`
-	Secrets               []KeyVaultSecrets `json:"secrets,omitempty"`
-	SSHEnabled            bool              `json:"sshEnabled,omitempty"`
+	AdminUsername          string            `json:"adminUsername"`
+	AdminPassword          string            `json:"adminPassword" conform:"redact"`
+	ImageVersion           string            `json:"imageVersion"`
+	WindowsImageSourceURL  string            `json:"windowsImageSourceURL"`
+	WindowsPublisher       string            `json:"windowsPublisher"`
+	WindowsOffer           string            `json:"windowsOffer"`
+	WindowsSku             string            `json:"windowsSku"`
+	WindowsDockerVersion   string            `json:"windowsDockerVersion"`
+	Secrets                []KeyVaultSecrets `json:"secrets,omitempty"`
+	SSHEnabled             bool              `json:"sshEnabled,omitempty"`
+	EnableAutomaticUpdates string            `json:"enableAutomaticUpdates,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.
@@ -1158,6 +1159,14 @@ func (w *WindowsProfile) GetWindowsSku() string {
 		return w.WindowsSku
 	}
 	return KubernetesDefaultWindowsSku
+}
+
+// GetEnableWindowsUpdate gets the flag for enable windows update or returns the default value
+func (w *WindowsProfile) GetEnableWindowsUpdate() string {
+	if w.EnableAutomaticUpdates != "" {
+		return w.EnableAutomaticUpdates
+	}
+	return "true"
 }
 
 // HasSecrets returns true if the customer specified secrets to install

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -207,7 +207,7 @@ type WindowsProfile struct {
 	WindowsDockerVersion   string            `json:"windowsDockerVersion"`
 	Secrets                []KeyVaultSecrets `json:"secrets,omitempty"`
 	SSHEnabled             bool              `json:"sshEnabled,omitempty"`
-	EnableAutomaticUpdates string            `json:"enableAutomaticUpdates,omitempty"`
+	EnableAutomaticUpdates *bool             `json:"enableAutomaticUpdates,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.
@@ -1162,11 +1162,11 @@ func (w *WindowsProfile) GetWindowsSku() string {
 }
 
 // GetEnableWindowsUpdate gets the flag for enable windows update or returns the default value
-func (w *WindowsProfile) GetEnableWindowsUpdate() string {
-	if w.EnableAutomaticUpdates != "" {
-		return w.EnableAutomaticUpdates
+func (w *WindowsProfile) GetEnableWindowsUpdate() bool {
+	if w.EnableAutomaticUpdates != nil {
+		return *w.EnableAutomaticUpdates
 	}
-	return "true"
+	return true
 }
 
 // HasSecrets returns true if the customer specified secrets to install

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1166,7 +1166,7 @@ func (w *WindowsProfile) GetEnableWindowsUpdate() bool {
 	if w.EnableAutomaticUpdates != nil {
 		return *w.EnableAutomaticUpdates
 	}
-	return true
+	return DefaultEnableAutomaticUpdates
 }
 
 // HasSecrets returns true if the customer specified secrets to install

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -848,6 +848,11 @@ func TestWindowsProfile(t *testing.T) {
 		t.Fatalf("Expected GetWindowsSku() to equal default KubernetesDefaultWindowsSku, got %s", windowsSku)
 	}
 
+	update := w.GetEnableWindowsUpdate()
+	if update != "true" {
+		t.Fatalf("Expected GetEnableWindowsUpdate() to equal default 'true', got %s", update)
+	}
+
 	w = WindowsProfile{
 		Secrets: []KeyVaultSecrets{
 			{
@@ -868,9 +873,9 @@ func TestWindowsProfile(t *testing.T) {
 	}
 
 	w = WindowsProfile{
-		WindowsDockerVersion: "18.03.1-ee-3",
-		WindowsSku:           "Datacenter-Core-1809-with-Containers-smalldisk",
-		SSHEnabled:           true,
+		WindowsDockerVersion:   "18.03.1-ee-3",
+		WindowsSku:             "Datacenter-Core-1809-with-Containers-smalldisk",
+		SSHEnabled:             true
 	}
 
 	dv = w.GetWindowsDockerVersion()

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -849,8 +849,8 @@ func TestWindowsProfile(t *testing.T) {
 	}
 
 	update := w.GetEnableWindowsUpdate()
-	if update != "true" {
-		t.Fatalf("Expected GetEnableWindowsUpdate() to equal default 'true', got %s", update)
+	if update != true {
+		t.Fatalf("Expected GetEnableWindowsUpdate() to equal default 'true', got %t", update)
 	}
 
 	w = WindowsProfile{
@@ -873,9 +873,9 @@ func TestWindowsProfile(t *testing.T) {
 	}
 
 	w = WindowsProfile{
-		WindowsDockerVersion:   "18.03.1-ee-3",
-		WindowsSku:             "Datacenter-Core-1809-with-Containers-smalldisk",
-		SSHEnabled:             true
+		WindowsDockerVersion: "18.03.1-ee-3",
+		WindowsSku:           "Datacenter-Core-1809-with-Containers-smalldisk",
+		SSHEnabled:           true,
 	}
 
 	dv = w.GetWindowsDockerVersion()

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -166,7 +166,7 @@ type WindowsProfile struct {
 	WindowsDockerVersion   string            `json:"windowsDockerVersion"`
 	Secrets                []KeyVaultSecrets `json:"secrets,omitempty"`
 	SSHEnabled             bool              `json:"sshEnabled,omitempty"`
-	EnableAutomaticUpdates string            `json:"enableAutomaticUpdates,omitempty"`
+	EnableAutomaticUpdates *bool             `json:"enableAutomaticUpdates,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -156,16 +156,17 @@ type CustomNodesDNS struct {
 
 // WindowsProfile represents the windows parameters passed to the cluster
 type WindowsProfile struct {
-	AdminUsername         string            `json:"adminUsername,omitempty"`
-	AdminPassword         string            `json:"adminPassword,omitempty"`
-	ImageVersion          string            `json:"imageVersion,omitempty"`
-	WindowsImageSourceURL string            `json:"WindowsImageSourceUrl"`
-	WindowsPublisher      string            `json:"WindowsPublisher"`
-	WindowsOffer          string            `json:"WindowsOffer"`
-	WindowsSku            string            `json:"WindowsSku"`
-	WindowsDockerVersion  string            `json:"windowsDockerVersion"`
-	Secrets               []KeyVaultSecrets `json:"secrets,omitempty"`
-	SSHEnabled            bool              `json:"sshEnabled,omitempty"`
+	AdminUsername          string            `json:"adminUsername,omitempty"`
+	AdminPassword          string            `json:"adminPassword,omitempty"`
+	ImageVersion           string            `json:"imageVersion,omitempty"`
+	WindowsImageSourceURL  string            `json:"WindowsImageSourceUrl"`
+	WindowsPublisher       string            `json:"WindowsPublisher"`
+	WindowsOffer           string            `json:"WindowsOffer"`
+	WindowsSku             string            `json:"WindowsSku"`
+	WindowsDockerVersion   string            `json:"windowsDockerVersion"`
+	Secrets                []KeyVaultSecrets `json:"secrets,omitempty"`
+	SSHEnabled             bool              `json:"sshEnabled,omitempty"`
+	EnableAutomaticUpdates string            `json:"enableAutomaticUpdates,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -840,11 +840,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.WindowsProfile.SSHEnabled
 		},
 		"WindowsAutomaticUpdateEnabled": func() bool {
-			val, err := strconv.ParseBool(cs.Properties.WindowsProfile.GetEnableWindowsUpdate())
-			if err == nil {
-				return val
-			}
-			return true
+			return cs.Properties.WindowsProfile.GetEnableWindowsUpdate()
 		},
 		"GetConfigurationScriptRootURL": func() string {
 			if cs.Properties.LinuxProfile.ScriptRootURL == "" {

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -839,6 +839,13 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"WindowsSSHEnabled": func() bool {
 			return cs.Properties.WindowsProfile.SSHEnabled
 		},
+		"WindowsAutomaticUpdateEnabled": func() bool {
+			val, err := strconv.ParseBool(cs.Properties.WindowsProfile.GetEnableWindowsUpdate())
+			if err == nil {
+				return val
+			}
+			return true
+		},
 		"GetConfigurationScriptRootURL": func() string {
 			if cs.Properties.LinuxProfile.ScriptRootURL == "" {
 				return DefaultConfigurationScriptRootURL


### PR DESCRIPTION
This pull request should fix #402.

**Reason for Change**:
Add functionality to disable automatic windows update

**Issue Fixed**:
Fixes #402 - Disable windows auto update

**Requirements**:
Add ability to disable automatic Windows updates. An entry for _windowsConfiguration_ will now be added under _osProfile_. This will default to true if the user does not provide a value. 

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [X] adds unit tests
- [x] tested upgrade from previous version

**Notes**: 
This is one of a few approaches I thought of when adding this functionality. Interested to hear if this is acceptable or not. I went with implementation of always adding the entry for  _windowsConfiguration_  under _osProfile_. I thought that explicitly setting this value would be better for consumers.

I wasn't sure if the changes should be put under _api_ or _vlabs_.