### PR TITLE
refactor: put each version on its own line in VHD script

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -62,22 +62,28 @@ fi
 
 installClearContainersRuntime
 
-VNET_CNI_VERSIONS="1.0.16 1.0.17"
-CNI_PLUGIN_VERSIONS="0.7.1"
-CONTAINERD_VERSIONS="1.1.5 1.1.6 1.2.4"
-
+VNET_CNI_VERSIONS="
+1.0.17
+1.0.16
+"
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do
     VNET_CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"
     downloadAzureCNI
     echo "  - Azure CNI version ${VNET_CNI_VERSION}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
+CNI_PLUGIN_VERSIONS="0.7.1"
 for CNI_PLUGIN_VERSION in $CNI_PLUGIN_VERSIONS; do
     CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v${CNI_PLUGIN_VERSION}.tgz"
     downloadCNI
     echo "  - CNI plugin version ${CNI_PLUGIN_VERSION}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
+CONTAINERD_VERSIONS="
+1.2.4
+1.1.6
+1.1.5
+"
 CONTAINERD_DOWNLOAD_URL_BASE="https://storage.googleapis.com/cri-containerd-release/"
 for CONTAINERD_VERSION in ${CONTAINERD_VERSIONS}; do
     downloadContainerd
@@ -103,14 +109,22 @@ for EXECHEALTHZ_VERSION in ${EXECHEALTHZ_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-ADDON_RESIZER_VERSIONS="1.8.4 1.8.1 1.7"
+ADDON_RESIZER_VERSIONS="
+1.8.4
+1.8.1
+1.7
+"
 for ADDON_RESIZER_VERSION in ${ADDON_RESIZER_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/addon-resizer:${ADDON_RESIZER_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-HEAPSTER_VERSIONS="1.5.4 1.5.3 1.5.1"
+HEAPSTER_VERSIONS="
+1.5.4
+1.5.3
+1.5.1
+"
 for HEAPSTER_VERSION in ${HEAPSTER_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/heapster-amd64:v${HEAPSTER_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
@@ -124,21 +138,36 @@ for METRICS_SERVER_VERSION in ${METRICS_SERVER_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-KUBE_DNS_VERSIONS="1.15.0 1.14.13 1.14.5"
+KUBE_DNS_VERSIONS="
+1.15.0
+1.14.13
+1.14.5
+"
 for KUBE_DNS_VERSION in ${KUBE_DNS_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/k8s-dns-kube-dns-amd64:${KUBE_DNS_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-KUBE_ADDON_MANAGER_VERSIONS="9.0 8.9 8.8 8.7 8.6"
+KUBE_ADDON_MANAGER_VERSIONS="
+9.0
+8.9
+8.8
+8.7
+8.6
+"
 for KUBE_ADDON_MANAGER_VERSION in ${KUBE_ADDON_MANAGER_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/kube-addon-manager-amd64:v${KUBE_ADDON_MANAGER_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-KUBE_DNS_MASQ_VERSIONS="1.15.0 1.14.10 1.14.8 1.14.5"
+KUBE_DNS_MASQ_VERSIONS="
+1.15.0
+1.14.10
+1.14.8
+1.14.5
+"
 for KUBE_DNS_MASQ_VERSION in ${KUBE_DNS_MASQ_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:${KUBE_DNS_MASQ_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
@@ -152,35 +181,60 @@ for PAUSE_VERSION in ${PAUSE_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-TILLER_VERSIONS="2.8.1 2.11.0"
+TILLER_VERSIONS="
+2.11.0
+2.8.1
+"
 for TILLER_VERSION in ${TILLER_VERSIONS}; do
     CONTAINER_IMAGE="gcr.io/kubernetes-helm/tiller:v${TILLER_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-CLUSTER_AUTOSCALER_VERSIONS="1.14.0 1.13.2 1.13.1 1.12.3 1.12.2 1.3.7 1.3.4 1.3.3 1.2.2 1.1.2"
+CLUSTER_AUTOSCALER_VERSIONS="
+1.14.0
+1.13.2
+1.13.1
+1.12.3
+1.12.2
+1.3.7
+1.3.4
+1.3.3
+1.2.2
+1.1.2
+"
 for CLUSTER_AUTOSCALER_VERSION in ${CLUSTER_AUTOSCALER_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/cluster-autoscaler:v${CLUSTER_AUTOSCALER_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-K8S_DNS_SIDECAR_VERSIONS="1.14.10 1.14.8 1.14.7"
+K8S_DNS_SIDECAR_VERSIONS="
+1.14.10
+1.14.8
+1.14.7
+"
 for K8S_DNS_SIDECAR_VERSION in ${K8S_DNS_SIDECAR_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/k8s-dns-sidecar-amd64:${K8S_DNS_SIDECAR_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-CORE_DNS_VERSIONS="1.3.1 1.2.6 1.2.2"
+CORE_DNS_VERSIONS="
+1.3.1
+1.2.6
+1.2.2
+"
 for CORE_DNS_VERSION in ${CORE_DNS_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/coredns:${CORE_DNS_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-RESCHEDULER_VERSIONS="0.4.0 0.3.1"
+RESCHEDULER_VERSIONS="
+0.4.0
+0.3.1
+"
 for RESCHEDULER_VERSION in ${RESCHEDULER_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/rescheduler:v${RESCHEDULER_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
@@ -208,7 +262,10 @@ for AZURE_NPM_VERSION in ${AZURE_NPM_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-NVIDIA_DEVICE_PLUGIN_VERSIONS="1.11 1.10"
+NVIDIA_DEVICE_PLUGIN_VERSIONS="
+1.11
+1.10
+"
 for NVIDIA_DEVICE_PLUGIN_VERSION in ${NVIDIA_DEVICE_PLUGIN_VERSIONS}; do
     CONTAINER_IMAGE="nvidia/k8s-device-plugin:${NVIDIA_DEVICE_PLUGIN_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
@@ -264,7 +321,10 @@ for KMS_PLUGIN_VERSION in ${KMS_PLUGIN_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
-FLANNEL_VERSIONS="0.8.0 0.10.0"
+FLANNEL_VERSIONS="
+0.10.0
+0.8.0
+"
 for FLANNEL_VERSION in ${FLANNEL_VERSIONS}; do
     CONTAINER_IMAGE="quay.io/coreos/flannel:v${FLANNEL_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
@@ -275,8 +335,19 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${RELEASE_NOTES_FILEPATH}
 
 # TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
-K8S_VERSIONS="1.9.10 1.9.11 1.10.12 1.10.13 1.11.8 1.11.9 1.12.6 1.12.7 1.13.4 1.13.5 1.14.0"
-
+K8S_VERSIONS="
+1.14.0
+1.13.5
+1.13.4
+1.12.7
+1.12.6
+1.11.9
+1.11.8
+1.10.13
+1.10.12
+1.9.11
+1.9.10
+"
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"
     extractHyperkube "docker"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Organizes the versions in the VHD creation script so each is on its own line to make merge conflicts less likely. Also lists versions consistently in descending order.

Kubernetes releases tend to appear in groups, as they did on Monday. Creating more than one PR to add version support basically guarantees `git` merge conflicts since changes are made to different sections of the same line. This should avoid that problem. I think it's a bit easier to read as well.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I only did this for components that actually have more than one version. We could expand it to all such variables, even those with a single value, for consistency if we prefer. Although in practice it's only the k8s versions and cluster-autoscaler that often conflict.