### PR TITLE
fix: enableEncryptionWithExternalKms with master VMSS missing objectID

### DIFF
--- a/pkg/engine/keyvaults.go
+++ b/pkg/engine/keyvaults.go
@@ -105,6 +105,7 @@ func CreateKeyVaultVMSS(cs *api.ContainerService) map[string]interface{} {
 
 	accessPolicy := map[string]interface{}{
 		"tenantId": "[variables('tenantID')]",
+		"objectId": "[parameters('servicePrincipalObjectId')]",
 		"permissions": map[string]interface{}{
 			"keys": []string{"create", "encrypt", "decrypt", "get", "list"},
 		},
@@ -116,8 +117,6 @@ func CreateKeyVaultVMSS(cs *api.ContainerService) map[string]interface{} {
 		if userAssignedIDEnabled {
 			dependencies = append(dependencies, "[variables('userAssignedIDReference')]")
 			accessPolicy["objectId"] = "[reference(variables('userAssignedIDReference'), variables('apiVersionManagedIdentity')).principalId]"
-		} else {
-			accessPolicy["objectId"] = "[parameters('servicePrincipalObjectId')]"
 		}
 		keyVaultMap["dependsOn"] = dependencies
 	}

--- a/pkg/engine/keyvaults_test.go
+++ b/pkg/engine/keyvaults_test.go
@@ -145,6 +145,7 @@ func TestCreateKeyVaultVMSS(t *testing.T) {
 		"properties": map[string]interface{}{
 			"accessPolicies": []interface{}{
 				map[string]interface{}{
+					"objectId": "[parameters('servicePrincipalObjectId')]",
 					"permissions": map[string]interface{}{
 						"keys": []string{"create", "encrypt", "decrypt", "get", "list"}},
 					"tenantId": "[variables('tenantID')]"}},


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Restore `CreateKeyVaultVMSS` to the behavior it had before the template refactor for `enableEncryptionWithExternalKms`. Compare with:
https://github.com/Azure/aks-engine/blob/release-v0.31.0/parts/k8s/kubernetesmasterresourcesvmss.t#L76

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1034

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
