### PR TITLE
feat: added support for direct array assignment using --set

### DIFF
--- a/pkg/engine/transform/apimodel_merger_test.go
+++ b/pkg/engine/transform/apimodel_merger_test.go
@@ -20,6 +20,7 @@ func TestAPIModelMergerMapValues(t *testing.T) {
 		"agentPoolProfiles[0].name=agentpool1",
 		"linuxProfile.adminUsername=admin",
 		"servicePrincipalProfile.clientId='123a1238-c6eb-4b61-9d6f-7db6f1e14123',servicePrincipalProfile.secret='=!,Test$^='",
+		"certificateProfile.etcdPeerCertificates[0]=certificate-value",
 	}
 
 	MapValues(m, values)
@@ -32,13 +33,23 @@ func TestAPIModelMergerMapValues(t *testing.T) {
 	Expect(m["linuxProfile.adminUsername"].stringValue).To(BeIdenticalTo("admin"))
 	Expect(m["servicePrincipalProfile.secret"].stringValue).To(BeIdenticalTo("=!,Test$^="))
 	Expect(m["servicePrincipalProfile.clientId"].stringValue).To(BeIdenticalTo("123a1238-c6eb-4b61-9d6f-7db6f1e14123"))
+	Expect(m["certificateProfile.etcdPeerCertificates[0]"].arrayValue).To(BeTrue())
+	Expect(m["certificateProfile.etcdPeerCertificates[0]"].arrayIndex).To(BeIdenticalTo(0))
+	Expect(m["certificateProfile.etcdPeerCertificates[0]"].arrayProperty).To(BeEmpty())
+	Expect(m["certificateProfile.etcdPeerCertificates[0]"].arrayName).To(BeIdenticalTo("certificateProfile.etcdPeerCertificates"))
+	Expect(m["certificateProfile.etcdPeerCertificates[0]"].stringValue).To(BeIdenticalTo("certificate-value"))
 }
 
 func TestMergeValuesWithAPIModel(t *testing.T) {
 	RegisterTestingT(t)
 
 	m := make(map[string]APIModelValue)
-	values := []string{"masterProfile.count=5", "agentPoolProfiles[0].name=agentpool1", "linuxProfile.adminUsername=admin"}
+	values := []string{
+		"masterProfile.count=5",
+		"agentPoolProfiles[0].name=agentpool1",
+		"linuxProfile.adminUsername=admin",
+		"certificateProfile.etcdPeerCertificates[0]=certificate-value",
+	}
 
 	MapValues(m, values)
 	tmpFile, _ := MergeValuesWithAPIModel("../testdata/simple/kubernetes.json", m)
@@ -57,4 +68,7 @@ func TestMergeValuesWithAPIModel(t *testing.T) {
 
 	agentPoolProfileName := jsonAPIModel.Path("properties.agentPoolProfiles").Index(0).Path("name").Data().(string)
 	Expect(agentPoolProfileName).To(BeIdenticalTo("agentpool1"))
+
+	etcdPeerCertificates := jsonAPIModel.Path("properties.certificateProfile.etcdPeerCertificates").Index(0).Data()
+	Expect(etcdPeerCertificates).To(BeIdenticalTo("certificate-value"))
 }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This fix enables configuring `etcdPeerCertificates` using `--set certificateProfile.etcdPeerCertificates[0]="aaa" --set certificateProfile.etcdPeerCertificates[1]="aaa"`
minor: It also fixes diagnostic formatting to use decimal numbers instead of binary numbers

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
