### PR TITLE
style: comment out unused constant

### DIFF
--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -142,17 +142,17 @@ const (
 
 // cloud-init (i.e. ARM customData) file references
 const (
-	kubernetesMasterNodeCustomDataYaml       = "k8s/cloud-init/masternodecustomdata.yml"
-	kubernetesNodeCustomDataYaml             = "k8s/cloud-init/nodecustomdata.yml"
-	kubernetesJumpboxCustomDataYaml          = "k8s/cloud-init/jumpboxcustomdata.yml"
-	kubernetesCSEMainScript                  = "k8s/cloud-init/artifacts/cse_main.sh"
-	kubernetesCSEHelpersScript               = "k8s/cloud-init/artifacts/cse_helpers.sh"
-	kubernetesCSEInstall                     = "k8s/cloud-init/artifacts/cse_install.sh"
-	kubernetesCSEConfig                      = "k8s/cloud-init/artifacts/cse_config.sh"
-	kubernetesCISScript                      = "k8s/cloud-init/artifacts/cis.sh"
-	kubernetesCSECustomCloud                 = "k8s/cloud-init/artifacts/cse_customcloud.sh"
-	kubernetesHealthMonitorScript            = "k8s/cloud-init/artifacts/health-monitor.sh"
-	kubernetesKubeletMonitorSystemdTimer     = "k8s/cloud-init/artifacts/kubelet-monitor.timer" // TODO enable
+	kubernetesMasterNodeCustomDataYaml = "k8s/cloud-init/masternodecustomdata.yml"
+	kubernetesNodeCustomDataYaml       = "k8s/cloud-init/nodecustomdata.yml"
+	kubernetesJumpboxCustomDataYaml    = "k8s/cloud-init/jumpboxcustomdata.yml"
+	kubernetesCSEMainScript            = "k8s/cloud-init/artifacts/cse_main.sh"
+	kubernetesCSEHelpersScript         = "k8s/cloud-init/artifacts/cse_helpers.sh"
+	kubernetesCSEInstall               = "k8s/cloud-init/artifacts/cse_install.sh"
+	kubernetesCSEConfig                = "k8s/cloud-init/artifacts/cse_config.sh"
+	kubernetesCISScript                = "k8s/cloud-init/artifacts/cis.sh"
+	kubernetesCSECustomCloud           = "k8s/cloud-init/artifacts/cse_customcloud.sh"
+	kubernetesHealthMonitorScript      = "k8s/cloud-init/artifacts/health-monitor.sh"
+	// kubernetesKubeletMonitorSystemdTimer     = "k8s/cloud-init/artifacts/kubelet-monitor.timer" // TODO enable
 	kubernetesKubeletMonitorSystemdService   = "k8s/cloud-init/artifacts/kubelet-monitor.service"
 	kubernetesDockerMonitorSystemdTimer      = "k8s/cloud-init/artifacts/docker-monitor.timer"
 	kubernetesDockerMonitorSystemdService    = "k8s/cloud-init/artifacts/docker-monitor.service"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
I'm seeing a linter error in master with the correct version of golangci-lint:

```shell
$ make test-style
==> Running shell script validator <==

==> Running static validations and linters <==
pkg/engine/const.go:155:2: U1000: const `kubernetesKubeletMonitorSystemdTimer` is unused (unused)
	kubernetesKubeletMonitorSystemdTimer     = "k8s/cloud-init/artifacts/kubelet-monitor.timer" // TODO enable
	^
make: *** [test-style] Error 1
```


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
