### PR TITLE
ci: run dep check before linting in the pr-e2e pipeline

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -49,11 +49,11 @@ jobs:
   - script: make bootstrap
     displayName: Install dependencies
     workingDirectory: $(modulePath)
-  - script: make validate-copyright-headers test-style
-    displayName: Run linting rules
-    workingDirectory: $(modulePath)
   - script: make validate-dependencies
     displayName: Check if imports, Gopkg.toml, and Gopkg.lock are in sync
+    workingDirectory: $(modulePath)
+  - script: make validate-copyright-headers test-style
+    displayName: Run linting rules
     workingDirectory: $(modulePath)
   - script: make build-cross
     displayName: Build cross-architectural binaries


### PR DESCRIPTION
Reason:
Linting rules in the CI depend on fully-working and compiled code to run. In cases where dependencies are completely in sync with their manifests and go imports, linting rules will fail.  This is why we would need to `dep check` to precede `test-style`