### PR TITLE
fix: use the actual pool index in the VM prefix for windows scale operations

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -375,8 +375,10 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 
 	addValue(parametersJSON, sc.agentPool.Name+"Count", countForTemplate)
 
+	// The agent pool is set to index 0 for the scale operation, we need to overwrite the template variables that rely on pool index.
 	if winPoolIndex != -1 {
 		templateJSON["variables"].(map[string]interface{})[sc.agentPool.Name+"Index"] = winPoolIndex
+		templateJSON["variables"].(map[string]interface{})[sc.agentPool.Name+"VMNamePrefix"] = sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, winPoolIndex)
 	}
 	if orchestratorInfo.OrchestratorType == api.Kubernetes {
 		err = transformer.NormalizeForK8sVMASScalingUp(sc.logger, templateJSON)

--- a/docs/topics/scale.md
+++ b/docs/topics/scale.md
@@ -15,12 +15,12 @@ This guide will assume you have a cluster deployed and the apimodel originally u
 To scale the cluster you will run a command like:
 
 ```console
-$ aks-engine scale --subscription-id 51ac25de-afdg-9201-d923-8d8e8e8e8e8e \
-    --resource-group mycluster --location westus2 \
+$ aks-engine scale --subscription-id <subscription_id> \
+    --resource-group mycluster --location <location> \
     --client-id '<service principal client ID>' \
     --client-secret '<service principal client secret>' \
-    --api-model _output/mycluster/apimodel.json --new-node-count 5 \
-    --node-pool agentpool1 --master-FQDN mycluster.westus2.cloudapp.azure.com
+    --api-model _output/mycluster/apimodel.json --new-node-count <desired node count> \
+    --node-pool agentpool1 --master-FQDN mycluster.<location>.cloudapp.azure.com
 ```
 
 This command will re-use the `apimodel.json` file inside the output directory as input for a new ARM template deployment that will execute the scaling operation against the desired agent pool. When the scaling operation is done it will update the cluster definition in that same `apimodel.json` file to reflect the new node count and thus the updated, current cluster configuration.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -819,7 +819,8 @@ func (p *Properties) K8sOrchestratorName() string {
 	return ""
 }
 
-func (p *Properties) getAgentPoolIndexByName(name string) int {
+// GetAgentPoolIndexByName returns the index of the provided agentpool.
+func (p *Properties) GetAgentPoolIndexByName(name string) int {
 	index := -1
 	for i, profile := range p.AgentPoolProfiles {
 		if profile.Name == name {
@@ -830,9 +831,8 @@ func (p *Properties) getAgentPoolIndexByName(name string) int {
 	return index
 }
 
-// GetAgentVMPrefix returns the VM prefix for an agentpool
-func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
-	index := p.getAgentPoolIndexByName(a.Name)
+// GetAgentVMPrefix returns the VM prefix for an agentpool.
+func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile, index int) string {
 	nameSuffix := p.GetClusterID()
 	vmPrefix := ""
 	if index != -1 {
@@ -910,7 +910,7 @@ func (p *Properties) GetPrimaryAvailabilitySetName() string {
 func (p *Properties) GetPrimaryScaleSetName() string {
 	if len(p.AgentPoolProfiles) > 0 {
 		if p.AgentPoolProfiles[0].AvailabilityProfile == VirtualMachineScaleSets {
-			return p.GetAgentVMPrefix(p.AgentPoolProfiles[0])
+			return p.GetAgentVMPrefix(p.AgentPoolProfiles[0], 0)
 		}
 	}
 	return ""

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3383,7 +3383,7 @@ func TestGetAgentVMPrefix(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			p := test.properties
-			actual := p.GetAgentVMPrefix(test.profile)
+			actual := p.GetAgentVMPrefix(test.profile, p.getAgentPoolIndexByName(test.profile.Name))
 
 			if actual != test.expectedVMPrefix {
 				t.Errorf("expected agent VM name %s, but got %s", test.expectedVMPrefix, actual)

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3247,7 +3247,7 @@ func TestGetAgentPoolIndexByName(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			actual := test.properties.getAgentPoolIndexByName(test.profileName)
+			actual := test.properties.GetAgentPoolIndexByName(test.profileName)
 
 			if actual != test.expectedIndex {
 				t.Errorf("expected agent pool index %d, but got %d", test.expectedIndex, actual)

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3383,7 +3383,7 @@ func TestGetAgentVMPrefix(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			p := test.properties
-			actual := p.GetAgentVMPrefix(test.profile, p.getAgentPoolIndexByName(test.profile.Name))
+			actual := p.GetAgentVMPrefix(test.profile, p.GetAgentPoolIndexByName(test.profile.Name))
 
 			if actual != test.expectedVMPrefix {
 				t.Errorf("expected agent VM name %s, but got %s", test.expectedVMPrefix, actual)

--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -168,8 +168,7 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 
 // GetK8sVMName reconstructs the VM name
 func GetK8sVMName(p *api.Properties, agentPoolProfile *api.AgentPoolProfile, agentIndex int) (string, error) {
-
-	vmPrefix := p.GetAgentVMPrefix(agentPoolProfile)
+	vmPrefix := p.GetAgentVMPrefix(agentPoolProfile, p.getAgentPoolIndexByName(agentPoolProfile.Name))
 	if vmPrefix != "" {
 		return vmPrefix + strconv.Itoa(agentIndex), nil
 	}

--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -168,7 +168,7 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 
 // GetK8sVMName reconstructs the VM name
 func GetK8sVMName(p *api.Properties, agentPoolProfile *api.AgentPoolProfile, agentIndex int) (string, error) {
-	vmPrefix := p.GetAgentVMPrefix(agentPoolProfile, p.getAgentPoolIndexByName(agentPoolProfile.Name))
+	vmPrefix := p.GetAgentVMPrefix(agentPoolProfile, p.GetAgentPoolIndexByName(agentPoolProfile.Name))
 	if vmPrefix != "" {
 		return vmPrefix + strconv.Itoa(agentIndex), nil
 	}

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -499,7 +499,7 @@ func getK8sAgentVars(cs *api.ContainerService, profile *api.AgentPoolProfile) ma
 	}
 
 	agentVars[agentsCount] = fmt.Sprintf("[parameters('%s')]", agentsCount)
-	agentVars[agentsVMNamePrefix] = cs.Properties.GetAgentVMPrefix(profile)
+	agentVars[agentsVMNamePrefix] = cs.Properties.GetAgentVMPrefix(profile, cs.Properties.GetAgentPoolIndexByName(agentName))
 
 	if profile.IsWindows() {
 		agentVars["winResourceNamePrefix"] = "[substring(parameters('nameSuffix'), 0, 5)]"

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -923,9 +923,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			imageRef := cs.Properties.MasterProfile.ImageRef
 			return imageRef != nil && len(imageRef.Name) > 0 && len(imageRef.ResourceGroup) > 0
 		},
-		"GetAgentVMPrefix": func(profile *api.AgentPoolProfile) string {
-			return cs.Properties.GetAgentVMPrefix(profile)
-		},
 		"GetMasterVMPrefix": func() string {
 			return cs.Properties.GetMasterVMPrefix()
 		},


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The scale code sets the container service to only have 1 agent pool, the one that is being scaled, https://github.com/Azure/aks-engine/blob/master/cmd/scale.go#L346.

When we generate the new template to deploy, we get the VM name prefix using https://github.com/Azure/aks-engine/blob/master/pkg/api/types.go#L835, which calculates the pool index according to the pool's position in the agent pool array - thus, new VMs always have an agent pool index of 00.

This is especially an issue because if there are 2 Windows pools:
3831k8s010
3831k8s011

3831k8s020
3831k8s021

And I scale pool 1, it will add a node named 3831k8s002. If I scale pool 2 after first scale, it will create a node named 3831k8s002 again, which will conflict with the existing one.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1065 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
