### PR TITLE
fix: restores cosmosDB etcd functionality after template generation r…

### DIFF
--- a/pkg/engine/cosmosdb.go
+++ b/pkg/engine/cosmosdb.go
@@ -6,7 +6,7 @@ package engine
 func createCosmosDBAccount() map[string]interface{} {
 	cosmosEtcdMap := map[string]interface{}{
 		"apiVersion": "[variables('apiVersionCosmos')]",
-		"name":       "Microsoft.DocumentDB/databaseAccounts",
+		"name":       "[variables('cosmosAccountName')]",
 		"location":   "[resourceGroup().location]",
 		"kind":       "GlobalDocumentDB",
 		"properties": map[string]interface{}{
@@ -31,16 +31,13 @@ func createCosmosDBAccount() map[string]interface{} {
 					"failoverPriority": 1,
 				},
 			},
+			"name":                             "[variables('cosmosAccountName')]",
+			"primaryClientCertificatePemBytes": "[variables('cosmosDBCertb64')]",
 		},
 		"tags": map[string]string{
 			"defaultExperience": "Etcd",
 		},
-		"consistencyPolicy": map[string]interface{}{
-			"defaultConsistencyLevel": "BoundedStaleness",
-			"maxIntervalInSeconds":    5,
-			"maxStalenessPrefix":      100,
-		},
-		"primaryClientCertificatePemBytes": "[variables('cosmosDBCertb64')]",
+		"type": "Microsoft.DocumentDB/databaseAccounts",
 	}
 	return cosmosEtcdMap
 }

--- a/pkg/engine/cosmosdb_test.go
+++ b/pkg/engine/cosmosdb_test.go
@@ -13,7 +13,7 @@ func TestCreateCosmosDB(t *testing.T) {
 	db := createCosmosDBAccount()
 	expected := map[string]interface{}{
 		"apiVersion": "[variables('apiVersionCosmos')]",
-		"name":       "Microsoft.DocumentDB/databaseAccounts",
+		"name":       "[variables('cosmosAccountName')]",
 		"location":   "[resourceGroup().location]",
 		"kind":       "GlobalDocumentDB",
 		"properties": map[string]interface{}{
@@ -38,16 +38,13 @@ func TestCreateCosmosDB(t *testing.T) {
 					"failoverPriority": 1,
 				},
 			},
+			"name":                             "[variables('cosmosAccountName')]",
+			"primaryClientCertificatePemBytes": "[variables('cosmosDBCertb64')]",
 		},
 		"tags": map[string]string{
 			"defaultExperience": "Etcd",
 		},
-		"consistencyPolicy": map[string]interface{}{
-			"defaultConsistencyLevel": "BoundedStaleness",
-			"maxIntervalInSeconds":    5,
-			"maxStalenessPrefix":      100,
-		},
-		"primaryClientCertificatePemBytes": "[variables('cosmosDBCertb64')]",
+		"type": "Microsoft.DocumentDB/databaseAccounts",
 	}
 
 	if diff := cmp.Diff(expected, db); diff != "" {


### PR DESCRIPTION
…efactor

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Addresses regressions in cosmosdb + etcd scenario from template refactor.

Here is the reference known-working implementation from v0.32.3 (pre-template generation refactor):

https://github.com/Azure/aks-engine/blob/v0.32.3/parts/k8s/kubernetesmasterresources.t#L1

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1119 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
