### PR TITLE
fix: add extra nil guard checks for LinuxProfiles

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -192,7 +192,7 @@
               }
               {{ end }}
             }
-            {{if HasLinuxSecrets}}
+            {{if and (HasLinuxProfile) (HasLinuxSecrets)}}
               ,
               "secrets": "[variables('linuxProfileSecrets')]"
             {{end}}

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -128,7 +128,7 @@
               }
               {{ end }}
             }
-            {{if HasLinuxSecrets}}
+            {{if and (HasLinuxProfile) (HasLinuxSecrets)}}
               ,
               "secrets": "[variables('linuxProfileSecrets')]"
             {{end}}

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -902,7 +902,7 @@
             }
             {{ end }}
           }
-          {{if .LinuxProfile.HasSecrets}}
+          {{if and (.LinuxProfile) (.LinuxProfile.HasSecrets)}}
           ,
           "secrets": "[variables('linuxProfileSecrets')]"
           {{end}}

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -179,7 +179,7 @@
       },
       "type": "string"
     }
-{{if .LinuxProfile.HasSecrets}}
+{{if and (.LinuxProfile) (.LinuxProfile.HasSecrets)}}
   {{range  $vIndex, $vault := .LinuxProfile.Secrets}}
     ,
     "linuxKeyVaultID{{$vIndex}}": {

--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -86,7 +86,8 @@ func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 		nicProperties.EnableIPForwarding = to.BoolPtr(true)
 	}
 
-	if cs.Properties.LinuxProfile.HasCustomNodesDNS() {
+	linuxProfile := cs.Properties.LinuxProfile
+	if linuxProfile != nil && linuxProfile.HasCustomNodesDNS() {
 		nicProperties.DNSSettings = &network.InterfaceDNSSettings{
 			DNSServers: &[]string{
 				"[parameters('dnsServer')]",
@@ -185,7 +186,8 @@ func createPrivateClusterNetworkInterface(cs *api.ContainerService) NetworkInter
 		nicProperties.EnableIPForwarding = to.BoolPtr(true)
 	}
 
-	if cs.Properties.LinuxProfile.HasCustomNodesDNS() {
+	linuxProfile := cs.Properties.LinuxProfile
+	if linuxProfile != nil && linuxProfile.HasCustomNodesDNS() {
 		nicProperties.DNSSettings = &network.InterfaceDNSSettings{
 			DNSServers: &[]string{
 				"[parameters('dnsServer')]",

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -39,14 +39,17 @@ func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVers
 
 	addValue(parametersMap, "fqdnEndpointSuffix", cloudSpecConfig.EndpointConfig.ResourceManagerVMDNSSuffix)
 	addValue(parametersMap, "targetEnvironment", helpers.GetTargetEnv(cs.Location, cs.Properties.GetCustomCloudName()))
-	addValue(parametersMap, "linuxAdminUsername", properties.LinuxProfile.AdminUsername)
-	if properties.LinuxProfile.CustomSearchDomain != nil {
-		addValue(parametersMap, "searchDomainName", properties.LinuxProfile.CustomSearchDomain.Name)
-		addValue(parametersMap, "searchDomainRealmUser", properties.LinuxProfile.CustomSearchDomain.RealmUser)
-		addValue(parametersMap, "searchDomainRealmPassword", properties.LinuxProfile.CustomSearchDomain.RealmPassword)
-	}
-	if properties.LinuxProfile.CustomNodesDNS != nil {
-		addValue(parametersMap, "dnsServer", properties.LinuxProfile.CustomNodesDNS.DNSServer)
+	linuxProfile := properties.LinuxProfile
+	if linuxProfile != nil {
+		addValue(parametersMap, "linuxAdminUsername", linuxProfile.AdminUsername)
+		if linuxProfile.CustomSearchDomain != nil {
+			addValue(parametersMap, "searchDomainName", linuxProfile.CustomSearchDomain.Name)
+			addValue(parametersMap, "searchDomainRealmUser", linuxProfile.CustomSearchDomain.RealmUser)
+			addValue(parametersMap, "searchDomainRealmPassword", linuxProfile.CustomSearchDomain.RealmPassword)
+		}
+		if linuxProfile.CustomNodesDNS != nil {
+			addValue(parametersMap, "dnsServer", linuxProfile.CustomNodesDNS.DNSServer)
+		}
 	}
 	// masterEndpointDNSNamePrefix is the basis for storage account creation across dcos, swarm, and k8s
 	if properties.MasterProfile != nil {
@@ -78,11 +81,14 @@ func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVers
 	if properties.HostedMasterProfile != nil {
 		addValue(parametersMap, "masterSubnet", properties.HostedMasterProfile.Subnet)
 	}
-	addValue(parametersMap, "sshRSAPublicKey", properties.LinuxProfile.SSH.PublicKeys[0].KeyData)
-	for i, s := range properties.LinuxProfile.Secrets {
-		addValue(parametersMap, fmt.Sprintf("linuxKeyVaultID%d", i), s.SourceVault.ID)
-		for j, c := range s.VaultCertificates {
-			addValue(parametersMap, fmt.Sprintf("linuxKeyVaultID%dCertificateURL%d", i, j), c.CertificateURL)
+
+	if linuxProfile != nil {
+		addValue(parametersMap, "sshRSAPublicKey", linuxProfile.SSH.PublicKeys[0].KeyData)
+		for i, s := range linuxProfile.Secrets {
+			addValue(parametersMap, fmt.Sprintf("linuxKeyVaultID%d", i), s.SourceVault.ID)
+			for j, c := range s.VaultCertificates {
+				addValue(parametersMap, fmt.Sprintf("linuxKeyVaultID%dCertificateURL%d", i, j), c.CertificateURL)
+			}
 		}
 	}
 

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -967,6 +967,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"HasAvailabilityZones": func(profile *api.AgentPoolProfile) bool {
 			return profile.HasAvailabilityZones()
 		},
+		"HasLinuxProfile": func() bool {
+			return cs.Properties.LinuxProfile != nil
+		},
 		"HasLinuxSecrets": func() bool {
 			return cs.Properties.LinuxProfile.HasSecrets()
 		},

--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -104,10 +104,11 @@ func CreateVirtualMachine(cs *api.ContainerService) VirtualMachineARM {
 		},
 	}
 
-	if len(cs.Properties.LinuxProfile.SSH.PublicKeys) > 1 {
+	linuxProfile := cs.Properties.LinuxProfile
+	if linuxProfile != nil && len(linuxProfile.SSH.PublicKeys) > 1 {
 		publicKeyPath := "[variables('sshKeyPath')]"
 		var publicKeys []compute.SSHPublicKey
-		for _, publicKey := range cs.Properties.LinuxProfile.SSH.PublicKeys {
+		for _, publicKey := range linuxProfile.SSH.PublicKeys {
 			publicKeyTrimmed := strings.TrimSpace(publicKey.KeyData)
 			publicKeys = append(publicKeys, compute.SSHPublicKey{
 				Path:    &publicKeyPath,
@@ -138,8 +139,8 @@ func CreateVirtualMachine(cs *api.ContainerService) VirtualMachineARM {
 		panic(err)
 	}
 
-	if cs.Properties.LinuxProfile.HasSecrets() {
-		vsg := getVaultSecretGroup(cs.Properties.LinuxProfile)
+	if linuxProfile != nil && linuxProfile.HasSecrets() {
+		vsg := getVaultSecretGroup(linuxProfile)
 		osProfile.Secrets = &vsg
 	}
 	vmProperties.OsProfile = osProfile
@@ -397,10 +398,11 @@ func createAgentAvailabilitySetVM(cs *api.ContainerService, profile *api.AgentPo
 			DisablePasswordAuthentication: to.BoolPtr(true),
 		}
 
-		if len(cs.Properties.LinuxProfile.SSH.PublicKeys) > 1 {
+		linuxProfile := cs.Properties.LinuxProfile
+		if linuxProfile != nil && len(linuxProfile.SSH.PublicKeys) > 1 {
 			publicKeyPath := "[variables('sshKeyPath')]"
 			publicKeys := []compute.SSHPublicKey{}
-			for _, publicKey := range cs.Properties.LinuxProfile.SSH.PublicKeys {
+			for _, publicKey := range linuxProfile.SSH.PublicKeys {
 				publicKeyTrimmed := strings.TrimSpace(publicKey.KeyData)
 				publicKeys = append(publicKeys, compute.SSHPublicKey{
 					Path:    &publicKeyPath,
@@ -429,8 +431,8 @@ func createAgentAvailabilitySetVM(cs *api.ContainerService, profile *api.AgentPo
 		agentCustomData := getCustomDataFromJSON(t.GetKubernetesAgentCustomDataJSON(cs, profile))
 		osProfile.CustomData = to.StringPtr(agentCustomData)
 
-		if cs.Properties.LinuxProfile.HasSecrets() {
-			vsg := getVaultSecretGroup(cs.Properties.LinuxProfile)
+		if linuxProfile != nil && linuxProfile.HasSecrets() {
+			vsg := getVaultSecretGroup(linuxProfile)
 			osProfile.Secrets = &vsg
 		}
 	} else {

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -176,10 +176,10 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 		},
 	}
 
-	if len(cs.Properties.LinuxProfile.SSH.PublicKeys) > 1 {
+	if linuxProfile != nil && len(linuxProfile.SSH.PublicKeys) > 1 {
 		publicKeyPath := "[variables('sshKeyPath')]"
 		var publicKeys []compute.SSHPublicKey
-		for _, publicKey := range cs.Properties.LinuxProfile.SSH.PublicKeys {
+		for _, publicKey := range linuxProfile.SSH.PublicKeys {
 			publicKeyTrimmed := strings.TrimSpace(publicKey.KeyData)
 			publicKeys = append(publicKeys, compute.SSHPublicKey{
 				Path:    &publicKeyPath,
@@ -210,8 +210,8 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 		panic(err)
 	}
 
-	if linuxProfile.HasSecrets() {
-		vsg := getVaultSecretGroup(cs.Properties.LinuxProfile)
+	if linuxProfile != nil && linuxProfile.HasSecrets() {
+		vsg := getVaultSecretGroup(linuxProfile)
 		osProfile.Secrets = &vsg
 	}
 
@@ -451,7 +451,7 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 
 	vmssNICConfig.IPConfigurations = &ipConfigurations
 
-	if linuxProfile.HasCustomNodesDNS() && !profile.IsWindows() {
+	if linuxProfile != nil && linuxProfile.HasCustomNodesDNS() && !profile.IsWindows() {
 		vmssNICConfig.DNSSettings = &compute.VirtualMachineScaleSetNetworkConfigurationDNSSettings{
 			DNSServers: &[]string{
 				"[parameters('dnsServer')]",
@@ -501,10 +501,10 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 			},
 		}
 
-		if len(cs.Properties.LinuxProfile.SSH.PublicKeys) > 1 {
+		if linuxProfile != nil && len(linuxProfile.SSH.PublicKeys) > 1 {
 			publicKeyPath := "[variables('sshKeyPath')]"
 			var publicKeys []compute.SSHPublicKey
-			for _, publicKey := range cs.Properties.LinuxProfile.SSH.PublicKeys {
+			for _, publicKey := range linuxProfile.SSH.PublicKeys {
 				publicKeyTrimmed := strings.TrimSpace(publicKey.KeyData)
 				publicKeys = append(publicKeys, compute.SSHPublicKey{
 					Path:    &publicKeyPath,
@@ -526,8 +526,8 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 			}
 		}
 
-		if linuxProfile.HasSecrets() {
-			vsg := getVaultSecretGroup(cs.Properties.LinuxProfile)
+		if linuxProfile != nil && linuxProfile.HasSecrets() {
+			vsg := getVaultSecretGroup(linuxProfile)
 			linuxOsProfile.Secrets = &vsg
 		}
 


### PR DESCRIPTION
Is there such a thing called "too many nil checks"?