### PR TITLE
test: check net.ipv4.tcp_retries2 kernel parameter

### DIFF
--- a/test/e2e/kubernetes/scripts/net-config-validate.sh
+++ b/test/e2e/kubernetes/scripts/net-config-validate.sh
@@ -4,6 +4,7 @@ IPV4_ACCEPT_SOURCE_ROUTE_VALUE=0
 IPV4_ACCEPT_REDIRECTS_VALUE=0
 IPV4_SECURE_REDIRECTS_VALUE=0
 IPV4_LOG_MARTIANS_VALUE=1
+IPV4_TCP_RETRIES2_VALUE=8
 IPV6_ACCEPT_RA_VALUE=0
 IPV6_ACCEPT_REDIRECTS_VALUE=0
 
@@ -22,3 +23,6 @@ cat /proc/sys/net/ipv6/conf/all/accept_ra | grep $IPV6_ACCEPT_RA_VALUE || exit 1
 cat /proc/sys/net/ipv6/conf/default/accept_ra | grep $IPV6_ACCEPT_RA_VALUE || exit 1
 cat /proc/sys/net/ipv6/conf/all/accept_redirects | grep $IPV6_ACCEPT_REDIRECTS_VALUE || exit 1
 cat /proc/sys/net/ipv6/conf/default/accept_redirects | grep $IPV6_ACCEPT_REDIRECTS_VALUE || exit 1
+
+# validate net config workaround from kubelet.service
+cat /proc/sys/net/ipv4/tcp_retries2 | grep $IPV4_TCP_RETRIES2_VALUE || exit 1


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Restores a bonus test from #1093 that was unrelated to the problem with setting `net.netfilter.nf_conntrack_tcp_be_liberal`.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
