### PR TITLE
fix: add the system role assignment object as the resource instead of the function pointer

### DIFF
--- a/pkg/engine/armresources.go
+++ b/pkg/engine/armresources.go
@@ -115,7 +115,7 @@ func createKubernetesAgentVMASResources(cs *api.ContainerService, profile *api.A
 	userAssignedIDEnabled := useManagedIdentity && cs.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID != ""
 
 	if useManagedIdentity && !userAssignedIDEnabled {
-		agentVMASSysRoleAssignment := createAgentVMASSysRoleAssignment
+		agentVMASSysRoleAssignment := createAgentVMASSysRoleAssignment(profile)
 		agentVMASResources = append(agentVMASResources, agentVMASSysRoleAssignment)
 	}
 


### PR DESCRIPTION
This should fix a bug in a scenario where system assigned MSI role assignments are used in the agent pool profiles.