### PR TITLE
test: add ubuntu time sync E2E validation

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1630,7 +1630,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			kubeConfig, err := GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 			master := fmt.Sprintf("%s@%s", eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, kubeConfig.GetServerName())
-			nodeList, err := node.Get()
+			nodeList, err := node.GetReady()
 			Expect(err).NotTo(HaveOccurred())
 			timeSyncValidateScript := "time-sync-validate.sh"
 			cmd := exec.Command("scp", "-i", masterSSHPrivateKeyFilepath, "-o", "StrictHostKeyChecking=no", filepath.Join(ScriptsDir, timeSyncValidateScript), master+":/tmp/"+timeSyncValidateScript)
@@ -1642,7 +1642,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			conn, err = remote.NewConnection(kubeConfig.GetServerName(), "22", eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
 			Expect(err).NotTo(HaveOccurred())
 			for _, node := range nodeList.Nodes {
-				if node.IsReady() && node.IsUbuntu() {
+				if node.IsUbuntu() {
 					err := conn.CopyToRemote(node.Metadata.Name, "/tmp/"+timeSyncValidateScript)
 					Expect(err).NotTo(HaveOccurred())
 					netConfigValidationCommand := fmt.Sprintf("\"/tmp/%s\"", timeSyncValidateScript)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1648,7 +1648,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					netConfigValidationCommand := fmt.Sprintf("\"/tmp/%s\"", timeSyncValidateScript)
 					cmd = exec.Command("ssh", "-A", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", master, "ssh", "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", node.Metadata.Name, netConfigValidationCommand)
 					util.PrintCommand(cmd)
-					_, err = cmd.CombinedOutput()
+					out, err = cmd.CombinedOutput()
+					log.Printf("%s\n", out)
 					Expect(err).NotTo(HaveOccurred())
 				}
 			}

--- a/test/e2e/kubernetes/scripts/time-sync-validate.sh
+++ b/test/e2e/kubernetes/scripts/time-sync-validate.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
+RELEASE=$(cat /etc/lsb-release | grep ^DISTRIB_RELEASE= | tr -d 'DISTRIB_RELEASE="' | awk '{print toupper($0)}')
 # verify that timesyncd configuration is healthy
-sudo timedatectl status | grep 'Network time on: yes' || exit 1
-sudo timedatectl status | grep 'NTP synchronized: yes' || exit 1
+set -x
+if [[ $RELEASE == "16.04" ]]; then
+  sudo timedatectl status | grep 'Network time on: yes' || exit 1
+  sudo timedatectl status | grep 'NTP synchronized: yes' || exit 1
+elif [[ $RELEASE == "18.04" ]]; then
+  sudo timedatectl status | grep 'systemd-timesyncd.service active: yes' || exit 1
+  sudo timedatectl status | grep 'System clock synchronized: yes' || exit 1
+  
+fi
 sudo timedatectl status | grep 'RTC in local TZ: no' || exit 1
 sudo systemctl status systemd-timesyncd | grep 'Active: active' || exit 1
 sudo systemctl status systemd-timesyncd | grep 'Status: "Synchronized to time server' || exit 1

--- a/test/e2e/kubernetes/scripts/time-sync-validate.sh
+++ b/test/e2e/kubernetes/scripts/time-sync-validate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# verify that timesyncd configuration is healthy
+sudo timedatectl status | grep 'Network time on: yes' || exit 1
+sudo timedatectl status | grep 'NTP synchronized: yes' || exit 1
+sudo timedatectl status | grep 'RTC in local TZ: no' || exit 1
+sudo systemctl status systemd-timesyncd | grep 'Active: active' || exit 1
+sudo systemctl status systemd-timesyncd | grep 'Status: "Synchronized to time server' || exit 1


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Add ubuntu host OS time sync validation to regular E2E tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
