### PR TITLE
fix: Remove retaining custom properties logic for master nodes

### DIFF
--- a/docs/topics/upgrade.md
+++ b/docs/topics/upgrade.md
@@ -47,8 +47,7 @@ Master nodes:
 - cordon the node and drain existing workloads
 - delete the VM
 - create new VM and install desired Kubernetes version
-- add the new VM to the cluster
-- copy the custom annotations, labels and taints of old node to new node.
+- add the new VM to the cluster (custom annotations, labels and taints etc are retained automatically)
 
 Agent nodes:
 

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -145,7 +145,7 @@ func (ku *Upgrader) upgradeMasterNodes(ctx context.Context) error {
 
 		masterIndex, _ := utils.GetVMNameIndex(vm.StorageProfile.OsDisk.OsType, *vm.Name)
 
-		err = upgradeMasterNode.DeleteNode(vm.Name, false)
+		err := upgradeMasterNode.DeleteNode(vm.Name, false)
 		if err != nil {
 			ku.logger.Infof("Error deleting master VM: %s, err: %v", *vm.Name, err)
 			return err

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -140,22 +140,10 @@ func (ku *Upgrader) upgradeMasterNodes(ctx context.Context) error {
 		upgradedMastersIndex[masterIndex] = true
 	}
 
-	client, err := ku.getKubernetesClient()
-	if err != nil {
-		ku.logger.Errorf("Error getting Kubernetes client: %v", err)
-		return err
-	}
-
 	for _, vm := range *ku.ClusterTopology.MasterVMs {
 		ku.logger.Infof("Upgrading Master VM: %s", *vm.Name)
 
 		masterIndex, _ := utils.GetVMNameIndex(vm.StorageProfile.OsDisk.OsType, *vm.Name)
-
-		// Get the old master node's propertyies before it is deleted
-		oldNode, err := client.GetNode(*vm.Name)
-		if err != nil {
-			return err
-		}
 
 		err = upgradeMasterNode.DeleteNode(vm.Name, false)
 		if err != nil {
@@ -173,16 +161,6 @@ func (ku *Upgrader) upgradeMasterNodes(ctx context.Context) error {
 		if err != nil {
 			ku.logger.Infof("Error validating upgraded master VM: %s", *vm.Name)
 			return err
-		}
-
-		newNode, err := client.GetNode(*vm.Name)
-		if err != nil {
-			return err
-		}
-
-		err = ku.copyCustomNodeProperties(client, *vm.Name, oldNode, *vm.Name, newNode)
-		if err != nil {
-			ku.logger.Warningf("Failed to preserve custom annotations, labels, taints for master node %s: %v", *vm.Name, err)
 		}
 
 		upgradedMastersIndex[masterIndex] = true


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
The custom node properties are retained automatically for aks-engine master nodes, we don't need our special logic to do so. 

**Issue Fixed**:
The custom node properties are retained automatically for aks-engine master nodes, we don't need our special logic to do so. 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
