### PR TITLE
fix: mark walinux for hold in cloud-init

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -306,5 +306,5 @@ coreos:
 runcmd:
 - set -x
 - . /opt/azure/containers/provision_source.sh
-- {{GetKubernetesAgentPreprovisionYaml .}}
+- aptmarkWALinuxAgent hold{{GetKubernetesAgentPreprovisionYaml .}}
 {{end}}

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -107,6 +107,14 @@ write_files:
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh container-runtime
 
+- path: /etc/apt/preferences
+  permissions: "0644"
+  owner: root
+  content: |
+    Package: walinuxagent
+    Pin: version 2.2.32.2
+    Pin-Priority: 550
+
 {{if .KubernetesConfig.RequiresDocker}}
     {{if not .IsCoreOS}}
 - path: /etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -114,12 +114,6 @@ ensureRPC() {
     systemctlEnableAndStart rpc-statd || exit $ERR_SYSTEMCTL_START_FAIL
 }
 
-runAptDaily() {
-    wait_for_apt_locks
-    /usr/lib/apt/apt.systemd.daily
-    aptmarkWALinuxAgent unhold
-}
-
 generateAggregatedAPICerts() {
     AGGREGATED_API_CERTS_SETUP_FILE=/etc/kubernetes/generate-proxy-certs.sh
     wait_for_file 1200 1 $AGGREGATED_API_CERTS_SETUP_FILE || exit $ERR_FILE_WATCH_TIMEOUT

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -5,15 +5,6 @@ PRIVATE_IP=$(hostname -I | cut -d' ' -f1)
 ETCD_PEER_URL="https://${PRIVATE_IP}:2380"
 ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
 
-holdWALinuxAgent() {
-    retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || \
-    if [[ "$1" == "hold" ]]; then
-        exit $ERR_HOLD_WALINUXAGENT
-    elif [[ "$1" == "unhold" ]]; then
-        exit $ERR_RELEASE_HOLD_WALINUXAGENT
-    fi
-}
-
 systemctlEnableAndStart() {
     systemctl_restart 100 5 30 $1
     RESTART_STATUS=$?
@@ -126,8 +117,7 @@ ensureRPC() {
 runAptDaily() {
     wait_for_apt_locks
     /usr/lib/apt/apt.systemd.daily
-    wait_for_apt_locks
-    holdWALinuxAgent "unhold"
+    aptmarkWALinuxAgent "unhold"
 }
 
 generateAggregatedAPICerts() {

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -117,7 +117,7 @@ ensureRPC() {
 runAptDaily() {
     wait_for_apt_locks
     /usr/lib/apt/apt.systemd.daily
-    aptmarkWALinuxAgent "unhold"
+    aptmarkWALinuxAgent unhold
 }
 
 generateAggregatedAPICerts() {

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -179,6 +179,7 @@ if $REBOOTREQUIRED; then
   fi
 else
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
-      runAptDaily &
+      /usr/lib/apt/apt.systemd.daily &
+      aptmarkWALinuxAgent unhold &
   fi
 fi

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -57,10 +57,6 @@ else
     FULL_INSTALL_REQUIRED=true
 fi
 
-if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    holdWALinuxAgent "hold"
-fi
-
 if [[ ! -z "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
     	installEtcd
 fi
@@ -179,7 +175,7 @@ if $REBOOTREQUIRED; then
   echo 'reboot required, rebooting node in 1 minute'
   /bin/bash -c "shutdown -r 1 &"
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
-      holdWALinuxAgent "unhold"
+      aptmarkWALinuxAgent "unhold"
   fi
 else
   if [[ $OS == $UBUNTU_OS_NAME ]]; then

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -57,10 +57,6 @@ else
     FULL_INSTALL_REQUIRED=true
 fi
 
-if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    apt-mark showhold | grep walinuxagent || aptmarkWALinuxAgent hold
-fi
-
 if [[ ! -z "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
     	installEtcd
 fi

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -57,6 +57,10 @@ else
     FULL_INSTALL_REQUIRED=true
 fi
 
+if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    apt-mark showhold | grep walinuxagent || aptmarkWALinuxAgent hold
+fi
+
 if [[ ! -z "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
     	installEtcd
 fi
@@ -175,7 +179,7 @@ if $REBOOTREQUIRED; then
   echo 'reboot required, rebooting node in 1 minute'
   /bin/bash -c "shutdown -r 1 &"
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
-      aptmarkWALinuxAgent "unhold"
+      aptmarkWALinuxAgent unhold
   fi
 else
   if [[ $OS == $UBUNTU_OS_NAME ]]; then

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -175,7 +175,7 @@ if $REBOOTREQUIRED; then
   echo 'reboot required, rebooting node in 1 minute'
   /bin/bash -c "shutdown -r 1 &"
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
-      aptmarkWALinuxAgent unhold
+      aptmarkWALinuxAgent unhold &
   fi
 else
   if [[ $OS == $UBUNTU_OS_NAME ]]; then

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -504,5 +504,6 @@ coreos:
 {{else}}
 runcmd:
 - set -x
-- {{GetKubernetesMasterPreprovisionYaml}}
+- . /opt/azure/containers/provision_source.sh
+- aptmarkWALinuxAgent hold{{GetKubernetesMasterPreprovisionYaml}}
 {{end}}

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -113,6 +113,14 @@ write_files:
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh container-runtime
 
+- path: /etc/apt/preferences
+  permissions: "0644"
+  owner: root
+  content: |
+    Package: walinuxagent
+    Pin: version 2.2.32.2
+    Pin-Priority: 550
+
 {{if .OrchestratorProfile.KubernetesConfig.RequiresDocker}}
     {{if not .MasterProfile.IsCoreOS}}
 - path: /etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf

--- a/parts/k8s/kubernetesprovisionsource.sh
+++ b/parts/k8s/kubernetesprovisionsource.sh
@@ -59,6 +59,16 @@ NVIDIA_DOCKER_VERSION=2.0.3
 DOCKER_VERSION=1.13.1-1
 NVIDIA_CONTAINER_RUNTIME_VERSION=2.0.0
 
+aptmarkWALinuxAgent() {
+    wait_for_apt_locks
+    retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || \
+    if [[ "$1" == "hold" ]]; then
+        exit $ERR_HOLD_WALINUXAGENT
+    elif [[ "$1" == "unhold" ]]; then
+        exit $ERR_RELEASE_HOLD_WALINUXAGENT
+    fi
+}
+
 retrycmd_if_failure() {
     retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
     for i in $(seq 1 $retries); do


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow-up of #771

Testing against the changes in #771 revealed that cloud-init itself is invoking `apt` to install some packages:

```
2019-03-15 19:26:12,725 - helpers.py[DEBUG]: Running update-sources using lock (<FileLock using file '/var/lib/cloud/instances/3557FA54-5097-654B-9116-21C59991226E/sem/update_sources'>)
2019-03-15 19:26:12,726 - util.py[DEBUG]: Running command ['eatmydata', 'apt-get', '--option=Dpkg::Options::=--force-confold', '--option=Dpkg::options::=--force-unsafe-io', '--assume-yes', '--quiet', 'update'] with allowed return codes [0] (shell=False, capture=False)
2019-03-15 19:26:25,480 - util.py[DEBUG]: apt-update [eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet update] took 12.754 seconds
2019-03-15 19:26:25,480 - helpers.py[DEBUG]: update-sources already ran (freq=once-per-instance)
2019-03-15 19:26:25,480 - util.py[DEBUG]: Running command ['eatmydata', 'apt-get', '--option=Dpkg::Options::=--force-confold', '--option=Dpkg::options::=--force-unsafe-io', '--assume-yes', '--quiet', 'install', 'jq', 'traceroute'] with allowed return codes [0] (shell=False, capture=False)
2019-03-15 19:26:34,734 - util.py[DEBUG]: apt-install [eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet install jq traceroute] took 9.254 seconds
2019-03-15 19:26:34,735 - handlers.py[DEBUG]: finish: modules-final/config-package-update-upgrade-install: SUCCESS: config-package-update-upgrade-install ran successfully
```

This means in practice that when we attempt to `apt-mark hold walinuxagent` in CSE it may fail due to cloud-init already having reserved the lock.

Additionally, we are explicitly pinning the version of walinuxagent to further protect against runtime changes to the walinuxagent. This last change is a defensive manouver. Based on production data following the introduction of `2.2.37` we want to introduce new version changes purposefully.

We can consider reverting to the prior behavior once we recover create stability, if the static version pinning produces undesired effects for long-lived clusters who wish to update their `walinuxagent` versions "out of band".

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
