### PR TITLE
fix: simplify comparison to satisfy linter

### DIFF
--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -849,7 +849,7 @@ func TestWindowsProfile(t *testing.T) {
 	}
 
 	update := w.GetEnableWindowsUpdate()
-	if update != true {
+	if !update {
 		t.Fatalf("Expected GetEnableWindowsUpdate() to equal default 'true', got %t", update)
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Fixes a `make test-style` problem that somehow crept in with #627, at least for me. It also fails inside `make dev`, so I assume this will be a problem for CI in general:
```console
==> Running static validations and linters <==
pkg/api/types_test.go:852:5: should omit comparison to bool constant, can be simplified to !update (megacheck.{unused,gosimple})
	if update != true {
	   ^
Makefile:126: recipe for target 'test-style' failed
make: *** [test-style] Error 1
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
