### PR TITLE
fix: detect GPU VMs with _Promo SKU suffix

### DIFF
--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -101,6 +101,8 @@ func IsNvidiaEnabledSKU(vmSize string) bool {
 		"Standard_NC24s_v3":  true,
 		"Standard_NC24rs_v3": true,
 	}
+	// Trim the optional _Promo suffix.
+	vmSize = strings.TrimSuffix(vmSize, "_Promo")
 	if _, ok := dm[vmSize]; ok {
 		return dm[vmSize]
 	}

--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -122,6 +122,10 @@ func GetNSeriesVMCasesForTesting() []struct {
 			true,
 		},
 		{
+			"Standard_NC6_Promo",
+			true,
+		},
+		{
 			"Standard_NC12",
 			true,
 		},


### PR DESCRIPTION
**Reason for Change**:
The `_Promo` SKU suffix is added to price-reduced variants with no difference in the underlying hardware. Without this patch, `Standard_NC6` is detected as a GPU VM (for example), but `Standard_NC6_Promo` is not. 

**Issue Fixed**:
Fixes #1203

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation (NA)
- [ ] adds unit tests (no, adds to an existing unit test)
- [ ] tested upgrade from previous version (NA)

**Notes**:


