### PR TITLE
test: ensure node is ready before running validations

### DIFF
--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -84,21 +84,27 @@ type List struct {
 	Nodes []Node `json:"items"`
 }
 
+// IsReady returns if the node is in a Ready state
+func (n *Node) IsReady() bool {
+	for _, condition := range n.Status.Conditions {
+		if condition.Type == "Ready" && condition.Status == "True" {
+			return true
+		}
+	}
+	return false
+}
+
 // AreAllReady returns a bool depending on cluster state
 func AreAllReady(nodeCount int) bool {
 	list, _ := Get()
 	var ready int
 	if list != nil && len(list.Nodes) == nodeCount {
 		for _, node := range list.Nodes {
-			nodeReady := false
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "True" {
-					ready++
-					nodeReady = true
-				}
-			}
+			nodeReady := node.IsReady()
 			if !nodeReady {
 				return false
+			} else {
+				ready++
 			}
 		}
 	}

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -103,9 +103,8 @@ func AreAllReady(nodeCount int) bool {
 			nodeReady := node.IsReady()
 			if !nodeReady {
 				return false
-			} else {
-				ready++
 			}
+			ready++
 		}
 	}
 	if ready == nodeCount {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

In some upgrade tests we're seeing the `k get nodes` return list of nodes after scale in. This change should allow us to further filter out non-Ready nodes to ensure we don't do e.g., ssh to node tests against nodes in a state of deletion that don't actually have functional VMs behind them.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
