### PR TITLE
test: single host OS DNS test script

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -127,14 +127,16 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			conn, err = remote.NewConnection(kubeConfig.GetServerName(), "22", eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
 			Expect(err).NotTo(HaveOccurred())
 			for _, node := range nodeList.Nodes {
-				err := conn.CopyToRemote(node.Metadata.Name, "/tmp/"+hostOSDNSValidateScript)
-				Expect(err).NotTo(HaveOccurred())
-				netConfigValidationCommand := fmt.Sprintf("\"%s /tmp/%s\"", envString, hostOSDNSValidateScript)
-				cmd = exec.Command("ssh", "-A", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", master, "ssh", "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", node.Metadata.Name, netConfigValidationCommand)
-				util.PrintCommand(cmd)
-				out, err = cmd.CombinedOutput()
-				log.Printf("%s\n", out)
-				Expect(err).NotTo(HaveOccurred())
+				if node.IsLinux() {
+					err := conn.CopyToRemote(node.Metadata.Name, "/tmp/"+hostOSDNSValidateScript)
+					Expect(err).NotTo(HaveOccurred())
+					netConfigValidationCommand := fmt.Sprintf("\"%s /tmp/%s\"", envString, hostOSDNSValidateScript)
+					cmd = exec.Command("ssh", "-A", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", master, "ssh", "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "LogLevel=ERROR", node.Metadata.Name, netConfigValidationCommand)
+					util.PrintCommand(cmd)
+					out, err = cmd.CombinedOutput()
+					log.Printf("%s\n", out)
+					Expect(err).NotTo(HaveOccurred())
+				}
 			}
 		})
 

--- a/test/e2e/kubernetes/scripts/host-os-dns-validate.sh
+++ b/test/e2e/kubernetes/scripts/host-os-dns-validate.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -x
+ifconfig -a -v || exit 1
+cat /etc/resolv.conf || exit 1
+set +x
+# validate that all node vms can resolve DNS to all other node vms, including themselves
+# also validate external DNS lookups
+# retry failures for up to 10 mins
+success="no"
+retries=1
+HOSTS="${NODE_HOSTNAMES} www.bing.com google.com"
+for i in $(seq 1 $retries); do
+  for host in $HOSTS; do
+    set -x
+    [ -s $(dig +short +search +answer ${host}) ]
+      if [ $? -eq 0  ]; then
+        success="no"
+        break
+      fi
+    set +x
+    success="yes"
+  done
+  if [[ "${success}" == "yes" ]]; then
+    break
+  fi
+  if [ $i -eq $retries ]; then
+    exit 1
+  else
+    sleep 10
+  fi
+done
+
+success="no"
+HOSTS="www.bing.com google.com"
+for i in $(seq 1 $retries); do
+  for host in $HOSTS; do
+    set -x
+    [ -s $(dig +short +search +answer ${host} @8.8.8.8) ]
+      if [ $? -eq 0  ]; then
+        success="no"
+        break
+      fi
+    set +x
+    success="yes"
+  done
+  if [[ "${success}" == "yes" ]]; then
+    break
+  fi
+  if [ $i -eq $retries ]; then
+    exit 1
+  else
+    sleep 10
+  fi
+done


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This simplifies the Linux host OS DNS E2E tests a bit.

1. consolidates all tests into a single shell script
2. runs this validation earlier in the E2E run as later tests will not work if host DNS (for example) is not healthy; in such cases we want to fail on the actual failure, which is host OS DNS
3. adds additional vm DNS resolution coverage: now all node vms will be validated against being able to resolve all nodes (previously we were just checking that the master could resolve node vns)
4. adds retry tolerance

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
