### PR TITLE
chore: reduce cloud-init var overhead for VHD scenarios

### DIFF
--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -112,21 +112,21 @@ write_files:
     {{CloudInitData "aptPreferences"}}
 
 {{if .MasterProfile.IsUbuntuNonVHD}}
-{{if .MasterProfile.IsUbuntu1604}}
+  {{if .MasterProfile.IsUbuntu1604}}
 - path: /etc/ssh/sshd_config
   permissions: "0600"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "sshdConfig1604"}}
-{{else}}
+  {{else}}
 - path: /etc/ssh/sshd_config
   permissions: "0600"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "sshdConfig"}}
-{{end}}
+  {{end}}
 
 - path: /etc/issue
   permissions: "0644"

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -106,21 +106,21 @@ write_files:
     {{CloudInitData "aptPreferences"}}
 
 {{if .IsUbuntuNonVHD}}
-{{if .IsUbuntu1604}}
+  {{if .IsUbuntu1604}}
 - path: /etc/ssh/sshd_config
   permissions: "0600"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "sshdConfig1604"}}
-{{else}}
+  {{else}}
 - path: /etc/ssh/sshd_config
   permissions: "0600"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "sshdConfig"}}
-{{end}}
+  {{end}}
 
 - path: /etc/issue
   permissions: "0644"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1045,7 +1045,10 @@ func (p *Properties) IsUbuntuDistroForAllNodes() bool {
 			}
 		}
 	}
-	return p.MasterProfile.Distro == Ubuntu || p.MasterProfile.Distro == Ubuntu1804
+	if p.MasterProfile != nil {
+		return p.MasterProfile.Distro == Ubuntu || p.MasterProfile.Distro == Ubuntu1804
+	}
+	return true
 }
 
 // HasAvailabilityZones returns true if the cluster contains a profile with zones

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1051,6 +1051,21 @@ func (p *Properties) IsUbuntuDistroForAllNodes() bool {
 	return true
 }
 
+// HasUbuntuDistroNodes returns true if any of the agent pools or masters are running the base Ubuntu image
+func (p *Properties) HasUbuntuDistroNodes() bool {
+	if len(p.AgentPoolProfiles) > 0 {
+		for _, ap := range p.AgentPoolProfiles {
+			if ap.Distro == Ubuntu || ap.Distro == Ubuntu1804 {
+				return true
+			}
+		}
+	}
+	if p.MasterProfile != nil {
+		return p.MasterProfile.Distro == Ubuntu || p.MasterProfile.Distro == Ubuntu1804
+	}
+	return false
+}
+
 // HasAvailabilityZones returns true if the cluster contains a profile with zones
 func (p *Properties) HasAvailabilityZones() bool {
 	hasZones := p.MasterProfile != nil && p.MasterProfile.HasAvailabilityZones()

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1066,6 +1066,36 @@ func (p *Properties) HasUbuntuDistroNodes() bool {
 	return false
 }
 
+// HasUbuntu1604DistroNodes returns true if any of the agent pools or masters are running the base Ubuntu 16.04-LTS image
+func (p *Properties) HasUbuntu1604DistroNodes() bool {
+	if len(p.AgentPoolProfiles) > 0 {
+		for _, ap := range p.AgentPoolProfiles {
+			if ap.Distro == Ubuntu {
+				return true
+			}
+		}
+	}
+	if p.MasterProfile != nil {
+		return p.MasterProfile.Distro == Ubuntu
+	}
+	return false
+}
+
+// HasUbuntu1804DistroNodes returns true if any of the agent pools or masters are running the base Ubuntu 18.04-LTS image
+func (p *Properties) HasUbuntu1804DistroNodes() bool {
+	if len(p.AgentPoolProfiles) > 0 {
+		for _, ap := range p.AgentPoolProfiles {
+			if ap.Distro == Ubuntu1804 {
+				return true
+			}
+		}
+	}
+	if p.MasterProfile != nil {
+		return p.MasterProfile.Distro == Ubuntu1804
+	}
+	return false
+}
+
 // HasAvailabilityZones returns true if the cluster contains a profile with zones
 func (p *Properties) HasAvailabilityZones() bool {
 	hasZones := p.MasterProfile != nil && p.MasterProfile.HasAvailabilityZones()

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1252,11 +1252,189 @@ func TestHasUbuntuDistroForAllNodes(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, c := range cases {
 		if c.p.IsUbuntuDistroForAllNodes() != c.expected {
 			t.Fatalf("expected IsUbuntuDistroForAllNodes() to return %t but instead returned %t", c.expected, c.p.IsUbuntuDistroForAllNodes())
+		}
+	}
+}
+
+func TestHasUbuntuDistroNodes(t *testing.T) {
+	cases := []struct {
+		p        Properties
+		expected bool
+	}{
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: AKS,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: Ubuntu1804,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: AKS,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: AKS,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		if c.p.HasUbuntuDistroNodes() != c.expected {
+			t.Fatalf("expected HasUbuntuDistroNodes() to return %t but instead returned %t", c.expected, c.p.HasUbuntuDistroNodes())
 		}
 	}
 }

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1439,6 +1439,318 @@ func TestHasUbuntuDistroNodes(t *testing.T) {
 	}
 }
 
+func TestHasUbuntu1604DistroNodes(t *testing.T) {
+	cases := []struct {
+		p        Properties
+		expected bool
+	}{
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: AKS,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: Ubuntu1804,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: AKS,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: AKS,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		if c.p.HasUbuntu1604DistroNodes() != c.expected {
+			t.Fatalf("expected HasUbuntu1604DistroNodes() to return %t but instead returned %t", c.expected, c.p.HasUbuntu1604DistroNodes())
+		}
+	}
+}
+
+func TestHasUbuntu1804DistroNodes(t *testing.T) {
+	cases := []struct {
+		p        Properties
+		expected bool
+	}{
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: AKS,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+					{
+						Count:  1,
+						Distro: Ubuntu1804,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: AKS,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: AKS,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: Ubuntu1804,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						Distro: Ubuntu,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		if c.p.HasUbuntu1804DistroNodes() != c.expected {
+			t.Fatalf("expected HasUbuntu1804DistroNodes() to return %t but instead returned %t", c.expected, c.p.HasUbuntu1804DistroNodes())
+		}
+	}
+}
+
 func TestUbuntuVersion(t *testing.T) {
 	cases := []struct {
 		p                  Properties

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -147,7 +147,7 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		"vnetResourceGroupNameResourceSegmentIndex": 4,
 	}
 
-	if cs.Properties.IsUbuntuDistroForAllNodes() {
+	if cs.Properties.HasUbuntuDistroNodes() {
 		masterVars["cloudInitFiles"] = map[string]interface{}{
 			"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
 			"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -147,6 +147,60 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		"vnetResourceGroupNameResourceSegmentIndex": 4,
 	}
 
+	if cs.Properties.IsUbuntuDistroForAllNodes() {
+		masterVars["cloudInitFiles"] = map[string]interface{}{
+			"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
+			"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
+			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
+			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
+			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
+			"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
+			"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
+			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
+			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
+			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
+			"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
+			"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
+			"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
+			"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
+			"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
+			"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
+			"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
+			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
+			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
+			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
+			"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
+			"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
+			"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
+			"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
+			"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
+			"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
+			"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
+			"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
+		}
+	} else {
+		masterVars["cloudInitFiles"] = map[string]interface{}{
+			"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
+			"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
+			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
+			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
+			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
+			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
+			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
+			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
+			"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
+			"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
+			"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
+			"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
+			"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
+			"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
+			"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
+			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
+			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
+			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
+		}
+	}
+
 	blockOutboundInternet := cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet")
 	var cosmosEndPointURI string
 	if hasCosmosEtcd {

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -109,36 +109,6 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		"routeTableID":           "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]",
 		"sshNatPorts":            []int{22, 2201, 2202, 2203, 2204},
 		"sshKeyPath":             "[concat('/home/',parameters('linuxAdminUsername'),'/.ssh/authorized_keys')]",
-		"cloudInitFiles": map[string]interface{}{
-			"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
-			"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
-			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
-			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
-			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
-			"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
-			"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
-			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
-			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
-			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
-			"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
-			"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
-			"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
-			"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
-			"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
-			"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
-			"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
-			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
-			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
-			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
-			"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
-			"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
-			"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
-			"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
-			"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
-			"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
-			"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
-			"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
-		},
 		"provisionScriptParametersCommon": fmt.Sprintf("[concat('ADMINUSER=',parameters('linuxAdminUsername'),' ETCD_DOWNLOAD_URL=',parameters('etcdDownloadURLBase'),' ETCD_VERSION=',parameters('etcdVersion'),' CONTAINERD_VERSION=',parameters('containerdVersion'),' MOBY_VERSION=',parameters('mobyVersion'),' TENANT_ID=',variables('tenantID'),' KUBERNETES_VERSION=%s HYPERKUBE_URL=',parameters('kubernetesHyperkubeSpec'),' APISERVER_PUBLIC_KEY=',parameters('apiServerCertificate'),' SUBSCRIPTION_ID=',variables('subscriptionId'),' RESOURCE_GROUP=',variables('resourceGroup'),' LOCATION=',variables('location'),' VM_TYPE=',variables('vmType'),' SUBNET=',variables('subnetName'),' NETWORK_SECURITY_GROUP=',variables('nsgName'),' VIRTUAL_NETWORK=',variables('virtualNetworkName'),' VIRTUAL_NETWORK_RESOURCE_GROUP=',variables('virtualNetworkResourceGroupName'),' ROUTE_TABLE=',variables('routeTableName'),' PRIMARY_AVAILABILITY_SET=',variables('primaryAvailabilitySetName'),' PRIMARY_SCALE_SET=',variables('primaryScaleSetName'),' SERVICE_PRINCIPAL_CLIENT_ID=',variables('servicePrincipalClientId'),' SERVICE_PRINCIPAL_CLIENT_SECRET=',variables('singleQuote'),variables('servicePrincipalClientSecret'),variables('singleQuote'),' KUBELET_PRIVATE_KEY=',parameters('clientPrivateKey'),' TARGET_ENVIRONMENT=',parameters('targetEnvironment'),' NETWORK_PLUGIN=',parameters('networkPlugin'),' NETWORK_POLICY=',parameters('networkPolicy'),' VNET_CNI_PLUGINS_URL=',parameters('vnetCniLinuxPluginsURL'),' CNI_PLUGINS_URL=',parameters('cniPluginsURL'),' CLOUDPROVIDER_BACKOFF=',toLower(string(parameters('cloudproviderConfig').cloudProviderBackoff)),' CLOUDPROVIDER_BACKOFF_RETRIES=',parameters('cloudproviderConfig').cloudProviderBackoffRetries,' CLOUDPROVIDER_BACKOFF_EXPONENT=',parameters('cloudproviderConfig').cloudProviderBackoffExponent,' CLOUDPROVIDER_BACKOFF_DURATION=',parameters('cloudproviderConfig').cloudProviderBackoffDuration,' CLOUDPROVIDER_BACKOFF_JITTER=',parameters('cloudproviderConfig').cloudProviderBackoffJitter,' CLOUDPROVIDER_RATELIMIT=',toLower(string(parameters('cloudproviderConfig').cloudProviderRatelimit)),' CLOUDPROVIDER_RATELIMIT_QPS=',parameters('cloudproviderConfig').cloudProviderRatelimitQPS,' CLOUDPROVIDER_RATELIMIT_BUCKET=',parameters('cloudproviderConfig').cloudProviderRatelimitBucket,' USE_MANAGED_IDENTITY_EXTENSION=',variables('useManagedIdentityExtension'),' USER_ASSIGNED_IDENTITY_ID=',variables('userAssignedClientID'),' USE_INSTANCE_METADATA=',variables('useInstanceMetadata'),' LOAD_BALANCER_SKU=',variables('loadBalancerSku'),' EXCLUDE_MASTER_FROM_STANDARD_LB=',variables('excludeMasterFromStandardLB'),' MAXIMUM_LOADBALANCER_RULE_COUNT=',variables('maximumLoadBalancerRuleCount'),' CONTAINER_RUNTIME=',parameters('containerRuntime'),' CONTAINERD_DOWNLOAD_URL_BASE=',parameters('containerdDownloadURLBase'),' POD_INFRA_CONTAINER_SPEC=',parameters('kubernetesPodInfraContainerSpec'),' KMS_PROVIDER_VAULT_NAME=',variables('clusterKeyVaultName'),' IS_HOSTED_MASTER=%t',' PRIVATE_AZURE_REGISTRY_SERVER=',parameters('privateAzureRegistryServer'),' AUTHENTICATION_METHOD=',variables('customCloudAuthenticationMethod'),' IDENTITY_SYSTEM=',variables('customCloudIdentifySystem'))]",
 			kubernetesVersion, isHostedMaster),
 		"orchestratorNameVersionTag":                fmt.Sprintf("%s:%s", orchProfile.OrchestratorType, orchProfile.OrchestratorVersion),
@@ -147,58 +117,42 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		"vnetResourceGroupNameResourceSegmentIndex": 4,
 	}
 
+	masterVars["cloudInitFiles"] = map[string]interface{}{
+		"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
+		"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
+		"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
+		"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
+		"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
+		"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
+		"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
+		"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
+		"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
+		"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
+		"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
+		"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
+		"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
+		"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
+		"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
+		"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
+		"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
+		"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
+	}
+
 	if cs.Properties.HasUbuntuDistroNodes() {
-		masterVars["cloudInitFiles"] = map[string]interface{}{
-			"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
-			"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
-			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
-			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
-			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
-			"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
-			"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
-			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
-			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
-			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
-			"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
-			"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
-			"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
-			"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
-			"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
-			"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
-			"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
-			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
-			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
-			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
-			"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
-			"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
-			"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
-			"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
-			"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
-			"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
-			"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
-			"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
-		}
-	} else {
-		masterVars["cloudInitFiles"] = map[string]interface{}{
-			"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
-			"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
-			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
-			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
-			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
-			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
-			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
-			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
-			"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
-			"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
-			"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
-			"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
-			"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
-			"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
-			"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
-			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
-			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
-			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
-		}
+		masterVars["cloudInitFiles"].(map[string]interface{})["etcIssue"] = getBase64EncodedGzippedCustomScript(etcIssue)
+		masterVars["cloudInitFiles"].(map[string]interface{})["etcIssueNet"] = getBase64EncodedGzippedCustomScript(etcIssueNet)
+		masterVars["cloudInitFiles"].(map[string]interface{})["cisNetEnforcement"] = getBase64EncodedGzippedCustomScript(cisNetEnforcement)
+		masterVars["cloudInitFiles"].(map[string]interface{})["cisLogEnforcement"] = getBase64EncodedGzippedCustomScript(cisLogEnforcement)
+		masterVars["cloudInitFiles"].(map[string]interface{})["modprobeConfCIS"] = getBase64EncodedGzippedCustomScript(modprobeConfCIS)
+		masterVars["cloudInitFiles"].(map[string]interface{})["pwQuality"] = getBase64EncodedGzippedCustomScript(pwQuality)
+		masterVars["cloudInitFiles"].(map[string]interface{})["defaultGrub"] = getBase64EncodedGzippedCustomScript(defaultGrub)
+		masterVars["cloudInitFiles"].(map[string]interface{})["pamDotDSU"] = getBase64EncodedGzippedCustomScript(pamDotDSU)
+	}
+	if cs.Properties.HasUbuntu1604DistroNodes() {
+		masterVars["cloudInitFiles"].(map[string]interface{})["sshdConfig1604"] = getBase64EncodedGzippedCustomScript(sshdConfig1604)
+	}
+	if cs.Properties.HasUbuntu1804DistroNodes() {
+		masterVars["cloudInitFiles"].(map[string]interface{})["sshdConfig"] = getBase64EncodedGzippedCustomScript(sshdConfig)
 	}
 
 	blockOutboundInternet := cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet")

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -186,8 +186,51 @@ func TestK8sVars(t *testing.T) {
 		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
 	}
 
-	// Test with ubuntu distro
-	cs.Properties.AgentPoolProfiles[0].Distro = "ubuntu"
+	// Test with ubuntu 16.04 distro
+	cs.Properties.AgentPoolProfiles[0].Distro = api.Ubuntu
+	varMap, err = GetKubernetesVariables(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedMap["cloudInitFiles"] = map[string]interface{}{
+		"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
+		"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
+		"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
+		"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
+		"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
+		"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
+		"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
+		"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
+		"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
+		"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
+		"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
+		"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
+		"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
+		"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
+		"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
+		"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
+		"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
+		"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
+		"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
+		"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
+		"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
+		"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
+		"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
+		"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
+		"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
+		"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
+		"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
+	}
+
+	diff = cmp.Diff(varMap, expectedMap)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
+
+	// Test with ubuntu 18.04 distro
+	cs.Properties.AgentPoolProfiles[0].Distro = api.Ubuntu1804
 	varMap, err = GetKubernetesVariables(cs)
 	if err != nil {
 		t.Fatal(err)
@@ -200,7 +243,6 @@ func TestK8sVars(t *testing.T) {
 		"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
 		"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
 		"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
-		"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
 		"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
 		"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
 		"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -187,7 +187,6 @@ func TestK8sVars(t *testing.T) {
 	}
 
 	// Test with ubuntu distro
-	cs.Properties.MasterProfile.Distro = "ubuntu"
 	cs.Properties.AgentPoolProfiles[0].Distro = "ubuntu"
 	varMap, err = GetKubernetesVariables(cs)
 	if err != nil {

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -131,8 +131,6 @@ func TestK8sVars(t *testing.T) {
 			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
 			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
 			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
-			"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
-			"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
 			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
 			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
 			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
@@ -146,14 +144,6 @@ func TestK8sVars(t *testing.T) {
 			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
 			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
 			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
-			"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
-			"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
-			"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
-			"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
-			"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
-			"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
-			"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
-			"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
 		},
 		"provisionScriptParametersCommon":           fmt.Sprintf("[concat('ADMINUSER=',parameters('linuxAdminUsername'),' ETCD_DOWNLOAD_URL=',parameters('etcdDownloadURLBase'),' ETCD_VERSION=',parameters('etcdVersion'),' CONTAINERD_VERSION=',parameters('containerdVersion'),' MOBY_VERSION=',parameters('mobyVersion'),' TENANT_ID=',variables('tenantID'),' KUBERNETES_VERSION=%s HYPERKUBE_URL=',parameters('kubernetesHyperkubeSpec'),' APISERVER_PUBLIC_KEY=',parameters('apiServerCertificate'),' SUBSCRIPTION_ID=',variables('subscriptionId'),' RESOURCE_GROUP=',variables('resourceGroup'),' LOCATION=',variables('location'),' VM_TYPE=',variables('vmType'),' SUBNET=',variables('subnetName'),' NETWORK_SECURITY_GROUP=',variables('nsgName'),' VIRTUAL_NETWORK=',variables('virtualNetworkName'),' VIRTUAL_NETWORK_RESOURCE_GROUP=',variables('virtualNetworkResourceGroupName'),' ROUTE_TABLE=',variables('routeTableName'),' PRIMARY_AVAILABILITY_SET=',variables('primaryAvailabilitySetName'),' PRIMARY_SCALE_SET=',variables('primaryScaleSetName'),' SERVICE_PRINCIPAL_CLIENT_ID=',variables('servicePrincipalClientId'),' SERVICE_PRINCIPAL_CLIENT_SECRET=',variables('singleQuote'),variables('servicePrincipalClientSecret'),variables('singleQuote'),' KUBELET_PRIVATE_KEY=',parameters('clientPrivateKey'),' TARGET_ENVIRONMENT=',parameters('targetEnvironment'),' NETWORK_PLUGIN=',parameters('networkPlugin'),' NETWORK_POLICY=',parameters('networkPolicy'),' VNET_CNI_PLUGINS_URL=',parameters('vnetCniLinuxPluginsURL'),' CNI_PLUGINS_URL=',parameters('cniPluginsURL'),' CLOUDPROVIDER_BACKOFF=',toLower(string(parameters('cloudproviderConfig').cloudProviderBackoff)),' CLOUDPROVIDER_BACKOFF_RETRIES=',parameters('cloudproviderConfig').cloudProviderBackoffRetries,' CLOUDPROVIDER_BACKOFF_EXPONENT=',parameters('cloudproviderConfig').cloudProviderBackoffExponent,' CLOUDPROVIDER_BACKOFF_DURATION=',parameters('cloudproviderConfig').cloudProviderBackoffDuration,' CLOUDPROVIDER_BACKOFF_JITTER=',parameters('cloudproviderConfig').cloudProviderBackoffJitter,' CLOUDPROVIDER_RATELIMIT=',toLower(string(parameters('cloudproviderConfig').cloudProviderRatelimit)),' CLOUDPROVIDER_RATELIMIT_QPS=',parameters('cloudproviderConfig').cloudProviderRatelimitQPS,' CLOUDPROVIDER_RATELIMIT_BUCKET=',parameters('cloudproviderConfig').cloudProviderRatelimitBucket,' USE_MANAGED_IDENTITY_EXTENSION=',variables('useManagedIdentityExtension'),' USER_ASSIGNED_IDENTITY_ID=',variables('userAssignedClientID'),' USE_INSTANCE_METADATA=',variables('useInstanceMetadata'),' LOAD_BALANCER_SKU=',variables('loadBalancerSku'),' EXCLUDE_MASTER_FROM_STANDARD_LB=',variables('excludeMasterFromStandardLB'),' MAXIMUM_LOADBALANCER_RULE_COUNT=',variables('maximumLoadBalancerRuleCount'),' CONTAINER_RUNTIME=',parameters('containerRuntime'),' CONTAINERD_DOWNLOAD_URL_BASE=',parameters('containerdDownloadURLBase'),' POD_INFRA_CONTAINER_SPEC=',parameters('kubernetesPodInfraContainerSpec'),' KMS_PROVIDER_VAULT_NAME=',variables('clusterKeyVaultName'),' IS_HOSTED_MASTER=false',' PRIVATE_AZURE_REGISTRY_SERVER=',parameters('privateAzureRegistryServer'),' AUTHENTICATION_METHOD=',variables('customCloudAuthenticationMethod'),' IDENTITY_SYSTEM=',variables('customCloudIdentifySystem'))]", testK8sVersion),
 		"provisionScriptParametersMaster":           "[concat('COSMOS_URI= MASTER_VM_NAME=',variables('masterVMNames')[variables('masterOffset')],' ETCD_PEER_URL=',variables('masterEtcdPeerURLs')[variables('masterOffset')],' ETCD_CLIENT_URL=',variables('masterEtcdClientURLs')[variables('masterOffset')],' MASTER_NODE=true NO_OUTBOUND=false CLUSTER_AUTOSCALER_ADDON=',parameters('kubernetesClusterAutoscalerEnabled'),' ACI_CONNECTOR_ADDON=',parameters('kubernetesACIConnectorEnabled'),' APISERVER_PRIVATE_KEY=',parameters('apiServerPrivateKey'),' CA_CERTIFICATE=',parameters('caCertificate'),' CA_PRIVATE_KEY=',parameters('caPrivateKey'),' MASTER_FQDN=',variables('masterFqdnPrefix'),' KUBECONFIG_CERTIFICATE=',parameters('kubeConfigCertificate'),' KUBECONFIG_KEY=',parameters('kubeConfigPrivateKey'),' ETCD_SERVER_CERTIFICATE=',parameters('etcdServerCertificate'),' ETCD_CLIENT_CERTIFICATE=',parameters('etcdClientCertificate'),' ETCD_SERVER_PRIVATE_KEY=',parameters('etcdServerPrivateKey'),' ETCD_CLIENT_PRIVATE_KEY=',parameters('etcdClientPrivateKey'),' ETCD_PEER_CERTIFICATES=',string(variables('etcdPeerCertificates')),' ETCD_PEER_PRIVATE_KEYS=',string(variables('etcdPeerPrivateKeys')),' ENABLE_AGGREGATED_APIS=',string(parameters('enableAggregatedAPIs')),' KUBECONFIG_SERVER=',variables('kubeconfigServer'))]",
@@ -189,7 +179,53 @@ func TestK8sVars(t *testing.T) {
 		"customCloudAuthenticationMethod":           cs.Properties.GetCustomCloudAuthenticationMethod(),
 		"customCloudIdentifySystem":                 cs.Properties.GetCustomCloudIdentitySystem(),
 	}
+
 	diff := cmp.Diff(varMap, expectedMap)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
+
+	// Test with ubuntu distro
+	cs.Properties.MasterProfile.Distro = "ubuntu"
+	cs.Properties.AgentPoolProfiles[0].Distro = "ubuntu"
+	varMap, err = GetKubernetesVariables(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedMap["cloudInitFiles"] = map[string]interface{}{
+		"provisionScript":                  getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript),
+		"provisionSource":                  getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript),
+		"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
+		"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
+		"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
+		"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
+		"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
+		"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
+		"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
+		"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
+		"mountEtcdScript":                  getBase64EncodedGzippedCustomScript(kubernetesMountEtcd),
+		"kubeletSystemdService":            getBase64EncodedGzippedCustomScript(kubeletSystemdService),
+		"kmsSystemdService":                getBase64EncodedGzippedCustomScript(kmsSystemdService),
+		"kubeletMonitorSystemdTimer":       getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdTimer),
+		"kubeletMonitorSystemdService":     getBase64EncodedGzippedCustomScript(kubernetesKubeletMonitorSystemdService),
+		"dockerMonitorSystemdTimer":        getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer),
+		"dockerMonitorSystemdService":      getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdService),
+		"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
+		"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
+		"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
+		"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
+		"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
+		"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
+		"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
+		"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
+		"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
+		"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
+		"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
+	}
+
+	diff = cmp.Diff(varMap, expectedMap)
 
 	if diff != "" {
 		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
@@ -515,8 +551,6 @@ func TestK8sVars(t *testing.T) {
 			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
 			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
 			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
-			"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
-			"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
 			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
 			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
 			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
@@ -530,14 +564,6 @@ func TestK8sVars(t *testing.T) {
 			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
 			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
 			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
-			"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
-			"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
-			"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
-			"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
-			"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
-			"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
-			"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
-			"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
 		},
 		"masterPublicLbFQDN":                        "blueorange.local.cloudapp.azurestack.external",
 		"provisionConfigsCustomCloud":               "H4sIAAAAAAAA/7RX7XLaSBb9z1PcyGzZrlgI72ZdKe+SlCKUCRMbXJKcVCak5Lb6CjoW3Up3yx9j8+5TLRBgwIakZvhhG3E559zT96O988K5ZNy5JGpYqyFXhUQPpWYpS4hGtbcP9zUAAPeP88API9f7GPvdT52g1z31u1H8e9jrxmdu9KFlOagT56q4RMlRo3LIn4VEpUlylWSioI3vSnBrGSvww9554Pnxqdt1f/OD2O+2z3qdbtS6SIiG+iZaeIDvP6AhUYlCJnhKOBmg9DnNBeMaHkBLsClYfcu6eJrbj9y2G7lzcqu+jUZnhJpQoomDU0L1luTMvkapmOCtfzcP/2s3D+3m4STvpJAZrEdeVlDGe+fBSRz40XnQ9Xptv1V/Wz7+eP7Oj71eNwp6Jyd+MJP1vnPit5ZPYUQ4S1FpVT60E8G1FFmG0h5NvGrckVFW4rIUvkJ9iRRetKAJ3/4Heoi8DDOvHQgwz0iCUP4cioyihFRIUCqDS8Yp44NZdAlsp1B/TvkKh3kppGAzsNTD/69FVoxQqezNgw2cjPDYcPX5JHAolD4jenhcPQDIzVvo940j/b5jgvtOglKrh4G1QcvzIk5FwfUjJZZSmTWnBhiZkLMnFSyGSiS0x7O7Y9CywI3aZtJSVls4D0/kd4wPjIXgms4LTeeBFEJDMm9o0KIMIXkuRS6ZeaS0kOUHlwhFTolG2pghL1ZrrxfFnh9Enfcdz438eFq80/a/JtLJ2KVzQ8gAuXYWx0gjx5G1FWbc9sOogiyUdDKRkMxRQyLRSYi9kIsZMWqBpZFIPSdJ8set9oz45wPnimbYE5fsJTnlx5gp/BsKf2dykMEpVKMNpv0K1ayp2uzR8TJlqkhppAcgcSSusQTapksXS91ZaDeHbluR6xBmvbI9TMpqC79qEztWVxPcsCwzNStRS4bUuG1yxVumIRG0NIMLDc1fGr4lTP1tbVyrJYKnbFBI/PhaeYXSYuSZjTbbjXibC6nNQa+qrE1aXMu7ZERjlsYpYVkhEY6acNiE/zTBrF6wk6e+q1DDy9upC5+HyME9jz743chUZ6fXNfI/9Nom2SRjyHW8UA8HpSNLBVL2OwXGtYArvINrkhX6oDLa5RRCP/jUMc0RdLpe58w9ib2Tjtm7oe8FfjRz3oCnIsvEjalDs+AhJ3eZIBRumB6a1JAevQLk5jwmBPdTHgCwzO60jsGq5+mtq94RhUev/DKWhloyPrAOlqKjuxwtOLby9PbRZzlR6kZIOkGr3kwCxrPt9hWs+v1a+w4Oxha0WmCtemgBfFtu0Q0GxW3f7M526wKToYD6/Yb4MTyUXh29AtumaAy42JrLzKqKaEtd01uTMXR7njM3DD/3gvavcVVnMudbWF5aslFZTEoTqU0tEU7NoDN/Wj/nxEazy7AdcyMcwz8B/a8p9M8buxm/Cv1Z+b9AMUljnoUZ3UHXj/ywnNZxuxO06nuUSXMDKvvKjNb5zXxs7c+/+zqsWIxD0/Vev1+DOXauXquYFHq42IMN0+8zuO3qzzCt9hW8gfo6OY/By38+1uUED9B/tO++/wDbJnKwNkeo3697PIbdBryEe0KoV44bM/TLy+LeWm37492nebc9z81TaBb6hL5JAx/vbXS+wil1r8jepZjtNWbYISYS9f7uhTmZFcOrm8DjEd5pmwEefYnDL2Hkn86GN6GpWjeud6Y3tnLGaOTINTBa3oTc9vsQkF8zKfgIuW5sXwgml4ZGTrjuUKjod+H5TKqdbt/WxrW/AgAA///LSOTXfg8AAA==",
@@ -680,8 +706,6 @@ func TestK8sVarsMastersOnly(t *testing.T) {
 			"provisionInstalls":                getBase64EncodedGzippedCustomScript(kubernetesCSEInstall),
 			"provisionConfigs":                 getBase64EncodedGzippedCustomScript(kubernetesCSEConfig),
 			"provisionCIS":                     getBase64EncodedGzippedCustomScript(kubernetesCISScript),
-			"sshdConfig":                       getBase64EncodedGzippedCustomScript(sshdConfig),
-			"sshdConfig1604":                   getBase64EncodedGzippedCustomScript(sshdConfig1604),
 			"healthMonitorScript":              getBase64EncodedGzippedCustomScript(kubernetesHealthMonitorScript),
 			"customSearchDomainsScript":        getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript),
 			"generateProxyCertsScript":         getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript),
@@ -695,14 +719,6 @@ func TestK8sVarsMastersOnly(t *testing.T) {
 			"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
 			"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
 			"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
-			"etcIssue":                         getBase64EncodedGzippedCustomScript(etcIssue),
-			"etcIssueNet":                      getBase64EncodedGzippedCustomScript(etcIssueNet),
-			"cisNetEnforcement":                getBase64EncodedGzippedCustomScript(cisNetEnforcement),
-			"cisLogEnforcement":                getBase64EncodedGzippedCustomScript(cisLogEnforcement),
-			"modprobeConfCIS":                  getBase64EncodedGzippedCustomScript(modprobeConfCIS),
-			"pwQuality":                        getBase64EncodedGzippedCustomScript(pwQuality),
-			"defaultGrub":                      getBase64EncodedGzippedCustomScript(defaultGrub),
-			"pamDotDSU":                        getBase64EncodedGzippedCustomScript(pamDotDSU),
 		},
 		"provisionScriptParametersCommon":           fmt.Sprintf("[concat('ADMINUSER=',parameters('linuxAdminUsername'),' ETCD_DOWNLOAD_URL=',parameters('etcdDownloadURLBase'),' ETCD_VERSION=',parameters('etcdVersion'),' CONTAINERD_VERSION=',parameters('containerdVersion'),' MOBY_VERSION=',parameters('mobyVersion'),' TENANT_ID=',variables('tenantID'),' KUBERNETES_VERSION=%s HYPERKUBE_URL=',parameters('kubernetesHyperkubeSpec'),' APISERVER_PUBLIC_KEY=',parameters('apiServerCertificate'),' SUBSCRIPTION_ID=',variables('subscriptionId'),' RESOURCE_GROUP=',variables('resourceGroup'),' LOCATION=',variables('location'),' VM_TYPE=',variables('vmType'),' SUBNET=',variables('subnetName'),' NETWORK_SECURITY_GROUP=',variables('nsgName'),' VIRTUAL_NETWORK=',variables('virtualNetworkName'),' VIRTUAL_NETWORK_RESOURCE_GROUP=',variables('virtualNetworkResourceGroupName'),' ROUTE_TABLE=',variables('routeTableName'),' PRIMARY_AVAILABILITY_SET=',variables('primaryAvailabilitySetName'),' PRIMARY_SCALE_SET=',variables('primaryScaleSetName'),' SERVICE_PRINCIPAL_CLIENT_ID=',variables('servicePrincipalClientId'),' SERVICE_PRINCIPAL_CLIENT_SECRET=',variables('singleQuote'),variables('servicePrincipalClientSecret'),variables('singleQuote'),' KUBELET_PRIVATE_KEY=',parameters('clientPrivateKey'),' TARGET_ENVIRONMENT=',parameters('targetEnvironment'),' NETWORK_PLUGIN=',parameters('networkPlugin'),' NETWORK_POLICY=',parameters('networkPolicy'),' VNET_CNI_PLUGINS_URL=',parameters('vnetCniLinuxPluginsURL'),' CNI_PLUGINS_URL=',parameters('cniPluginsURL'),' CLOUDPROVIDER_BACKOFF=',toLower(string(parameters('cloudproviderConfig').cloudProviderBackoff)),' CLOUDPROVIDER_BACKOFF_RETRIES=',parameters('cloudproviderConfig').cloudProviderBackoffRetries,' CLOUDPROVIDER_BACKOFF_EXPONENT=',parameters('cloudproviderConfig').cloudProviderBackoffExponent,' CLOUDPROVIDER_BACKOFF_DURATION=',parameters('cloudproviderConfig').cloudProviderBackoffDuration,' CLOUDPROVIDER_BACKOFF_JITTER=',parameters('cloudproviderConfig').cloudProviderBackoffJitter,' CLOUDPROVIDER_RATELIMIT=',toLower(string(parameters('cloudproviderConfig').cloudProviderRatelimit)),' CLOUDPROVIDER_RATELIMIT_QPS=',parameters('cloudproviderConfig').cloudProviderRatelimitQPS,' CLOUDPROVIDER_RATELIMIT_BUCKET=',parameters('cloudproviderConfig').cloudProviderRatelimitBucket,' USE_MANAGED_IDENTITY_EXTENSION=',variables('useManagedIdentityExtension'),' USER_ASSIGNED_IDENTITY_ID=',variables('userAssignedClientID'),' USE_INSTANCE_METADATA=',variables('useInstanceMetadata'),' LOAD_BALANCER_SKU=',variables('loadBalancerSku'),' EXCLUDE_MASTER_FROM_STANDARD_LB=',variables('excludeMasterFromStandardLB'),' MAXIMUM_LOADBALANCER_RULE_COUNT=',variables('maximumLoadBalancerRuleCount'),' CONTAINER_RUNTIME=',parameters('containerRuntime'),' CONTAINERD_DOWNLOAD_URL_BASE=',parameters('containerdDownloadURLBase'),' POD_INFRA_CONTAINER_SPEC=',parameters('kubernetesPodInfraContainerSpec'),' KMS_PROVIDER_VAULT_NAME=',variables('clusterKeyVaultName'),' IS_HOSTED_MASTER=false',' PRIVATE_AZURE_REGISTRY_SERVER=',parameters('privateAzureRegistryServer'),' AUTHENTICATION_METHOD=',variables('customCloudAuthenticationMethod'),' IDENTITY_SYSTEM=',variables('customCloudIdentifySystem'))]", testK8sVersion),
 		"provisionScriptParametersMaster":           "[concat('COSMOS_URI= MASTER_VM_NAME=',variables('masterVMNames')[variables('masterOffset')],' ETCD_PEER_URL=',variables('masterEtcdPeerURLs')[variables('masterOffset')],' ETCD_CLIENT_URL=',variables('masterEtcdClientURLs')[variables('masterOffset')],' MASTER_NODE=true NO_OUTBOUND=false CLUSTER_AUTOSCALER_ADDON=',parameters('kubernetesClusterAutoscalerEnabled'),' ACI_CONNECTOR_ADDON=',parameters('kubernetesACIConnectorEnabled'),' APISERVER_PRIVATE_KEY=',parameters('apiServerPrivateKey'),' CA_CERTIFICATE=',parameters('caCertificate'),' CA_PRIVATE_KEY=',parameters('caPrivateKey'),' MASTER_FQDN=',variables('masterFqdnPrefix'),' KUBECONFIG_CERTIFICATE=',parameters('kubeConfigCertificate'),' KUBECONFIG_KEY=',parameters('kubeConfigPrivateKey'),' ETCD_SERVER_CERTIFICATE=',parameters('etcdServerCertificate'),' ETCD_CLIENT_CERTIFICATE=',parameters('etcdClientCertificate'),' ETCD_SERVER_PRIVATE_KEY=',parameters('etcdServerPrivateKey'),' ETCD_CLIENT_PRIVATE_KEY=',parameters('etcdClientPrivateKey'),' ETCD_PEER_CERTIFICATES=',string(variables('etcdPeerCertificates')),' ETCD_PEER_PRIVATE_KEYS=',string(variables('etcdPeerPrivateKeys')),' ENABLE_AGGREGATED_APIS=',string(parameters('enableAggregatedAPIs')),' KUBECONFIG_SERVER=',variables('kubeconfigServer'))]",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR reduces the ARM template overhead in non-ubuntu distro (i.e., VHD) scenarios. The vars that we deliver to populate cloud-init are only needed when cloud-init will actually consume them.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
