### PR TITLE
fix: add missing parameter ComputerNamePrefix for VMSS agents using Windows

### DIFF
--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -475,8 +475,9 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 
 		customDataStr := getCustomDataFromJSON(t.GetKubernetesWindowsAgentCustomDataJSON(cs, profile))
 		windowsOsProfile := compute.VirtualMachineScaleSetOSProfile{
-			AdminUsername: to.StringPtr("[parameters('windowsAdminUsername')]"),
-			AdminPassword: to.StringPtr("[parameters('windowsAdminPassword')]"),
+			AdminUsername:      to.StringPtr("[parameters('windowsAdminUsername')]"),
+			AdminPassword:      to.StringPtr("[parameters('windowsAdminPassword')]"),
+			ComputerNamePrefix: to.StringPtr(fmt.Sprintf("[variables('%sVMNamePrefix')]", profile.Name)),
 			WindowsConfiguration: &compute.WindowsConfiguration{
 				EnableAutomaticUpdates: to.BoolPtr(cs.Properties.WindowsProfile.GetEnableWindowsUpdate()),
 			},

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -390,9 +390,10 @@ func TestCreateAgentVMSS(t *testing.T) {
 	expectedCustomDataStr = getCustomDataFromJSON(tg.GetKubernetesWindowsAgentCustomDataJSON(cs, cs.Properties.AgentPoolProfiles[0]))
 
 	expected.VirtualMachineProfile.OsProfile = &compute.VirtualMachineScaleSetOSProfile{
-		AdminUsername: to.StringPtr("[parameters('windowsAdminUsername')]"),
-		AdminPassword: to.StringPtr("[parameters('windowsAdminPassword')]"),
-		CustomData:    to.StringPtr(expectedCustomDataStr),
+		AdminUsername:      to.StringPtr("[parameters('windowsAdminUsername')]"),
+		AdminPassword:      to.StringPtr("[parameters('windowsAdminPassword')]"),
+		CustomData:         to.StringPtr(expectedCustomDataStr),
+		ComputerNamePrefix: to.StringPtr("[variables('agentpool1VMNamePrefix')]"),
 		WindowsConfiguration: &compute.WindowsConfiguration{
 			EnableAutomaticUpdates: to.BoolPtr(cs.Properties.WindowsProfile.GetEnableWindowsUpdate()),
 		},


### PR DESCRIPTION
This fixes a bug in VMSS scenarios for windows agents.