### PR TITLE
fix: restore back-compat for clusters that have an older --audit-poli…

### DIFF
--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -118,6 +118,13 @@ func (cs *ContainerService) setAPIServerConfig() {
 			if _, ok := o.KubernetesConfig.APIServerConfig[key]; !ok {
 				// then assign the default value
 				o.KubernetesConfig.APIServerConfig[key] = val
+			} else {
+				// Manual override of "--audit-policy-file" for back-compat
+				if key == "--audit-policy-file" {
+					if o.KubernetesConfig.APIServerConfig[key] == "/etc/kubernetes/manifests/audit-policy.yaml" {
+						o.KubernetesConfig.APIServerConfig[key] = val
+					}
+				}
 			}
 		}
 	}

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -420,6 +420,20 @@ func TestAPIServerConfigRepairMalformedUpdates(t *testing.T) {
 	}
 }
 
+func TestAPIServerAuditPolicyBackCompatOverride(t *testing.T) {
+	// Validate that we statically override "--audit-policy-file" values of "/etc/kubernetes/manifests/audit-policy.yaml" for back-compat
+	auditPolicyKey := "--audit-policy-file"
+	cs := CreateMockContainerService("testcluster", "1.10.8", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig[auditPolicyKey] = "/etc/kubernetes/manifests/audit-policy.yaml"
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a[auditPolicyKey] != "/etc/kubernetes/addons/audit-policy.yaml" {
+		t.Fatalf("got unexpected default value for '%s' API server config: %s",
+			auditPolicyKey, a[auditPolicyKey])
+	}
+}
+
 func TestAPIServerWeakCipherSuites(t *testing.T) {
 	// Test allowed versions
 	for _, version := range []string{"1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0"} {


### PR DESCRIPTION
…cy-file

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

The on-disk location for "--audit-policy-file" changed at some point in the past, and this breaks backwards-compatibility via `aks-engine upgrade` for cluster built before that change.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #477

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
