### PR TITLE
fix: add err != nil checks for json Unmarshal in scale and upgrade ops

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -190,7 +190,11 @@ func (sc *scaleCmd) load(cmd *cobra.Command) error {
 	contents, _ := ioutil.ReadFile(templatePath)
 
 	var template interface{}
-	json.Unmarshal(contents, &template)
+
+	err = json.Unmarshal(contents, &template)
+	if err != nil {
+		return errors.Wrap(err, "error while trying to unmarshal the ARM template")
+	}
 
 	templateMap := template.(map[string]interface{})
 	templateParameters := templateMap["parameters"].(map[string]interface{})

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -593,8 +593,17 @@ func (ku *Upgrader) generateUpgradeTemplate(upgradeContainerService *api.Contain
 
 	var template interface{}
 	var parameters interface{}
-	json.Unmarshal([]byte(templateJSON), &template)
-	json.Unmarshal([]byte(parametersJSON), &parameters)
+
+	err = json.Unmarshal([]byte(templateJSON), &template)
+	if err != nil {
+		return nil, nil, ku.Translator.Errorf("error while unmarshaling the ARM template JSON: %s", err.Error())
+	}
+
+	err = json.Unmarshal([]byte(parametersJSON), &parameters)
+	if err != nil {
+		return nil, nil, ku.Translator.Errorf("error while unmarshaling the ARM parameters JSON: %s", err.Error())
+	}
+
 	templateMap := template.(map[string]interface{})
 	parametersMap := parameters.(map[string]interface{})
 


### PR DESCRIPTION
Add appropriate err != nil checks to avoid panics when a json string isn't unmarshalled succesfully.