### PR TITLE
 fix: error handling in CIS bash script

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -35,7 +35,7 @@ assignFilePermissions() {
     "
     for FILE in ${FILES}; do
         touch /var/log/${FILE}
-        chmod 640 ${FILE}
+        chmod 640 /var/log/${FILE}
     done
     find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
     chmod 600 /etc/passwd-

--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -35,7 +35,7 @@ assignFilePermissions() {
     "
     for FILE in ${FILES}; do
         DIR=$(dirname "${FILE}")
-        mkdir -p ${DIR}
+        mkdir -p ${DIR} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
         touch /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
         chmod 640 /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done

--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -8,7 +8,7 @@ assignRootPW() {
     CMD="import crypt, getpass, pwd; print crypt.crypt('$SECRET', '\$6\$$SALT\$')"
     HASH=`python -c "$CMD"`
 
-    echo 'root:'$HASH | /usr/sbin/chpasswd -e 2>/dev/null;
+    echo 'root:'$HASH | /usr/sbin/chpasswd -e || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
   fi
 }
 
@@ -34,14 +34,14 @@ assignFilePermissions() {
     blobfuse-flexvol-installer.log
     "
     for FILE in ${FILES}; do
-        touch /var/log/${FILE}
-        chmod 640 /var/log/${FILE}
+        touch /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+        chmod 640 /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done
     find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
-    chmod 600 /etc/passwd-
-    chmod 600 /etc/shadow-
-    chmod 600 /etc/group-
-    chmod 644 /etc/sysctl.d/60-CIS.conf
+    chmod 600 /etc/passwd- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+    chmod 600 /etc/shadow- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+    chmod 600 /etc/group- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+    chmod 644 /etc/sysctl.d/60-CIS.conf || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
 }
 
 applyCIS() {

--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -34,6 +34,8 @@ assignFilePermissions() {
     blobfuse-flexvol-installer.log
     "
     for FILE in ${FILES}; do
+        DIR=$(dirname "${FILE}")
+        mkdir -p ${DIR}
         touch /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
         chmod 640 /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done

--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -34,10 +34,11 @@ assignFilePermissions() {
     blobfuse-flexvol-installer.log
     "
     for FILE in ${FILES}; do
-        DIR=$(dirname "${FILE}")
+        FILEPATH="/var/log/${FILE}"
+        DIR=$(dirname "${FILEPATH}")
         mkdir -p ${DIR} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
-        touch /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
-        chmod 640 /var/log/${FILE} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+        touch ${FILEPATH} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+        chmod 640 ${FILEPATH} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done
     find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
     chmod 600 /etc/passwd- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -47,8 +47,9 @@ ERR_APT_DAILY_TIMEOUT=98 # Timeout waiting for apt daily updates
 ERR_APT_UPDATE_TIMEOUT=99 # Timeout waiting for apt-get update to complete
 ERR_CSE_PROVISION_SCRIPT_NOT_READY_TIMEOUT=100 # Timeout waiting for cloud-init to place this (!) script on the vm
 ERR_APT_DIST_UPGRADE_TIMEOUT=101 # Timeout waiting for apt-get dist-upgrade to complete
-ERR_CIS_HARDENING_ERROR=102 # Error applying CIS enforcement
 ERR_SYSCTL_RELOAD=103 # Error reloading sysctl config
+ERR_CIS_ASSIGN_ROOT_PW=111 # Error assigning root password in CIS enforcement
+ERR_CIS_ASSIGN_FILE_PERMISSION=112 # Error assigning permission to a file in CIS enforcement
 
 OS=$(cat /etc/*-release | grep ^ID= | tr -d 'ID="' | awk '{print toupper($0)}')
 UBUNTU_OS_NAME="UBUNTU"

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -182,7 +182,7 @@ ps auxfww > /opt/azure/provision-ps.log &
 
 if $FULL_INSTALL_REQUIRED; then
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    applyCIS || exit $ERR_CIS_HARDENING_ERROR
+    applyCIS
   fi
 else
   cleanUpContainerImages


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Looking at the VHD build logs, I found that the chmod commands were always failing because the directory part of the path was missing. I fixed the path and also fixed error handling in the script so we actually exit on errors from now on.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
