### PR TITLE
fix: don't try to create empty dir when saving model file

### DIFF
--- a/pkg/helpers/filesaver.go
+++ b/pkg/helpers/filesaver.go
@@ -24,9 +24,11 @@ func (f *FileSaver) SaveFileString(dir string, file string, data string) error {
 
 // SaveFile saves binary data to file
 func (f *FileSaver) SaveFile(dir string, file string, data []byte) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if e := os.MkdirAll(dir, 0700); e != nil {
-			return f.Translator.Errorf("error creating directory '%s': %s", dir, e.Error())
+	if dir != "" {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if e := os.MkdirAll(dir, 0700); e != nil {
+				return f.Translator.Errorf("error creating directory '%s': %s", dir, e.Error())
+			}
 		}
 	}
 

--- a/pkg/helpers/filesaver_test.go
+++ b/pkg/helpers/filesaver_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package helpers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/Azure/aks-engine/pkg/i18n"
+)
+
+func TestFileSaver(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "filesavertest")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	tmpFile, err := ioutil.TempFile("", "filesavertest")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	type SaveFileEntry struct {
+		Dir  string
+		File string
+		Data string
+	}
+	saveFileEntries := []SaveFileEntry{
+		SaveFileEntry{
+			Dir:  "", // test that an empty dir doesn't error
+			File: tmpFile.Name(),
+			Data: "",
+		},
+		SaveFileEntry{
+			Dir:  tmpDir,
+			File: "ubernetes.json",
+			Data: "",
+		},
+	}
+
+	f := FileSaver{Translator: &i18n.Translator{}}
+
+	for _, sfe := range saveFileEntries {
+		err := f.SaveFileString(sfe.Dir, sfe.File, sfe.Data)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/pkg/helpers/filesaver_test.go
+++ b/pkg/helpers/filesaver_test.go
@@ -30,12 +30,12 @@ func TestFileSaver(t *testing.T) {
 		Data string
 	}
 	saveFileEntries := []SaveFileEntry{
-		SaveFileEntry{
+		{
 			Dir:  "", // test that an empty dir doesn't error
 			File: tmpFile.Name(),
 			Data: "",
 		},
-		SaveFileEntry{
+		{
 			Dir:  tmpDir,
 			File: "ubernetes.json",
 			Data: "",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Changes `SaveFile` to check for an empty string `""` before trying to create directories.

This was an input it never actually received until #890 was merged.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1048 


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This needs unit tests.