### PR TITLE
fix: fix parameter name for ScaleSetEvictionPolicy

### DIFF
--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -478,7 +478,7 @@ func getK8sAgentVars(cs *api.ContainerService, profile *api.AgentPoolProfile) ma
 	agentOffset := fmt.Sprintf("%sOffset", agentName)
 	agentAvailabilitySet := fmt.Sprintf("%sAvailabilitySet", agentName)
 	agentScaleSetPriority := fmt.Sprintf("%sScaleSetPriority", agentName)
-	agentScaleSetEvictionPolicy := fmt.Sprintf("%sEvictionPolicy", agentName)
+	agentScaleSetEvictionPolicy := fmt.Sprintf("%sScaleSetEvictionPolicy", agentName)
 	agentVMSize := fmt.Sprintf("%sVMSize", agentName)
 	agentVnetSubnetID := fmt.Sprintf("%sVnetSubnetID", agentName)
 	agentSubnetName := fmt.Sprintf("%sSubnetName", agentName)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The parameter for  ScaleSetEvictionPolicy is defined as `"{{.Name}}ScaleSetEvictionPolicy"`. This fixes a regression from the template refactor which referenced a param `<agentName>EvictionPolicy` that doesn't exist.
https://github.com/Azure/aks-engine/blob/master/parts/agentparams.t#L30

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1058 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
