### PR TITLE
Revert "fix: set nodes to panic and reboot on oom (#503)"

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -146,16 +146,6 @@ write_files:
     }
 {{end}}
 
-- path: /etc/sysctl.d/10-oom-panic.conf
-  permissions: "0644"
-  owner: root
-  content: |
-    # These settings, and other Node settings are put in place by AKS. Do not attempt to change these values as any alterations will be removed by the service
-    # This setting disabled the linux OOM killer and sets panic on OOM to prevent partial node failures in out of memory conditions
-    vm.panic_on_oom = 1
-    # This setting instructs the kernel to reboot 30 seconds after a panic event to allow the node to automatically recover
-    kernel.panic = 30
-
 {{if HasCiliumNetworkPlugin }}
 - path: /etc/systemd/system/sys-fs-bpf.mount
   permissions: "0644"


### PR DESCRIPTION
This reverts commit 76720109c4bd418dc0c73d2465413d91f8ed402b.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The sysctl files are basically just for show. The kubelet will override the panic_on_oom toggle on process start every time.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
This file are deceptive for anyone debugging kernel parameters on the nodes.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Bug filed with the Kubernetes project: [74151](https://github.com/kubernetes/kubernetes/issues/74151)
