### PR TITLE
chore: add system.conf with static JoinControllers configuration

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -45,6 +45,13 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "sshdConfig"}}
 
+- path: /etc/systemd/system.conf
+  permissions: "0644"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{WrapAsVariable "systemConf"}}
+
 - path: /usr/local/bin/health-monitor.sh
   permissions: "0544"
   encoding: gzip

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -51,6 +51,13 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "sshdConfig"}}
 
+- path: /etc/systemd/system.conf
+  permissions: "0644"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{WrapAsVariable "systemConf"}}
+
 - path: /usr/local/bin/health-monitor.sh
   permissions: "0544"
   encoding: gzip

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -145,6 +145,7 @@
     {{if IsAzureStackCloud}}
     "provisionConfigsCustomCloud": "{{GetKubernetesB64ConfigsCustomCloud}}",
     {{end}}
+    "systemConf": "{{GetB64systemConf}}",
     "mountetcdScript": "{{GetKubernetesB64Mountetcd}}",
     "customSearchDomainsScript": "{{GetKubernetesB64CustomSearchDomainsScript}}",
     "sshdConfig": "{{GetB64sshdConfig}}",

--- a/parts/k8s/system.conf
+++ b/parts/k8s/system.conf
@@ -1,0 +1,2 @@
+[Manager]
+JoinControllers=cpu,cpuacct,cpuset,net_cls,net_prio,hugetlb,memory

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -138,6 +138,7 @@ const (
 	kubernetesWindowsAzureCniFunctionsPS1 = "k8s/windowsazurecnifunc.ps1"
 	kubernetesWindowsOpenSSHFunctionPS1   = "k8s/windowsinstallopensshfunc.ps1"
 	sshdConfig                            = "k8s/sshd_config"
+	systemConf                            = "k8s/system.conf"
 )
 
 const (

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -645,6 +645,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"GetB64sshdConfig": func() string {
 			return getBase64CustomScript(sshdConfig)
 		},
+		"GetB64systemConf": func() string {
+			return getBase64CustomScript(systemConf)
+		},
 		"HasMultipleSshKeys": func() bool {
 			return len(cs.Properties.LinuxProfile.SSH.PublicKeys) > 1
 		},


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This configuration was recently removed because of systemd release notes announcing deprecation of JoinControllers starting with version 240:

https://lists.freedesktop.org/archives/systemd-devel/2018-December/041852.html

However, Ubuntu 16.04-LTS (current default OS SKU) version of systemd is not using that version:

```
$ systemd --version
systemd 229
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN
```

Here is the recently reverted PR:

https://github.com/Azure/aks-engine/pull/410

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: