### PR TITLE
fix: add UDP Standard LB rule to enable outbound access

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-elb-svc.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-elb-svc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,24 @@ spec:
   ports:
   - port: 8765
     targetPort: 9376
+    protocol: TCP
+  selector:
+    app: "<svcName>"
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: elb-udp
+  namespace: kube-system
+spec:
+  ports:
+  - port: 8765
+    targetPort: 9376
+    protocol: UDP
   selector:
     app: "<svcName>"
   type: LoadBalancer

--- a/pkg/engine/loadbalancers.go
+++ b/pkg/engine/loadbalancers.go
@@ -91,7 +91,7 @@ func CreateLoadBalancer(prop *api.Properties, isVMSS bool) LoadBalancerARM {
 					ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
 				},
 				Protocol:             network.TransportProtocolUDP,
-				FrontendPort:         to.Int32Ptr(123),
+				FrontendPort:         to.Int32Ptr(1123),
 				BackendPort:          to.Int32Ptr(1123),
 				EnableFloatingIP:     to.BoolPtr(false),
 				IdleTimeoutInMinutes: to.Int32Ptr(5),
@@ -241,7 +241,7 @@ func CreateMasterInternalLoadBalancer(cs *api.ContainerService) LoadBalancerARM 
 				FrontendIPConfiguration: &network.SubResource{
 					ID: to.StringPtr("[variables('masterInternalLbIPConfigID')]"),
 				},
-				FrontendPort:         to.Int32Ptr(123),
+				FrontendPort:         to.Int32Ptr(1123),
 				IdleTimeoutInMinutes: to.Int32Ptr(5),
 				Protocol:             network.TransportProtocolUDP,
 				Probe: &network.SubResource{
@@ -271,8 +271,8 @@ func getUDPLoadBalancingRule() network.LoadBalancingRule {
 				ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
 			},
 			Protocol:             network.TransportProtocolUDP,
-			FrontendPort:         to.Int32Ptr(123),
-			BackendPort:          to.Int32Ptr(123),
+			FrontendPort:         to.Int32Ptr(1123),
+			BackendPort:          to.Int32Ptr(1123),
 			EnableFloatingIP:     to.BoolPtr(false),
 			IdleTimeoutInMinutes: to.Int32Ptr(5),
 			LoadDistribution:     network.Default,

--- a/pkg/engine/loadbalancers.go
+++ b/pkg/engine/loadbalancers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
-func CreateLoadBalancer(masterCount int, isVMSS bool) LoadBalancerARM {
+func CreateLoadBalancer(prop *api.Properties, isVMSS bool) LoadBalancerARM {
 
 	loadBalancer := LoadBalancerARM{
 		ARMResource: ARMResource{
@@ -80,6 +80,30 @@ func CreateLoadBalancer(masterCount int, isVMSS bool) LoadBalancerARM {
 		},
 	}
 
+	if prop.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "Standard" {
+		udpRule := network.LoadBalancingRule{
+			Name: to.StringPtr("LBRuleUDP"),
+			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+				FrontendIPConfiguration: &network.SubResource{
+					ID: to.StringPtr("[variables('masterLbIPConfigID')]"),
+				},
+				BackendAddressPool: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+				},
+				Protocol:             network.TransportProtocolUDP,
+				FrontendPort:         to.Int32Ptr(123),
+				BackendPort:          to.Int32Ptr(1123),
+				EnableFloatingIP:     to.BoolPtr(false),
+				IdleTimeoutInMinutes: to.Int32Ptr(5),
+				LoadDistribution:     network.Default,
+				Probe: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterLbID'),'/probes/tcpHTTPSProbe')]"),
+				},
+			},
+		}
+		*loadBalancer.LoadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules = append(*loadBalancer.LoadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules, udpRule)
+	}
+
 	if isVMSS {
 		inboundNATPools := []network.InboundNatPool{
 			{
@@ -107,7 +131,7 @@ func CreateLoadBalancer(masterCount int, isVMSS bool) LoadBalancerARM {
 			2203,
 			2204,
 		}
-		for i := 0; i < masterCount; i++ {
+		for i := 0; i < prop.MasterProfile.Count; i++ {
 			inboundNATRule := network.InboundNatRule{
 				Name: to.StringPtr(fmt.Sprintf("[concat('SSH-', variables('masterVMNamePrefix'), %d)]", i)),
 				InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
@@ -204,10 +228,57 @@ func CreateMasterInternalLoadBalancer(cs *api.ContainerService) LoadBalancerARM 
 		},
 		Type: to.StringPtr("Microsoft.Network/loadBalancers"),
 	}
+
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "Standard" {
+		udpRule := network.LoadBalancingRule{
+			Name: to.StringPtr("LBRuleUDP"),
+			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+				BackendAddressPool: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+				},
+				BackendPort:      to.Int32Ptr(1123),
+				EnableFloatingIP: to.BoolPtr(false),
+				FrontendIPConfiguration: &network.SubResource{
+					ID: to.StringPtr("[variables('masterInternalLbIPConfigID')]"),
+				},
+				FrontendPort:         to.Int32Ptr(123),
+				IdleTimeoutInMinutes: to.Int32Ptr(5),
+				Protocol:             network.TransportProtocolUDP,
+				Probe: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterInternalLbID'),'/probes/tcpHTTPSProbe')]"),
+				},
+			},
+		}
+		*loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules = append(*loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules, udpRule)
+	}
+
 	loadBalancerARM := LoadBalancerARM{
 		ARMResource:  armResource,
 		LoadBalancer: loadBalancer,
 	}
 
 	return loadBalancerARM
+}
+
+func getUDPLoadBalancingRule() network.LoadBalancingRule {
+	return network.LoadBalancingRule{
+		Name: to.StringPtr("LBRuleUDP"),
+		LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+			FrontendIPConfiguration: &network.SubResource{
+				ID: to.StringPtr("[variables('masterLbIPConfigID')]"),
+			},
+			BackendAddressPool: &network.SubResource{
+				ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+			},
+			Protocol:             network.TransportProtocolUDP,
+			FrontendPort:         to.Int32Ptr(123),
+			BackendPort:          to.Int32Ptr(123),
+			EnableFloatingIP:     to.BoolPtr(false),
+			IdleTimeoutInMinutes: to.Int32Ptr(5),
+			LoadDistribution:     network.Default,
+			Probe: &network.SubResource{
+				ID: to.StringPtr("[concat(variables('masterLbID'),'/probes/tcpHTTPSProbe')]"),
+			},
+		},
+	}
 }

--- a/pkg/engine/loadbalancers_test.go
+++ b/pkg/engine/loadbalancers_test.go
@@ -190,8 +190,8 @@ func TestCreateLoadBalancerStandard(t *testing.T) {
 								ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
 							},
 							Protocol:             network.TransportProtocolUDP,
-							FrontendPort:         to.Int32Ptr(123),
-							BackendPort:          to.Int32Ptr(123),
+							FrontendPort:         to.Int32Ptr(1123),
+							BackendPort:          to.Int32Ptr(1123),
 							EnableFloatingIP:     to.BoolPtr(false),
 							IdleTimeoutInMinutes: to.Int32Ptr(5),
 							LoadDistribution:     network.Default,
@@ -481,7 +481,7 @@ func TestCreateMasterInternalLoadBalancer(t *testing.T) {
 				FrontendIPConfiguration: &network.SubResource{
 					ID: to.StringPtr("[variables('masterInternalLbIPConfigID')]"),
 				},
-				FrontendPort:         to.Int32Ptr(123),
+				FrontendPort:         to.Int32Ptr(1123),
 				IdleTimeoutInMinutes: to.Int32Ptr(5),
 				Protocol:             network.TransportProtocolUDP,
 				Probe: &network.SubResource{

--- a/pkg/engine/loadbalancers_test.go
+++ b/pkg/engine/loadbalancers_test.go
@@ -15,7 +15,19 @@ import (
 )
 
 func TestCreateLoadBalancer(t *testing.T) {
-	actual := CreateLoadBalancer(1, false)
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			MasterProfile: &api.MasterProfile{
+				Count: 1,
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: "Basic",
+				},
+			},
+		},
+	}
+	actual := CreateLoadBalancer(cs.Properties, false)
 
 	expected := LoadBalancerARM{
 		ARMResource: ARMResource{
@@ -106,8 +118,144 @@ func TestCreateLoadBalancer(t *testing.T) {
 
 }
 
+func TestCreateLoadBalancerStandard(t *testing.T) {
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			MasterProfile: &api.MasterProfile{
+				Count: 1,
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: "Standard",
+				},
+			},
+		},
+	}
+	actual := CreateLoadBalancer(cs.Properties, false)
+
+	expected := LoadBalancerARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]",
+			},
+		},
+		LoadBalancer: network.LoadBalancer{
+			Location: to.StringPtr("[variables('location')]"),
+			Name:     to.StringPtr("[variables('masterLbName')]"),
+			LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+				BackendAddressPools: &[]network.BackendAddressPool{
+					{
+						Name: to.StringPtr("[variables('masterLbBackendPoolName')]"),
+					},
+				},
+				FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
+					{
+						Name: to.StringPtr("[variables('masterLbIPConfigName')]"),
+						FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &network.PublicIPAddress{
+								ID: to.StringPtr("[resourceId('Microsoft.Network/publicIpAddresses',variables('masterPublicIPAddressName'))]"),
+							},
+						},
+					},
+				},
+				LoadBalancingRules: &[]network.LoadBalancingRule{
+					{
+						Name: to.StringPtr("LBRuleHTTPS"),
+						LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &network.SubResource{
+								ID: to.StringPtr("[variables('masterLbIPConfigID')]"),
+							},
+							BackendAddressPool: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+							},
+							Protocol:             network.TransportProtocolTCP,
+							FrontendPort:         to.Int32Ptr(443),
+							BackendPort:          to.Int32Ptr(443),
+							EnableFloatingIP:     to.BoolPtr(false),
+							IdleTimeoutInMinutes: to.Int32Ptr(5),
+							LoadDistribution:     network.Default,
+							Probe: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('masterLbID'),'/probes/tcpHTTPSProbe')]"),
+							},
+						},
+					},
+					{
+						Name: to.StringPtr("LBRuleUDP"),
+						LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &network.SubResource{
+								ID: to.StringPtr("[variables('masterLbIPConfigID')]"),
+							},
+							BackendAddressPool: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+							},
+							Protocol:             network.TransportProtocolUDP,
+							FrontendPort:         to.Int32Ptr(123),
+							BackendPort:          to.Int32Ptr(123),
+							EnableFloatingIP:     to.BoolPtr(false),
+							IdleTimeoutInMinutes: to.Int32Ptr(5),
+							LoadDistribution:     network.Default,
+							Probe: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('masterLbID'),'/probes/tcpHTTPSProbe')]"),
+							},
+						},
+					},
+				},
+				InboundNatRules: &[]network.InboundNatRule{
+					{
+						Name: to.StringPtr("[concat('SSH-', variables('masterVMNamePrefix'), 0)]"),
+						InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
+							FrontendIPConfiguration: &network.SubResource{
+								ID: to.StringPtr("[variables('masterLbIPConfigID')]"),
+							},
+							Protocol:         network.TransportProtocol("Tcp"),
+							FrontendPort:     to.Int32Ptr(22),
+							BackendPort:      to.Int32Ptr(22),
+							EnableFloatingIP: to.BoolPtr(false),
+						},
+					},
+				},
+				Probes: &[]network.Probe{
+					{
+						Name: to.StringPtr("tcpHTTPSProbe"),
+						ProbePropertiesFormat: &network.ProbePropertiesFormat{
+							Protocol:          network.ProbeProtocolTCP,
+							Port:              to.Int32Ptr(443),
+							IntervalInSeconds: to.Int32Ptr(5),
+							NumberOfProbes:    to.Int32Ptr(2),
+						},
+					},
+				},
+			},
+			Sku: &network.LoadBalancerSku{
+				Name: "[variables('loadBalancerSku')]",
+			},
+			Type: to.StringPtr("Microsoft.Network/loadBalancers"),
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing availability sets: %s", diff)
+	}
+
+}
+
 func TestCreateLoadBalancerVMSS(t *testing.T) {
-	actual := CreateLoadBalancer(1, true)
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			MasterProfile: &api.MasterProfile{
+				Count: 1,
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: "Basic",
+				},
+			},
+		},
+	}
+	actual := CreateLoadBalancer(cs.Properties, true)
 
 	expected := LoadBalancerARM{
 		ARMResource: ARMResource{
@@ -200,10 +348,15 @@ func TestCreateLoadBalancerVMSS(t *testing.T) {
 }
 
 func TestCreateMasterInternalLoadBalancer(t *testing.T) {
-	// Test without custom VNET
+	// Test with Basic LB
 	cs := &api.ContainerService{
 		Properties: &api.Properties{
 			MasterProfile: &api.MasterProfile{},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: "Basic",
+				},
+			},
 		},
 	}
 
@@ -283,11 +436,77 @@ func TestCreateMasterInternalLoadBalancer(t *testing.T) {
 		t.Errorf("unexpected error while comparing availability sets: %s", diff)
 	}
 
+	// Test with Standard LB
+	cs = &api.ContainerService{
+		Properties: &api.Properties{
+			MasterProfile: &api.MasterProfile{},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: "Standard",
+				},
+			},
+		},
+	}
+
+	actual = CreateMasterInternalLoadBalancer(cs)
+
+	expected.LoadBalancerPropertiesFormat.LoadBalancingRules = &[]network.LoadBalancingRule{
+		{
+			Name: to.StringPtr("InternalLBRuleHTTPS"),
+			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+				BackendAddressPool: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+				},
+				BackendPort:      to.Int32Ptr(4443),
+				EnableFloatingIP: to.BoolPtr(false),
+				FrontendIPConfiguration: &network.SubResource{
+					ID: to.StringPtr("[variables('masterInternalLbIPConfigID')]"),
+				},
+				FrontendPort:         to.Int32Ptr(443),
+				IdleTimeoutInMinutes: to.Int32Ptr(5),
+				Protocol:             network.TransportProtocolTCP,
+				Probe: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterInternalLbID'),'/probes/tcpHTTPSProbe')]"),
+				},
+			},
+		},
+		{
+			Name: to.StringPtr("LBRuleUDP"),
+			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+				BackendAddressPool: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+				},
+				BackendPort:      to.Int32Ptr(1123),
+				EnableFloatingIP: to.BoolPtr(false),
+				FrontendIPConfiguration: &network.SubResource{
+					ID: to.StringPtr("[variables('masterInternalLbIPConfigID')]"),
+				},
+				FrontendPort:         to.Int32Ptr(123),
+				IdleTimeoutInMinutes: to.Int32Ptr(5),
+				Protocol:             network.TransportProtocolUDP,
+				Probe: &network.SubResource{
+					ID: to.StringPtr("[concat(variables('masterInternalLbID'),'/probes/tcpHTTPSProbe')]"),
+				},
+			},
+		},
+	}
+
+	diff = cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing availability sets: %s", diff)
+	}
+
 	// Test with custom Vnet
 	cs = &api.ContainerService{
 		Properties: &api.Properties{
 			MasterProfile: &api.MasterProfile{
 				VnetSubnetID: "fooSubnet",
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: "Standard",
+				},
 			},
 		},
 	}
@@ -310,6 +529,11 @@ func TestCreateMasterInternalLoadBalancer(t *testing.T) {
 			MasterProfile: &api.MasterProfile{
 				VnetSubnetID:        "fooSubnet",
 				AvailabilityProfile: api.VirtualMachineScaleSets,
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: "Standard",
+				},
 			},
 		},
 	}

--- a/pkg/engine/masterarmresources.go
+++ b/pkg/engine/masterarmresources.go
@@ -43,7 +43,7 @@ func createKubernetesMasterResourcesVMAS(cs *api.ContainerService) []interface{}
 
 	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
 		publicIPAddress := CreatePublicIPAddress()
-		loadBalancer := CreateLoadBalancer(cs.Properties.MasterProfile.Count, false)
+		loadBalancer := CreateLoadBalancer(cs.Properties, false)
 		masterNic := CreateNetworkInterfaces(cs)
 
 		masterResources = append(masterResources, publicIPAddress, loadBalancer, masterNic)
@@ -144,7 +144,7 @@ func createKubernetesMasterResourcesVMSS(cs *api.ContainerService) []interface{}
 	}
 
 	publicIPAddress := CreatePublicIPAddress()
-	loadBalancer := CreateLoadBalancer(cs.Properties.MasterProfile.Count, true)
+	loadBalancer := CreateLoadBalancer(cs.Properties, true)
 	masterResources = append(masterResources, publicIPAddress, loadBalancer)
 
 	kubernetesConfig := cs.Properties.OrchestratorProfile.KubernetesConfig


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Azure Standard Load Balancers do not grant outbound access by default to backend VMs by default. This PR adds a UDP LB rule to the Standard LB spec to enable UDP outbound internet access on master VMs behind a Standard LB.

Additionally, added a UDP svc spec to enable UDP outbound for nodes.

Fixes #1099 
Fixes #1125

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
