### PR TITLE
fix: actually apt-mark hold walinuxagent during all CSE runs

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -316,6 +316,5 @@ coreos:
 runcmd:
 - set -x
 - . /opt/azure/containers/provision_source.sh
-- timeout 10 apt-mark hold walinuxagent{{GetKubernetesAgentPreprovisionYaml .}}
-- timeout 10 apt-mark unhold walinuxagent
+- {{GetKubernetesAgentPreprovisionYaml .}}
 {{end}}

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -6,10 +6,11 @@ ETCD_PEER_URL="https://${PRIVATE_IP}:2380"
 ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
 
 holdWALinuxAgent() {
+    retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || \
     if [[ "$1" == "hold" ]]; then
-        retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || exit $ERR_HOLD_WALINUXAGENT
+        exit $ERR_HOLD_WALINUXAGENT
     elif [[ "$1" == "unhold" ]]; then
-        retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || exit $ERR_RELEASE_HOLD_WALINUXAGENT
+        exit $ERR_RELEASE_HOLD_WALINUXAGENT
     fi
 }
 

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -7,9 +7,7 @@ ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
 
 holdWALinuxAgent() {
     if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        wait_for_apt_locks
         retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || exit $ERR_HOLD_WALINUXAGENT
-        wait_for_apt_locks
     fi
 }
 

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -6,8 +6,10 @@ ETCD_PEER_URL="https://${PRIVATE_IP}:2380"
 ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
 
 holdWALinuxAgent() {
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    if [[ "$1" == "hold" ]]; then
         retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || exit $ERR_HOLD_WALINUXAGENT
+    elif [[ "$1" == "unhold" ]]; then
+        retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || exit $ERR_RELEASE_HOLD_WALINUXAGENT
     fi
 }
 

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -57,7 +57,9 @@ else
     FULL_INSTALL_REQUIRED=true
 fi
 
-holdWALinuxAgent "hold"
+if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    holdWALinuxAgent "hold"
+fi
 
 if [[ ! -z "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
     	installEtcd
@@ -176,7 +178,11 @@ fi
 if $REBOOTREQUIRED; then
   echo 'reboot required, rebooting node in 1 minute'
   /bin/bash -c "shutdown -r 1 &"
-  holdWALinuxAgent "unhold"
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+      holdWALinuxAgent "unhold"
+  fi
 else
-  runAptDaily &
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+      runAptDaily &
+  fi
 fi

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -57,11 +57,12 @@ else
     FULL_INSTALL_REQUIRED=true
 fi
 
+holdWALinuxAgent "hold"
+
 if [[ ! -z "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
     	installEtcd
 fi
 
-holdWALinuxAgent "hold"
 if $FULL_INSTALL_REQUIRED; then
     installDeps
 else 

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -504,6 +504,5 @@ coreos:
 {{else}}
 runcmd:
 - set -x
-- timeout 10 apt-mark hold walinuxagent{{GetKubernetesMasterPreprovisionYaml}}
-- timeout 10 apt-mark unhold walinuxagent
+- {{GetKubernetesMasterPreprovisionYaml}}
 {{end}}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

By not marking walinuxagent for "hold" (i.e., do not modify via apt) during CSE, even VHD scenarios, we risk walinuxagent being updated via CSE, which will never finish, because walinuxagent updates require a non-active CSE operation.

Additionally, we were releasing the hold too early, as apt system.daily operations are able to update waagent, and despite the invocation being sent to the background, the fact that it is a child process of the parent CSE runtime process in practice means we see these symptoms.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #768 Fixes #758 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
