### PR TITLE
ci: permit optional scope field when generating changelog

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -18,9 +18,10 @@ options:
       style: Code Style 🎶
       test: Testing 💚
   header:
-    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
     pattern_maps:
       - Type
+      - Scope
       - Subject
   notes:
     keywords:


### PR DESCRIPTION
**Reason for Change**:
Some commits didn't show up in the [v0.35.0](https://github.com/Azure/aks-engine/releases/tag/v0.35.0) changelog initially because their message contained a scope field. This was because the `git-chglog` config file was generated initially with the simplified option. Updating the regex to the `msg(scope):` form fixes it.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
