### PR TITLE
test: don't ignore errors from SetPropertiesDefaults 

### DIFF
--- a/pkg/engine/params_k8s_test.go
+++ b/pkg/engine/params_k8s_test.go
@@ -39,7 +39,9 @@ func TestAssignKubernetesParameters(t *testing.T) {
 		parametersMap := paramsMap{}
 		containerService.Location = "eastus"
 		cloudSpecConfig := containerService.GetCloudSpecConfig()
-		containerService.SetPropertiesDefaults(false, false)
+		if _, err = containerService.SetPropertiesDefaults(false, false); err != nil {
+			t.Errorf("setting properties defaults for apimodel %s: %s", tuple.APIModelFilename, err)
+		}
 		assignKubernetesParameters(containerService.Properties, parametersMap, cloudSpecConfig, DefaultGeneratorCode)
 		for k, v := range parametersMap {
 			switch val := v.(paramsMap)["value"].(type) {

--- a/pkg/engine/params_test.go
+++ b/pkg/engine/params_test.go
@@ -37,8 +37,13 @@ func TestAssignParameters(t *testing.T) {
 		}
 
 		containerService.Location = "eastus"
-		containerService.SetPropertiesDefaults(false, false)
-		parametersMap := getParameters(containerService, DefaultGeneratorCode, "testversion")
+		if _, err = containerService.SetPropertiesDefaults(false, false); err != nil {
+			t.Errorf("setting properties defaults for apimodel %s: %s", tuple.APIModelFilename, err)
+		}
+		parametersMap, err := getParameters(containerService, DefaultGeneratorCode, "testversion")
+		if err != nil {
+			t.Errorf("should not get error when populating parameters")
+		}
 		for k, v := range parametersMap {
 			switch val := v.(paramsMap)["value"].(type) {
 			case *bool:

--- a/pkg/engine/params_test.go
+++ b/pkg/engine/params_test.go
@@ -40,10 +40,7 @@ func TestAssignParameters(t *testing.T) {
 		if _, err = containerService.SetPropertiesDefaults(false, false); err != nil {
 			t.Errorf("setting properties defaults for apimodel %s: %s", tuple.APIModelFilename, err)
 		}
-		parametersMap, err := getParameters(containerService, DefaultGeneratorCode, "testversion")
-		if err != nil {
-			t.Errorf("should not get error when populating parameters")
-		}
+		parametersMap := getParameters(containerService, DefaultGeneratorCode, "testversion")
 		for k, v := range parametersMap {
 			switch val := v.(paramsMap)["value"].(type) {
 			case *bool:

--- a/pkg/helpers/pki.go
+++ b/pkg/helpers/pki.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -236,7 +235,7 @@ func privateKeyToPem(privateKey *rsa.PrivateKey) []byte {
 func pemToCertificate(raw string) (*x509.Certificate, error) {
 	cpb, _ := pem.Decode([]byte(raw))
 	if cpb == nil {
-		return nil, errors.New(fmt.Sprintf("The raw pem is not a valid PEM formatted block:\n%s\n", raw))
+		return nil, fmt.Errorf("the raw pem is not a valid PEM formatted block:\n%s", raw)
 	}
 	return x509.ParseCertificate(cpb.Bytes)
 }
@@ -244,7 +243,7 @@ func pemToCertificate(raw string) (*x509.Certificate, error) {
 func pemToKey(raw string) (*rsa.PrivateKey, error) {
 	kpb, _ := pem.Decode([]byte(raw))
 	if kpb == nil {
-		return nil, errors.New(fmt.Sprintf("The raw pem is not a valid PEM formatted block:\n%s\n", raw))
+		return nil, fmt.Errorf("the raw pem is not a valid PEM formatted block:\n%s", raw)
 	}
 	return x509.ParsePKCS1PrivateKey(kpb.Bytes)
 }

--- a/pkg/helpers/pki.go
+++ b/pkg/helpers/pki.go
@@ -236,7 +236,7 @@ func privateKeyToPem(privateKey *rsa.PrivateKey) []byte {
 func pemToCertificate(raw string) (*x509.Certificate, error) {
 	cpb, _ := pem.Decode([]byte(raw))
 	if cpb == nil {
-		return nil, errors.New("The raw pem is not a valid PEM formatted block")
+		return nil, errors.New(fmt.Sprintf("The raw pem is not a valid PEM formatted block:\n%s\n", raw))
 	}
 	return x509.ParseCertificate(cpb.Bytes)
 }
@@ -244,7 +244,7 @@ func pemToCertificate(raw string) (*x509.Certificate, error) {
 func pemToKey(raw string) (*rsa.PrivateKey, error) {
 	kpb, _ := pem.Decode([]byte(raw))
 	if kpb == nil {
-		return nil, errors.New("The raw pem is not a valid PEM formatted block")
+		return nil, errors.New(fmt.Sprintf("The raw pem is not a valid PEM formatted block:\n%s\n", raw))
 	}
 	return x509.ParsePKCS1PrivateKey(kpb.Bytes)
 }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
In trying to enable the `errcheck` linter, a problem was exposed. If `masterProfile.count` > 1, the `SetPropertiesDefaults` func returns a key decoding error:

```
The raw pem is not a valid PEM formatted block:
caCertificate
```

This PR ensures that we check the return value of `SetPropertiesDefaults` in tests, and then works around the problem for now by setting `masterProfile.count` = 1 in `pkg/engine/testdata/azurestack/kubernetes.json`.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See #991, which still needs fixing


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
