### PR TITLE
fix: AKS VMSS windows agent pool upgrade

### DIFF
--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -32,12 +32,16 @@ const (
 
 	k8sWindowsOldVMNamingFormat = "^([a-fA-F0-9]{5})([0-9a-zA-Z]{3})([9])([a-zA-Z0-9]{3,5})$"
 	k8sWindowsVMNamingFormat    = "^([a-fA-F0-9]{4})([0-9a-zA-Z]{3})([0-9]{3,8})$"
+
+	windowsVmssNamingFormatV2       = "aks([0-9a-zA-Z]+)$"
+	windowsVmssAgentPoolNameIndexV2 = 1
 )
 
 var vmnameLinuxRegexp *regexp.Regexp
 var vmssnameRegexp *regexp.Regexp
 var vmnameWindowsRegexp *regexp.Regexp
 var oldvmnameWindowsRegexp *regexp.Regexp
+var windowsVmssRegexV2 *regexp.Regexp
 
 func init() {
 	vmnameLinuxRegexp = regexp.MustCompile(k8sLinuxVMNamingFormat)
@@ -45,6 +49,7 @@ func init() {
 	oldvmnameWindowsRegexp = regexp.MustCompile(k8sWindowsOldVMNamingFormat)
 
 	vmssnameRegexp = regexp.MustCompile(vmssNamingFormat)
+	windowsVmssRegexV2 = regexp.MustCompile(windowsVmssNamingFormatV2)
 }
 
 // ResourceName returns the last segment (the resource name) for the specified resource identifier.
@@ -98,6 +103,17 @@ func VmssNameParts(vmssName string) (poolIdentifier, nameSuffix string, err erro
 	}
 
 	return vmssNameParts[vmssAgentPoolNameIndex], vmssNameParts[vmssClusterIDIndex], nil
+}
+
+// WindowsVmssNameParts returns the agent pool name from the VMSS name.
+// For windows, the VMSS name is 'aks' concatenated with agentpool name
+func WindowsVmssNameParts(vmssName string) (poolIdentifier string, err error) {
+	vmssNameParts := windowsVmssRegexV2.FindStringSubmatch(vmssName)
+	if len(vmssNameParts) != 2 {
+		return "", errors.New("resource name was missing from identifier")
+	}
+
+	return vmssNameParts[windowsVmssAgentPoolNameIndexV2], nil
 }
 
 // WindowsVMNameParts returns parts of Windows VM name

--- a/pkg/armhelpers/utils/util_test.go
+++ b/pkg/armhelpers/utils/util_test.go
@@ -82,6 +82,26 @@ func Test_VMSSNameParts(t *testing.T) {
 	}
 }
 
+func Test_WindowsVMSSNameParts(t *testing.T) {
+	data := []struct {
+		poolIdentifier string
+	}{
+		{"winpo1"},
+		{"win2po"},
+	}
+
+	for _, el := range data {
+		vmssName := fmt.Sprintf("aks%s", el.poolIdentifier)
+		poolIdentifier, err := WindowsVmssNameParts(vmssName)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if poolIdentifier != el.poolIdentifier {
+			t.Fatalf("incorrect poolIdentifier. expected=%s actual=%s", el.poolIdentifier, poolIdentifier)
+		}
+	}
+}
+
 func Test_WindowsVMNameParts(t *testing.T) {
 	data := []struct {
 		VMName, expectedPoolPrefix, expectedOrch string

--- a/pkg/engine/transform/transform.go
+++ b/pkg/engine/transform/transform.go
@@ -31,6 +31,7 @@ const (
 	createOptionFieldName          = "createOption"
 	tagsFieldName                  = "tags"
 	managedDiskFieldName           = "managedDisk"
+	windowsConfigurationFieldName  = "windowsConfiguration"
 
 	// ARM resource Types
 	nsgResourceType  = "Microsoft.Network/networkSecurityGroups"
@@ -268,7 +269,7 @@ func (t *Transformer) removeCustomData(logger *logrus.Entry, resourceProperties 
 		return ok
 	}
 
-	if osProfile[customDataFieldName] != nil {
+	if osProfile[customDataFieldName] != nil && osProfile[windowsConfigurationFieldName] == nil {
 		delete(osProfile, customDataFieldName)
 	}
 	return ok

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -46,6 +46,7 @@ type AgentPoolScaleSet struct {
 	Name         string
 	Sku          compute.Sku
 	Location     string
+	IsWindows    bool
 	VMsToUpgrade []AgentPoolScaleSetVM
 }
 
@@ -143,6 +144,12 @@ func (uc *UpgradeCluster) getClusterNodeStatus(az armhelpers.AKSEngineClient, re
 					Name:     *vmScaleSet.Name,
 					Sku:      *vmScaleSet.Sku,
 					Location: *vmScaleSet.Location,
+				}
+				if vmScaleSet.VirtualMachineProfile != nil &&
+					vmScaleSet.VirtualMachineProfile.OsProfile != nil &&
+					vmScaleSet.VirtualMachineProfile.OsProfile.WindowsConfiguration != nil {
+					scaleSetToUpgrade.IsWindows = true
+					uc.Logger.Infof("Set isWindows flag for vmss %s.", *vmScaleSet.Name)
 				}
 				for _, vm := range vmScaleSetVMsPage.Values() {
 					currentVersion := uc.getNodeVersion(kubeClient, *vm.Name, vm.Tags)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Upgrade windows nodes's kubernetes version requires keeping the custom data of the windows profile because the kubernetes version is fixed in the custom data.
Also added retry with a 5 minutes timeout for copying node properties because windows node takes a little bit longer to show up.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
