### PR TITLE
fix: use cordon/drain timeout for pod eviction timeout during upgrade

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -319,7 +319,7 @@ func (ku *Upgrader) upgradeAgentPools(ctx context.Context) error {
 		}
 
 		newCreatedVMs := []string{}
-		client, err := ku.getKubernetesClient()
+		client, err := ku.getKubernetesClient(10 * time.Second)
 		if err != nil {
 			ku.logger.Errorf("Error getting Kubernetes client: %v", err)
 			return err
@@ -498,7 +498,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 			ku.logger.Infof("Successfully set capacity for VMSS %s", vmssToUpgrade.Name)
 
 			// Before we can delete the node we should safely and responsibly drain it
-			client, err := ku.getKubernetesClient()
+			client, err := ku.getKubernetesClient(cordonDrainTimeout)
 			if err != nil {
 				ku.logger.Errorf("Error getting Kubernetes client: %v", err)
 				return err
@@ -711,14 +711,13 @@ func (ku *Upgrader) copyCustomNodeProperties(client armhelpers.KubernetesClient,
 	return err
 }
 
-func (ku *Upgrader) getKubernetesClient() (armhelpers.KubernetesClient, error) {
-	getClientTimeout := 10 * time.Second
+func (ku *Upgrader) getKubernetesClient(timeout time.Duration) (armhelpers.KubernetesClient, error) {
 
 	return ku.Client.GetKubernetesClient(
 		ku.DataModel.Properties.GetMasterFQDN(),
 		ku.kubeConfig,
 		interval,
-		getClientTimeout)
+		timeout)
 }
 
 // return unused index within the range of agent indices, or subsequent index


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
When testing changes from PR #938 I found that the [`WaitForDelete`](https://github.com/Azure/aks-engine/blob/c2229858c671013388bd2e14776d357fc9edc386/pkg/armhelpers/kubeclient.go#L144) call to delete/evict a pod was still using a 10s timeout. This caused some pods to not evict in time and the upgrade to fail. To quickly address this I have updated the getKubernetesClient to allow the `cordonDrainTimeout` to be passed in. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #930 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
