### PR TITLE
fix: make conntrack more liberal on packets

### DIFF
--- a/parts/k8s/cloud-init/artifacts/kubelet.service
+++ b/parts/k8s/cloud-init/artifacts/kubelet.service
@@ -12,6 +12,9 @@ ExecStartPre=/bin/mkdir -p /var/lib/kubelet
 ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=/bin/bash -c "if [ $(mount | grep \"/var/lib/kubelet\" | wc -l) -le 0 ] ; then /bin/mount --bind /var/lib/kubelet /var/lib/kubelet ; fi"
 ExecStartPre=/bin/mount --make-shared /var/lib/kubelet
+# This is a workaround to this upstream Kubernetes issue:
+#  https://github.com/kubernetes/kubernetes/issues/74839
+ExecStartPre=/sbin/sysctl -w net.netfilter.nf_conntrack_tcp_be_liberal=1
 # This is a partial workaround to this upstream Kubernetes issue:
 #  https://github.com/kubernetes/kubernetes/issues/41916#issuecomment-312428731
 ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_retries2=8

--- a/test/e2e/kubernetes/scripts/net-config-validate.sh
+++ b/test/e2e/kubernetes/scripts/net-config-validate.sh
@@ -6,6 +6,8 @@ IPV4_SECURE_REDIRECTS_VALUE=0
 IPV4_LOG_MARTIANS_VALUE=1
 IPV6_ACCEPT_RA_VALUE=0
 IPV6_ACCEPT_REDIRECTS_VALUE=0
+IPV4_TCP_RETRIES2_VALUE=8
+NF_CONNTRACK_TCP_BE_LIBERAL_VALUE=1
 
 set -x
 cat /proc/sys/net/ipv4/conf/all/send_redirects | grep $IPV4_SEND_REDIRECTS_VALUE || exit 1
@@ -22,3 +24,7 @@ cat /proc/sys/net/ipv6/conf/all/accept_ra | grep $IPV6_ACCEPT_RA_VALUE || exit 1
 cat /proc/sys/net/ipv6/conf/default/accept_ra | grep $IPV6_ACCEPT_RA_VALUE || exit 1
 cat /proc/sys/net/ipv6/conf/all/accept_redirects | grep $IPV6_ACCEPT_REDIRECTS_VALUE || exit 1
 cat /proc/sys/net/ipv6/conf/default/accept_redirects | grep $IPV6_ACCEPT_REDIRECTS_VALUE || exit 1
+
+# validate net config workarounds from kubelet.service
+cat /proc/sys/net/ipv4/tcp_retries2 | grep $IPV4_TCP_RETRIES2_VALUE || exit 1
+cat /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal | grep $NF_CONNTRACK_TCP_BE_LIBERAL_VALUE || exit 1


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Works around a [TCP reset bug](https://github.com/kubernetes/kubernetes/issues/74839) in Kubernetes by setting the value of kernel parameter `net.netfilter.nf_conntrack_tcp_be_liberal` to `1` (true) before starting `kubelet`. 

Also piggy-backs on the `net-config-validate.sh` script to test this parameter as well as`net.ipv4.tcp_retries2` (which was also set by `kubelet.service`).

See [Debugging an Intermittent Connection Reset](https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/) for a good explanation of the issue.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1068 


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
