### PR TITLE
fix: include vnet CIDR in windows node CNI outbound NAT exception list

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -79,6 +79,7 @@ $global:PrimaryScaleSetName = "{{WrapAsVariable "primaryScaleSetName"}}"
 
 $global:KubeClusterCIDR = "{{WrapAsParameter "kubeClusterCidr"}}"
 $global:KubeServiceCIDR = "{{WrapAsParameter "kubeServiceCidr"}}"
+$global:VNetCIDR = "{{WrapAsParameter "vnetCidr"}}"
 $global:KubeletNodeLabels = "{{GetAgentKubernetesLabels . "',variables('labelResourceGroup'),'"}}"
 $global:KubeletConfigArgs = @( {{GetKubeletConfigKeyValsPsh .KubernetesConfig }} )
 
@@ -220,7 +221,8 @@ try
                                -KubeDnsSearchPath $global:KubeDnsSearchPath `
                                -KubeClusterCIDR $global:KubeClusterCIDR `
                                -MasterSubnet $global:MasterSubnet `
-                               -KubeServiceCIDR $global:KubeServiceCIDR
+                               -KubeServiceCIDR $global:KubeServiceCIDR `
+                               -VNetCIDR $global:VNetCIDR
         } elseif ($global:NetworkPlugin -eq "kubenet") {
             Update-WinCNI -CNIPath $global:CNIPath
             Get-HnsPsm1 -HNSModule $global:HNSModule

--- a/parts/k8s/windowsazurecnifunc.ps1
+++ b/parts/k8s/windowsazurecnifunc.ps1
@@ -65,7 +65,9 @@ Set-AzureCNIConfig
         [Parameter(Mandatory=$true)][string]
         $MasterSubnet,
         [Parameter(Mandatory=$true)][string]
-        $KubeServiceCIDR
+        $KubeServiceCIDR,
+        [Parameter(Mandatory=$true)][string]
+        $VNetCIDR
     )
     # Fill in DNS information for kubernetes.
     $fileName  = [Io.path]::Combine("$AzureCNIConfDir", "10-azure.conflist")
@@ -75,6 +77,7 @@ Set-AzureCNIConfig
     $configJson.plugins.AdditionalArgs[0].Value.ExceptionList[0] = $KubeClusterCIDR
     $configJson.plugins.AdditionalArgs[0].Value.ExceptionList[1] = $MasterSubnet
     $configJson.plugins.AdditionalArgs[1].Value.DestinationPrefix  = $KubeServiceCIDR
+    $configJson.plugins.AdditionalArgs[0].Value.ExceptionList += $VNetCIDR
 
     $configJson | ConvertTo-Json -depth 20 | Out-File -encoding ASCII -filepath $fileName
 }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
For windows node provisioned in custom vnet with CNI, we should include VNETCIDR in the outbound NAT exception list. Otherwise VMs in different subnet won't be able to reach the windows pods.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
