### PR TITLE
fix: move /var/log/ during VHD build to a vhd specific directory

### DIFF
--- a/packer/cleanup-vhd.sh
+++ b/packer/cleanup-vhd.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -eux
 
-## Cleanup packer SSH key and machine ID generated for this boot
+# Cleanup packer SSH key and machine ID generated for this boot
 rm -f /root/.ssh/authorized_keys
 rm -f /home/packer/.ssh/authorized_keys
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+# Move logs under /var/log from VHD creation
+sudo mkdir /var/log.vhd
+sudo mv /var/log /var/log.vhd

--- a/packer/cleanup-vhd.sh
+++ b/packer/cleanup-vhd.sh
@@ -6,6 +6,6 @@ rm -f /home/packer/.ssh/authorized_keys
 rm -f /etc/machine-id
 touch /etc/machine-id
 
-# Move logs under /var/log from VHD creation
-sudo mkdir /var/log.vhd
+# Move logs from VHD creation out of /var/log 
 sudo mv /var/log /var/log.vhd
+sudo mkdir /var/log


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
When we look at the logs such as /var/log/kern.log on VM created from AKS VHD, we see logs from when the VHD was created. For example, I only booted up the VM once, but I saw it twice in kern.log.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#664 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
