### PR TITLE
feat: pre-pull Pause from Azure Stack's docker repo

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -180,7 +180,7 @@ PAUSE_VERSIONS="3.1"
 for PAUSE_VERSION in ${PAUSE_VERSIONS}; do
     # Image 'msazurestackdocker/pause-amd64' is the same as 'k8s.gcr.io/pause-amd64'
     # At the time, re-tagging and pushing to docker hub seemed simpler than changing how `defaults-kubelet.go` sets `--pod-infra-container-image`
-    for IMAGE_BASE in "k8s.gcr.io msazurestackdocker"; do
+    for IMAGE_BASE in k8s.gcr.io msazurestackdocker; do
       CONTAINER_IMAGE="${IMAGE_BASE}/pause-amd64:${PAUSE_VERSION}"
       pullContainerImage "docker" ${CONTAINER_IMAGE}
       echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -178,14 +178,13 @@ done
 
 PAUSE_VERSIONS="3.1"
 for PAUSE_VERSION in ${PAUSE_VERSIONS}; do
-    CONTAINER_IMAGE="k8s.gcr.io/pause-amd64:${PAUSE_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
-    echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
     # Image 'msazurestackdocker/pause-amd64' is the same as 'k8s.gcr.io/pause-amd64'
-    # Re-tagging seemed simpler than changing how `defaults-kubelet.go` sets `--pod-infra-container-image`
-    CONTAINER_IMAGE="msazurestackdocker/pause-amd64:${PAUSE_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
-    echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
+    # At the time, re-tagging and pushing to docker hub seemed simpler than changing how `defaults-kubelet.go` sets `--pod-infra-container-image`
+    for IMAGE_BASE in "k8s.gcr.io msazurestackdocker"; do
+      CONTAINER_IMAGE="${IMAGE_BASE}/pause-amd64:${PAUSE_VERSION}"
+      pullContainerImage "docker" ${CONTAINER_IMAGE}
+      echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
+    done
 done
 
 TILLER_VERSIONS="

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -181,6 +181,11 @@ for PAUSE_VERSION in ${PAUSE_VERSIONS}; do
     CONTAINER_IMAGE="k8s.gcr.io/pause-amd64:${PAUSE_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
+    # Image 'msazurestackdocker/pause-amd64' is the same as 'k8s.gcr.io/pause-amd64'
+    # Re-tagging seemed simpler than changing how `defaults-kubelet.go` sets `--pod-infra-container-image`
+    CONTAINER_IMAGE="msazurestackdocker/pause-amd64:${PAUSE_VERSION}"
+    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done
 
 TILLER_VERSIONS="


### PR DESCRIPTION
**Reason for Change**:
AKSe assumes that both `hyperkube` and `pause` share the same repository prefix.
In the past, the Azure Stack team re-tagged the official pause image and re-pushed to docker hub to satisfy this requirement.
For disconnected instances, we need to pre-pull or re-tag during the VHD provisioning process.

**Issue Fixed**:
Fixes #990

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version