### PR TITLE
refactor: move isPrivateCluster to types.go

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1330,6 +1330,14 @@ func (o *OrchestratorProfile) RequireRouteTable() bool {
 	}
 }
 
+// IsPrivateCluster returns true if this deployment is a private cluster
+func (o *OrchestratorProfile) IsPrivateCluster() bool {
+	if !o.IsKubernetes() {
+		return false
+	}
+	return o.KubernetesConfig != nil && o.KubernetesConfig.PrivateCluster != nil && to.Bool(o.KubernetesConfig.PrivateCluster.Enabled)
+}
+
 // NeedsExecHealthz returns whether or not we have a configuration that requires exechealthz pod anywhere
 func (o *OrchestratorProfile) NeedsExecHealthz() bool {
 	return o.IsKubernetes() &&

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -873,6 +873,65 @@ func TestRequireRouteTable(t *testing.T) {
 	}
 }
 
+func TestIsPrivateCluster(t *testing.T) {
+	cases := []struct {
+		p        Properties
+		expected bool
+	}{
+		{
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: DCOS,
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+					KubernetesConfig: &KubernetesConfig{
+						PrivateCluster: &PrivateCluster{
+							Enabled: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+					KubernetesConfig: &KubernetesConfig{
+						PrivateCluster: &PrivateCluster{
+							Enabled: to.BoolPtr(false),
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+					KubernetesConfig: &KubernetesConfig{
+						PrivateCluster: &PrivateCluster{},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		if c.p.OrchestratorProfile.IsPrivateCluster() != c.expected {
+			t.Fatalf("expected IsPrivateCluster() to return %t but instead got %t", c.expected, c.p.OrchestratorProfile.IsPrivateCluster())
+		}
+	}
+}
+
 func TestIsAzureCNI(t *testing.T) {
 	k := &KubernetesConfig{
 		NetworkPlugin: NetworkPluginAzure,

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -890,6 +890,14 @@ func TestIsPrivateCluster(t *testing.T) {
 			p: Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: Kubernetes,
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
 					KubernetesConfig: &KubernetesConfig{
 						PrivateCluster: &PrivateCluster{
 							Enabled: to.BoolPtr(true),

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -910,7 +910,7 @@ func TestIsPrivateCluster(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			p: Properties{

--- a/pkg/engine/armoutputs.go
+++ b/pkg/engine/armoutputs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/aks-engine/pkg/api"
-	"github.com/Azure/go-autorest/autorest/to"
 )
 
 func GetKubernetesOutputs(cs *api.ContainerService) map[string]interface{} {
@@ -79,9 +78,7 @@ func getMasterOutputs(cs *api.ContainerService) map[string]interface{} {
 	outputs := map[string]interface{}{}
 	masterFQDN := ""
 
-	isPrivateCluster := to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled)
-
-	if !isPrivateCluster {
+	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
 		masterFQDN = "[reference(concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))).dnsSettings.fqdn]"
 	}
 

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -51,7 +51,7 @@ func getK8sMasterVars(cs *api.ContainerService) map[string]interface{} {
 	profiles := cs.Properties.AgentPoolProfiles
 
 	var useManagedIdentity, userAssignedID, userAssignedClientID, enableEncryptionWithExternalKms bool
-	var excludeMasterFromStandardLB, provisionJumpbox, isPrivateCluster bool
+	var excludeMasterFromStandardLB, provisionJumpbox bool
 	var maxLoadBalancerCount int
 	var useInstanceMetadata *bool
 	if kubernetesConfig != nil {
@@ -62,9 +62,6 @@ func getK8sMasterVars(cs *api.ContainerService) map[string]interface{} {
 		useInstanceMetadata = kubernetesConfig.UseInstanceMetadata
 		excludeMasterFromStandardLB = to.Bool(kubernetesConfig.ExcludeMasterFromStandardLB)
 		maxLoadBalancerCount = kubernetesConfig.MaximumLoadBalancerRuleCount
-		if kubernetesConfig.PrivateCluster != nil {
-			isPrivateCluster = to.Bool(kubernetesConfig.PrivateCluster.Enabled)
-		}
 		provisionJumpbox = kubernetesConfig.PrivateJumpboxProvision()
 	}
 	isHostedMaster := cs.Properties.IsHostedMasterProfile()
@@ -327,7 +324,7 @@ func getK8sMasterVars(cs *api.ContainerService) map[string]interface{} {
 		masterVars["kubernetesAPIServerIP"] = "[parameters('kubernetesEndpoint')]"
 		masterVars["agentNamePrefix"] = "[concat(parameters('orchestratorName'), '-agentpool-', parameters('nameSuffix'), '-')]"
 	} else {
-		if isPrivateCluster {
+		if cs.Properties.OrchestratorProfile.IsPrivateCluster() {
 			masterVars["kubeconfigServer"] = "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]"
 			if provisionJumpbox {
 				masterVars["jumpboxOSDiskName"] = "[concat(parameters('jumpboxVMName'), '-osdisk')]"

--- a/pkg/engine/masterarmresources.go
+++ b/pkg/engine/masterarmresources.go
@@ -41,12 +41,7 @@ func createKubernetesMasterResourcesVMAS(cs *api.ContainerService) []interface{}
 
 	kubernetesConfig := cs.Properties.OrchestratorProfile.KubernetesConfig
 
-	var isPrivateCluster bool
-	if kubernetesConfig != nil && kubernetesConfig.PrivateCluster != nil {
-		isPrivateCluster = to.Bool(kubernetesConfig.PrivateCluster.Enabled)
-	}
-
-	if !isPrivateCluster {
+	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
 		publicIPAddress := CreatePublicIPAddress()
 		loadBalancer := CreateLoadBalancer(cs.Properties.MasterProfile.Count, false)
 		masterNic := CreateNetworkInterfaces(cs)

--- a/pkg/engine/storageaccounts.go
+++ b/pkg/engine/storageaccounts.go
@@ -16,7 +16,7 @@ func createStorageAccount(cs *api.ContainerService) StorageAccountARM {
 		APIVersion: "[variables('apiVersionStorage')]",
 	}
 
-	if !to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled) {
+	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
 		armResource.DependsOn = []string{
 			"[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]",
 		}
@@ -89,9 +89,7 @@ func createAgentVMASStorageAccount(cs *api.ContainerService, profile *api.AgentP
 		},
 	}
 
-	isPrivateCluster := to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled)
-
-	if !cs.Properties.IsHostedMasterProfile() && !isPrivateCluster {
+	if !cs.Properties.IsHostedMasterProfile() && !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
 		armResource.DependsOn = []string{
 			"[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]",
 		}

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -460,10 +460,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.OrchestratorProfile.RequireRouteTable()
 		},
 		"IsPrivateCluster": func() bool {
-			if !cs.Properties.OrchestratorProfile.IsKubernetes() {
-				return false
-			}
-			return to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled)
+			return cs.Properties.OrchestratorProfile.IsPrivateCluster()
 		},
 		"ProvisionJumpbox": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision()


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Noticed that some isPrivateCluster assignments were missing nil checks and got carried away... This makes sure the function is in one central place and is unit tested.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
