### PR TITLE
fix: zones values for VMAS masters is an array of a single string

### DIFF
--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -59,7 +59,7 @@ func CreateVirtualMachine(cs *api.ContainerService) VirtualMachineARM {
 
 	if hasAvailabilityZones {
 		virtualMachine.Zones = &[]string{
-			"split(string(parameters('availabilityZones')[mod(copyIndex(variables('masterOffset')), length(parameters('availabilityZones')))]), ',')",
+			"[string(parameters('availabilityZones')[mod(copyIndex(variables('masterOffset')), length(parameters('availabilityZones')))])]",
 		}
 	}
 

--- a/pkg/engine/virtualmachines_test.go
+++ b/pkg/engine/virtualmachines_test.go
@@ -152,7 +152,7 @@ func TestCreateVirtualMachines(t *testing.T) {
 	}
 
 	expectedVM.VirtualMachine.Zones = &[]string{
-		"split(string(parameters('availabilityZones')[mod(copyIndex(variables('masterOffset')), length(parameters('availabilityZones')))]), ',')",
+		"[string(parameters('availabilityZones')[mod(copyIndex(variables('masterOffset')), length(parameters('availabilityZones')))])]",
 	}
 
 	diff = cmp.Diff(actualVM, expectedVM)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Addresses a regression introduced in #682. With the strongly typed representation of a vm, we now need to evaluate just a string to include inside the strongly typed array. Using the pre-template refactor ARM expression was resulting in an array inside an array, breaking the type req's.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #902

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
