### PR TITLE
ci: return error if Go linter can't compile source code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ run:
   skip-files:
     - pkg/i18n/i18n.go
     - pkg/i18n/translations.go
-    - exclude pkg/engine/templates.go
 
 linters:
   disable-all: true

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -52,7 +52,7 @@ jobs:
   - script: make validate-dependencies
     displayName: Check if imports, Gopkg.toml, and Gopkg.lock are in sync
     workingDirectory: $(modulePath)
-  - script: make validate-copyright-headers test-style
+  - script: make validate-copyright-headers generate test-style
     displayName: Run linting rules
     workingDirectory: $(modulePath)
   - script: make build-cross

--- a/pkg/engine/loadbalancers.go
+++ b/pkg/engine/loadbalancers.go
@@ -259,26 +259,3 @@ func CreateMasterInternalLoadBalancer(cs *api.ContainerService) LoadBalancerARM 
 
 	return loadBalancerARM
 }
-
-func getUDPLoadBalancingRule() network.LoadBalancingRule {
-	return network.LoadBalancingRule{
-		Name: to.StringPtr("LBRuleUDP"),
-		LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-			FrontendIPConfiguration: &network.SubResource{
-				ID: to.StringPtr("[variables('masterLbIPConfigID')]"),
-			},
-			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
-			},
-			Protocol:             network.TransportProtocolUDP,
-			FrontendPort:         to.Int32Ptr(1123),
-			BackendPort:          to.Int32Ptr(1123),
-			EnableFloatingIP:     to.BoolPtr(false),
-			IdleTimeoutInMinutes: to.Int32Ptr(5),
-			LoadDistribution:     network.Default,
-			Probe: &network.SubResource{
-				ID: to.StringPtr("[concat(variables('masterLbID'),'/probes/tcpHTTPSProbe')]"),
-			},
-		},
-	}
-}

--- a/scripts/validate-go.sh
+++ b/scripts/validate-go.sh
@@ -15,8 +15,6 @@
 # limitations under the License.
 set -euo pipefail
 
-exit_code=0
-
 echo
 echo "==> Running Go linter <=="
 golangci-lint --version
@@ -24,7 +22,10 @@ if [ -f /.dockerenv ]; then
     echo "Running inside container";
 fi
 
-# Run linters that should return errors
-golangci-lint run || exit_code=1
-
-exit $exit_code
+# exit 1 if golangci-lint output contains error text, to work
+# around https://github.com/golangci/golangci-lint/issues/276
+exec 5>&1
+OUTPUT=$(golangci-lint run 2>&1 | tee >(cat - >&5))
+if [ $? != 0 ] || grep 'skipped due to error' <<< $OUTPUT; then
+  exit 1
+fi

--- a/scripts/validate-go.sh
+++ b/scripts/validate-go.sh
@@ -18,7 +18,12 @@ set -euo pipefail
 exit_code=0
 
 echo
-echo "==> Running static validations and linters <=="
+echo "==> Running Go linter <=="
+golangci-lint --version
+if [ -f /.dockerenv ]; then
+    echo "Running inside container";
+fi
+
 # Run linters that should return errors
 golangci-lint run || exit_code=1
 

--- a/scripts/validate-shell.sh
+++ b/scripts/validate-shell.sh
@@ -5,7 +5,11 @@
 
 set -euo pipefail
 
-echo "==> Running shell script validator <=="
+echo "==> Running shell linter <=="
+shellcheck --version
+if [ -f /.dockerenv ]; then
+    echo "Running inside container";
+fi
 
 # All shell scripts, except those that support deprecated orchestrators or are in vendored code.
 files=$(find . -type f -name "*.sh" -not -path './vendor/*' -not -path "*dcos*" -not -path "*swarm*")


### PR DESCRIPTION
**Reason for Change**:
The `golangci-lint` tool [doesn't return an error](https://github.com/golangci/golangci-lint/issues/276) if it can't do its job because the Go source code won't compile. This fixes that by returning an error if the command output includes `skipped due to error`. Hopefully this closes the loophole that has allowed a couple of linter errors to make it into master.

This also removes some dead Go code that was causing `govet` to complain, and adds the output of the `--version` command to the script for both the Go and shell linters to help users reproduce any failures.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
