### PR TITLE
perf: increased default max pod limit to 110 for azure cni

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -262,7 +262,7 @@ Below is a list of kubelet options that aks-engine will configure by default:
 | "--cloud-provider"                  | "azure"                                                                                                                                                       |
 | "--cluster-domain"                  | "cluster.local"                                                                                                                                               |
 | "--pod-infra-container-image"       | "pause-amd64:_version_"                                                                                                                                       |
-| "--max-pods"                        | "30", or "110" if using kubenet --network-plugin (i.e., `"networkPlugin": "kubenet"`)                                                                         |
+| "--max-pods"                        | "110"                                                                                                                                                         |
 | "--eviction-hard"                   | "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"                                                                                            |
 | "--node-status-update-frequency"    | "10s"                                                                                                                                                         |
 | "--image-gc-high-threshold"         | "85"                                                                                                                                                          |

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -310,7 +310,7 @@ const (
 	// DefaultKubernetesMaxPods is the maximum number of pods to run on a node.
 	DefaultKubernetesMaxPods = 110
 	// DefaultKubernetesMaxPodsVNETIntegrated is the maximum number of pods to run on a node when VNET integration is enabled.
-	DefaultKubernetesMaxPodsVNETIntegrated = 30
+	DefaultKubernetesMaxPodsVNETIntegrated = 110
 	// DefaultKubernetesClusterDomain is the dns suffix used in the cluster (used as a SAN in the PKI generation)
 	DefaultKubernetesClusterDomain = "cluster.local"
 	// DefaultInternalLbStaticIPOffset specifies the offset of the internal LoadBalancer's IP


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This PR increases the default limit of maz pods to 110 for azure cni (#820 , #87)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #820 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
