### PR TITLE
chore: Include billing extensions for AzureUSGovernmentCloud

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -203,9 +203,9 @@ var (
 		},
 	}
 
-	//AzureUSGovernmentCloud is the US government config.
-	AzureUSGovernmentCloud = AzureEnvironmentSpecConfig{
-		CloudName:            azureUSGovernmentCloud,
+	//AzureUSGovernmentCloudSpec is the US government config.
+	AzureUSGovernmentCloudSpec = AzureEnvironmentSpecConfig{
+		CloudName:            AzureUSGovernmentCloud,
 		DockerSpecConfig:     DefaultDockerSpecConfig,
 		KubernetesSpecConfig: DefaultKubernetesSpecConfig,
 		DCOSSpecConfig:       DefaultDCOSSpecConfig,
@@ -267,7 +267,7 @@ var (
 	AzureCloudSpecEnvMap = map[string]AzureEnvironmentSpecConfig{
 		AzureChinaCloud:        AzureChinaCloudSpec,
 		azureGermanCloud:       AzureGermanCloudSpec,
-		azureUSGovernmentCloud: AzureUSGovernmentCloud,
+		AzureUSGovernmentCloud: AzureUSGovernmentCloudSpec,
 		AzurePublicCloud:       AzureCloudSpec,
 	}
 )

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -421,8 +421,8 @@ const (
 	// AzurePublicCloud is a const string reference identifier for public cloud
 	AzurePublicCloud = "AzurePublicCloud"
 	// AzureChinaCloud is a const string reference identifier for china cloud
-	AzureChinaCloud        = "AzureChinaCloud"
-	azureGermanCloud       = "AzureGermanCloud"
+	AzureChinaCloud  = "AzureChinaCloud"
+	azureGermanCloud = "AzureGermanCloud"
 	// AzureUSGovernmentCloud is a const string reference identifier for us government cloud
 	AzureUSGovernmentCloud = "AzureUSGovernmentCloud"
 	// AzureStackCloud is a const string reference identifier for Azure Stack cloud

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -423,7 +423,8 @@ const (
 	// AzureChinaCloud is a const string reference identifier for china cloud
 	AzureChinaCloud        = "AzureChinaCloud"
 	azureGermanCloud       = "AzureGermanCloud"
-	azureUSGovernmentCloud = "AzureUSGovernmentCloud"
+	// AzureUSGovernmentCloud is a const string reference identifier for us government cloud
+	AzureUSGovernmentCloud = "AzureUSGovernmentCloud"
 	// AzureStackCloud is a const string reference identifier for Azure Stack cloud
 	AzureStackCloud = "AzureStackCloud"
 )

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1481,8 +1481,8 @@ func (cs *ContainerService) GetLocations() []string {
 }
 
 // GetCustomCloudAuthenticationMethod returns authentication method which k8s azure cloud provider will use
-// For AzurePublicCloud,AzureChinaCloud,azureGermanCloud,azureUSGovernmentCloud, it will be always be client_secret
-// For AzureStackCloud, if it is specifiled in configuration, the value will be used, if not ,the default value is client_secret.
+// For AzurePublicCloud,AzureChinaCloud,azureGermanCloud,AzureUSGovernmentCloud, it will be always be client_secret
+// For AzureStackCloud, if it is specified in configuration, the value will be used, if not ,the default value is client_secret.
 func (p *Properties) GetCustomCloudAuthenticationMethod() string {
 	if p.IsAzureStackCloud() {
 		return p.CustomCloudProfile.AuthenticationMethod
@@ -1491,8 +1491,8 @@ func (p *Properties) GetCustomCloudAuthenticationMethod() string {
 }
 
 // GetCustomCloudIdentitySystem returns identity system method for azure stack.
-// For AzurePublicCloud,AzureChinaCloud,azureGermanCloud,azureUSGovernmentCloud, it will be always be AzureAD
-// For AzureStackCloud, if it is specifiled in configuration, the value will be used, if not ,the default value is AzureAD.
+// For AzurePublicCloud,AzureChinaCloud,azureGermanCloud,AzureUSGovernmentCloud, it will be always be AzureAD
+// For AzureStackCloud, if it is specified in configuration, the value will be used, if not ,the default value is AzureAD.
 func (p *Properties) GetCustomCloudIdentitySystem() string {
 	if p.IsAzureStackCloud() {
 		return p.CustomCloudProfile.IdentitySystem
@@ -1598,7 +1598,7 @@ func (cs *ContainerService) GetCloudSpecConfig() AzureEnvironmentSpecConfig {
 // IsAKSBillingEnabled checks if the AKS Billing Extension should be enabled for a cloud environment.
 func (cs *ContainerService) IsAKSBillingEnabled() bool {
 	cloudSpecConfig := cs.GetCloudSpecConfig()
-	return cloudSpecConfig.CloudName == AzurePublicCloud || cloudSpecConfig.CloudName == AzureChinaCloud
+	return cloudSpecConfig.CloudName == AzurePublicCloud || cloudSpecConfig.CloudName == AzureChinaCloud || cloudSpecConfig.CloudName == AzureUSGovernmentCloud
 }
 
 // GetAzureProdFQDN returns the formatted FQDN string for a given apimodel.


### PR DESCRIPTION
**Reason for Change**: The AKS billing extensions are now available in the Azure Government cloud. This change allows aks-engine to include that extension when generating templates for that cloud.