### PR TITLE
refactor: don't call log.Fatal except from main.go

### DIFF
--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -352,7 +352,11 @@ func TestGenerateARMResources(t *testing.T) {
 		},
 	}
 
-	expectedCustomDataStr = getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(&cs))
+	customDataObj, err := tg.GetMasterCustomDataJSONObject(&cs)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedCustomDataStr = getCustomDataFromJSON(customDataObj)
 
 	masterVM := VirtualMachineARM{
 		ARMResource: ARMResource{
@@ -508,7 +512,11 @@ func TestGenerateARMResources(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID = "fooUserAssignedID"
 	cs.Properties.AgentPoolProfiles[0].StorageProfile = api.StorageAccount
 
-	masterVM.VirtualMachineProperties.OsProfile.CustomData = to.StringPtr(getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(&cs)))
+	customDataObj, err = tg.GetMasterCustomDataJSONObject(&cs)
+	if err != nil {
+		t.Error(err)
+	}
+	masterVM.VirtualMachineProperties.OsProfile.CustomData = to.StringPtr(getCustomDataFromJSON(customDataObj))
 	masterVM.VirtualMachine.Identity = &compute.VirtualMachineIdentity{
 		Type: compute.ResourceIdentityType("UserAssigned"),
 		UserAssignedIdentities: map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{
@@ -794,7 +802,11 @@ func TestGenerateARMResourceWithVMASAgents(t *testing.T) {
 		},
 	}
 
-	expectedMasterCustomData := getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(&cs))
+	customDataObj, err := tg.GetMasterCustomDataJSONObject(&cs)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedMasterCustomData := getCustomDataFromJSON(customDataObj)
 
 	masterVM := VirtualMachineARM{
 		ARMResource: ARMResource{

--- a/pkg/engine/masterarmresources_test.go
+++ b/pkg/engine/masterarmresources_test.go
@@ -76,7 +76,11 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 	}
 
 	tg, _ := InitializeTemplateGenerator(Context{})
-	expectedCustomDataStr := getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(&cs))
+	customDataObj, err := tg.GetMasterCustomDataJSONObject(&cs)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedCustomDataStr := getCustomDataFromJSON(customDataObj)
 
 	masterVMAS := VirtualMachineARM{
 		ARMResource: ARMResource{
@@ -408,7 +412,11 @@ func TestCreateKubernetesMasterResourcesVMSS(t *testing.T) {
 	}
 
 	tg, _ := InitializeTemplateGenerator(Context{})
-	expectedCustomDataStr := getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(&cs))
+	customDataObj, err := tg.GetMasterCustomDataJSONObject(&cs)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedCustomDataStr := getCustomDataFromJSON(customDataObj)
 
 	masterVMSS := VirtualMachineScaleSetARM{
 		ARMResource: ARMResource{

--- a/pkg/engine/transform/transform.go
+++ b/pkg/engine/transform/transform.go
@@ -427,13 +427,13 @@ func (t *Transformer) NormalizeResourcesForK8sMasterUpgrade(logger *logrus.Entry
 func (t *Transformer) NormalizeResourcesForK8sAgentUpgrade(logger *logrus.Entry, templateMap map[string]interface{}, isMasterManagedDisk bool, agentPoolsToPreserve map[string]bool) error {
 	logger.Infoln(fmt.Sprintf("Running NormalizeResourcesForK8sMasterUpgrade...."))
 	if err := t.NormalizeResourcesForK8sMasterUpgrade(logger, templateMap, isMasterManagedDisk, agentPoolsToPreserve); err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return err
 	}
 
 	logger.Infoln(fmt.Sprintf("Running NormalizeForK8sVMASScalingUp...."))
 	if err := t.NormalizeForK8sVMASScalingUp(logger, templateMap); err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return err
 	}
 

--- a/pkg/engine/transform/transform.go
+++ b/pkg/engine/transform/transform.go
@@ -5,7 +5,6 @@ package transform
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 
@@ -427,13 +426,11 @@ func (t *Transformer) NormalizeResourcesForK8sMasterUpgrade(logger *logrus.Entry
 func (t *Transformer) NormalizeResourcesForK8sAgentUpgrade(logger *logrus.Entry, templateMap map[string]interface{}, isMasterManagedDisk bool, agentPoolsToPreserve map[string]bool) error {
 	logger.Infoln(fmt.Sprintf("Running NormalizeResourcesForK8sMasterUpgrade...."))
 	if err := t.NormalizeResourcesForK8sMasterUpgrade(logger, templateMap, isMasterManagedDisk, agentPoolsToPreserve); err != nil {
-		log.Println(err)
 		return err
 	}
 
 	logger.Infoln(fmt.Sprintf("Running NormalizeForK8sVMASScalingUp...."))
 	if err := t.NormalizeForK8sVMASScalingUp(logger, templateMap); err != nil {
-		log.Println(err)
 		return err
 	}
 

--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -131,13 +131,16 @@ func CreateVirtualMachine(cs *api.ContainerService) VirtualMachineARM {
 	}
 
 	t, err := InitializeTemplateGenerator(Context{})
-
-	customDataStr := getCustomDataFromJSON(t.GetMasterCustomDataJSONObject(cs))
-	osProfile.CustomData = to.StringPtr(customDataStr)
-
 	if err != nil {
 		panic(err)
 	}
+
+	customDataObj, err := t.GetMasterCustomDataJSONObject(cs)
+	if err != nil {
+		panic(err)
+	}
+	customDataStr := getCustomDataFromJSON(customDataObj)
+	osProfile.CustomData = to.StringPtr(customDataStr)
 
 	if linuxProfile != nil && linuxProfile.HasSecrets() {
 		vsg := getVaultSecretGroup(linuxProfile)

--- a/pkg/engine/virtualmachines_test.go
+++ b/pkg/engine/virtualmachines_test.go
@@ -24,7 +24,11 @@ func TestCreateVirtualMachines(t *testing.T) {
 	}
 
 	tg, _ := InitializeTemplateGenerator(Context{})
-	expectedCustomDataStr := getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(cs))
+	customDataObj, err := tg.GetMasterCustomDataJSONObject(cs)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedCustomDataStr := getCustomDataFromJSON(customDataObj)
 
 	actualVM := CreateVirtualMachine(cs)
 	expectedVM := VirtualMachineARM{

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -200,13 +200,16 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 	}
 
 	t, err := InitializeTemplateGenerator(Context{})
-
-	customDataStr := getCustomDataFromJSON(t.GetMasterCustomDataJSONObject(cs))
-	osProfile.CustomData = to.StringPtr(customDataStr)
-
 	if err != nil {
 		panic(err)
 	}
+
+	customDataObj, err := t.GetMasterCustomDataJSONObject(cs)
+	if err != nil {
+		panic(err)
+	}
+	customDataStr := getCustomDataFromJSON(customDataObj)
+	osProfile.CustomData = to.StringPtr(customDataStr)
 
 	if linuxProfile != nil && linuxProfile.HasSecrets() {
 		vsg := getVaultSecretGroup(linuxProfile)

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -23,7 +23,11 @@ func TestCreateMasterVMSS(t *testing.T) {
 	json.Unmarshal([]byte(apiModelStr), &cs)
 
 	tg, _ := InitializeTemplateGenerator(Context{})
-	expectedCustomDataStr := getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(cs))
+	customDataObj, err := tg.GetMasterCustomDataJSONObject(cs)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedCustomDataStr := getCustomDataFromJSON(customDataObj)
 
 	actual := CreateMasterVMSS(cs)
 	expected := VirtualMachineScaleSetARM{
@@ -158,7 +162,11 @@ func TestCreateMasterVMSS(t *testing.T) {
 
 	expected.Sku.Capacity = to.Int64Ptr(3)
 
-	expectedCustomDataStr = getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(cs))
+	customDataObj, err = tg.GetMasterCustomDataJSONObject(cs)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedCustomDataStr = getCustomDataFromJSON(customDataObj)
 	expected.VirtualMachineProfile.OsProfile.CustomData = to.StringPtr(expectedCustomDataStr)
 
 	ipConfigs := *getIPConfigsMaster()

--- a/pkg/operations/remote_ssh.go
+++ b/pkg/operations/remote_ssh.go
@@ -6,7 +6,6 @@ package operations
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net"
 
 	"golang.org/x/crypto/ssh"
@@ -17,7 +16,6 @@ func RemoteRun(user string, addr string, port int, sshKey []byte, cmd string) (s
 	// Create the Signer for this private key.
 	signer, err := ssh.ParsePrivateKey(sshKey)
 	if err != nil {
-		log.Printf("unable to parse private key: %v", err)
 		return "", err
 	}
 

--- a/pkg/operations/remote_ssh.go
+++ b/pkg/operations/remote_ssh.go
@@ -17,7 +17,8 @@ func RemoteRun(user string, addr string, port int, sshKey []byte, cmd string) (s
 	// Create the Signer for this private key.
 	signer, err := ssh.ParsePrivateKey(sshKey)
 	if err != nil {
-		log.Fatalf("unable to parse private key: %v", err)
+		log.Printf("unable to parse private key: %v", err)
+		return "", err
 	}
 
 	// Authentication


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Removes usage of [`log.Fatal`](https://golang.org/pkg/log/#Fatal) from non-test code.

`log.Fatal` and friends call `os.Exit(1)`, breaking the return flow of Go errors and making unit testing impossible.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #963
See also #997



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
