### PR TITLE
chore: Use moby for GPU instances

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -52,13 +52,14 @@ if [[ ${FEATURE_FLAGS} == *"docker-engine"* ]]; then
     installDockerEngine
     overrideDockerEngineStorageDriver
     echo "  - docker-engine v${DOCKER_ENGINE_VERSION}" >> ${RELEASE_NOTES_FILEPATH}
-    installGPUDrivers
-    echo "  - nvidia-docker2 nvidia-container-runtime" >> ${RELEASE_NOTES_FILEPATH}
 else
     MOBY_VERSION="3.0.4"
     installMoby
     echo "  - moby v${MOBY_VERSION}" >> ${RELEASE_NOTES_FILEPATH}
 fi
+
+installGPUDrivers
+echo "  - nvidia-docker2 nvidia-container-runtime" >> ${RELEASE_NOTES_FILEPATH}
 
 installClearContainersRuntime
 

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -415,6 +415,7 @@ configGPUDrivers() {
     retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0 || exit $ERR_GPU_DRIVERS_START_FAIL
     retrycmd_if_failure 120 5 25 $GPU_DEST/bin/nvidia-smi || exit $ERR_GPU_DRIVERS_START_FAIL
     retrycmd_if_failure 120 5 25 ldconfig || exit $ERR_GPU_DRIVERS_START_FAIL
+    cat /etc/docker/daemon.json | jq '.runtimes["nvidia"] = {"path": "nvidia-container-runtime", "runtimeArgs": {}}' > /etc/docker/daemon.json
 }
 
 ensureGPUDrivers() {

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -77,6 +77,8 @@ if [[ "${GPU_NODE}" = true ]]; then
         installGPUDrivers
     fi
     ensureGPUDrivers
+else
+    # remove GPU drivers?
 fi
 installKubeletAndKubectl
 ensureRPC

--- a/parts/k8s/kubernetesprovisionsource.sh
+++ b/parts/k8s/kubernetesprovisionsource.sh
@@ -178,6 +178,22 @@ apt_get_install() {
     echo Executed apt-get install --no-install-recommends -y \"$@\" $i times;
     wait_for_apt_locks
 }
+apt_get_remove() {
+    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
+    for i in $(seq 1 $retries); do
+        wait_for_apt_locks
+        apt-get remove -y ${@}
+        [ $? -eq 0  ] && break || \
+        if [ $i -eq $retries ]; then
+            return 1
+        else
+            sleep $wait_sleep
+            apt_get_update
+        fi
+    done
+    echo Executed apt-get remove -y \"$@\" $i times;
+    wait_for_apt_locks
+}
 systemctl_restart() {
     retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
     for i in $(seq 1 $retries); do

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -240,11 +240,7 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		}
 
 		// GPU nodes need docker-engine as the container runtime
-		if properties.HasNSeriesSKU() {
-			addValue(parametersMap, "dockerEngineDownloadRepo", cloudSpecConfig.DockerSpecConfig.DockerEngineRepo)
-		} else {
-			addValue(parametersMap, "dockerEngineDownloadRepo", "")
-		}
+		addValue(parametersMap, "dockerEngineDownloadRepo", "")
 
 		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
 			addValue(parametersMap, "mobyVersion", properties.OrchestratorProfile.KubernetesConfig.MobyVersion)


### PR DESCRIPTION
This was stuck on docker 1.13 due to packaging issues with nvidia-docker
(which has a hard dep on docker specific package versions).

This change manually installs nvidia-docker2, but uses apt to install
the rest of the nvidia-* packages which don't have this hard dep.

nvidia-docker2 is really just a docker CLI clone (not sure if there are
changes to it) and a custom `/etc/docker/daemon.json` which sets the
default runtime to nvidia-container-runtime.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #534

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
