### PR TITLE
fix: 2 Azure Stack vars are obligatory

### DIFF
--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -133,10 +133,11 @@ func getK8sMasterVars(cs *api.ContainerService) map[string]interface{} {
 		masterVars["apiVersionNetwork"] = "2017-10-01"
 		masterVars["apiVersionKeyVault"] = "2016-10-01"
 		masterVars["environmentJSON"] = cs.Properties.GetCustomEnvironmentJSON(false)
-		masterVars["customCloudAuthenticationMethod"] = cs.Properties.GetCustomCloudAuthenticationMethod()
-		masterVars["customCloudIdentifySystem"] = cs.Properties.GetCustomCloudIdentitySystem()
 		masterVars["provisionConfigsCustomCloud"] = GetKubernetesB64ConfigsCustomCloud()
 	}
+
+	masterVars["customCloudAuthenticationMethod"] = cs.Properties.GetCustomCloudAuthenticationMethod()
+	masterVars["customCloudIdentifySystem"] = cs.Properties.GetCustomCloudIdentitySystem()
 
 	if !isHostedMaster {
 		if isMasterVMSS {

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -158,6 +158,8 @@ func TestK8sVars(t *testing.T) {
 		"vnetNameResourceSegmentIndex":              8,
 		"vnetResourceGroupNameResourceSegmentIndex": 4,
 		"vnetSubnetID":                              "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+		"customCloudAuthenticationMethod":           cs.Properties.GetCustomCloudAuthenticationMethod(),
+		"customCloudIdentifySystem":                 cs.Properties.GetCustomCloudIdentitySystem(),
 	}
 	diff := cmp.Diff(varMap, expectedMap)
 


### PR DESCRIPTION
Based on the current implementation, we always need these variables for composition by the ARM template.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow-up from #677 

The added Azure Stack variables are implemented in a way that requires them to exist.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
