### PR TITLE
ci: exclude a test mock file from coverage report

### DIFF
--- a/.codecov/codecov.yml
+++ b/.codecov/codecov.yml
@@ -32,6 +32,7 @@ ignore:
   - "**/*_generated.go"
   - "test/**/*.go"
   - "pkg/api/mocks.go"
+  - "pkg/armhelpers/azurestack/httpMockClient.go"
   - "pkg/armhelpers/mockclients.go"
   - "pkg/engine/testutils.go"
   - "pkg/test/*.go"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Adds a mock implementation to codecov's exclusion list.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Refs #1160

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This will probably drop our coverage a bit, since it was artificially boosting it before. 😞 
