### PR TITLE
fix: agentpools have their own “is custom vnet” logic

### DIFF
--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -267,7 +267,7 @@ func createJumpboxNetworkInterface(cs *api.ContainerService) NetworkInterfaceARM
 
 func createAgentVMASNetworkInterface(cs *api.ContainerService, profile *api.AgentPoolProfile) NetworkInterfaceARM {
 	isWindows := profile.IsWindows()
-	isCustomVNet := cs.Properties.MasterProfile.IsCustomVNET()
+	isCustomVNet := profile.IsCustomVNET()
 	isAzureCNI := cs.Properties.OrchestratorProfile.IsAzureCNI()
 
 	armResource := ARMResource{

--- a/pkg/engine/networkinterfaces_test.go
+++ b/pkg/engine/networkinterfaces_test.go
@@ -680,7 +680,7 @@ func TestCreateAgentVMASNIC(t *testing.T) {
 
 	// Test AgentVMAS NIC with Custom Vnet
 
-	cs.Properties.MasterProfile.VnetSubnetID = "fooSubnet"
+	profile.VnetSubnetID = "fooSubnet"
 
 	actual = createAgentVMASNetworkInterface(cs, profile)
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

A small change to agentpool NIC logic in new template implementation to achieve parity with existing template implementation.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
