### PR TITLE
fix: port long running dns check windows in e2e tests

### DIFF
--- a/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
@@ -21,7 +21,18 @@
         "count": 2,
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "AvailabilitySet",
-        "osType": "Windows"
+        "osType": "Windows",
+        "extensions": [
+          {
+            "name": "winrm"
+          }
+        ]
+      }
+    ],
+    "extensionProfiles": [
+      {
+        "name": "winrm",
+        "version": "v1"
       }
     ],
     "windowsProfile": {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -319,6 +319,20 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, err := p.WaitOnReady(retryTimeWhenWaitingForPodReady, 2*time.Minute)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
+			}
+			if eng.HasWindowsAgents() && !eng.HasNetworkPolicy("calico") {
+				windowsPod, err := pod.CreatePodFromFile(filepath.Join(WorkloadDir, "dns-liveness-windows.yaml"), "dns-liveness-windows", "default", 1*time.Second, cfg.Timeout)
+				if cfg.SoakClusterName == "" {
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					if err != nil {
+						windowsPod, err = pod.Get("dns-liveness-windows", "default")
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+				running, err := windowsPod.WaitOnReady(30*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
 			} else {
 				Skip("We don't run DNS liveness checks on calico clusters ( //TODO )")
 			}
@@ -1378,6 +1392,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 	Describe("after the cluster has been up for awhile", func() {
 		It("dns-liveness pod should not have any restarts", func() {
 			if !eng.HasNetworkPolicy("calico") {
+				By("by checking restarts on pod")
 				pod, err := pod.Get("dns-liveness", "default")
 				Expect(err).NotTo(HaveOccurred())
 				running, err := pod.WaitOnReady(retryTimeWhenWaitingForPodReady, 3*time.Minute)
@@ -1390,6 +1405,22 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					Expect(restarts).To(Equal(0))
 				} else {
 					log.Printf("%d DNS livenessProbe restarts since this cluster was created...\n", restarts)
+				}
+			}
+			if eng.HasWindowsAgents() && !eng.HasNetworkPolicy("calico") {
+				By("by checking restarts on windows pod")
+				windowspod, err := pod.Get("dns-liveness-windows", "default")
+				Expect(err).NotTo(HaveOccurred())
+				running, err := windowspod.WaitOnReady(5*time.Second, 3*time.Minute)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+				restarts := windowspod.Status.ContainerStatuses[0].RestartCount
+				if cfg.SoakClusterName == "" {
+					err = windowspod.Delete(deleteResourceRetries)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(restarts).To(Equal(0))
+				} else {
+					log.Printf("%d Windows DNS livenessProbe restarts since this cluster was created...\n", restarts)
 				}
 			} else {
 				Skip("We don't run DNS liveness checks on calico clusters ( //TODO )")

--- a/test/e2e/kubernetes/workloads/dns-liveness-windows.yaml
+++ b/test/e2e/kubernetes/workloads/dns-liveness-windows.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness
+  name: dns-liveness-windows
+spec:
+  containers:
+  - name: dns-liveness
+    image: microsoft/windowsservercore:1803
+    args:
+    - powershell
+    - "-command"
+    - "while ($true){ Start-Sleep -s 5; echo 'sleeping'}"
+    livenessProbe:
+      exec:
+        command:
+        - nslookup
+        - bbc.co.uk
+      initialDelaySeconds: 5
+      periodSeconds: 5
+  nodeSelector:
+        beta.kubernetes.io/os: windows


### PR DESCRIPTION
**Reason for Change**:
adds tests for e2e scenarios in windows containers. From issue #3632, 
* Port linux tests that make sense to a windows 
* Add [after awhile DNS check tests](https://github.com/Azure/acs-engine/blob/8824c1c9f8d03f86acbe04b4eb5bef46f60b0a92/test/e2e/kubernetes/kubernetes_test.go#L850) for dns lookups for windows containers.


**Issue Fixed**:


**Requirements**:


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
Reopening this issue from acs-engine:
https://github.com/Azure/acs-engine/pull/3765