### PR TITLE
feat: enable calico 3.5 for AKS

### DIFF
--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -190,11 +190,7 @@ configureCNI() {
     # needed for the iptables rules to work on bridges
     retrycmd_if_failure 120 5 25 modprobe br_netfilter || exit $ERR_MODPROBE_FAIL
     echo -n "br_netfilter" > /etc/modules-load.d/br_netfilter.conf
-    if [ "$IS_HOSTED_MASTER" = "true" ]; then
-        configureCNIIPTablesAKS
-    else
-        configureCNIIPTables
-    fi
+    configureCNIIPTables
     if [[ "${NETWORK_PLUGIN}" = "cilium" ]]; then
         systemctl enable sys-fs-bpf.mount
         systemctl restart sys-fs-bpf.mount
@@ -208,16 +204,6 @@ configureCNIIPTables() {
         chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
         if [[ "${NETWORK_POLICY}" == "calico" ]]; then
           sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-        fi
-        /sbin/ebtables -t nat --list
-    fi
-}
-
-configureCNIIPTablesAKS() {
-    if [[ "${NETWORK_PLUGIN}" = "azure" ]]; then
-        if [[ "${NETWORK_POLICY}" != "calico" ]]; then
-            mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
-            chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
         fi
         /sbin/ebtables -t nat --list
     fi


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Enables calico 3.5 for the AKS / hosted masters code path by calling `configureCNIIPTables` unconditionally. Basically reverting #952.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #993


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
