### PR TITLE
build: compress aks-engine binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build-windows-k8s:
 	./scripts/build-windows-k8s.sh -v ${K8S_VERSION} -p ${PATCH_VERSION}
 
 .PHONY: dist
-dist: build-cross
+dist: build-cross compress-binaries
 	( \
 		cd _dist && \
 		$(DIST_DIRS) cp ../LICENSE {} \; && \
@@ -102,6 +102,11 @@ dist: build-cross
 		$(DIST_DIRS) tar -zcf {}.tar.gz {} \; && \
 		$(DIST_DIRS) zip -r {}.zip {} \; \
 	)
+
+.PHONY: compress-binaries
+compress-binaries:
+	@which upx || (echo "Please install the upx executable packer tool. See https://upx.github.io/" && exit 1)
+	find _dist -type f \( -name "aks-engine" -o -name "aks-engine.exe" \) -exec upx -9 {} +
 
 .PHONY: checksum
 checksum:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Uses the [`upx`](https://upx.github.io/) tool to compress the `aks-engine` and `aks-engine.exe` binaries.

Since `upx` knows tricks specific to each binary format, it compresses better than `zip` or `tar` in this case. This makes our commonly-downloaded artifacts a bit smaller:

```sh
$ git co master && make clean dist && akse-dist-sizes
...
-rw-r--r--  1 matt  staff    19M Mar  8 14:05 _dist/aks-engine-2f96b59c2-darwin-amd64.tar.gz
-rw-r--r--  1 matt  staff    19M Mar  8 14:05 _dist/aks-engine-2f96b59c2-darwin-amd64.zip
-rwxr-xr-x  1 matt  staff    49M Mar  8 14:05 _dist/aks-engine-2f96b59c2-darwin-amd64/aks-engine
-rw-r--r--  1 matt  staff    11M Mar  8 14:05 _dist/aks-engine-2f96b59c2-linux-amd64.tar.gz
-rw-r--r--  1 matt  staff    11M Mar  8 14:05 _dist/aks-engine-2f96b59c2-linux-amd64.zip
-rwxr-xr-x  1 matt  staff    36M Mar  8 14:05 _dist/aks-engine-2f96b59c2-linux-amd64/aks-engine
-rw-r--r--  1 matt  staff    11M Mar  8 14:05 _dist/aks-engine-2f96b59c2-windows-amd64.tar.gz
-rw-r--r--  1 matt  staff    11M Mar  8 14:06 _dist/aks-engine-2f96b59c2-windows-amd64.zip
-rwxr-xr-x  1 matt  staff    36M Mar  8 14:05 _dist/aks-engine-2f96b59c2-windows-amd64/aks-engine.exe
$ git co upx-the-binaries && make clean dist && akse-dist-sizes
...
-rw-r--r--  1 matt  staff    18M Mar  8 14:04 _dist/aks-engine-318d9f129-darwin-amd64.tar.gz
-rw-r--r--  1 matt  staff    18M Mar  8 14:04 _dist/aks-engine-318d9f129-darwin-amd64.zip
-rwxr-xr-x  1 matt  staff    18M Mar  8 14:03 _dist/aks-engine-318d9f129-darwin-amd64/aks-engine
-rw-r--r--  1 matt  staff    10M Mar  8 14:04 _dist/aks-engine-318d9f129-linux-amd64.tar.gz
-rw-r--r--  1 matt  staff    10M Mar  8 14:04 _dist/aks-engine-318d9f129-linux-amd64.zip
-rwxr-xr-x  1 matt  staff    11M Mar  8 14:03 _dist/aks-engine-318d9f129-linux-amd64/aks-engine
-rw-r--r--  1 matt  staff    10M Mar  8 14:04 _dist/aks-engine-318d9f129-windows-amd64.tar.gz
-rw-r--r--  1 matt  staff    10M Mar  8 14:04 _dist/aks-engine-318d9f129-windows-amd64.zip
-rwxr-xr-x  1 matt  staff    11M Mar  8 14:03 _dist/aks-engine-318d9f129-windows-amd64/aks-engine.exe
```

Compressing the binary also has the advantage of shrinking Docker images that contain it:

```sh
$ docker images
REPOSITORY             TAG          IMAGE ID       CREATED             SIZE
microsoft/aks-engine   0.32.0       8c325d720bad   3 minutes ago       53.3MB
microsoft/aks-engine   d20cde97e8   a2fa26d7f72e   5 minutes ago       28MB
```


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This adds a dependency on `upx` and a couple minutes to the `make dist` task. It offers a slight decrease in archive and Docker image sizes. This approach was used in Deis Workflow components without any problems, but it may be preferable for AKS Engine to keep things simple instead.
