### PR TITLE
chore: remove Kubernetes 1.10 from e2e testing

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -71,13 +71,6 @@ jobs:
 
 - template: e2e-job-template.yaml
   parameters:
-    name: 'k8s_1_10_release_e2e'
-    k8sRelease: '1.10'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
-
-- template: e2e-job-template.yaml
-  parameters:
     name: 'k8s_1_11_release_e2e'
     k8sRelease: '1.11'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
@@ -103,12 +96,6 @@ jobs:
     k8sRelease: '1.14'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_windows_1_10_release_e2e'
-    k8sRelease: '1.10'
-    apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
 
 - template: e2e-job-template.yaml
   parameters:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Removes Kubernetes 1.10 from Azure DevOps end-to-end testing.

Kubernetes 1.10 is [now unsupported](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew) with the release of 1.14. This will save some testing resources.

*Edit*: actually, Kubernetes 1.11 is now unsupported according to the policy, and 1.10 has been unsupported since 1.13 was released. That's a stronger argument for removing 1.10.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
It's not impossible that Kubernetes 1.10 still could get a patch release in the event of an earth-shattering CVE, but it's not likely given the stated policy. Let me know if you think this is premature.
