### PR TITLE
feat: enable WindowsProfile in defaults enforcement code flow

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -230,6 +230,18 @@ const (
 	DefaultEnableVMSSNodePublicIP = false
 )
 
+// WindowsProfile defaults
+const (
+	// DefaultWindowsPublisher sets the default WindowsPublisher value in WindowsProfile
+	DefaultWindowsPublisher = "MicrosoftWindowsServer"
+	// DefaultWindowsOffer sets the default WindowsOffer value in WindowsProfile
+	DefaultWindowsOffer = "WindowsServerSemiAnnual"
+	// DefaultWindowsSku sets the default WindowsSku value in WindowsProfile
+	DefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
+	// DefaultImageVersion sets the default ImageVersion value in WindowsProfile
+	DefaultImageVersion = "1809.0.20190314"
+)
+
 const (
 	// AgentPoolProfileRoleEmpty is the empty role.  Deprecated; only used in
 	// aks-engine.

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -59,6 +59,10 @@ func (cs *ContainerService) SetPropertiesDefaults(isUpgrade, isScale bool) (bool
 		properties.setHostedMasterProfileDefaults()
 	}
 
+	if cs.Properties.WindowsProfile != nil {
+		properties.setWindowsProfileDefaults(isUpgrade, isScale)
+	}
+
 	certsGenerated, _, e := cs.SetDefaultCerts()
 	if e != nil {
 		return false, e
@@ -500,6 +504,25 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 
 		if profile.EnableVMSSNodePublicIP == nil {
 			profile.EnableVMSSNodePublicIP = to.BoolPtr(DefaultEnableVMSSNodePublicIP)
+		}
+	}
+}
+
+// setWindowsProfileDefaults sets default WindowsProfile values
+func (p *Properties) setWindowsProfileDefaults(isUpgrade, isScale bool) {
+	windowsProfile := p.WindowsProfile
+	if !isUpgrade && !isScale {
+		if windowsProfile.WindowsPublisher == "" {
+			windowsProfile.WindowsPublisher = DefaultWindowsPublisher
+		}
+		if windowsProfile.WindowsOffer == "" {
+			windowsProfile.WindowsOffer = DefaultWindowsOffer
+		}
+		if windowsProfile.WindowsSku == "" {
+			windowsProfile.WindowsSku = DefaultWindowsSku
+		}
+		if windowsProfile.ImageVersion == "" {
+			windowsProfile.ImageVersion = DefaultImageVersion
 		}
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1075,6 +1075,90 @@ func TestSetComponentsNetworkDefaults(t *testing.T) {
 	}
 }
 
+func TestWindowsProfileDefaults(t *testing.T) {
+
+	var tests = []struct {
+		name                   string // test case name
+		windowsProfile         WindowsProfile
+		expectedWindowsProfile WindowsProfile
+	}{
+		{
+			"defaults",
+			WindowsProfile{},
+			WindowsProfile{
+				WindowsPublisher:      DefaultWindowsPublisher,
+				WindowsOffer:          DefaultWindowsOffer,
+				WindowsSku:            DefaultWindowsSku,
+				ImageVersion:          DefaultImageVersion,
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            false,
+			},
+		},
+		{
+			"user overrides",
+			WindowsProfile{
+				WindowsPublisher: "override",
+				WindowsOffer:     "override",
+				WindowsSku:       "override",
+				ImageVersion:     "override",
+			},
+			WindowsProfile{
+				WindowsPublisher:      "override",
+				WindowsOffer:          "override",
+				WindowsSku:            "override",
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		mockAPI := getMockAPIProperties("1.14.0")
+		mockAPI.WindowsProfile = &test.windowsProfile
+		mockAPI.setWindowsProfileDefaults(false, false)
+		if mockAPI.WindowsProfile.WindowsPublisher != test.expectedWindowsProfile.WindowsPublisher {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.WindowsPublisher, test.expectedWindowsProfile.WindowsPublisher)
+		}
+		if mockAPI.WindowsProfile.WindowsOffer != test.expectedWindowsProfile.WindowsOffer {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.WindowsOffer, test.expectedWindowsProfile.WindowsOffer)
+		}
+		if mockAPI.WindowsProfile.WindowsSku != test.expectedWindowsProfile.WindowsSku {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.WindowsSku, test.expectedWindowsProfile.WindowsSku)
+		}
+		if mockAPI.WindowsProfile.ImageVersion != test.expectedWindowsProfile.ImageVersion {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.ImageVersion, test.expectedWindowsProfile.ImageVersion)
+		}
+		if mockAPI.WindowsProfile.AdminUsername != test.expectedWindowsProfile.AdminUsername {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.AdminUsername, test.expectedWindowsProfile.AdminUsername)
+		}
+		if mockAPI.WindowsProfile.AdminPassword != test.expectedWindowsProfile.AdminPassword {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.AdminPassword, test.expectedWindowsProfile.AdminPassword)
+		}
+		if mockAPI.WindowsProfile.WindowsImageSourceURL != test.expectedWindowsProfile.WindowsImageSourceURL {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.WindowsImageSourceURL, test.expectedWindowsProfile.WindowsImageSourceURL)
+		}
+		if mockAPI.WindowsProfile.WindowsDockerVersion != test.expectedWindowsProfile.WindowsDockerVersion {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.WindowsDockerVersion, test.expectedWindowsProfile.WindowsDockerVersion)
+		}
+		if mockAPI.WindowsProfile.Secrets != nil {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.Secrets, nil)
+		}
+		if mockAPI.WindowsProfile.SSHEnabled != test.expectedWindowsProfile.SSHEnabled {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.SSHEnabled, test.expectedWindowsProfile.SSHEnabled)
+		}
+		if mockAPI.WindowsProfile.EnableAutomaticUpdates != nil {
+			t.Fatalf("setWindowsProfileDefaults() test case %v did not return right default values %v != %v", test.name, mockAPI.WindowsProfile.EnableAutomaticUpdates, nil)
+		}
+	}
+}
+
 func TestIsAzureCNINetworkmonitorAddon(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Adds `WindowsProfile` into the standard defaults enforcement code flow. We retain the existing ARM parameters defaults to ensure back-compat defaults enforcement for pre-existing clusters.

This PR delivers the following opinionated defaults, which are subject to review:

```
// DefaultWindowsPublisher sets the default WindowsPublisher value in WindowsProfile
DefaultWindowsPublisher = "MicrosoftWindowsServer"
// DefaultWindowsOffer sets the default WindowsOffer value in WindowsProfile
DefaultWindowsOffer = "WindowsServerSemiAnnual"
// DefaultWindowsSku sets the default WindowsSku value in WindowsProfile
DefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
// DefaultImageVersion sets the default ImageVersion value in WindowsProfile
DefaultImageVersion = "1809.0.20190314"
```

Previous defaults were:

WindowsPublisher = "MicrosoftWindowsServer" (unchanged in this PR)
WindowsOffer = "WindowsServerSemiAnnual" (unchanged in this PR)
WindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk" (unchanged in this PR)
WindowsVersion = "latest" (**_this PR changes this value to an opinonated, dated version_**)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: