### PR TITLE
fix: add err check while JSON marshalling the ARM template

### DIFF
--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -1141,7 +1141,10 @@ func (t *TemplateGenerator) GenerateTemplateV2(containerService *api.ContainerSe
 		Outputs:        armOutputs,
 	}
 
-	templBytes, _ := json.Marshal(armTemplate)
+	var templBytes []byte
+	if templBytes, err = json.Marshal(armTemplate); err != nil {
+		return "", "", err
+	}
 	templateRaw = string(templBytes)
 
 	var parametersMap paramsMap


### PR DESCRIPTION
omitting err in multi-valued contexts is considered bad practice. It also makes it harder to debug issues without it.