### PR TITLE
test: fix NetworkPolicy tests for pre-1.11 cluster configurations

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -44,6 +44,7 @@ const (
 	retryTimeWhenWaitingForPodReady = 1 * time.Minute
 	stabilityCommandTimeout         = 5 * time.Second
 	windowsCommandTimeout           = 1 * time.Minute
+	validateNetworkPolicyTimeout    = 3 * time.Minute
 )
 
 var (
@@ -1058,7 +1059,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 				By("Ensuring we no longer have ingress access from the network-policy pods to backend pods")
 				for _, backendPod := range backendPods {
-					pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, cfg.Timeout)
+					pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, validateNetworkPolicyTimeout)
 					Expect(err).Should(HaveOccurred())
 					Expect(pass).To(BeFalse())
 				}
@@ -1066,53 +1067,55 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Cleaning up after ourselves")
 				networkpolicy.DeleteNetworkPolicy(nwpolicyName, namespace)
 
-				By("Applying a network policy to only allow ingress access to app: webapp, role: backend pods in development namespace from pods in any namespace with the same labels")
-				nwpolicyName, namespace = "backend-allow-ingress-pod-label", nsDev
-				err = networkpolicy.CreateNetworkPolicyFromFile(filepath.Join(PolicyDir, "backend-policy-allow-ingress-pod-label.yaml"), nwpolicyName, namespace)
-				Expect(err).NotTo(HaveOccurred())
-
-				By("Ensuring we have ingress access from pods with matching labels")
-				pl = pod.List{Pods: backendPods}
-				for _, backendDstPod := range backendPods {
-					pass, err = pl.ValidateCurlConnection(backendDstPod.Status.PodIP, 5*time.Second, cfg.Timeout)
+				if common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.11.0") {
+					By("Applying a network policy to only allow ingress access to app: webapp, role: backend pods in development namespace from pods in any namespace with the same labels")
+					nwpolicyName, namespace = "backend-allow-ingress-pod-label", nsDev
+					err = networkpolicy.CreateNetworkPolicyFromFile(filepath.Join(PolicyDir, "backend-policy-allow-ingress-pod-label.yaml"), nwpolicyName, namespace)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(pass).To(BeTrue())
-				}
 
-				By("Ensuring we don't have ingress access from pods without matching labels")
-				pl = pod.List{Pods: nwpolicyPods}
-				for _, backendPod := range backendPods {
-					pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, cfg.Timeout)
-					Expect(err).Should(HaveOccurred())
-					Expect(pass).To(BeFalse())
-				}
+					By("Ensuring we have ingress access from pods with matching labels")
+					pl = pod.List{Pods: backendPods}
+					for _, backendDstPod := range backendPods {
+						pass, err = pl.ValidateCurlConnection(backendDstPod.Status.PodIP, 5*time.Second, cfg.Timeout)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(pass).To(BeTrue())
+					}
 
-				By("Cleaning up after ourselves")
-				networkpolicy.DeleteNetworkPolicy(nwpolicyName, namespace)
+					By("Ensuring we don't have ingress access from pods without matching labels")
+					pl = pod.List{Pods: nwpolicyPods}
+					for _, backendPod := range backendPods {
+						pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, validateNetworkPolicyTimeout)
+						Expect(err).Should(HaveOccurred())
+						Expect(pass).To(BeFalse())
+					}
 
-				By("Applying a network policy to only allow ingress access to app: webapp role:backends in development namespace from pods with label app:webapp, role: frontendProd within namespace with label purpose: development")
-				nwpolicyName, namespace = "backend-policy-allow-ingress-pod-namespace-label", nsDev
-				err = networkpolicy.CreateNetworkPolicyFromFile(filepath.Join(PolicyDir, "backend-policy-allow-ingress-pod-namespace-label.yaml"), nwpolicyName, namespace)
-				Expect(err).NotTo(HaveOccurred())
+					By("Cleaning up after ourselves")
+					networkpolicy.DeleteNetworkPolicy(nwpolicyName, namespace)
 
-				By("Ensuring we don't have ingress access from role:frontend pods in production namespace")
-				pl = pod.List{Pods: frontendProdPods}
-				for _, backendPod := range backendPods {
-					pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, cfg.Timeout)
-					Expect(err).Should(HaveOccurred())
-					Expect(pass).To(BeFalse())
-				}
-
-				By("Ensuring we have ingress access from role:frontend pods in development namespace")
-				pl = pod.List{Pods: frontendDevPods}
-				for _, backendPod := range backendPods {
-					pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, cfg.Timeout)
+					By("Applying a network policy to only allow ingress access to app: webapp role:backends in development namespace from pods with label app:webapp, role: frontendProd within namespace with label purpose: development")
+					nwpolicyName, namespace = "backend-policy-allow-ingress-pod-namespace-label", nsDev
+					err = networkpolicy.CreateNetworkPolicyFromFile(filepath.Join(PolicyDir, "backend-policy-allow-ingress-pod-namespace-label.yaml"), nwpolicyName, namespace)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(pass).To(BeTrue())
-				}
 
-				By("Cleaning up after ourselves")
-				networkpolicy.DeleteNetworkPolicy(nwpolicyName, namespace)
+					By("Ensuring we don't have ingress access from role:frontend pods in production namespace")
+					pl = pod.List{Pods: frontendProdPods}
+					for _, backendPod := range backendPods {
+						pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, validateNetworkPolicyTimeout)
+						Expect(err).Should(HaveOccurred())
+						Expect(pass).To(BeFalse())
+					}
+
+					By("Ensuring we have ingress access from role:frontend pods in development namespace")
+					pl = pod.List{Pods: frontendDevPods}
+					for _, backendPod := range backendPods {
+						pass, err = pl.ValidateCurlConnection(backendPod.Status.PodIP, 5*time.Second, cfg.Timeout)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(pass).To(BeTrue())
+					}
+
+					By("Cleaning up after ourselves")
+					networkpolicy.DeleteNetworkPolicy(nwpolicyName, namespace)
+				}
 
 				By("Cleaning up after ourselves")
 				err = frontendProdDeployment.Delete(deleteResourceRetries)

--- a/test/e2e/kubernetes/namespace/namespace.go
+++ b/test/e2e/kubernetes/namespace/namespace.go
@@ -75,7 +75,7 @@ func (n *Namespace) Delete() error {
 
 // Label a namespace
 func (n *Namespace) Label(label string) error {
-	cmd := exec.Command("k", "label", "namespace/"+n.Metadata.Name, label)
+	cmd := exec.Command("k", "label", "--overwrite=true", "namespace/"+n.Metadata.Name, label)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow-up from #638

This PR guards new NetworkPolicy tests added in the above PR to reflect that you need a 1.11 or greater versioned cluster to execute the new tests.

Also, reduces the wait time to validate NetworkPolicy enforcement, and enables re-use scenarios by enabling the label creation statement to be idempotent (`--overwrite=true`).

Here is an example of the errors you get running these tests against a 1.10 cluster:

```
$ k create -f workloads/policies/backend-policy-allow-ingress-pod-label.yaml
2019/03/21 16:57:56 Error trying to create NetworkPolicy backend-allow-ingress-pod-label:The NetworkPolicy "backend-allow-ingress-pod-label" is invalid: spec.ingress[0].from[0]: Forbidden: may not specify more than 1 from type
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
