### PR TITLE
feat: windows agentpool support for AKS

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -128,17 +128,25 @@ func (cs *ContainerService) setKubeletConfig() {
 		if profile.KubernetesConfig == nil {
 			profile.KubernetesConfig = &KubernetesConfig{}
 			profile.KubernetesConfig.KubeletConfig = make(map[string]string)
-			if profile.OSType == "Windows" {
-				for key, val := range staticWindowsKubeletConfig {
-					profile.KubernetesConfig.KubeletConfig[key] = val
-				}
+		}
+
+		if profile.OSType == "Windows" {
+			for key, val := range staticWindowsKubeletConfig {
+				profile.KubernetesConfig.KubeletConfig[key] = val
 			}
 		}
+
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 
 		if profile.OSType == "Windows" {
 			// Remove Linux-specific values
 			delete(profile.KubernetesConfig.KubeletConfig, "--pod-manifest-path")
+
+			if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) {
+				for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
+					delete(profile.KubernetesConfig.KubeletConfig, key)
+				}
+			}
 		}
 
 		// For N Series (GPU) VMs

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -149,14 +149,6 @@ func (cs *ContainerService) setKubeletConfig() {
 
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 
-		if profile.OSType == "Windows" {
-			if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) {
-				for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
-					delete(profile.KubernetesConfig.KubeletConfig, key)
-				}
-			}
-		}
-
 		// For N Series (GPU) VMs
 		if strings.Contains(profile.VMSize, "Standard_N") {
 			if !cs.Properties.IsNVIDIADevicePluginEnabled() && !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.11.0") {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -532,7 +532,7 @@ type AgentPoolProfile struct {
 	SinglePlacementGroup                *bool                `json:"singlePlacementGroup,omitempty"`
 	VnetCidrs                           []string             `json:"vnetCidrs,omitempty"`
 	PreserveNodesProperties             *bool                `json:"preserveNodesProperties,omitempty"`
-	NewWindowsVMNaming                  *bool                `json:"newWindowsVMNaming,omitempty"`
+	WindowsNameVersion                  string               `json:"windowsNameVersion,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role
@@ -809,7 +809,7 @@ func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
 	vmPrefix := ""
 	if index != -1 {
 		if a.IsWindows() {
-			if a.NewWindowsVMNaming != nil && *a.NewWindowsVMNaming {
+			if a.WindowsNameVersion == "v2" {
 				vmPrefix = p.K8sOrchestratorName() + a.Name
 			} else {
 				vmPrefix = nameSuffix[:4] + p.K8sOrchestratorName() + fmt.Sprintf("%02d", index)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -532,6 +532,7 @@ type AgentPoolProfile struct {
 	SinglePlacementGroup                *bool                `json:"singlePlacementGroup,omitempty"`
 	VnetCidrs                           []string             `json:"vnetCidrs,omitempty"`
 	PreserveNodesProperties             *bool                `json:"preserveNodesProperties,omitempty"`
+	NewWindowsVMNaming                  *bool                `json:"newWindowsVMNaming,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role
@@ -808,7 +809,11 @@ func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
 	vmPrefix := ""
 	if index != -1 {
 		if a.IsWindows() {
-			vmPrefix = nameSuffix[:4] + p.K8sOrchestratorName() + fmt.Sprintf("%02d", index)
+			if a.NewWindowsVMNaming != nil && *a.NewWindowsVMNaming {
+				vmPrefix = p.K8sOrchestratorName() + a.Name
+			} else {
+				vmPrefix = nameSuffix[:4] + p.K8sOrchestratorName() + fmt.Sprintf("%02d", index)
+			}
 		} else {
 			vmPrefix = p.K8sOrchestratorName() + "-" + a.Name + "-" + nameSuffix + "-"
 			if a.IsVirtualMachineScaleSets() {

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -563,6 +563,45 @@ func TestPerAgentPoolVersionAndState(t *testing.T) {
 	}
 }
 
+func TestPerAgentPoolNewWindowsVMNaming(t *testing.T) {
+	useNewWindowsVMNaming := true
+	doNotUseNewWindowsVMNaming := false
+
+	cases := []struct {
+		ap                         AgentPoolProfile
+		expectedNewWindowsVMNaming *bool
+	}{
+		{
+			ap: AgentPoolProfile{
+				Name:               "agentpool1",
+				NewWindowsVMNaming: &useNewWindowsVMNaming,
+			},
+			expectedNewWindowsVMNaming: &useNewWindowsVMNaming,
+		},
+		{
+			ap: AgentPoolProfile{
+				Name: "agentpool2",
+			},
+			expectedNewWindowsVMNaming: nil,
+		},
+		{
+			ap: AgentPoolProfile{
+				Name:               "agentpool3",
+				NewWindowsVMNaming: &doNotUseNewWindowsVMNaming,
+			},
+			expectedNewWindowsVMNaming: &doNotUseNewWindowsVMNaming,
+		},
+	}
+
+	for _, c := range cases {
+		if c.expectedNewWindowsVMNaming == nil && c.ap.NewWindowsVMNaming != nil {
+			t.Fatalf("NewWindowsVMNaming flag mismatch. Expected: nil. Got: %v.", c.ap.NewWindowsVMNaming)
+		} else if c.expectedNewWindowsVMNaming != c.ap.NewWindowsVMNaming {
+			t.Fatalf("NewWindowsVMNaming flag mismatch. Expected: %v. Got: %v.", &c.expectedNewWindowsVMNaming, &c.ap.NewWindowsVMNaming)
+		}
+	}
+}
+
 func TestIsCustomVNET(t *testing.T) {
 	cases := []struct {
 		p              Properties

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -563,41 +563,29 @@ func TestPerAgentPoolVersionAndState(t *testing.T) {
 	}
 }
 
-func TestPerAgentPoolNewWindowsVMNaming(t *testing.T) {
-	useNewWindowsVMNaming := true
-	doNotUseNewWindowsVMNaming := false
-
+func TestPerAgentPoolWindowsNameVersion(t *testing.T) {
 	cases := []struct {
 		ap                         AgentPoolProfile
-		expectedNewWindowsVMNaming *bool
+		expectedWindowsNameVersion string
 	}{
 		{
 			ap: AgentPoolProfile{
 				Name:               "agentpool1",
-				NewWindowsVMNaming: &useNewWindowsVMNaming,
+				WindowsNameVersion: "v2",
 			},
-			expectedNewWindowsVMNaming: &useNewWindowsVMNaming,
+			expectedWindowsNameVersion: "v2",
 		},
 		{
 			ap: AgentPoolProfile{
 				Name: "agentpool2",
 			},
-			expectedNewWindowsVMNaming: nil,
-		},
-		{
-			ap: AgentPoolProfile{
-				Name:               "agentpool3",
-				NewWindowsVMNaming: &doNotUseNewWindowsVMNaming,
-			},
-			expectedNewWindowsVMNaming: &doNotUseNewWindowsVMNaming,
+			expectedWindowsNameVersion: "",
 		},
 	}
 
 	for _, c := range cases {
-		if c.expectedNewWindowsVMNaming == nil && c.ap.NewWindowsVMNaming != nil {
-			t.Fatalf("NewWindowsVMNaming flag mismatch. Expected: nil. Got: %v.", c.ap.NewWindowsVMNaming)
-		} else if c.expectedNewWindowsVMNaming != c.ap.NewWindowsVMNaming {
-			t.Fatalf("NewWindowsVMNaming flag mismatch. Expected: %v. Got: %v.", &c.expectedNewWindowsVMNaming, &c.ap.NewWindowsVMNaming)
+		if c.expectedWindowsNameVersion != c.ap.WindowsNameVersion {
+			t.Fatalf("WindowsNameVersion flag mismatch. Expected: %v. Got: %v.", &c.expectedWindowsNameVersion, &c.ap.WindowsNameVersion)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
AKS windows agent pool support needs a few changes
1. Windows VM name prefix should not include agent pool index since AKS agent pool can be dynamically added and deleted. The new naming prefix get rid of the clusterId and agent pool index. It is now "k8s"+agentpoolname. It is up to AKS code to ensure the agent pool name can't be more than 6 chars.
2. Included a new flag NewWindowsNaming in agent pool profile data model to indicate new naming. Right now, this flag is NOT exposed to AKS-engine users. Only AKS can set this flag.
2. The generation of kubelet config for windows agent pool assumes kubernetes config being null for windows agent pool definition. This might not always be the case for AKS.
3. The two kubelet flags removed for linux agent pool when secure kubelet is not enabled are NOT removed for windows agentpool.  We should remove them too to be consistent with Linux agent pool.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
