### PR TITLE
fix: address govet and gosimple issues

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
@@ -482,7 +481,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Tests GetLastVMNameInVMSS", func() {
-		ctx, _ := context.WithTimeout(context.Background(), 90*time.Minute)
+		ctx := context.Background()
 
 		mockClient := armhelpers.MockAKSEngineClient{}
 		mockClient.FakeListVirtualMachineScaleSetsResult = func() []compute.VirtualMachineScaleSet {

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -631,7 +631,7 @@ func (ku *Upgrader) getLastVMNameInVMSS(ctx context.Context, resourceGroup strin
 		}
 
 		vms := vmScaleSetVMsPage.Values()
-		if vms != nil && len(vms) > 0 {
+		if len(vms) > 0 {
 			vm := vms[len(vms)-1]
 			lastVMName = *vm.VirtualMachineScaleSetVMProperties.OsProfile.ComputerName
 		}


### PR DESCRIPTION
PR #570 introduced some code issues. This fixes that.

```
pkg/operations/kubernetesupgrade/upgradecluster_test.go:485:8: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak (govet)
                ctx, _ := context.WithTimeout(context.Background(), 90*time.Minute)
                     ^
pkg/operations/kubernetesupgrade/upgrader.go:634:6: S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
                if vms != nil && len(vms) > 0 {
```
