### PR TITLE
feat: use all VMAS fault domains in a region

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1844,6 +1844,15 @@ func (cs *ContainerService) GetAzureProdFQDN() string {
 	return FormatProdFQDNByLocation(cs.Properties.MasterProfile.DNSPrefix, cs.Location, cs.Properties.GetCustomCloudName())
 }
 
+// SetPlatformFaultDomainCount sets the fault domain count value for all VMASes in a cluster.
+func (cs *ContainerService) SetPlatformFaultDomainCount(count int) {
+	// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
+	cs.Properties.MasterProfile.PlatformFaultDomainCount = &count
+	for _, pool := range cs.Properties.AgentPoolProfiles {
+		pool.PlatformFaultDomainCount = &count
+	}
+}
+
 // FormatAzureProdFQDNByLocation constructs an Azure prod fqdn
 func FormatAzureProdFQDNByLocation(fqdnPrefix string, location string) string {
 	targetEnv := helpers.GetCloudTargetEnv(location)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -469,6 +469,7 @@ type MasterProfile struct {
 	ImageRef                 *ImageReference   `json:"imageReference,omitempty"`
 	CustomFiles              *[]CustomFile     `json:"customFiles,omitempty"`
 	AvailabilityProfile      string            `json:"availabilityProfile"`
+	PlatformFaultDomainCount *int              `json:"platformFaultDomainCount"`
 	AgentSubnet              string            `json:"agentSubnet,omitempty"`
 	AvailabilityZones        []string          `json:"availabilityZones,omitempty"`
 	SinglePlacementGroup     *bool             `json:"singlePlacementGroup,omitempty"`
@@ -518,6 +519,7 @@ type AgentPoolProfile struct {
 	Ports                               []int                `json:"ports,omitempty"`
 	ProvisioningState                   ProvisioningState    `json:"provisioningState,omitempty"`
 	AvailabilityProfile                 string               `json:"availabilityProfile"`
+	PlatformFaultDomainCount            *int                 `json:"platformFaultDomainCount"`
 	ScaleSetPriority                    string               `json:"scaleSetPriority,omitempty"`
 	ScaleSetEvictionPolicy              string               `json:"scaleSetEvictionPolicy,omitempty"`
 	StorageProfile                      string               `json:"storageProfile,omitempty"`

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -4956,3 +4956,29 @@ func TestKubernetesConfigIsAddonEnabled(t *testing.T) {
 		}
 	}
 }
+
+func TestSetPlatformFaultDomainCount(t *testing.T) {
+	// check that the default value is nil
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 1, 3, false)
+	if cs.Properties.MasterProfile.PlatformFaultDomainCount != nil {
+		t.Errorf("expected master platformFaultDomainCount to be nil, not %v", cs.Properties.MasterProfile.PlatformFaultDomainCount)
+	}
+	for _, pool := range cs.Properties.AgentPoolProfiles {
+		if pool.PlatformFaultDomainCount != nil {
+			t.Errorf("expected agent platformFaultDomainCount to be nil, not %v", pool.PlatformFaultDomainCount)
+		}
+	}
+
+	// check that pfdc can be set to legal values
+	for i := 1; i <= 3; i++ {
+		cs.SetPlatformFaultDomainCount(i)
+		if *cs.Properties.MasterProfile.PlatformFaultDomainCount != i {
+			t.Errorf("expected master platformFaultDomainCount to be %d, not %v", i, cs.Properties.MasterProfile.PlatformFaultDomainCount)
+		}
+		for _, pool := range cs.Properties.AgentPoolProfiles {
+			if *pool.PlatformFaultDomainCount != i {
+				t.Errorf("expected agent platformFaultDomainCount to be %d, not %v", i, pool.PlatformFaultDomainCount)
+			}
+		}
+	}
+}

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -67,6 +67,7 @@ type AzureClient struct {
 	virtualMachineScaleSetVMsClient compute.VirtualMachineScaleSetVMsClient
 	virtualMachineExtensionsClient  compute.VirtualMachineExtensionsClient
 	disksClient                     compute.DisksClient
+	availabilitySetsClient          compute.AvailabilitySetsClient
 
 	applicationsClient      graphrbac.ApplicationsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
@@ -348,6 +349,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armAuthor
 		virtualMachineScaleSetVMsClient: compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 		virtualMachineExtensionsClient:  compute.NewVirtualMachineExtensionsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 		disksClient:                     compute.NewDisksClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		availabilitySetsClient:          compute.NewAvailabilitySetsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 
 		applicationsClient:      graphrbac.NewApplicationsClientWithBaseURI(env.GraphEndpoint, tenantID),
 		servicePrincipalsClient: graphrbac.NewServicePrincipalsClientWithBaseURI(env.GraphEndpoint, tenantID),
@@ -366,6 +368,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armAuthor
 	c.virtualMachineScaleSetsClient.Authorizer = armAuthorizer
 	c.virtualMachineScaleSetVMsClient.Authorizer = armAuthorizer
 	c.disksClient.Authorizer = armAuthorizer
+	c.availabilitySetsClient.Authorizer = armAuthorizer
 
 	c.deploymentsClient.PollingDelay = time.Second * 5
 	c.resourcesClient.PollingDelay = time.Second * 5
@@ -384,6 +387,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armAuthor
 	c.virtualMachineScaleSetsClient.PollingDuration = DefaultARMOperationTimeout
 	c.virtualMachineScaleSetVMsClient.PollingDuration = DefaultARMOperationTimeout
 	c.virtualMachinesClient.PollingDuration = DefaultARMOperationTimeout
+	c.availabilitySetsClient.PollingDuration = DefaultARMOperationTimeout
 
 	c.applicationsClient.Authorizer = graphAuthorizer
 	c.servicePrincipalsClient.Authorizer = graphAuthorizer

--- a/pkg/armhelpers/azureclient_test.go
+++ b/pkg/armhelpers/azureclient_test.go
@@ -21,33 +21,20 @@ func TestAzureClient(t *testing.T) {
 	RunSpecsWithReporters(t, "AzureClient Tests", "Server Suite")
 }
 
-var _ = Describe("AzureClient", func() {
-	Context("in public cloud", func() {
-		It("should set auxiliary token", func() {
-			env, err := azure.EnvironmentFromName("AZUREPUBLICCLOUD")
-			Expect(err).To(BeNil())
+var _ = Describe("AzureClient Aux token tests", func() {
+	It("Should set Aux token", func() {
+		env, err := azure.EnvironmentFromName("AZUREPUBLICCLOUD")
+		Expect(err).To(BeNil())
 
-			token := "eyJ0eXAiOiJKV1QiL"
-			azureClient, err := NewAzureClientWithClientSecretExternalTenant(env, "subID", "d1a3-4ea4", "clientID", "secret")
-			Expect(err).To(BeNil())
-			azureClient.AddAuxiliaryTokens([]string{token})
-			request, err := azureClient.deploymentsClient.GetPreparer(context.Background(), "testRG", "testDeployment")
-			Expect(err).To(BeNil())
-			Expect(request).To(Not(BeNil()))
-			request, err = autorest.Prepare(request, azureClient.deploymentsClient.WithInspection())
-			Expect(err).To(BeNil())
-			Expect(request.Header.Get("x-ms-authorization-auxiliary")).To(Equal(fmt.Sprintf("Bearer %s", token)))
-		})
-		Context("with mock client", func() {
-			It("should find the platform fault domain count for a cluster", func() {
-				azureClient := MockAKSEngineClient{}
-				vmas, err := azureClient.GetAvailabilitySet(nil, "resourceGroup", "vmasname")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(vmas).NotTo(BeNil())
-				count, err := azureClient.GetAvailabilitySetFaultDomainCount(nil, "resourceGroup", []string{"ID1", "ID2"})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(count).To(Equal(3))
-			})
-		})
+		token := "eyJ0eXAiOiJKV1QiL"
+		azureClient, _ := NewAzureClientWithClientSecretExternalTenant(env, "subID", "d1a3-4ea4", "clientID", "secret")
+		Expect(err).To(BeNil())
+		azureClient.AddAuxiliaryTokens([]string{token})
+		request, err := azureClient.deploymentsClient.GetPreparer(context.Background(), "testRG", "testDeployment")
+		Expect(err).To(BeNil())
+		Expect(request).To(Not(BeNil()))
+		request, err = autorest.Prepare(request, azureClient.deploymentsClient.WithInspection())
+		Expect(err).To(BeNil())
+		Expect(request.Header.Get("x-ms-authorization-auxiliary")).To(Equal(fmt.Sprintf("Bearer %s", token)))
 	})
 })

--- a/pkg/armhelpers/azureclient_test.go
+++ b/pkg/armhelpers/azureclient_test.go
@@ -21,20 +21,33 @@ func TestAzureClient(t *testing.T) {
 	RunSpecsWithReporters(t, "AzureClient Tests", "Server Suite")
 }
 
-var _ = Describe("AzureClient Aux token tests", func() {
-	It("Should set Aux token", func() {
-		env, err := azure.EnvironmentFromName("AZUREPUBLICCLOUD")
-		Expect(err).To(BeNil())
+var _ = Describe("AzureClient", func() {
+	Context("in public cloud", func() {
+		It("should set auxiliary token", func() {
+			env, err := azure.EnvironmentFromName("AZUREPUBLICCLOUD")
+			Expect(err).To(BeNil())
 
-		token := "eyJ0eXAiOiJKV1QiL"
-		azureClient, _ := NewAzureClientWithClientSecretExternalTenant(env, "subID", "d1a3-4ea4", "clientID", "secret")
-		Expect(err).To(BeNil())
-		azureClient.AddAuxiliaryTokens([]string{token})
-		request, err := azureClient.deploymentsClient.GetPreparer(context.Background(), "testRG", "testDeployment")
-		Expect(err).To(BeNil())
-		Expect(request).To(Not(BeNil()))
-		request, err = autorest.Prepare(request, azureClient.deploymentsClient.WithInspection())
-		Expect(err).To(BeNil())
-		Expect(request.Header.Get("x-ms-authorization-auxiliary")).To(Equal(fmt.Sprintf("Bearer %s", token)))
+			token := "eyJ0eXAiOiJKV1QiL"
+			azureClient, err := NewAzureClientWithClientSecretExternalTenant(env, "subID", "d1a3-4ea4", "clientID", "secret")
+			Expect(err).To(BeNil())
+			azureClient.AddAuxiliaryTokens([]string{token})
+			request, err := azureClient.deploymentsClient.GetPreparer(context.Background(), "testRG", "testDeployment")
+			Expect(err).To(BeNil())
+			Expect(request).To(Not(BeNil()))
+			request, err = autorest.Prepare(request, azureClient.deploymentsClient.WithInspection())
+			Expect(err).To(BeNil())
+			Expect(request.Header.Get("x-ms-authorization-auxiliary")).To(Equal(fmt.Sprintf("Bearer %s", token)))
+		})
+		Context("with mock client", func() {
+			It("should find the platform fault domain count for a cluster", func() {
+				azureClient := MockAKSEngineClient{}
+				vmas, err := azureClient.GetAvailabilitySet(nil, "resourceGroup", "vmasname")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vmas).NotTo(BeNil())
+				count, err := azureClient.GetAvailabilitySetFaultDomainCount(nil, "resourceGroup", []string{"ID1", "ID2"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(3))
+			})
+		})
 	})
 })

--- a/pkg/armhelpers/azurestack/azureclient.go
+++ b/pkg/armhelpers/azurestack/azureclient.go
@@ -63,6 +63,7 @@ type AzureClient struct {
 	virtualMachineScaleSetVMsClient compute.VirtualMachineScaleSetVMsClient
 	virtualMachineExtensionsClient  compute.VirtualMachineExtensionsClient
 	disksClient                     compute.DisksClient
+	availabilitySetsClient          compute.AvailabilitySetsClient
 
 	applicationsClient      graphrbac.ApplicationsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
@@ -213,6 +214,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armAuthor
 		virtualMachineScaleSetVMsClient: compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 		virtualMachineExtensionsClient:  compute.NewVirtualMachineExtensionsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 		disksClient:                     compute.NewDisksClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		availabilitySetsClient:          compute.NewAvailabilitySetsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 
 		applicationsClient:      graphrbac.NewApplicationsClientWithBaseURI(env.GraphEndpoint, tenantID),
 		servicePrincipalsClient: graphrbac.NewServicePrincipalsClientWithBaseURI(env.GraphEndpoint, tenantID),
@@ -231,6 +233,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armAuthor
 	c.virtualMachineScaleSetsClient.Authorizer = armAuthorizer
 	c.virtualMachineScaleSetVMsClient.Authorizer = armAuthorizer
 	c.disksClient.Authorizer = armAuthorizer
+	c.availabilitySetsClient.Authorizer = armAuthorizer
 
 	c.deploymentsClient.PollingDelay = time.Second * 5
 	c.resourcesClient.PollingDelay = time.Second * 5
@@ -249,6 +252,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armAuthor
 	c.virtualMachineScaleSetsClient.PollingDuration = DefaultARMOperationTimeout
 	c.virtualMachineScaleSetVMsClient.PollingDuration = DefaultARMOperationTimeout
 	c.virtualMachinesClient.PollingDuration = DefaultARMOperationTimeout
+	c.availabilitySetsClient.PollingDuration = DefaultARMOperationTimeout
 
 	c.applicationsClient.Authorizer = graphAuthorizer
 	c.servicePrincipalsClient.Authorizer = graphAuthorizer

--- a/pkg/armhelpers/azurestack/compute.go
+++ b/pkg/armhelpers/azurestack/compute.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/aks-engine/pkg/armhelpers"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-03-30/compute"
 	azcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	log "github.com/sirupsen/logrus"
 )
 
 // ListVirtualMachines returns (the first page of) the machines in the specified resource group.
@@ -159,4 +160,19 @@ func (az *AzureClient) SetVirtualMachineScaleSetCapacity(ctx context.Context, re
 
 	_, err = future.Result(az.virtualMachineScaleSetsClient)
 	return err
+}
+
+// GetAvailabilitySet retrieves the specified VM availability set.
+func (az *AzureClient) GetAvailabilitySet(ctx context.Context, resourceGroup, availabilitySetName string) (azcompute.AvailabilitySet, error) {
+	azVMAS := azcompute.AvailabilitySet{}
+	vmas, err := az.availabilitySetsClient.Get(ctx, resourceGroup, availabilitySetName)
+	if err != nil {
+		log.Printf("fail to get availability set, %v", err)
+		return azVMAS, err
+	}
+	if err = DeepCopy(&azVMAS, vmas); err != nil {
+		log.Printf("fail to convert availability set, %v", err)
+		return azVMAS, err
+	}
+	return azVMAS, nil
 }

--- a/pkg/armhelpers/azurestack/compute_test.go
+++ b/pkg/armhelpers/azurestack/compute_test.go
@@ -185,3 +185,66 @@ func TestDeleteVirtualMachine(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetAvailabilitySet(t *testing.T) {
+	mc, err := NewHTTPMockClient()
+	if err != nil {
+		t.Fatalf("failed to create HttpMockClient - %s", err)
+	}
+	mc.Activate()
+	defer mc.DeactivateAndReset()
+	mc.RegisterLogin()
+	env := mc.GetEnvironment()
+
+	azureClient, err := NewAzureClientWithClientSecret(env, subscriptionID, "clientID", "secret")
+	if err != nil {
+		t.Fatalf("can not get client %s", err)
+	}
+
+	mc.RegisterGetAvailabilitySet()
+
+	vmas, err := azureClient.GetAvailabilitySet(context.Background(), resourceGroup, virtualMachineAvailabilitySetName)
+	if err != nil {
+		t.Fatalf("can't get availability set: %s", err)
+	}
+
+	var expected int32 = 3
+	if *vmas.PlatformFaultDomainCount != expected {
+		t.Fatalf("expected PlatformFaultDomainCount of %d but got %v", expected, *vmas.PlatformFaultDomainCount)
+	}
+	if *vmas.PlatformUpdateDomainCount != expected {
+		t.Fatalf("expected PlatformUpdateDomainCount of %d but got %v", expected, *vmas.PlatformUpdateDomainCount)
+	}
+	l := "eastus"
+	if *vmas.Location != l {
+		t.Fatalf("expected Location of %s but got %v", l, *vmas.Location)
+	}
+}
+
+func TestGetAvailabilitySetFaultDomainCount(t *testing.T) {
+	mc, err := NewHTTPMockClient()
+	if err != nil {
+		t.Fatalf("failed to create HttpMockClient - %s", err)
+	}
+	mc.Activate()
+	defer mc.DeactivateAndReset()
+	mc.RegisterLogin()
+	env := mc.GetEnvironment()
+
+	azureClient, err := NewAzureClientWithClientSecret(env, subscriptionID, "clientID", "secret")
+	if err != nil {
+		t.Fatalf("can not get client %s", err)
+	}
+
+	mc.RegisterGetAvailabilitySetFaultDomainCount()
+
+	count, err := azureClient.GetAvailabilitySetFaultDomainCount(context.Background(), resourceGroup, []string{"id1", "id2"})
+	if err != nil {
+		t.Fatalf("can't get availability set platform fault domain count: %s", err)
+	}
+
+	expected := 3
+	if count != expected {
+		t.Fatalf("platform fault domain count: expected %d but got %d", expected, count)
+	}
+}

--- a/pkg/armhelpers/azurestack/httpMockClient.go
+++ b/pkg/armhelpers/azurestack/httpMockClient.go
@@ -23,6 +23,7 @@ const (
 	deploymentName                        = "testDeplomentName"
 	deploymentStatus                      = "08586474508192185203"
 	virtualMachineScaleSetName            = "vmscalesetName"
+	virtualMachineAvailabilitySetName     = "vmavailabilitysetName"
 	virtualMachineName                    = "testVirtualMachineName"
 	virtualNicName                        = "testVirtualNicName"
 	virutalDiskName                       = "testVirtualdickName"
@@ -35,6 +36,7 @@ const (
 	filePathGetVirtualMachine             = "httpMockClientData/getVirtualMachine.json"
 	fileDeployVirtualMachine              = "httpMockClientData/deployVMResponse.json"
 	fileDeployVirtualMachineError         = "httpMockClientData/deploymentVMError.json"
+	filePathGetAvailabilitySet            = "httpMockClientData/getAvailabilitySet.json"
 )
 
 //HTTPMockClient is an wrapper of httpmock
@@ -60,6 +62,7 @@ type HTTPMockClient struct {
 	ResponseGetVirtualMachine             string
 	ResponseDeployVirtualMachine          string
 	ResponseDeployVirtualMachineError     string
+	ResponseGetAvailabilitySet            string
 }
 
 //VirtualMachineScaleSetListValues is an wrapper of virtual machine scale set list response values
@@ -122,6 +125,10 @@ func NewHTTPMockClient() (HTTPMockClient, error) {
 		return client, err
 	}
 	client.ResponseDeployVirtualMachineError, err = readFromFile(fileDeployVirtualMachineError)
+	if err != nil {
+		return client, err
+	}
+	client.ResponseGetAvailabilitySet, err = readFromFile(filePathGetAvailabilitySet)
 	if err != nil {
 		return client, err
 	}
@@ -189,6 +196,26 @@ func (mc HTTPMockClient) RegisterListVirtualMachines() {
 
 		func(req *http.Request) (*http.Response, error) {
 			resp := httpmock.NewStringResponse(200, mc.ResponseListVirtualMachines)
+			return resp, nil
+		},
+	)
+}
+
+// RegisterGetAvailabilitySet registers the mock response for GetAvailabilitySet.
+func (mc HTTPMockClient) RegisterGetAvailabilitySet() {
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/vmavailabilitysetName?api-version=%s", mc.SubscriptionID, mc.ResourceGroup, mc.ComputeAPIVersion),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, mc.ResponseGetAvailabilitySet)
+			return resp, nil
+		},
+	)
+}
+
+// RegisterGetAvailabilitySetFaultDomainCount registers a mock response for GetAvailabilitySet.
+func (mc HTTPMockClient) RegisterGetAvailabilitySetFaultDomainCount() {
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/id1?api-version=%s", mc.SubscriptionID, mc.ResourceGroup, mc.ComputeAPIVersion),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, mc.ResponseGetAvailabilitySet)
 			return resp, nil
 		},
 	)

--- a/pkg/armhelpers/azurestack/httpMockClientData/getAvailabilitySet.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/getAvailabilitySet.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "platformUpdateDomainCount": 3,
+    "platformFaultDomainCount": 3,
+    "virtualMachines": [
+      {
+        "id": "/subscriptions/12345678-1234-4fe0-86da-28abc43fc4c7/resourceGroups/MYGROUP/providers/Microsoft.Compute/virtualMachines/K8S-MASTER-26399701-0"
+      }
+    ]
+  },
+  "type": "Microsoft.Compute/availabilitySets",
+  "location": "eastus",
+  "id": "/subscriptions/12345678-1234-4fe0-86da-28abc43fc4c7/resourceGroups/mygroup/providers/Microsoft.Compute/availabilitySets/master-availabilityset-26399701",
+  "name": "master-availabilityset-26399701",
+  "sku": {
+    "name": "Aligned"
+  }
+}

--- a/pkg/armhelpers/compute.go
+++ b/pkg/armhelpers/compute.go
@@ -5,6 +5,7 @@ package armhelpers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 )
@@ -130,4 +131,22 @@ func (az *AzureClient) SetVirtualMachineScaleSetCapacity(ctx context.Context, re
 // GetAvailabilitySet retrieves the specified VM availability set.
 func (az *AzureClient) GetAvailabilitySet(ctx context.Context, resourceGroup, availabilitySetName string) (compute.AvailabilitySet, error) {
 	return az.availabilitySetsClient.Get(ctx, resourceGroup, availabilitySetName)
+}
+
+// GetAvailabilitySetFaultDomainCount returns the first existing fault domain count it finds from the IDs provided.
+func (az *AzureClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
+	var count int
+	for _, id := range vmasIDs {
+		// extract the last element of the id for VMAS name
+		ss := strings.Split(id, "/")
+		name := ss[len(ss)-1]
+		vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
+		if err != nil {
+			return 0, err
+		}
+		// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
+		count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
+		break
+	}
+	return count, nil
 }

--- a/pkg/armhelpers/compute.go
+++ b/pkg/armhelpers/compute.go
@@ -126,3 +126,8 @@ func (az *AzureClient) SetVirtualMachineScaleSetCapacity(ctx context.Context, re
 	_, err = future.Result(az.virtualMachineScaleSetsClient)
 	return err
 }
+
+// GetAvailabilitySet retrieves the specified VM availability set.
+func (az *AzureClient) GetAvailabilitySet(ctx context.Context, resourceGroup, availabilitySetName string) (compute.AvailabilitySet, error) {
+	return az.availabilitySetsClient.Get(ctx, resourceGroup, availabilitySetName)
+}

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -131,6 +131,10 @@ type AKSEngineClient interface {
 	// GetAvailabilitySet retrieves the specified VM availability set.
 	GetAvailabilitySet(ctx context.Context, resourceGroup, availabilitySet string) (compute.AvailabilitySet, error)
 
+	// GetAvailabilitySetFaultDomainCount returns the first platform fault domain count it finds from the
+	// VM availability set IDs provided.
+	GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error)
+
 	//
 	// STORAGE
 

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -128,6 +128,9 @@ type AKSEngineClient interface {
 	// SetVirtualMachineScaleSetCapacity sets the VMSS capacity
 	SetVirtualMachineScaleSetCapacity(ctx context.Context, resourceGroup, virtualMachineScaleSet string, sku compute.Sku, location string) error
 
+	// GetAvailabilitySet retrieves the specified VM availability set.
+	GetAvailabilitySet(ctx context.Context, resourceGroup, availabilitySet string) (compute.AvailabilitySet, error)
+
 	//
 	// STORAGE
 

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -788,6 +788,11 @@ func (mc *MockAKSEngineClient) GetAvailabilitySet(ctx context.Context, resourceG
 	return compute.AvailabilitySet{}, errors.New("not implemented")
 }
 
+// GetAvailabilitySetFaultDomainCount mock
+func (mc *MockAKSEngineClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
+	return 0, errors.New("not implemented")
+}
+
 //GetStorageClient mock
 func (mc *MockAKSEngineClient) GetStorageClient(ctx context.Context, resourceGroup, accountName string) (AKSStorageClient, error) {
 	if mc.FailGetStorageClient {

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -558,7 +558,11 @@ func (mc *MockAKSEngineClient) ListVirtualMachines(ctx context.Context, resource
 
 	if mc.FakeListVirtualMachineResult == nil {
 		mc.FakeListVirtualMachineResult = func() []compute.VirtualMachine {
-			return []compute.VirtualMachine{mc.MakeFakeVirtualMachine(DefaultFakeVMName, defaultK8sVersionForFakeVMs)}
+			machine := mc.MakeFakeVirtualMachine(DefaultFakeVMName, defaultK8sVersionForFakeVMs)
+			machine.AvailabilitySet = &compute.SubResource{
+				ID: to.StringPtr("MockAvailabilitySet"),
+			}
+			return []compute.VirtualMachine{machine}
 		}
 	}
 	vms := mc.FakeListVirtualMachineResult()

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -783,6 +783,11 @@ func (mc *MockAKSEngineClient) ListVirtualMachineScaleSetVMs(ctx context.Context
 	}, nil
 }
 
+// GetAvailabilitySet mock
+func (mc *MockAKSEngineClient) GetAvailabilitySet(ctx context.Context, resourceGroup, availabilitySetName string) (compute.AvailabilitySet, error) {
+	return compute.AvailabilitySet{}, errors.New("not implemented")
+}
+
 //GetStorageClient mock
 func (mc *MockAKSEngineClient) GetStorageClient(ctx context.Context, resourceGroup, accountName string) (AKSStorageClient, error) {
 	if mc.FailGetStorageClient {

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -790,7 +790,7 @@ func (mc *MockAKSEngineClient) GetAvailabilitySet(ctx context.Context, resourceG
 
 // GetAvailabilitySetFaultDomainCount mock
 func (mc *MockAKSEngineClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
-	return 0, errors.New("not implemented")
+	return 3, nil // hat tip to Slipknot
 }
 
 //GetStorageClient mock

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -785,12 +785,12 @@ func (mc *MockAKSEngineClient) ListVirtualMachineScaleSetVMs(ctx context.Context
 
 // GetAvailabilitySet mock
 func (mc *MockAKSEngineClient) GetAvailabilitySet(ctx context.Context, resourceGroup, availabilitySetName string) (compute.AvailabilitySet, error) {
-	return compute.AvailabilitySet{}, errors.New("not implemented")
+	return compute.AvailabilitySet{}, nil
 }
 
 // GetAvailabilitySetFaultDomainCount mock
 func (mc *MockAKSEngineClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
-	return 3, nil // hat tip to Slipknot
+	return 3, nil
 }
 
 //GetStorageClient mock

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -149,7 +149,6 @@ func TestGenerateARMResourcesWithVMSSAgentPool(t *testing.T) {
 				Name: to.StringPtr("Aligned"),
 			},
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
-				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
 			},
 		},
@@ -991,7 +990,6 @@ func TestGenerateARMResourceWithVMASAgents(t *testing.T) {
 		AvailabilitySet: compute.AvailabilitySet{
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
-				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 			},
 			Sku: &compute.Sku{
 				Name: to.StringPtr("Aligned"),

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -149,7 +149,7 @@ func TestGenerateARMResourcesWithVMSSAgentPool(t *testing.T) {
 				Name: to.StringPtr("Aligned"),
 			},
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
-				PlatformFaultDomainCount:  to.Int32Ptr(2),
+				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
 			},
 		},
@@ -991,7 +991,7 @@ func TestGenerateARMResourceWithVMASAgents(t *testing.T) {
 		AvailabilitySet: compute.AvailabilitySet{
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
-				PlatformFaultDomainCount:  to.Int32Ptr(2),
+				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 			},
 			Sku: &compute.Sku{
 				Name: to.StringPtr("Aligned"),

--- a/pkg/engine/armtype.go
+++ b/pkg/engine/armtype.go
@@ -5,6 +5,8 @@ package engine
 
 import (
 	"encoding/json"
+	"regexp"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
@@ -63,6 +65,40 @@ type RoleAssignmentARM struct {
 type AvailabilitySetARM struct {
 	ARMResource
 	compute.AvailabilitySet
+}
+
+// MarshalJSON is the custom marshaler for an AvailabilitySetARM.
+// It acts as a decorator by replacing the JSON field "platformFaultDomainCount"
+// with an ARM expression if the value was not set.
+func (a AvailabilitySetARM) MarshalJSON() ([]byte, error) {
+	// alias the type to avoid infinite recursion in marshaling
+	type Alias AvailabilitySetARM
+	bytes, err := json.Marshal((Alias)(a))
+	if err != nil {
+		return nil, err
+	}
+
+	// armExpr is evaluated by Azure Resource Manager at deployment time:
+	//   if location is in the three-fault-domain list, return 3
+	//   else if location is "canary" (testing), return 1
+	//   else return 2
+	// NOTE: use fault_domains_expr.py to update this ARM expression.
+	armExpr := `"[
+	if( contains(
+	      split('canadacentral,centralus,eastus,eastus2,northcentralus,northeurope,southcentralus,westeurope,westus', ','),
+	        variables('location') ),
+	  3,
+	if( equals('centraluseuap', variables('location') ),
+	  1,
+	  2
+	))]"`
+	// strip all whitespace
+	armExpr = strings.Join(strings.Fields(armExpr), "")
+	// replace "platformFaultDomainCount":0 (engine.PlatformFaultDomainCountNotSet) with the ARM expression
+	re := regexp.MustCompile(`\"platformFaultDomainCount\" *: *\"?0\"?`)
+	s := re.ReplaceAllLiteralString(string(bytes), `"platformFaultDomainCount":`+armExpr)
+
+	return []byte(s), nil
 }
 
 // StorageAccountARM embeds the ARMResource type in storage.Account.

--- a/pkg/engine/armtype_test.go
+++ b/pkg/engine/armtype_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/gomega"
 )
 
 func TestMarshalJSON(t *testing.T) {
@@ -38,6 +41,117 @@ func TestMarshalJSON(t *testing.T) {
 	}
 	armObject := CreateCustomScriptExtension(cs)
 
-	jsonObj, _ := json.MarshalIndent(armObject, "", "   ")
+	jsonObj, err := json.MarshalIndent(armObject, "", "   ")
+	if err != nil {
+		t.Error(err)
+	}
+	// TODO: why print this? Let's validate it.
 	fmt.Println(string(jsonObj))
+}
+
+func TestMarshalJSONAvailabilitySetARM(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type VMASTestDatum struct {
+		avSet AvailabilitySetARM
+		json  string
+	}
+
+	vmasTestData := []VMASTestDatum{
+		{
+			avSet: AvailabilitySetARM{
+				ARMResource: ARMResource{
+					APIVersion: "[variables('apiVersionCompute')]",
+				},
+				AvailabilitySet: compute.AvailabilitySet{
+					Name:     to.StringPtr("[variables('masterAvailabilitySet')]"),
+					Location: to.StringPtr("[variables('location')]"),
+					Type:     to.StringPtr("Microsoft.Compute/availabilitySets"),
+					Sku: &compute.Sku{
+						Name: to.StringPtr("Aligned"),
+					},
+					AvailabilitySetProperties: &compute.AvailabilitySetProperties{
+						PlatformFaultDomainCount:  to.Int32Ptr(3),
+						PlatformUpdateDomainCount: to.Int32Ptr(3),
+					},
+				},
+			},
+			json: `{
+			"apiVersion": "[variables('apiVersionCompute')]",
+			"properties": {
+				"platformFaultDomainCount": 3,
+				"platformUpdateDomainCount": 3
+			},
+			"sku": {
+				"name": "Aligned"
+			},
+			"name": "[variables('masterAvailabilitySet')]",
+			"type": "Microsoft.Compute/availabilitySets",
+			"location": "[variables('location')]",
+			"tags": null
+		}`},
+		{
+			avSet: AvailabilitySetARM{
+				ARMResource: ARMResource{
+					APIVersion: "[variables('apiVersionCompute')]",
+				},
+				AvailabilitySet: compute.AvailabilitySet{
+					Name:     to.StringPtr("[variables('masterAvailabilitySet')]"),
+					Location: to.StringPtr("[variables('location')]"),
+					Type:     to.StringPtr("Microsoft.Compute/availabilitySets"),
+					Sku: &compute.Sku{
+						Name: to.StringPtr("Aligned"),
+					},
+					AvailabilitySetProperties: &compute.AvailabilitySetProperties{
+						PlatformUpdateDomainCount: to.Int32Ptr(3),
+					},
+				},
+			},
+			json: `{
+			"apiVersion": "[variables('apiVersionCompute')]",
+			"properties": {
+				"platformFaultDomainCount": "[if(contains(split('canadacentral,centralus,eastus,eastus2,northcentralus,northeurope,southcentralus,westeurope,westus',','),variables('location')),3,if(equals('centraluseuap',variables('location')),1,2))]",
+				"platformUpdateDomainCount": 3
+			},
+			"sku": {
+				"name": "Aligned"
+			},
+			"name": "[variables('masterAvailabilitySet')]",
+			"type": "Microsoft.Compute/availabilitySets",
+			"location": "[variables('location')]",
+			"tags": null
+		}`},
+		{
+			avSet: AvailabilitySetARM{
+				ARMResource: ARMResource{
+					APIVersion: "[variables('apiVersionCompute')]",
+				},
+				AvailabilitySet: compute.AvailabilitySet{
+					Name:     to.StringPtr("[variables('masterAvailabilitySet')]"),
+					Location: to.StringPtr("[variables('location')]"),
+					Type:     to.StringPtr("Microsoft.Compute/availabilitySets"),
+					Sku: &compute.Sku{
+						Name: to.StringPtr("Aligned"),
+					},
+					AvailabilitySetProperties: &compute.AvailabilitySetProperties{},
+				},
+			},
+			json: `{
+			"apiVersion": "[variables('apiVersionCompute')]",
+			"properties": {},
+			"sku": {
+				"name": "Aligned"
+			},
+			"name": "[variables('masterAvailabilitySet')]",
+			"type": "Microsoft.Compute/availabilitySets",
+			"location": "[variables('location')]",
+			"tags": null
+		}`},
+	}
+
+	for _, vmasTestDatum := range vmasTestData {
+		output, err := json.Marshal(vmasTestDatum.avSet)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(string(output)).To(MatchJSON(vmasTestDatum.json))
+	}
 }

--- a/pkg/engine/availabilitysets.go
+++ b/pkg/engine/availabilitysets.go
@@ -11,6 +11,13 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
+// PlatformFaultDomainCountUnset indicates an ARM expression should replace this value.
+const PlatformFaultDomainCountNotSet = 0
+
+// PlatformFaultDomainCount is the global value used to populate the fault domain count
+// for a VMAS. It may be changed when upgrade inspects an existing cluster.
+var PlatformFaultDomainCount int32 = PlatformFaultDomainCountNotSet
+
 func CreateAvailabilitySet(cs *api.ContainerService, isManagedDisks bool) AvailabilitySetARM {
 
 	armResource := ARMResource{
@@ -26,7 +33,7 @@ func CreateAvailabilitySet(cs *api.ContainerService, isManagedDisks bool) Availa
 	if !cs.Properties.MasterProfile.HasAvailabilityZones() {
 		if isManagedDisks {
 			avSet.AvailabilitySetProperties = &compute.AvailabilitySetProperties{
-				PlatformFaultDomainCount:  to.Int32Ptr(2),
+				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCount),
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
 			}
 			avSet.Sku = &compute.Sku{
@@ -57,7 +64,7 @@ func createAgentAvailabilitySets(profile *api.AgentPoolProfile) AvailabilitySetA
 	}
 
 	if profile.IsManagedDisks() {
-		avSet.PlatformFaultDomainCount = to.Int32Ptr(2)
+		avSet.PlatformFaultDomainCount = to.Int32Ptr(PlatformFaultDomainCount)
 		avSet.PlatformUpdateDomainCount = to.Int32Ptr(3)
 		avSet.Sku = &compute.Sku{
 			Name: to.StringPtr("Aligned"),

--- a/pkg/engine/availabilitysets_test.go
+++ b/pkg/engine/availabilitysets_test.go
@@ -105,6 +105,41 @@ func TestCreateAvailabilitySet(t *testing.T) {
 		t.Errorf("unexpected error while comparing availability sets: %s", diff)
 	}
 
+	// Test availability set with platform fault domain count set
+	count := 3
+	cs = &api.ContainerService{
+		Properties: &api.Properties{
+			MasterProfile: &api.MasterProfile{
+				PlatformFaultDomainCount: &count,
+			},
+		},
+	}
+
+	avSet = CreateAvailabilitySet(cs, true)
+
+	expectedAvSet = AvailabilitySetARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionCompute')]",
+		},
+		AvailabilitySet: compute.AvailabilitySet{
+			Name:     to.StringPtr("[variables('masterAvailabilitySet')]"),
+			Location: to.StringPtr("[variables('location')]"),
+			Type:     to.StringPtr("Microsoft.Compute/availabilitySets"),
+			Sku: &compute.Sku{
+				Name: to.StringPtr("Aligned"),
+			},
+			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
+				PlatformFaultDomainCount:  to.Int32Ptr(int32(count)),
+				PlatformUpdateDomainCount: to.Int32Ptr(3),
+			},
+		},
+	}
+
+	diff = cmp.Diff(avSet, expectedAvSet)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing availability sets: %s", diff)
+	}
 }
 
 func TestCreateAgentAvailabilitySets(t *testing.T) {
@@ -165,4 +200,37 @@ func TestCreateAgentAvailabilitySets(t *testing.T) {
 		t.Errorf("unexpected error while comparing availability sets: %s", diff)
 	}
 
+	// Test availability set with platform fault domain count set
+	count := 3
+	profile = &api.AgentPoolProfile{
+		Name:                     "foobar",
+		StorageProfile:           api.ManagedDisks,
+		PlatformFaultDomainCount: &count,
+	}
+
+	avSet = createAgentAvailabilitySets(profile)
+
+	expectedAvSet = AvailabilitySetARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionCompute')]",
+		},
+		AvailabilitySet: compute.AvailabilitySet{
+			Name:     to.StringPtr("[variables('foobarAvailabilitySet')]"),
+			Location: to.StringPtr("[variables('location')]"),
+			Type:     to.StringPtr("Microsoft.Compute/availabilitySets"),
+			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
+				PlatformFaultDomainCount:  to.Int32Ptr(int32(count)),
+				PlatformUpdateDomainCount: to.Int32Ptr(3),
+			},
+			Sku: &compute.Sku{
+				Name: to.StringPtr("Aligned"),
+			},
+		},
+	}
+
+	diff = cmp.Diff(avSet, expectedAvSet)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing availability sets: %s", diff)
+	}
 }

--- a/pkg/engine/availabilitysets_test.go
+++ b/pkg/engine/availabilitysets_test.go
@@ -65,7 +65,7 @@ func TestCreateAvailabilitySet(t *testing.T) {
 				Name: to.StringPtr("Aligned"),
 			},
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
-				PlatformFaultDomainCount:  to.Int32Ptr(2),
+				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
 			},
 		},
@@ -152,7 +152,7 @@ func TestCreateAgentAvailabilitySets(t *testing.T) {
 			Location: to.StringPtr("[variables('location')]"),
 			Type:     to.StringPtr("Microsoft.Compute/availabilitySets"),
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
-				PlatformFaultDomainCount:  to.Int32Ptr(2),
+				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
 			},
 			Sku: &compute.Sku{

--- a/pkg/engine/availabilitysets_test.go
+++ b/pkg/engine/availabilitysets_test.go
@@ -65,7 +65,6 @@ func TestCreateAvailabilitySet(t *testing.T) {
 				Name: to.StringPtr("Aligned"),
 			},
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
-				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
 			},
 		},
@@ -152,7 +151,6 @@ func TestCreateAgentAvailabilitySets(t *testing.T) {
 			Location: to.StringPtr("[variables('location')]"),
 			Type:     to.StringPtr("Microsoft.Compute/availabilitySets"),
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
-				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
 			},
 			Sku: &compute.Sku{

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -635,7 +635,7 @@ func TestGenerateKubeConfig(t *testing.T) {
 		t.Errorf("Got unexpected kubeconfig payload: %v", kubeConfig)
 	}
 	if err != nil {
-		t.Errorf("Failed to call GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
+		t.Errorf("Failed to g186 GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
 	}
 
 	p := api.Properties{}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -635,7 +635,7 @@ func TestGenerateKubeConfig(t *testing.T) {
 		t.Errorf("Got unexpected kubeconfig payload: %v", kubeConfig)
 	}
 	if err != nil {
-		t.Errorf("Failed to g186 GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
+		t.Errorf("Failed to call GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
 	}
 
 	p := api.Properties{}

--- a/pkg/engine/masterarmresources_test.go
+++ b/pkg/engine/masterarmresources_test.go
@@ -361,7 +361,7 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 		AvailabilitySet: compute.AvailabilitySet{
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
-				PlatformFaultDomainCount:  to.Int32Ptr(2),
+				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 			},
 			Sku: &compute.Sku{
 				Name: to.StringPtr("Aligned"),

--- a/pkg/engine/masterarmresources_test.go
+++ b/pkg/engine/masterarmresources_test.go
@@ -361,7 +361,6 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 		AvailabilitySet: compute.AvailabilitySet{
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 				PlatformUpdateDomainCount: to.Int32Ptr(3),
-				PlatformFaultDomainCount:  to.Int32Ptr(PlatformFaultDomainCountNotSet),
 			},
 			Sku: &compute.Sku{
 				Name: to.StringPtr("Aligned"),

--- a/scripts/fault_domains_expr.py
+++ b/scripts/fault_domains_expr.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+"""
+Generates an Azure Resource Manager (ARM) expression that will evaluate at
+deployment time to the number of fault domains available in a given location.
+Also generates Go code referencing the expression.
+
+Since there is no API to query the fault domain count for an Azure location,
+this script parses the public documentation to find out.
+"""
+
+import os
+import re
+import textwrap
+import urllib.request
+
+
+ARM_EXPR = """\
+"[
+if( contains(
+      split('{}', ','),
+        variables('location') ),
+  3,
+if( equals('centraluseuap', variables('location') ),
+  1,
+  2
+))]"\
+"""
+
+GO_CODE = """\
+// armExpr is evaluated by Azure Resource Manager at deployment time:
+//   if location is in the three-fault-domain list, return 3
+//   else if location is "canary" (testing), return 1
+//   else return 2
+// NOTE: use {} to update this ARM expression.
+armExpr := `{}`
+// strip all whitespace
+armExpr = strings.Join(strings.Fields(armExpr), "")
+""".format(os.path.basename(__file__), ARM_EXPR)
+
+SOURCE_DOC = 'https://raw.githubusercontent.com/MicrosoftDocs/azure-docs/master/includes/managed-disks-common-fault-domain-region-list.md'  # pylint: disable=line-too-long
+
+
+def main():
+    """
+    Print an ARM expression that returns the fault domain count for an Azure
+    location, as well as the associated Go code, ready for copy-and-paste.
+    """
+    regex = re.compile(r"""
+    \|\s*             # vertical bar followed by whitespace
+    ([A-Za-z0-9 ]*?)  # >= 0 location name characters (lazy, capture)
+    \s+\|\s*          # >= 1 whitespace chars, vertical bar, more whitespace
+    (\d)              # a single digit (capture)
+    \s*\|             # whitespace followed by a vertical bar
+    """, re.VERBOSE)
+
+    markdown = urllib.request.urlopen(SOURCE_DOC).read().decode("utf8")
+    # Since the canary region is hard-coded, only the regions with three
+    # fault domains need to be included in the expression.
+    threes = (m[0].replace(' ', '').lower() for m in regex.findall(markdown)
+              if int(m[1]) == 3)
+    threes = ','.join(sorted(threes))
+
+    print("\n\033[1;36mARM expression minified:\033[0;0m \n")
+    print("".join(ARM_EXPR.format(threes).split()))
+    print("\n\033[1;34mGo code snippet:\033[0;0m \n")
+    print(textwrap.indent(GO_CODE.format(threes), "\t"))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Changes the hard-coded default of `2` for an availability set's `platformFaultDomainCount` to an ARM expression that will calculate the available number of fault domains in the deployment location. Also respects the current availability sets' value during scale and upgrade.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #671

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
There is definitely some weirdness in here, so I'm looking for feedback. ~~There are no tests yet, but~~ I have tested it thoroughly by hand.
