### PR TITLE
chore: backport tests + cloud-init usage for CIS changes

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -6,12 +6,15 @@ source /home/packer/cis.sh
 RELEASE_NOTES_FILEPATH=/var/log/azure/golden-image-install.complete
 SYSCTL_CONFIG_SRC=/home/packer/sysctl-d-60-CIS.conf
 SYSCTL_CONFIG_DEST=/etc/sysctl.d/60-CIS.conf
+ETC_ISSUE_CONFIG_SRC=/home/packer/sysctl-d-60-CIS.conf
+ETC_ISSUE_CONFIG_DEST=/etc/sysctl.d/60-CIS.conf
 
 echo "Starting build on " `date` > ${RELEASE_NOTES_FILEPATH}
 echo "Using kernel:" >> ${RELEASE_NOTES_FILEPATH}
 cat /proc/version | tee -a ${RELEASE_NOTES_FILEPATH}
 cp $SYSCTL_CONFIG_SRC $SYSCTL_CONFIG_DEST
 sysctl_reload 20 5 10
+cp $ETC_ISSUE_CONFIG_SRC $ETC_ISSUE_CONFIG_DEST
 
 echo ""
 echo "Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):" >> ${RELEASE_NOTES_FILEPATH}

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -6,8 +6,8 @@ source /home/packer/cis.sh
 RELEASE_NOTES_FILEPATH=/var/log/azure/golden-image-install.complete
 SYSCTL_CONFIG_SRC=/home/packer/sysctl-d-60-CIS.conf
 SYSCTL_CONFIG_DEST=/etc/sysctl.d/60-CIS.conf
-ETC_ISSUE_CONFIG_SRC=/home/packer/sysctl-d-60-CIS.conf
-ETC_ISSUE_CONFIG_DEST=/etc/sysctl.d/60-CIS.conf
+ETC_ISSUE_CONFIG_SRC=/home/packer/etc-issue
+ETC_ISSUE_CONFIG_DEST=/etc/issue
 
 echo "Starting build on " `date` > ${RELEASE_NOTES_FILEPATH}
 echo "Using kernel:" >> ${RELEASE_NOTES_FILEPATH}

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -75,6 +75,11 @@
             "destination": "/home/packer/sysctl-d-60-CIS.conf"
         },
         {
+            "type": "file",
+            "source": "parts/k8s/cloud-init/artifacts/etc-issue",
+            "destination": "/home/packer/etc-issue"
+        },
+        {
             "type": "shell",
             "inline": [
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",

--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -24,6 +24,11 @@ assignFilePermissions() {
     lastlog
     waagent.log
     syslog
+    unattended-upgrades/unattended-upgrades.log
+    azure-vnet-ipam.log
+    azure-vnet-telemetry.log
+    azure-cnimonitor.log
+    azure-vnet.log
     "
     for FILE in ${FILES}; do
         touch /var/log/${FILE}

--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -29,6 +29,9 @@ assignFilePermissions() {
     azure-vnet-telemetry.log
     azure-cnimonitor.log
     azure-vnet.log
+    kv-driver.log
+    blobfuse-driver.log
+    blobfuse-flexvol-installer.log
     "
     for FILE in ${FILES}; do
         touch /var/log/${FILE}

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -134,12 +134,14 @@ write_files:
   content: !!binary |
     {{CloudInitData "aptPreferences"}}
 
+{{if .MasterProfile.IsUbuntuNonVHD}}
 - path: /etc/issue
   permissions: "0644"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "etcIssue"}}
+{{end}}
 
 {{if .OrchestratorProfile.KubernetesConfig.RequiresDocker}}
     {{if not .MasterProfile.IsCoreOS}}

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -119,12 +119,14 @@ write_files:
   content: !!binary |
     {{CloudInitData "aptPreferences"}}
 
+{{if .IsUbuntuNonVHD}}
 - path: /etc/issue
   permissions: "0644"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "etcIssue"}}
+{{end}}
 
 {{if .IsUbuntuNonVHD}}
 - path: /etc/sysctl.d/60-CIS.conf

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -205,6 +205,37 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		It("should validate all cloud-init-paved files", func() {
+			if eng.ExpandedDefinition.Properties.IsUbuntuDistroForAllNodes() {
+				kubeConfig, err := GetConfig()
+				Expect(err).NotTo(HaveOccurred())
+				master := fmt.Sprintf("%s@%s", eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, kubeConfig.GetServerName())
+				nodeList, err := node.Get()
+				Expect(err).NotTo(HaveOccurred())
+				cloudInitFilesValidateScript := "cloud-init-files-validate.sh"
+				cmd := exec.Command("scp", "-i", masterSSHPrivateKeyFilepath, "-o", "StrictHostKeyChecking=no", filepath.Join(ScriptsDir, cloudInitFilesValidateScript), master+":/tmp/"+cloudInitFilesValidateScript)
+				util.PrintCommand(cmd)
+				out, err := cmd.CombinedOutput()
+				log.Printf("%s\n", out)
+				Expect(err).NotTo(HaveOccurred())
+				var conn *remote.Connection
+				conn, err = remote.NewConnection(kubeConfig.GetServerName(), "22", eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
+				Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodeList.Nodes {
+					err := conn.CopyToRemote(node.Metadata.Name, "/tmp/"+cloudInitFilesValidateScript)
+					Expect(err).NotTo(HaveOccurred())
+					netConfigValidationCommand := fmt.Sprintf("\"/tmp/%s\"", cloudInitFilesValidateScript)
+					cmd = exec.Command("ssh", "-A", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", master, "ssh", "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", node.Metadata.Name, netConfigValidationCommand)
+					util.PrintCommand(cmd)
+					out, err = cmd.CombinedOutput()
+					log.Printf("%s\n", out)
+					Expect(err).NotTo(HaveOccurred())
+				}
+			} else {
+				Skip("cloud-init files validation only works on ubuntu distro until this lands in a VHD")
+			}
+		})
+
 		It("should report all nodes in a Ready state", func() {
 			nodeCount := eng.NodeCount()
 			log.Printf("Checking for %d Ready nodes\n", nodeCount)

--- a/test/e2e/kubernetes/scripts/cloud-init-files-validate.sh
+++ b/test/e2e/kubernetes/scripts/cloud-init-files-validate.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+CLOUD_INIT_FILES="
+/etc/issue
+"
+for CLOUD_INIT_FILE in ${CLOUD_INIT_FILES}; do
+    ls -la $CLOUD_INIT_FILE || exit 2
+    [ -s $CLOUD_INIT_FILE ] || exit 1
+done
+
+# verify that no files under /var/log have read access to everyone
+find /var/log -type f -perm '/o+r' | (! grep ^) || exit 1

--- a/test/e2e/kubernetes/scripts/cloud-init-files-validate.sh
+++ b/test/e2e/kubernetes/scripts/cloud-init-files-validate.sh
@@ -9,4 +9,4 @@ for CLOUD_INIT_FILE in ${CLOUD_INIT_FILES}; do
 done
 
 # verify that no files under /var/log have read access to everyone
-find /var/log -type f -perm '/o+r' | (! grep ^) || exit 1
+sudo find /var/log -type f -perm '/o+r' | (! grep ^) || exit 1


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow-up from PRs #1024 and #1031 to include validation tests; and to only pave files via cloud-init in non-VHD flows.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
