### PR TITLE
style: use errors.Errorf instead of fmt.Errorf as it's more idiomatic

### DIFF
--- a/cmd/get_versions.go
+++ b/cmd/get_versions.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/pkg/errors"
+
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/spf13/cobra"
@@ -82,7 +84,7 @@ func (gvc *getVersionsCmd) run(cmd *cobra.Command, args []string) error {
 		}
 		w.Flush()
 	default:
-		return fmt.Errorf("output format \"%s\" is not supported", gvc.output)
+		return errors.Errorf(`output format "%s" is not supported`, gvc.output)
 	}
 
 	return nil

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/Azure/aks-engine/pkg/helpers"
 
 	"github.com/spf13/cobra"
@@ -66,7 +68,7 @@ func getVersion(outputType string) (string, error) {
 	case "json":
 		return getJSONVersion(), nil
 	default:
-		return "", fmt.Errorf("output format \"%s\" is not supported", outputType)
+		return "", errors.Errorf(`output format "%s" is not supported`, outputType)
 	}
 }
 

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -5,7 +5,6 @@ package vlabs
 
 import (
 	"encoding/base64"
-	"fmt"
 	"net"
 	"net/url"
 	"regexp"
@@ -1271,7 +1270,7 @@ func validatePoolOSType(os OSType) error {
 
 func validatePoolAcceleratedNetworking(vmSize string) error {
 	if !helpers.AcceleratedNetworkingSupported(vmSize) {
-		return fmt.Errorf("AgentPoolProfile.vmsize %s does not support AgentPoolProfile.acceleratedNetworking", vmSize)
+		return errors.Errorf("AgentPoolProfile.vmsize %s does not support AgentPoolProfile.acceleratedNetworking", vmSize)
 	}
 	return nil
 }

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/armhelpers"
 	"github.com/Azure/aks-engine/pkg/armhelpers/utils"
@@ -626,7 +628,7 @@ func (ku *Upgrader) getLastVMNameInVMSS(ctx context.Context, resourceGroup strin
 	}
 
 	if lastVMName == "" {
-		return "", fmt.Errorf("failed to get the last VM name in Scale Set %s", vmScaleSetName)
+		return "", errors.Errorf("failed to get the last VM name in Scale Set %s", vmScaleSetName)
 	}
 
 	return lastVMName, nil

--- a/test/e2e/kubernetes/util/util.go
+++ b/test/e2e/kubernetes/util/util.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // PrintCommand prints a command string
@@ -28,7 +30,7 @@ func RunAndLogCommand(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
 	total := time.Since(start)
 	log.Printf("#### %s completed in %s", cmdLine, end.Sub(start).String())
 	if total.Seconds() > timeout.Seconds() {
-		err = fmt.Errorf(fmt.Sprintf("%s took too long!", cmdLine))
+		err = errors.Errorf("%s took too long!", cmdLine)
 	}
 	return out, err
 }


### PR DESCRIPTION
Apparently `pkg/errors` is also artisanal.

https://github.com/pkg/