### PR TITLE
feat: grant user assigned identity 'Reader' role for hosted cluster

### DIFF
--- a/pkg/engine/armresources.go
+++ b/pkg/engine/armresources.go
@@ -111,7 +111,7 @@ func createKubernetesAgentVMASResources(cs *api.ContainerService, profile *api.A
 				Name: to.StringPtr(fmt.Sprintf("[variables('%sAvailabilitySet')]",
 					profile.Name)),
 				AvailabilitySetProperties: &compute.AvailabilitySetProperties{},
-				Type: to.StringPtr("Microsoft.Compute/availabilitySets"),
+				Type:                      to.StringPtr("Microsoft.Compute/availabilitySets"),
 			},
 		}
 

--- a/pkg/engine/roleassignments.go
+++ b/pkg/engine/roleassignments.go
@@ -8,7 +8,16 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
-func createMSIRoleAssignment() RoleAssignmentARM {
+type IdentityRoleDefinition string
+
+const (
+	// IdentityContributorRole means created user assigned identity will have "Contributor" role in created resource group
+	IdentityContributorRole IdentityRoleDefinition = "[variables('contributorRoleDefinitionId')]"
+	// IdentityReaderRole means created user assigned identity will have "Reader" role in created resource group
+	IdentityReaderRole IdentityRoleDefinition = "[variables('readerRoleDefinitionId')]"
+)
+
+func createMSIRoleAssignment(identityRoleDefinition IdentityRoleDefinition) RoleAssignmentARM {
 	return RoleAssignmentARM{
 		ARMResource: ARMResource{
 			APIVersion: "[variables('apiVersionAuthorizationUser')]",
@@ -20,7 +29,7 @@ func createMSIRoleAssignment() RoleAssignmentARM {
 			Type: to.StringPtr("Microsoft.Authorization/roleAssignments"),
 			Name: to.StringPtr("[guid(concat(variables('userAssignedID'), 'roleAssignment', resourceGroup().id))]"),
 			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
-				RoleDefinitionID: to.StringPtr("[variables('contributorRoleDefinitionId')]"),
+				RoleDefinitionID: to.StringPtr(string(identityRoleDefinition)),
 				PrincipalID:      to.StringPtr("[reference(concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))).principalId]"),
 				PrincipalType:    authorization.ServicePrincipal,
 				Scope:            to.StringPtr("[resourceGroup().id]"),


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Background: there is an upcoming feature in AKS: support authenticating to Azure using MSI. In the implementation, agent nodes will use an auto-generated user assigned identity and master components won't use this identity to authenticate. In this case, it enough to grant the generated user assigned identity only "Reader" role in the created resource group. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
