### PR TITLE
Use mcr for hyperkube

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -268,7 +268,7 @@ echo "  - busybox" >> ${RELEASE_NOTES_FILEPATH}
 K8S_VERSIONS="1.9.10 1.9.11 1.10.12 1.10.13 1.11.7 1.11.8 1.12.5 1.12.6 1.13.3 1.13.4"
 
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
-    HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"
+    HYPERKUBE_URL="mcr.microsoft.com/k8s/core/hyperkube-amd64:v${KUBERNETES_VERSION}"
     extractHyperkube "docker"
     CONTAINER_IMAGE="k8s.gcr.io/cloud-controller-manager-amd64:v${KUBERNETES_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -66,7 +66,6 @@ type AzureOSImageConfig struct {
 var (
 	//DefaultKubernetesSpecConfig is the default Docker image source of Kubernetes
 	DefaultKubernetesSpecConfig = KubernetesSpecConfig{
-		KubernetesImageBase:              "k8s.gcr.io/",
 		TillerImageBase:                  "gcr.io/kubernetes-helm/",
 		ACIConnectorImageBase:            "microsoft/",
 		NVIDIAImageBase:                  "nvidia/",


### PR DESCRIPTION
This implementation is a work-around until we have all k8s images on
mcr.

- Remove the `KubernetesImageBase` setting from the generated default
spec
- `KubernetesImageBase` gets set later, if the user spec did not have
`KubernetesImageBase`, then we'll use gcr for everything except for
hyperkube.