### PR TITLE
chore: add two missing /var/log files for 18.04 in CIS script

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -25,6 +25,7 @@ assignFilePermissions() {
     waagent.log
     syslog
     unattended-upgrades/unattended-upgrades.log
+    unattended-upgrades/unattended-upgrades-dpkg.log
     azure-vnet-ipam.log
     azure-vnet-telemetry.log
     azure-cnimonitor.log
@@ -32,6 +33,7 @@ assignFilePermissions() {
     kv-driver.log
     blobfuse-driver.log
     blobfuse-flexvol-installer.log
+    landscape/sysinfo.log
     "
     for FILE in ${FILES}; do
         FILEPATH="/var/log/${FILE}"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Adds `/var/log/landscape/sysinfo.log and /var/log/unattended-upgrades/unattended-upgrades-dpkg.log` to `assignFilePermissions`. Fixes E2E with Ubuntu 18.04-LTS distro.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
