### PR TITLE
fix : prometheus-grafana extension : cAdvisor deployment is not namespaced

### DIFF
--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -182,7 +182,7 @@ install_cadvisor() {
     DAEMONSET_API=$(daemonset_api)
     echo "$(date) - Using DaemonSet api group $DAEMONSET_API"
     sed -i 's|DAEMONSET_API|'"$DAEMONSET_API"'|g' cadvisor_ds.yml
-    kubectl apply -f ./cadvisor_ds.yml
+    kubectl apply -f ./cadvisor_ds.yml --namespace=$NAMESPACE
 }
 
 update_helm() {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->


**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

The prometheus-grafana (and cadvisor) extension use an extensionParameter to customize its  deployment, as documented here. 
https://github.com/Azure/aks-engine/tree/master/extensions/prometheus-grafana-k8s#configuration

This is nice, but I noticed the cAdvisor deployment was not namespaced when using it. 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
