### PR TITLE
fix: always configure the container runtime for GPU in an N series context

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -143,14 +143,14 @@ write_files:
       "log-opts":  {
          "max-size": "50m",
          "max-file": "5"
-      }{{if IsNSeriesSKU .}}{{if IsNVIDIADevicePluginEnabled}}
+      }{{if IsNSeriesSKU .}}
       ,"default-runtime": "nvidia",
       "runtimes": {
          "nvidia": {
              "path": "/usr/bin/nvidia-container-runtime",
              "runtimeArgs": []
         }
-      }{{end}}{{end}}
+      }{{end}}
     }
 {{end}}
 

--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -16,11 +16,6 @@
       {{range $index, $agent := .AgentPoolProfiles}}
           "{{.Name}}Index": {{$index}},
           {{template "k8s/kubernetesagentvars.t" .}}
-          {{if IsNSeriesSKU .}}
-            {{if IsNVIDIADevicePluginEnabled}}
-            "registerWithGpuTaints": "nvidia.com/gpu=true:NoSchedule",
-            {{end}}
-          {{end}}
           {{if .IsStorageAccount}}
             {{if .HasDisks}}
               "{{.Name}}DataAccountName": "[concat(variables('storageAccountBaseName'), 'data{{$index}}')]",

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/Azure/aks-engine/pkg/api"
-	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/go-autorest/autorest/to"
 )
@@ -25,12 +24,6 @@ func GetKubernetesVariables(cs *api.ContainerService) map[string]interface{} {
 
 		for k, v := range agentVars {
 			k8sVars[k] = v
-		}
-
-		if common.IsNvidiaEnabledSKU(profile.VMSize) {
-			if cs.Properties.IsNVIDIADevicePluginEnabled() {
-				k8sVars["registerWithGpuTaints"] = "nvidia.com/gpu=true:NoSchedule"
-			}
 		}
 
 		if profile.IsStorageAccount() {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

We currently configure docker as GPU-enabled only if the particular nvidia addon that we deliver is enabled. This is problematic in the event that someone wants to disable *out* addon and configure their own. In that event, we should *always* configure the container runtime for GPU in an N series context.

Also cleaned up an unused taints variable.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
