### PR TITLE
fix: ip-masq-agent container image has a different repo base in VHD

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -305,6 +305,11 @@ done
 
 IP_MASQ_AGENT_VERSIONS="2.0.0"
 for IP_MASQ_AGENT_VERSION in ${IP_MASQ_AGENT_VERSIONS}; do
+    # TODO remove the gcr.io/google-containers image once AKS switches to use k8s.gcr.io
+    DEPRECATED_CONTAINER_IMAGE="gcr.io/google-containers/ip-masq-agent-amd64:v${IP_MASQ_AGENT_VERSION}"
+    pullContainerImage "docker" ${DEPRECATED_CONTAINER_IMAGE}
+    echo "  - ${DEPRECATED_CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
+
     CONTAINER_IMAGE="k8s.gcr.io/ip-masq-agent-amd64:v${IP_MASQ_AGENT_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -305,7 +305,7 @@ done
 
 IP_MASQ_AGENT_VERSIONS="2.0.0"
 for IP_MASQ_AGENT_VERSION in ${IP_MASQ_AGENT_VERSIONS}; do
-    CONTAINER_IMAGE="gcr.io/google-containers/ip-masq-agent-amd64:v${IP_MASQ_AGENT_VERSION}"
+    CONTAINER_IMAGE="k8s.gcr.io/ip-masq-agent-amd64:v${IP_MASQ_AGENT_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Follow up from #459. We pre-pull gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0 onto our VHDs but the default addon spec for ip-masq-agent specifies "k8s.gcr.io/ip-masq-agent-amd64:v2.0.0".  This PR updates the VHD script to pre-pull the both images. We keep the gcr.io/google-containers for now because AKS uses it. In the future, we will update AKS to use the same image as AKS Engine and remove the old image from the VHD.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#910

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
