### PR TITLE
fix: commands return errors rather than exit

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -94,16 +94,21 @@ func getAPIModelWithoutServicePrincipalProfile(baseAPIModel string, useManagedId
 }
 
 func TestNewDeployCmd(t *testing.T) {
-	output := newDeployCmd()
-	if output.Use != deployName || output.Short != deployShortDescription || output.Long != deployLongDescription {
-		t.Fatalf("deploy command should have use %s equal %s, short %s equal %s and long %s equal to %s", output.Use, deployName, output.Short, deployShortDescription, output.Long, versionLongDescription)
+	command := newDeployCmd()
+	if command.Use != deployName || command.Short != deployShortDescription || command.Long != deployLongDescription {
+		t.Fatalf("deploy command should have use %s equal %s, short %s equal %s and long %s equal to %s", command.Use, deployName, command.Short, deployShortDescription, command.Long, versionLongDescription)
 	}
 
 	expectedFlags := []string{"api-model", "dns-prefix", "auto-suffix", "output-directory", "ca-private-key-path", "resource-group", "location", "force-overwrite"}
 	for _, f := range expectedFlags {
-		if output.Flags().Lookup(f) == nil {
+		if command.Flags().Lookup(f) == nil {
 			t.Fatalf("deploy command should have flag %s", f)
 		}
+	}
+
+	command.SetArgs([]string{})
+	if err := command.Execute(); err == nil {
+		t.Fatalf("expected an error when calling deploy with no arguments")
 	}
 }
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -10,16 +10,21 @@ import (
 )
 
 func TestNewGenerateCmd(t *testing.T) {
-	output := newGenerateCmd()
-	if output.Use != generateName || output.Short != generateShortDescription || output.Long != generateLongDescription {
-		t.Fatalf("generate command should have use %s equal %s, short %s equal %s and long %s equal to %s", output.Use, generateName, output.Short, generateShortDescription, output.Long, generateLongDescription)
+	command := newGenerateCmd()
+	if command.Use != generateName || command.Short != generateShortDescription || command.Long != generateLongDescription {
+		t.Fatalf("generate command should have use %s equal %s, short %s equal %s and long %s equal to %s", command.Use, generateName, command.Short, generateShortDescription, command.Long, generateLongDescription)
 	}
 
 	expectedFlags := []string{"api-model", "output-directory", "ca-certificate-path", "ca-private-key-path", "set", "no-pretty-print", "parameters-only"}
 	for _, f := range expectedFlags {
-		if output.Flags().Lookup(f) == nil {
+		if command.Flags().Lookup(f) == nil {
 			t.Fatalf("generate command should have flag %s", f)
 		}
+	}
+
+	command.SetArgs([]string{})
+	if err := command.Execute(); err == nil {
+		t.Fatalf("expected an error when calling generate with no arguments")
 	}
 }
 

--- a/cmd/get_versions_test.go
+++ b/cmd/get_versions_test.go
@@ -4,19 +4,26 @@
 package cmd
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("The get-versions command", func() {
 	It("should create a get-versions command", func() {
-		output := newGetVersionsCmd()
+		command := newGetVersionsCmd()
 
-		Expect(output.Use).Should(Equal(getVersionsName))
-		Expect(output.Short).Should(Equal(getVersionsShortDescription))
-		Expect(output.Long).Should(Equal(getVersionsLongDescription))
-		Expect(output.Flags().Lookup("orchestrator")).To(BeNil())
-		Expect(output.Flags().Lookup("version")).NotTo(BeNil())
+		Expect(command.Use).Should(Equal(getVersionsName))
+		Expect(command.Short).Should(Equal(getVersionsShortDescription))
+		Expect(command.Long).Should(Equal(getVersionsLongDescription))
+		Expect(command.Flags().Lookup("orchestrator")).To(BeNil())
+		Expect(command.Flags().Lookup("version")).NotTo(BeNil())
+
+		// Use a trimmed copy of os.Args to work around ginkgo flags.Parse() issue
+		command.SetArgs(os.Args[:1])
+		err := command.Execute()
+		Expect(err).To(BeNil())
 	})
 
 	It("should support JSON output", func() {

--- a/cmd/get_versions_test.go
+++ b/cmd/get_versions_test.go
@@ -18,7 +18,6 @@ var _ = Describe("The get-versions command", func() {
 		Expect(command.Flags().Lookup("orchestrator")).To(BeNil())
 		Expect(command.Flags().Lookup("version")).NotTo(BeNil())
 
-		// Use a trimmed copy of os.Args to work around ginkgo flags.Parse() issue
 		command.SetArgs([]string{})
 		err := command.Execute()
 		Expect(err).To(BeNil())

--- a/cmd/get_versions_test.go
+++ b/cmd/get_versions_test.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -21,7 +19,7 @@ var _ = Describe("The get-versions command", func() {
 		Expect(command.Flags().Lookup("version")).NotTo(BeNil())
 
 		// Use a trimmed copy of os.Args to work around ginkgo flags.Parse() issue
-		command.SetArgs(os.Args[:1])
+		command.SetArgs([]string{})
 		err := command.Execute()
 		Expect(err).To(BeNil())
 	})

--- a/cmd/get_versions_test.go
+++ b/cmd/get_versions_test.go
@@ -20,7 +20,7 @@ var _ = Describe("The get-versions command", func() {
 
 		command.SetArgs([]string{})
 		err := command.Execute()
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should support JSON output", func() {
@@ -30,7 +30,7 @@ var _ = Describe("The get-versions command", func() {
 			output:       "json",
 		}
 		err := command.run(nil, nil)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should support human-readable output", func() {
@@ -40,7 +40,7 @@ var _ = Describe("The get-versions command", func() {
 			output:       "human",
 		}
 		err := command.run(nil, nil)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should error on an invalid output option", func() {
@@ -50,7 +50,7 @@ var _ = Describe("The get-versions command", func() {
 			output:       "yaml",
 		}
 		err := command.run(nil, nil)
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("output format \"yaml\" is not supported"))
 	})
 })

--- a/cmd/orchestrators_test.go
+++ b/cmd/orchestrators_test.go
@@ -4,19 +4,26 @@
 package cmd
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("The orchestrators command", func() {
 	It("should create an orchestrators command", func() {
-		output := newOrchestratorsCmd()
+		command := newOrchestratorsCmd()
 
-		Expect(output.Use).Should(Equal(orchestratorsName))
-		Expect(output.Short).Should(Equal(orchestratorsShortDescription))
-		Expect(output.Long).Should(Equal(orchestratorsLongDescription))
-		Expect(output.Flags().Lookup("orchestrator")).NotTo(BeNil())
-		Expect(output.Flags().Lookup("version")).NotTo(BeNil())
+		Expect(command.Use).Should(Equal(orchestratorsName))
+		Expect(command.Short).Should(Equal(orchestratorsShortDescription))
+		Expect(command.Long).Should(Equal(orchestratorsLongDescription))
+		Expect(command.Flags().Lookup("orchestrator")).NotTo(BeNil())
+		Expect(command.Flags().Lookup("version")).NotTo(BeNil())
+
+		// Use a trimmed copy of os.Args to work around ginkgo flags.Parse() issue
+		command.SetArgs(os.Args[:1])
+		err := command.Execute()
+		Expect(err).To(BeNil())
 	})
 
 	It("should fail on unsupported orchestrator", func() {

--- a/cmd/orchestrators_test.go
+++ b/cmd/orchestrators_test.go
@@ -20,7 +20,7 @@ var _ = Describe("The orchestrators command", func() {
 
 		command.SetArgs([]string{})
 		err := command.Execute()
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should fail on unsupported orchestrator", func() {
@@ -29,7 +29,7 @@ var _ = Describe("The orchestrators command", func() {
 		}
 
 		err := command.run(nil, nil)
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("Unsupported orchestrator 'unsupported'"))
 	})
 
@@ -39,7 +39,7 @@ var _ = Describe("The orchestrators command", func() {
 		}
 
 		err := command.run(nil, nil)
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("Must specify orchestrator for version '1.1.1'"))
 	})
 
@@ -50,7 +50,7 @@ var _ = Describe("The orchestrators command", func() {
 		}
 
 		err := command.run(nil, nil)
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("Kubernetes version 1.1.1 is not supported"))
 	})
 
@@ -62,6 +62,6 @@ var _ = Describe("The orchestrators command", func() {
 		}
 
 		err := command.run(nil, nil)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/cmd/orchestrators_test.go
+++ b/cmd/orchestrators_test.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -20,8 +18,7 @@ var _ = Describe("The orchestrators command", func() {
 		Expect(command.Flags().Lookup("orchestrator")).NotTo(BeNil())
 		Expect(command.Flags().Lookup("version")).NotTo(BeNil())
 
-		// Use a trimmed copy of os.Args to work around ginkgo flags.Parse() issue
-		command.SetArgs(os.Args[:1])
+		command.SetArgs([]string{})
 		err := command.Execute()
 		Expect(err).To(BeNil())
 	})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -235,8 +235,8 @@ func getCompletionCmd(root *cobra.Command) *cobra.Command {
 	# ~/.bashrc or ~/.profile
 	source <(aks-engine completion)
 	`,
-		Run: func(cmd *cobra.Command, args []string) {
-			root.GenBashCompletion(os.Stdout)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return root.GenBashCompletion(os.Stdout)
 		},
 	}
 	return completionCmd

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -24,7 +24,7 @@ func TestNewRootCmd(t *testing.T) {
 		}
 	}
 
-	command.SetArgs([]string{})
+	command.SetArgs([]string{"--debug"})
 	err := command.Execute()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -12,16 +12,22 @@ import (
 )
 
 func TestNewRootCmd(t *testing.T) {
-	output := NewRootCmd()
-	if output.Use != rootName || output.Short != rootShortDescription || output.Long != rootLongDescription {
-		t.Fatalf("root command should have use %s equal %s, short %s equal %s and long %s equal to %s", output.Use, rootName, output.Short, rootShortDescription, output.Long, rootLongDescription)
+	command := NewRootCmd()
+	if command.Use != rootName || command.Short != rootShortDescription || command.Long != rootLongDescription {
+		t.Fatalf("root command should have use %s equal %s, short %s equal %s and long %s equal to %s", command.Use, rootName, command.Short, rootShortDescription, command.Long, rootLongDescription)
 	}
-	expectedCommands := []*cobra.Command{getCompletionCmd(output), newDeployCmd(), newGenerateCmd(), newGetVersionsCmd(), newOrchestratorsCmd(), newScaleCmd(), newUpgradeCmd(), newVersionCmd()}
-	rc := output.Commands()
+	expectedCommands := []*cobra.Command{getCompletionCmd(command), newDeployCmd(), newGenerateCmd(), newGetVersionsCmd(), newOrchestratorsCmd(), newScaleCmd(), newUpgradeCmd(), newVersionCmd()}
+	rc := command.Commands()
 	for i, c := range expectedCommands {
 		if rc[i].Use != c.Use {
 			t.Fatalf("root command should have command %s", c.Use)
 		}
+	}
+
+	command.SetArgs([]string{})
+	err := command.Execute()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,6 +31,36 @@ func TestNewRootCmd(t *testing.T) {
 	}
 }
 
+func TestShowDefaultModelArg(t *testing.T) {
+	command := NewRootCmd()
+	command.SetArgs([]string{"--show-default-model"})
+	err := command.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// TODO: examine command output
+}
+
+func TestDebugArg(t *testing.T) {
+	command := NewRootCmd()
+	command.SetArgs([]string{"--show-default-model"})
+	err := command.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// TODO: examine command output
+}
+
+func TestCompletionCommand(t *testing.T) {
+	command := getCompletionCmd(NewRootCmd())
+	command.SetArgs([]string{})
+	err := command.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// TODO: examine command output
+}
+
 func TestGetSelectedCloudFromAzConfig(t *testing.T) {
 	for _, test := range []struct {
 		desc   string

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -356,7 +356,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 
 	err = json.Unmarshal([]byte(parameters), &parametersJSON)
 	if err != nil {
-		return errors.Wrap(err, "errror unmarshalling parameters")
+		return errors.Wrap(err, "errror unmarshaling parameters")
 	}
 
 	transformer := transform.Transformer{Translator: translator.Translator}

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -335,8 +335,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 
 	_, err = sc.containerService.SetPropertiesDefaults(false, true)
 	if err != nil {
-		log.Fatalf("error in SetPropertiesDefaults template %s: %s", sc.apiModelPath, err.Error())
-		os.Exit(1)
+		return errors.Wrapf(err, "error in SetPropertiesDefaults template %s", sc.apiModelPath)
 	}
 	template, parameters, err := templateGenerator.GenerateTemplate(sc.containerService, engine.DefaultGeneratorCode, BuildTag)
 	if err != nil {

--- a/cmd/scale_test.go
+++ b/cmd/scale_test.go
@@ -11,16 +11,21 @@ import (
 )
 
 func TestNewScaleCmd(t *testing.T) {
-	output := newScaleCmd()
-	if output.Use != scaleName || output.Short != scaleShortDescription || output.Long != scaleLongDescription {
-		t.Fatalf("scale command should have use %s equal %s, short %s equal %s and long %s equal to %s", output.Use, scaleName, output.Short, scaleShortDescription, output.Long, scaleLongDescription)
+	command := newScaleCmd()
+	if command.Use != scaleName || command.Short != scaleShortDescription || command.Long != scaleLongDescription {
+		t.Fatalf("scale command should have use %s equal %s, short %s equal %s and long %s equal to %s", command.Use, scaleName, command.Short, scaleShortDescription, command.Long, scaleLongDescription)
 	}
 
 	expectedFlags := []string{"location", "resource-group", "deployment-dir", "new-node-count", "node-pool", "master-FQDN"}
 	for _, f := range expectedFlags {
-		if output.Flags().Lookup(f) == nil {
+		if command.Flags().Lookup(f) == nil {
 			t.Fatalf("scale command should have flag %s", f)
 		}
+	}
+
+	command.SetArgs([]string{})
+	if err := command.Execute(); err == nil {
+		t.Fatalf("expected an error when calling scale with no arguments")
 	}
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -254,12 +254,12 @@ func readNameSuffixFromARMTemplate(armTemplateHandle io.Reader) (string, error) 
 func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 	err := uc.validate(cmd)
 	if err != nil {
-		log.Fatalf("Error validating upgrade command: %v", err)
+		return errors.Wrap(err, "validating upgrade command")
 	}
 
 	err = uc.loadCluster(cmd)
 	if err != nil {
-		log.Fatalf("Error loading existing cluster: %v", err)
+		return errors.Wrap(err, "loading existing cluster")
 	}
 
 	upgradeCluster := kubernetesupgrade.UpgradeCluster{
@@ -281,11 +281,11 @@ func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 
 	kubeConfig, err := engine.GenerateKubeConfig(uc.containerService.Properties, uc.location)
 	if err != nil {
-		log.Fatalf("Failed to generate kubeconfig: %v", err)
+		return errors.Wrap(err, "generating kubeconfig")
 	}
 
 	if err = upgradeCluster.UpgradeCluster(uc.client, kubeConfig, BuildTag); err != nil {
-		log.Fatalf("Error upgrading cluster: %v\n", err)
+		return errors.Wrap(err, "upgrading cluster")
 	}
 
 	// Save the new apimodel to reflect the cluster's state.

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -108,17 +108,22 @@ func TestUpgradeCommandShouldBeValidated(t *testing.T) {
 	}
 }
 
-func TestCreateUpgradeCommandSuccesfully(t *testing.T) {
+func TestCreateUpgradeCommand(t *testing.T) {
 	g := NewGomegaWithT(t)
-	output := newUpgradeCmd()
+	command := newUpgradeCmd()
 
-	g.Expect(output.Use).Should(Equal(upgradeName))
-	g.Expect(output.Short).Should(Equal(upgradeShortDescription))
-	g.Expect(output.Long).Should(Equal(upgradeLongDescription))
-	g.Expect(output.Flags().Lookup("location")).NotTo(BeNil())
-	g.Expect(output.Flags().Lookup("resource-group")).NotTo(BeNil())
-	g.Expect(output.Flags().Lookup("deployment-dir")).NotTo(BeNil())
-	g.Expect(output.Flags().Lookup("upgrade-version")).NotTo(BeNil())
+	g.Expect(command.Use).Should(Equal(upgradeName))
+	g.Expect(command.Short).Should(Equal(upgradeShortDescription))
+	g.Expect(command.Long).Should(Equal(upgradeLongDescription))
+	g.Expect(command.Flags().Lookup("location")).NotTo(BeNil())
+	g.Expect(command.Flags().Lookup("resource-group")).NotTo(BeNil())
+	g.Expect(command.Flags().Lookup("deployment-dir")).NotTo(BeNil())
+	g.Expect(command.Flags().Lookup("upgrade-version")).NotTo(BeNil())
+
+	command.SetArgs([]string{})
+	if err := command.Execute(); err == nil {
+		t.Fatalf("expected an error when calling upgrade with no arguments")
+	}
 }
 
 func TestUpgradeShouldFailForSameVersion(t *testing.T) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Azure/aks-engine/pkg/helpers"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -31,7 +30,7 @@ var (
 const (
 	versionName             = "version"
 	versionShortDescription = "Print the version of AKS Engine"
-	versionLongDescription  = "Print the version of AKS Engine"
+	versionLongDescription  = versionShortDescription
 )
 
 type versionInfo struct {
@@ -49,12 +48,10 @@ func init() {
 }
 
 func getHumanVersion() string {
-	r := fmt.Sprintf("Version: %s\nGitCommit: %s\nGitTreeState: %s",
+	return fmt.Sprintf("Version: %s\nGitCommit: %s\nGitTreeState: %s",
 		version.GitTag,
 		version.GitCommit,
 		version.GitTreeState)
-
-	return r
 }
 
 func getJSONVersion() string {
@@ -62,18 +59,15 @@ func getJSONVersion() string {
 	return string(jsonVersion)
 }
 
-func getVersion(outputType string) string {
-	var output string
-
-	if outputType == "human" {
-		output = getHumanVersion()
-	} else if outputType == "json" {
-		output = getJSONVersion()
-	} else {
-		log.Fatalf("output format \"%s\" is not supported", outputFormat)
+func getVersion(outputType string) (string, error) {
+	switch outputType {
+	case "human":
+		return getHumanVersion(), nil
+	case "json":
+		return getJSONVersion(), nil
+	default:
+		return "", fmt.Errorf("output format \"%s\" is not supported", outputType)
 	}
-
-	return output
 }
 
 func newVersionCmd() *cobra.Command {
@@ -82,8 +76,12 @@ func newVersionCmd() *cobra.Command {
 		Short: versionShortDescription,
 		Long:  versionLongDescription,
 
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(getVersion(outputFormat))
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output, err := getVersion(outputFormat)
+			if err == nil {
+				fmt.Println(output)
+			}
+			return err
 		},
 	}
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -21,7 +21,7 @@ var _ = Describe("the version command", func() {
 
 		command.SetArgs([]string{})
 		err := command.Execute()
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should print a json version of AKS Engine", func() {
@@ -46,7 +46,7 @@ var _ = Describe("the version command", func() {
 	It("should error when asked for a yaml version of AKS Engine", func() {
 		output, err := getVersion("yaml")
 
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("output format \"yaml\" is not supported"))
 		Expect(output).To(BeEmpty())
 	})

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/Azure/aks-engine/pkg/helpers"
 	. "github.com/onsi/ginkgo"
@@ -13,13 +14,15 @@ import (
 
 var _ = Describe("the version command", func() {
 	It("should create a version command", func() {
-		output := newVersionCmd()
-		Expect(output.Use).Should(Equal(versionName))
-		Expect(output.Short).Should(Equal(versionShortDescription))
-		Expect(output.Long).Should(Equal(versionLongDescription))
-		Expect(output.Flags().Lookup("output")).NotTo(BeNil())
+		command := newVersionCmd()
+		Expect(command.Use).Should(Equal(versionName))
+		Expect(command.Short).Should(Equal(versionShortDescription))
+		Expect(command.Long).Should(Equal(versionLongDescription))
+		Expect(command.Flags().Lookup("output")).NotTo(BeNil())
 
-		err := output.Execute()
+		// Use a trimmed copy of os.Args to work around ginkgo flags.Parse() issue
+		command.SetArgs(os.Args[:1])
+		err := command.Execute()
 		Expect(err).To(BeNil())
 	})
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/Azure/aks-engine/pkg/helpers"
 	. "github.com/onsi/ginkgo"
@@ -20,8 +19,7 @@ var _ = Describe("the version command", func() {
 		Expect(command.Long).Should(Equal(versionLongDescription))
 		Expect(command.Flags().Lookup("output")).NotTo(BeNil())
 
-		// Use a trimmed copy of os.Args to work around ginkgo flags.Parse() issue
-		command.SetArgs(os.Args[:1])
+		command.SetArgs([]string{})
 		err := command.Execute()
 		Expect(err).To(BeNil())
 	})

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -18,17 +18,21 @@ var _ = Describe("the version command", func() {
 		Expect(output.Short).Should(Equal(versionShortDescription))
 		Expect(output.Long).Should(Equal(versionLongDescription))
 		Expect(output.Flags().Lookup("output")).NotTo(BeNil())
+
+		err := output.Execute()
+		Expect(err).To(BeNil())
 	})
 
 	It("should print a json version of AKS Engine", func() {
-		output := getVersion("json")
+		output, _ := getVersion("json")
 
 		expectedOutput, _ := helpers.JSONMarshalIndent(version, "", "  ", false)
 
 		Expect(output).Should(Equal(string(expectedOutput)))
 	})
+
 	It("should print a humanized version of AKS Engine", func() {
-		output := getVersion("human")
+		output, _ := getVersion("human")
 
 		expectedOutput := fmt.Sprintf("Version: %s\nGitCommit: %s\nGitTreeState: %s",
 			BuildTag,
@@ -38,11 +42,11 @@ var _ = Describe("the version command", func() {
 		Expect(output).Should(Equal(expectedOutput))
 	})
 
-	It("should print a json version of AKS Engine", func() {
-		output := getVersion("json")
+	It("should error when asked for a yaml version of AKS Engine", func() {
+		output, err := getVersion("yaml")
 
-		expectedOutput, _ := helpers.JSONMarshalIndent(version, "", "  ", false)
-
-		Expect(output).Should(Equal(string(expectedOutput)))
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("output format \"yaml\" is not supported"))
+		Expect(output).To(BeEmpty())
 	})
 })

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/Azure/aks-engine/cmd"
 	colorable "github.com/mattn/go-colorable"
 	log "github.com/sirupsen/logrus"
@@ -13,6 +15,6 @@ func main() {
 	log.SetFormatter(&log.TextFormatter{ForceColors: true})
 	log.SetOutput(colorable.NewColorableStdout())
 	if err := cmd.NewRootCmd().Execute(); err != nil {
-		log.Fatalln(err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Many places in the `cmd` module were calling `log.Fatalf` which makes that code untestable since it calls `os.Exit`. (This also meant that errors in a couple commands would have a return code of 0.)

This refactors commands so errors are returned all the way to the caller in `main.go` where they can be handled consistently. This also add some basic test coverage at that level, although there is more that can be done in that respect.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #536
Fixes #518

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
