### PR TITLE
style: remove unneeded nil check

### DIFF
--- a/pkg/api/converterfromagentpoolonlyapi.go
+++ b/pkg/api/converterfromagentpoolonlyapi.go
@@ -145,7 +145,7 @@ func convertKubernetesConfigToEnableRBACV20180331AgentPoolOnly(kc *KubernetesCon
 	}
 	// We use KubernetesConfig.EnableRbac to convert to versioned api model
 	// The assumption here is KubernetesConfig.EnableSecureKubelet is set to be same
-	if kc != nil && kc.EnableRbac != nil && *kc.EnableRbac {
+	if kc.EnableRbac != nil && *kc.EnableRbac {
 		return to.BoolPtr(true)
 	}
 	return to.BoolPtr(false)

--- a/pkg/api/converterfromagentpoolonlyapi.go
+++ b/pkg/api/converterfromagentpoolonlyapi.go
@@ -140,15 +140,9 @@ func convertResourcePurchasePlanToV20180331AgentPoolOnly(api *ResourcePurchasePl
 }
 
 func convertKubernetesConfigToEnableRBACV20180331AgentPoolOnly(kc *KubernetesConfig) *bool {
-	if kc == nil {
-		return to.BoolPtr(false)
-	}
 	// We use KubernetesConfig.EnableRbac to convert to versioned api model
 	// The assumption here is KubernetesConfig.EnableSecureKubelet is set to be same
-	if kc.EnableRbac != nil && *kc.EnableRbac {
-		return to.BoolPtr(true)
-	}
-	return to.BoolPtr(false)
+	return to.BoolPtr(kc != nil && kc.EnableRbac != nil && *kc.EnableRbac)
 }
 
 func convertPropertiesToV20180331AgentPoolOnly(api *Properties, p *v20180331.Properties) {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
In master there is some (old) code that fails `govet` with golangci-lint v1.16.0. This removes a redundant nil check to satisfy it. Look at the code just above the diff to see why it's redundant.

```
==> Running static validations and linters <==
pkg/api/converterfromagentpoolonlyapi.go:148:8: nilness: tautological condition: non-nil != nil (govet)
	if kc != nil && kc.EnableRbac != nil && *kc.EnableRbac {
	      ^
Makefile:138: recipe for target 'test-style' failed
make: *** [test-style] Error 1
```


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Unblocks #1088 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I'm not sure how this made it into master without us noticing. The code hasn't been changed, and the linter version changed a while ago...