### PR TITLE
fix: master vmss cluster configuration errors in template refactor

### DIFF
--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -239,10 +239,11 @@ func getK8sMasterVars(cs *api.ContainerService) map[string]interface{} {
 			} else {
 				masterVars["subnetName"] = "[concat(parameters('orchestratorName'), '-subnet')]"
 				masterVars["vnetSubnetID"] = "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
-				masterVars["virtualNetworkName"] = "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]"
-				masterVars["vnetID"] = "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]"
-				masterVars["virtualNetworkResourceGroupName"] = "''"
+
 			}
+			masterVars["virtualNetworkName"] = "[concat(parameters('orchestratorName'), '-vnet-', parameters('nameSuffix'))]"
+			masterVars["vnetID"] = "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]"
+			masterVars["virtualNetworkResourceGroupName"] = "''"
 		}
 		masterVars["routeTableName"] = "[concat(variables('masterVMNamePrefix'),'routetable')]"
 		if masterProfile.IsStorageAccount() {

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -56,7 +56,7 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 		Location: to.StringPtr("[variables('location')]"),
 		Name:     to.StringPtr("[concat(variables('masterVMNamePrefix'), 'vmss')]"),
 		Tags: map[string]*string{
-			"creationSource":     to.StringPtr("[concat(parameters('generatorCode'), '-', variables('masterVMNamePrefix'), 'vmss']"),
+			"creationSource":     to.StringPtr("[concat(parameters('generatorCode'), '-', variables('masterVMNamePrefix'), 'vmss')]"),
 			"resourceNameSuffix": to.StringPtr("[parameters('nameSuffix')]"),
 			"orchestrator":       to.StringPtr("[variables('orchestratorNameVersionTag')]"),
 			"aksEngineVersion":   to.StringPtr("[parameters('aksEngineVersion')]"),


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow-up from #324

- Fixes a typo the `creationSource` value of master VMSS object (missing closing param)
- Fixes conditional logic regression for non-hosted master / non-custom VNET scenarios
  - See the reference here for what needs to be implemented:
    - https://github.com/Azure/aks-engine/blob/master/parts/k8s/kubernetesmastervars.t#L206

Addresses some of https://github.com/Azure/aks-engine/issues/685

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
