### PR TITLE
fix: fix sshd logging to auth.log for OMS

### DIFF
--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -288,7 +288,7 @@ ensureJournal(){
     echo "Storage=persistent" >> /etc/systemd/journald.conf
     echo "SystemMaxUse=1G" >> /etc/systemd/journald.conf
     echo "RuntimeMaxUse=1G" >> /etc/systemd/journald.conf
-    echo "ForwardToSyslog=no" >> /etc/systemd/journald.conf
+    echo "ForwardToSyslog=yes" >> /etc/systemd/journald.conf
     systemctlEnableAndStart systemd-journald || exit $ERR_SYSTEMCTL_START_FAIL
 }
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
https://icm.ad.msft.net/imp/v3/incidents/details/108362084/home
OMS agent relies on auth.log for getting ssh logs for security monitoring purposes. https://docs.microsoft.com/en-us/azure/log-analytics/log-analytics-data-sources-syslog#configure-syslog-on-linux-agent
https://github.com/Azure/acs-engine/pull/1956 disabled `ForwardToSyslog` which broke this scenario. See for additional context: https://github.com/Azure/acs-engine/pull/1956#issuecomment-382822102

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
