### PR TITLE
 fix: Allow masters with custom images to use data disks for etcd

### DIFF
--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -908,7 +908,6 @@
           {{end}}
         },
         "storageProfile": {
-          {{if not UseMasterCustomImage}}
           "dataDisks": [
             {
               "createOption": "Empty"
@@ -922,7 +921,6 @@
               {{end}}
             }
           ],
-          {{end}}
           "imageReference": {
             {{if UseMasterCustomImage}}
             "id": "[resourceId(parameters('osImageResourceGroup'), 'Microsoft.Compute/images', parameters('osImageName'))]"

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -555,7 +555,6 @@
             {{end}}
         },
         "storageProfile": {
-          {{if not UseMasterCustomImage }}
           "dataDisks": [
             {
               "createOption": "Empty",
@@ -563,7 +562,6 @@
               "lun": 0
             }
           ],
-          {{end}}
           "imageReference": {
             {{if UseMasterCustomImage}}
             "id": "[resourceId(parameters('osImageResourceGroup'), 'Microsoft.Compute/images', parameters('osImageName'))]"

--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -143,24 +143,21 @@ func CreateVirtualMachine(cs *api.ContainerService) VirtualMachineARM {
 	storageProfile := &compute.StorageProfile{}
 	imageRef := cs.Properties.MasterProfile.ImageRef
 	useMasterCustomImage := imageRef != nil && len(imageRef.Name) > 0 && len(imageRef.ResourceGroup) > 0
-	if !useMasterCustomImage {
-		etcdSizeGB, _ := strconv.Atoi(cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
-		dataDisk := compute.DataDisk{
-			CreateOption: compute.DiskCreateOptionTypesEmpty,
-			DiskSizeGB:   to.Int32Ptr(int32(etcdSizeGB)),
-			Lun:          to.Int32Ptr(0),
-			Name:         to.StringPtr("[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"),
-		}
-		if cs.Properties.MasterProfile.IsStorageAccount() {
-			dataDisk.Vhd = &compute.VirtualHardDisk{
-				URI: to.StringPtr("[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"),
-			}
-		}
-		storageProfile.DataDisks = &[]compute.DataDisk{
-			dataDisk,
+	etcdSizeGB, _ := strconv.Atoi(cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
+	dataDisk := compute.DataDisk{
+		CreateOption: compute.DiskCreateOptionTypesEmpty,
+		DiskSizeGB:   to.Int32Ptr(int32(etcdSizeGB)),
+		Lun:          to.Int32Ptr(0),
+		Name:         to.StringPtr("[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"),
+	}
+	if cs.Properties.MasterProfile.IsStorageAccount() {
+		dataDisk.Vhd = &compute.VirtualHardDisk{
+			URI: to.StringPtr("[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"),
 		}
 	}
-
+	storageProfile.DataDisks = &[]compute.DataDisk{
+		dataDisk,
+	}
 	imgReference := &compute.ImageReference{}
 	if useMasterCustomImage {
 		imgReference.ID = to.StringPtr("[resourceId(parameters('osImageResourceGroup'), 'Microsoft.Compute/images', parameters('osImageName'))]")

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -215,16 +215,14 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 	storageProfile := compute.VirtualMachineScaleSetStorageProfile{}
 	imageRef := masterProfile.ImageRef
 	useMasterCustomImage := imageRef != nil && len(imageRef.Name) > 0 && len(imageRef.ResourceGroup) > 0
-	if !useMasterCustomImage {
-		etcdSizeGB, _ := strconv.Atoi(k8sConfig.EtcdDiskSizeGB)
-		dataDisk := compute.VirtualMachineScaleSetDataDisk{
-			CreateOption: compute.DiskCreateOptionTypesEmpty,
-			DiskSizeGB:   to.Int32Ptr(int32(etcdSizeGB)),
-			Lun:          to.Int32Ptr(0),
-		}
-		storageProfile.DataDisks = &[]compute.VirtualMachineScaleSetDataDisk{
-			dataDisk,
-		}
+	etcdSizeGB, _ := strconv.Atoi(k8sConfig.EtcdDiskSizeGB)
+	dataDisk := compute.VirtualMachineScaleSetDataDisk{
+		CreateOption: compute.DiskCreateOptionTypesEmpty,
+		DiskSizeGB:   to.Int32Ptr(int32(etcdSizeGB)),
+		Lun:          to.Int32Ptr(0),
+	}
+	storageProfile.DataDisks = &[]compute.VirtualMachineScaleSetDataDisk{
+		dataDisk,
 	}
 	imgReference := &compute.ImageReference{}
 	if useMasterCustomImage {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Allow masters with custom images to use data disks for etcd

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #496 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Tested with a custom ubuntu 16.04 image. And this model:
```
{
  "apiVersion": "vlabs",
  "properties": {
    "orchestratorProfile": {
      "orchestratorType": "Kubernetes",
      "kubernetesConfig": {
      "etcdDiskSizeGB": "256"
}
    },
    "masterProfile": {
      "count": 1,
      "dnsPrefix": "",
      "vmSize": "Standard_DS2_v2",
      "imageReference": {
        "name": "ubuntu-16-04",
        "resourceGroup": "test-images"
      },
      "availabilityProfile": "AvailabilitySet"
    },
    "agentPoolProfiles": [
      {
        "name": "agent",
        "count": 1,
        "vmSize": "Standard_DS2_v2",
        "storageProfile" : "ManagedDisks",
      "imageReference": {
        "name": "ubuntu-16-04",
        "resourceGroup": "test-images"
      },
        "availabilityProfile": "VirtualMachineScaleSets"
      }
    ],
    "linuxProfile": {
      "adminUsername": "azureuser",
      "ssh": {
        "publicKeys": [
          {
            "keyData": ""
          }
        ]
      }
    },
    "servicePrincipalProfile": {
      "clientId": "",
      "secret": ""
    }
  }
}
```

etcd volume is created using a Premium SSD and mounted at 
```
Filesystem     Mounted on
/dev/sdc1      /var/lib/etcddisk
```