### PR TITLE
test: remove obsolete allocateNodeCidrs var

### DIFF
--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -531,7 +531,6 @@ func TestK8sVarsMastersOnly(t *testing.T) {
 
 	varMap := GetKubernetesVariables(cs)
 	expectedMap := map[string]interface{}{
-		"allocateNodeCidrs":                         false,
 		"apiVersionAuthorizationSystem":             "2018-01-01-preview",
 		"apiVersionAuthorizationUser":               "2018-09-01-preview",
 		"apiVersionCompute":                         "2018-10-01",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

"allocateNodeCidrs" var reference needs to be removed from TestK8sVarsMastersOnly unit test

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
