### PR TITLE
feat: add selective agentpool upgrade support - VMSS

### DIFF
--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -160,26 +160,3 @@ func GetK8sVMName(p *api.Properties, agentPoolProfile *api.AgentPoolProfile, age
 
 	return "", errors.Errorf("Failed to reconstruct VM Name")
 }
-
-// IsVMSSUpgradeable - checks if the current vm(in case of VMA) or vm instance (in case of VMSS)
-// is specified in the upgradeMap.
-func IsVMSSUpgradeable(upgradeMap map[string]bool, vmssName string) bool {
-	if len(upgradeMap) > 0 {
-		// Per agentpool upgrade is supported as of now only for linux agentpool names.
-		// When the windows and linux agentpool names will be unified to same format
-		// this will apply across.
-		regexp := regexp.MustCompile(vmssNamingFormat)
-		if capture := regexp.FindStringSubmatch(vmssName); capture != nil {
-			agentPoolName := capture[vmssAgentPoolNameIndex]
-			// Skip the VMSS pool if not requested by caller.
-			if upgradeMap[agentPoolName] {
-				return true
-			} else {
-				return false
-			}
-		}
-	}
-	// If the map is not given, or could not match up any naming convention,
-	// then just return back true to let the upgrade proceed as before.
-	return true
-}

--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -160,3 +160,26 @@ func GetK8sVMName(p *api.Properties, agentPoolProfile *api.AgentPoolProfile, age
 
 	return "", errors.Errorf("Failed to reconstruct VM Name")
 }
+
+// IsVMSSUpgradeable - checks if the current vm(in case of VMA) or vm instance (in case of VMSS)
+// is specified in the upgradeMap.
+func IsVMSSUpgradeable(upgradeMap map[string]bool, vmssName string) bool {
+	if len(upgradeMap) > 0 {
+		// Per agentpool upgrade is supported as of now only for linux agentpool names.
+		// When the windows and linux agentpool names will be unified to same format
+		// this will apply across.
+		regexp := regexp.MustCompile(vmssNamingFormat)
+		if capture := regexp.FindStringSubmatch(vmssName); capture != nil {
+			agentPoolName := capture[vmssAgentPoolNameIndex]
+			// Skip the VMSS pool if not requested by caller.
+			if upgradeMap[agentPoolName] {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+	// If the map is not given, or could not match up any naming convention,
+	// then just return back true to let the upgrade proceed as before.
+	return true
+}

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -18,6 +18,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// IsVMSSToBeUpgradedCb - Call back for checking whether the given vmss is to be upgraded or not.
+type IsVMSSToBeUpgradedCb func(vmss string, cs *api.ContainerService) bool
+
 // ClusterTopology contains resources of the cluster the upgrade operation
 // is targeting
 type ClusterTopology struct {
@@ -34,6 +37,8 @@ type ClusterTopology struct {
 
 	MasterVMs         *[]compute.VirtualMachine
 	UpgradedMasterVMs *[]compute.VirtualMachine
+
+	IsVMSSToBeUpgraded IsVMSSToBeUpgradedCb
 }
 
 // AgentPoolScaleSet contains necessary data required to upgrade a VMSS
@@ -127,7 +132,7 @@ func (uc *UpgradeCluster) getClusterNodeStatus(az armhelpers.AKSEngineClient, re
 			return err
 		}
 		for _, vmScaleSet := range vmScaleSetPage.Values() {
-			if !utils.IsVMSSUpgradeable(uc.AgentPoolsToUpgrade, *vmScaleSet.Name) {
+			if uc.IsVMSSToBeUpgraded != nil && !uc.IsVMSSToBeUpgraded(*vmScaleSet.Name, uc.DataModel) {
 				continue
 			}
 			for vmScaleSetVMsPage, err := uc.Client.ListVirtualMachineScaleSetVMs(ctx, resourceGroup, *vmScaleSet.Name); vmScaleSetVMsPage.NotDone(); err = vmScaleSetVMsPage.NextWithContext(ctx) {

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -127,6 +127,9 @@ func (uc *UpgradeCluster) getClusterNodeStatus(az armhelpers.AKSEngineClient, re
 			return err
 		}
 		for _, vmScaleSet := range vmScaleSetPage.Values() {
+			if !utils.IsVMSSUpgradeable(uc.AgentPoolsToUpgrade, *vmScaleSet.Name) {
+				continue
+			}
 			for vmScaleSetVMsPage, err := uc.Client.ListVirtualMachineScaleSetVMs(ctx, resourceGroup, *vmScaleSet.Name); vmScaleSetVMsPage.NotDone(); err = vmScaleSetVMsPage.NextWithContext(ctx) {
 				if err != nil {
 					return err


### PR DESCRIPTION
Currently the upgrade operaton upgrades the entire cluster, even if the 'AgentPoolsToUpgrade' is specified in the upgrade operation. This change adds the relevant code to skip agentpools which are not specified in the AgentPoolsToUpgrade, thus providing agentpool level upgrade support. This change only supports VMSS.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
