### PR TITLE
test: describe pod object in error scenario

### DIFF
--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -498,6 +498,10 @@ func WaitOnReady(podPrefix, namespace string, successesNeeded int, sleep, durati
 					if e != nil {
 						log.Printf("Unable to print pod logs for pod %s", p.Metadata.Name)
 					}
+					e = p.Describe()
+					if e != nil {
+						log.Printf("Unable to describe pod %s", p.Metadata.Name)
+					}
 				}
 			}
 			return false, err
@@ -789,6 +793,17 @@ func (p *Pod) Logs() error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// Describe will describe a pod resource
+func (p *Pod) Describe() error {
+	cmd := exec.Command("k", "describe", "pod", p.Metadata.Name, p.Metadata.Namespace)
+	out, err := util.RunAndLogCommand(cmd, commandTimeout)
+	log.Printf("\n%s\n", string(out))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -799,7 +799,7 @@ func (p *Pod) Logs() error {
 
 // Describe will describe a pod resource
 func (p *Pod) Describe() error {
-	cmd := exec.Command("k", "describe", "pod", p.Metadata.Name, p.Metadata.Namespace)
+	cmd := exec.Command("k", "describe", "pod", p.Metadata.Name, "-n", p.Metadata.Namespace)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))
 	if err != nil {

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -496,11 +496,11 @@ func WaitOnReady(podPrefix, namespace string, successesNeeded int, sleep, durati
 				for _, p := range pods {
 					e := p.Logs()
 					if e != nil {
-						log.Printf("Unable to print pod logs for pod %s", p.Metadata.Name)
+						log.Printf("Unable to print pod logs for pod %s: %s", p.Metadata.Name, e)
 					}
 					e = p.Describe()
 					if e != nil {
-						log.Printf("Unable to describe pod %s", p.Metadata.Name)
+						log.Printf("Unable to describe pod %s: %s", p.Metadata.Name, e)
 					}
 				}
 			}

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -802,10 +802,7 @@ func (p *Pod) Describe() error {
 	cmd := exec.Command("k", "describe", "pod", p.Metadata.Name, "-n", p.Metadata.Namespace)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // ValidateAzureFile will keep retrying the check if azure file is mounted in Pod


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Adds some additional pod introspection foo in the service of debugging #679. This will have general value, so "kubectl pod describe" has been added to the error gathering implementation for the various "wait for all pods to become ready" tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
