### PR TITLE
[CIS conformance] fix: disable ReadOnlyPort since it's only for heapster

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -223,21 +223,29 @@ Below is a list of kubelet options that aks-engine will configure by default:
 
 | kubelet option                      | default value                                                                                                                                                 |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "--cadvisor-port"    | "0"                                                                                                                                                         |
 | "--cloud-config"                    | "/etc/kubernetes/azure.json"                                                                                                                                  |
 | "--cloud-provider"                  | "azure"                                                                                                                                                       |
 | "--cluster-domain"                  | "cluster.local"                                                                                                                                               |
+| "--event-qps"    | "0"                                                                                                                                                         |
 | "--pod-infra-container-image"       | "pause-amd64:_version_"                                                                                                                                       |
+| "--network-plugin"                           | "cni"                                            |
 | "--max-pods"                        | "30", or "110" if using kubenet --network-plugin (i.e., `"networkPlugin": "kubenet"`)                                                                         |
-| "--eviction-hard"                   | "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"                                                                                            |
+| "--eviction-hard"                   | "memory.available<750Mi,nodefs.available<10%,nodefs.inodesFree<5%"                                                                                            |
 | "--node-status-update-frequency"    | "10s"                                                                                                                                                         |
 | "--image-gc-high-threshold"         | "85"                                                                                                                                                          |
-| "--image-gc-low-threshold"          | "850"                                                                                                                                                         |
-| "--non-masquerade-cidr"             | "10.0.0.0/8"                                                                                                                                                  |
+| "--image-gc-low-threshold"          | "80"                                                                                                                                                         |
+| "--non-masquerade-cidr"             | "0.0.0.0/0" (unless ip-masq-agent is disabled, in which case this is set to the value of `kubernetesConfig.ClusterSubnet` )                                                                                                                                                  |
 | "--azure-container-registry-config" | "/etc/kubernetes/azure.json"                                                                                                                                  |
 | "--pod-max-pids"                    | "-1" (need to activate the feature in --feature-gates=SupportPodPidsLimit=true)                                                                              |
 | "--image-pull-progress-deadline"    | "30m"                                                                                                                                                         |
 | "--feature-gates"                   | No default (can be a comma-separated list). On agent nodes `Accelerators=true` will be applied in the `--feature-gates` option for k8s versions before 1.11.0 |
 | "--enforce-node-allocatable"        | "pods" |
+| "--streaming-connection-idle-timeout"        | "4h" |
+| "--rotate-certificates"        | "true" (this default is set for clusters >= 1.11.9 ) |
+| "--tls-cipher-suites"        | "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256" |
+| "--authentication-token-webhook"        | "true" (this default is set for clusters >= 1.16.0 ) |
+| "--read-only-port"        | "0" (this default is set for clusters >= 1.16.0 ) |
 
 Below is a list of kubelet options that are _not_ currently user-configurable, either because a higher order configuration vector is available that enforces kubelet configuration, or because a static configuration is required to build a functional cluster:
 
@@ -246,7 +254,6 @@ Below is a list of kubelet options that are _not_ currently user-configurable, e
 | "--address"                                  | "0.0.0.0"                                        |
 | "--allow-privileged"                         | "true"                                           |
 | "--pod-manifest-path"                        | "/etc/kubernetes/manifests"                      |
-| "--network-plugin"                           | "cni"                                            |
 | "--node-labels"                              | (based on Azure node metadata)                   |
 | "--cgroups-per-qos"                          | "true"                                           |
 | "--kubeconfig"                               | "/var/lib/kubelet/kubeconfig"                    |
@@ -291,8 +298,6 @@ Below is a list of controller-manager options that are _not_ currently user-conf
 | "--allocate-node-cidrs"              | "false"                                                 |
 | "--cluster-cidr"                     | _uses clusterSubnet value_                              |
 | "--cluster-name"                     | _auto-generated using api model properties_             |
-| "--cloud-provider"                   | "azure"                                                 |
-| "--cloud-config"                     | "/etc/kubernetes/azure.json"                            |
 | "--root-ca-file"                     | "/etc/kubernetes/certs/ca.crt"                          |
 | "--cluster-signing-cert-file"        | "/etc/kubernetes/certs/ca.crt"                          |
 | "--cluster-signing-key-file"         | "/etc/kubernetes/certs/ca.key"                          |

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -120,7 +120,9 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
 		// for enabling metrics-server v0.3.0+
 		defaultKubeletConfig["--authentication-token-webhook"] = "true"
-		defaultKubeletConfig["--read-only-port"] = "0" // we only have metrics-server v0.3 support in 1.16.0 and above
+		if !cs.Properties.IsHostedMasterProfile() { // Skip for AKS until it supports metrics-server v0.3
+			defaultKubeletConfig["--read-only-port"] = "0" // we only have metrics-server v0.3 support in 1.16.0 and above
+		}
 	}
 
 	// If no user-configurable kubelet config values exists, use the defaults

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -117,9 +117,10 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		defaultKubeletConfig["--tls-cipher-suites"] = TLSStrongCipherSuitesKubelet
 	}
 
-	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0-beta.1") {
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
 		// for enabling metrics-server v0.3.0+
 		defaultKubeletConfig["--authentication-token-webhook"] = "true"
+		defaultKubeletConfig["--read-only-port"] = "0" // we only have metrics-server v0.3 support in 1.16.0 and above
 	}
 
 	// If no user-configurable kubelet config values exists, use the defaults

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -1982,6 +1982,22 @@ func TestReadOnlyPort(t *testing.T) {
 			},
 			expectedReadOnlyPort: "0",
 		},
+		{
+			name: "AKS 1.16",
+			cs: &ContainerService{
+				Properties: &Properties{
+					HostedMasterProfile: &HostedMasterProfile{
+						FQDN: "foo",
+					},
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.16.0",
+						KubernetesConfig:    &KubernetesConfig{},
+					},
+				},
+			},
+			expectedReadOnlyPort: "",
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -1950,12 +1950,11 @@ func TestSupportPodPidsLimitFeatureGateInAgentPool(t *testing.T) {
 	}
 
 }
-
 func TestReadOnlyPort(t *testing.T) {
 	cases := []struct {
-		name                                   string
-		cs                                     *ContainerService
-		expectedReadOnlyPort                     string
+		name                 string
+		cs                   *ContainerService
+		expectedReadOnlyPort string
 	}{
 		{
 			name: "default pre-1.16",
@@ -1968,7 +1967,7 @@ func TestReadOnlyPort(t *testing.T) {
 					},
 				},
 			},
-			expectedReadOnlyPort:                     "",
+			expectedReadOnlyPort: "",
 		},
 		{
 			name: "default 1.16",
@@ -1981,7 +1980,7 @@ func TestReadOnlyPort(t *testing.T) {
 					},
 				},
 			},
-			expectedReadOnlyPort:                     "0",
+			expectedReadOnlyPort: "0",
 		},
 	}
 

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -118,7 +118,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		}
 	}
 
-	cs = CreateMockContainerService("testcluster", "1.16.0-beta.1", 3, 2, false)
+	cs = CreateMockContainerService("testcluster", "1.16.0", 3, 2, false)
 	cs.setKubeletConfig(false)
 	kubeletConfig = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	expectedKeys := []string{

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -1950,3 +1950,51 @@ func TestSupportPodPidsLimitFeatureGateInAgentPool(t *testing.T) {
 	}
 
 }
+
+func TestReadOnlyPort(t *testing.T) {
+	cases := []struct {
+		name                                   string
+		cs                                     *ContainerService
+		expectedReadOnlyPort                     string
+	}{
+		{
+			name: "default pre-1.16",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.15.0",
+						KubernetesConfig:    &KubernetesConfig{},
+					},
+				},
+			},
+			expectedReadOnlyPort:                     "",
+		},
+		{
+			name: "default 1.16",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.16.0",
+						KubernetesConfig:    &KubernetesConfig{},
+					},
+				},
+			},
+			expectedReadOnlyPort:                     "0",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setKubeletConfig(false)
+			readOnlyPort := c.cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--read-only-port"]
+			if readOnlyPort != c.expectedReadOnlyPort {
+				t.Fatalf("expected --read-only-port be equal to %s, got %s", c.expectedReadOnlyPort, readOnlyPort)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
`read-only-port`(default: `10255`) is only for heapster, while our aks-engine and aks has now switched to use metric server which uses `10250` by default.
This PR disabled `read-only-port` by set it as 0, here are the k8s ports definitons:
https://github.com/kubernetes/kubernetes/blob/b8b7ab39ec457b11caffbe0d31bd527cc8aa6f09/pkg/master/ports/ports.go#L38-L43

https://github.com/Azure/acs-engine/pull/2091

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
461

Original CIS conformance test result:
```
[FAIL] 2.1.4 Ensure that the --read-only-port argument is set to 0 (Scored)
== Remediations ==
2.1.4 If using a Kubelet config file, edit the file to set readOnlyPort to 0 .
If using command line arguments, edit the kubelet service file
/etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and
set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
--read-only-port=0
Based on your system, restart the kubelet service. For example:
systemctl daemon-reload
systemctl restart kubelet.service
```

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
/assign @jackfrancis 
cc @feiskyer @leifei87
