### PR TITLE
fix: primaryScaleSetName and primaryAvailabilitySetName var logic is …

### DIFF
--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -304,14 +304,17 @@ func getK8sMasterVars(cs *api.ContainerService) map[string]interface{} {
 	if cs.Properties.AnyAgentUsesVirtualMachineScaleSets() {
 		if hasAgentPool {
 			masterVars["primaryScaleSetName"] = fmt.Sprintf("[concat(parameters('orchestratorName'), '-%s-',parameters('nameSuffix'), '-vmss')]", profiles[0].Name)
+		} else {
+			masterVars["primaryScaleSetName"] = ""
 		}
 		masterVars["primaryAvailabilitySetName"] = ""
 		masterVars["vmType"] = "vmss"
 	} else {
 		if hasAgentPool {
 			masterVars["primaryAvailabilitySetName"] = fmt.Sprintf("[concat('%s-availabilitySet-',parameters('nameSuffix'))]", profiles[0].Name)
+		} else {
+			masterVars["primaryAvailabilitySetName"] = ""
 		}
-		masterVars["primaryAvailabilitySetName"] = ""
 		masterVars["primaryScaleSetName"] = ""
 		masterVars["vmType"] = "standard"
 	}


### PR DESCRIPTION
…incorrect

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Partly a regression from #692.

The var logic for primaryScaleSetName and primaryAvailabilitySetName is not correct in the v2 template generation implementation.

Reference implementation is here:

https://github.com/Azure/aks-engine/blob/master/parts/k8s/kubernetesmastervars.t#L211

Basically, we need to account for the masters-only scenario in both VMAS and VMSS.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes https://github.com/Azure/aks-engine/issues/707

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
