### PR TITLE
fix: fix disable rbac + enable aggregated API upgrade bug

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -217,6 +217,10 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpdate bool) {
 				// TODO make EnableAggregatedAPIs a pointer to bool so that a user can opt out of it
 				a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true
 			}
+		} else if isUpdate && a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+			// Upgrade scenario:
+			// We need to force set EnableAggregatedAPIs to false if RBAC was previously disabled
+			a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = false
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet == nil {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1244,7 +1244,7 @@ func TestAzureCNIVersionString(t *testing.T) {
 	}
 }
 
-func TestDefaultDisableRbac(t *testing.T) {
+func TestEnableAggregatedAPIs(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
@@ -1253,6 +1253,17 @@ func TestDefaultDisableRbac(t *testing.T) {
 
 	if properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
 		t.Fatalf("got unexpected EnableAggregatedAPIs config value for EnableRbac=false: %t",
+			properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs)
+	}
+
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(true)
+	mockCS.setOrchestratorDefaults(true)
+
+	if !properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+		t.Fatalf("got unexpected EnableAggregatedAPIs config value for EnableRbac=true: %t",
 			properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs)
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1266,7 +1266,7 @@ func TestAlwaysSetEnableAggregatedAPIsToFalseIfRBACDisabled(t *testing.T) {
 	mockCS.setOrchestratorDefaults(true)
 
 	if properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
-		t.Fatalf("got unexpected EnableAggregatedAPIs config value for EnableRbac=false: %t",
+		t.Fatalf("expected EnableAggregatedAPIs to be manually set to false in update scenario, instead got %t",
 			properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs)
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1257,6 +1257,20 @@ func TestDefaultDisableRbac(t *testing.T) {
 	}
 }
 
+func TestAlwaysSetEnableAggregatedAPIsToFalseIfRBACDisabled(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.3")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(false)
+	properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true
+	mockCS.setOrchestratorDefaults(true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+		t.Fatalf("got unexpected EnableAggregatedAPIs config value for EnableRbac=false: %t",
+			properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs)
+	}
+}
+
 func TestDefaultCloudProvider(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

For a period of time, there was a bug in default assignment w/ respect to `enableAggregatedAPI` and `enableRBAC`. Specifically: `enableAggregatedAPI` configuration depends upon `enableRBAC` (the former can only be `true` if the latter is also `true`).

Proper default enforcement was implemented here:

https://github.com/Azure/acs-engine/pull/3813

Prior to that it was possible to create a cluster w/ a pathological config (primarily because CSE was permissive to `enableAggregatedAPI` being set to true without RBAC, see https://github.com/Azure/acs-engine/pull/3751 for when that started to change).

The purpose of this PR is to detect pathological configurations in upgrade scenarios, and to fix them via defaults enforcements flow.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #905 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: