### PR TITLE
fix: Fix the CNI lock file names

### DIFF
--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -413,29 +413,29 @@ if (`$hnsNetwork)
     Remove-HnsNetwork `$hnsNetwork
     # Kill all cni instances & stale data left by cni
     # Cleanup all files related to cni
+    taskkill /IM azure-vnet.exe /f
+    taskkill /IM azure-vnet-ipam.exe /f
     `$cnijson = [io.path]::Combine("$KubeDir", "azure-vnet-ipam.json")
     if ((Test-Path `$cnijson))
     {
         Remove-Item `$cnijson
     }
-    `$cnilock = [io.path]::Combine("$KubeDir", "azure-vnet-ipam.lock")
+    `$cnilock = [io.path]::Combine("$KubeDir", "azure-vnet-ipam.json.lock")
     if ((Test-Path `$cnilock))
     {
         Remove-Item `$cnilock
     }
-    taskkill /IM azure-vnet-ipam.exe /f
 
     `$cnijson = [io.path]::Combine("$KubeDir", "azure-vnet.json")
     if ((Test-Path `$cnijson))
     {
         Remove-Item `$cnijson
     }
-    `$cnilock = [io.path]::Combine("$KubeDir", "azure-vnet.lock")
+    `$cnilock = [io.path]::Combine("$KubeDir", "azure-vnet.json.lock")
     if ((Test-Path `$cnilock))
     {
         Remove-Item `$cnilock
     }
-    taskkill /IM azure-vnet.exe /f
 }
 
 # Restart Kubeproxy, which would wait, until the network is created


### PR DESCRIPTION
Fix CNI lock file names and kill the processes before
getting rid of the config files

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
On restart of Kubelet Azure CNI would leak a lock file. The kubelet start script had incorrect lock file names which is causing the lock files to be left behind when kubelet starts.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
cc: @ashvindeodhar @PatrickLang 