### PR TITLE
fix: always assign target version on upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -157,7 +157,7 @@ func (uc *upgradeCmd) loadCluster(cmd *cobra.Command) error {
 		return errors.Wrap(err, "error reading ARM file")
 	}
 	defer armTemplateHandle.Close()
-	err = uc.validateCurrentLocalState(armTemplateHandle)
+	err = uc.initializeFromLocalState(armTemplateHandle)
 	if err != nil {
 		return errors.Wrap(err, "error validating the api model")
 	}
@@ -184,7 +184,7 @@ func (uc *upgradeCmd) validateTargetVersion() error {
 	return nil
 }
 
-func (uc *upgradeCmd) validateCurrentLocalState(armTemplateHandle io.Reader) error {
+func (uc *upgradeCmd) initializeFromLocalState(armTemplateHandle io.Reader) error {
 	if uc.containerService.Location == "" {
 		uc.containerService.Location = uc.location
 	} else if uc.containerService.Location != uc.location {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -171,11 +171,9 @@ func (uc *upgradeCmd) validateTargetVersion() error {
 		return errors.Wrap(err, "error getting list of available upgrades")
 	}
 
-	// Validate desired upgrade version and set goal state.
 	found := false
 	for _, up := range orchestratorInfo.Upgrades {
 		if up.OrchestratorVersion == uc.upgradeVersion {
-			uc.containerService.Properties.OrchestratorProfile.OrchestratorVersion = uc.upgradeVersion
 			found = true
 			break
 		}
@@ -199,6 +197,7 @@ func (uc *upgradeCmd) validateCurrentLocalState(armTemplateHandle io.Reader) err
 			return errors.Wrap(err, "Invalid upgrade target version. Consider using --force if you really want to proceed")
 		}
 	}
+	uc.containerService.Properties.OrchestratorProfile.OrchestratorVersion = uc.upgradeVersion
 
 	//allows to identify VMs in the resource group that belong to this cluster.
 	if nameSuffix, err := readNameSuffixFromARMTemplate(armTemplateHandle); err == nil {

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -140,7 +140,7 @@ func TestUpgradeShouldFailForSameVersion(t *testing.T) {
 	containerServiceMock := api.CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
-	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
+	err := upgradeCmd.initializeFromLocalState(fakeARMTemplateHandle)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("upgrading from Kubernetes version 1.10.13 to version 1.10.13 is not supported"))
 	resetValidVersions()
@@ -166,7 +166,7 @@ func TestUpgradeShouldFailForInvalidUpgradePath(t *testing.T) {
 	containerServiceMock := api.CreateMockContainerService("testcluster", "1.10.12", 3, 2, false)
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
-	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
+	err := upgradeCmd.initializeFromLocalState(fakeARMTemplateHandle)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("upgrading from Kubernetes version 1.10.12 to version 1.10.13 is not supported"))
 	resetValidVersions()
@@ -191,7 +191,7 @@ func TestUpgradeShouldSuceedForValidUpgradePath(t *testing.T) {
 	containerServiceMock := api.CreateMockContainerService("testcluster", "1.10.12", 3, 2, false)
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
-	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
+	err := upgradeCmd.initializeFromLocalState(fakeARMTemplateHandle)
 	g.Expect(err).NotTo(HaveOccurred())
 	resetValidVersions()
 }
@@ -212,7 +212,7 @@ func TestUpgradeFailWithPathWhenAzureDeployJsonIsInvalid(t *testing.T) {
 	containerServiceMock := api.CreateMockContainerService("testcluster", "1.13.2", 3, 2, false)
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
-	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
+	err := upgradeCmd.initializeFromLocalState(fakeARMTemplateHandle)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("_output/myspecialtestfolder/azuredeploy.json"))
 }
@@ -236,7 +236,7 @@ func TestUpgradeForceSameVersionShouldSucceed(t *testing.T) {
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
 	upgradeCmd.force = true
-	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
+	err := upgradeCmd.initializeFromLocalState(fakeARMTemplateHandle)
 	g.Expect(err).NotTo(HaveOccurred())
 	resetValidVersions()
 }
@@ -262,7 +262,7 @@ func TestUpgradeForceDowngradeShouldSetVersionOnContainerService(t *testing.T) {
 	containerServiceMock.Location = "centralus"
 	upgradeCmd.containerService = containerServiceMock
 	upgradeCmd.force = true
-	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
+	err := upgradeCmd.initializeFromLocalState(fakeARMTemplateHandle)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(upgradeCmd.containerService.Properties.OrchestratorProfile.OrchestratorVersion).To(Equal("1.10.12"))
 	resetValidVersions()

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -240,3 +240,30 @@ func TestUpgradeForceSameVersionShouldSucceed(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	resetValidVersions()
 }
+
+func TestUpgradeForceDowngradeShouldSetVersionOnContainerService(t *testing.T) {
+	setupValidVersions(map[string]bool{
+		"1.10.12": true,
+		"1.10.13": true,
+	})
+	fakeARMTemplateHandle := strings.NewReader(`{"parameters" : { "nameSuffix" : {"defaultValue" : "test"}}}`)
+	g := NewGomegaWithT(t)
+	upgradeCmd := &upgradeCmd{
+		resourceGroupName:   "rg",
+		deploymentDirectory: "_output/test",
+		upgradeVersion:      "1.10.12",
+		location:            "centralus",
+		timeoutInMinutes:    60,
+
+		client: &armhelpers.MockAKSEngineClient{},
+	}
+
+	containerServiceMock := api.CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	containerServiceMock.Location = "centralus"
+	upgradeCmd.containerService = containerServiceMock
+	upgradeCmd.force = true
+	err := upgradeCmd.validateCurrentLocalState(fakeARMTemplateHandle)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(upgradeCmd.containerService.Properties.OrchestratorProfile.OrchestratorVersion).To(Equal("1.10.12"))
+	resetValidVersions()
+}


### PR DESCRIPTION
**Reason for Change**:  
<!-- What does this PR improve or fix in aks-engine? -->
This fixes a bug that did not assign the target version on the containerService object when `--force` was applied to the upgrade command.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
issue wasn't raised

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [x] adds unit tests

**Notes**:
The fix is implemented with the simplest change possible (move the assignment out of the if block) and does not refactor the upgrade command logic to make it less prone to such errors.

related to #525 