### PR TITLE
test: idempotent e2e changes for soak test scenarios

### DIFF
--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -159,6 +159,14 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 		prop.ServicePrincipalProfile.ObjectID = config.ClientObjectID
 	}
 
+	if prop.OrchestratorProfile.KubernetesConfig == nil {
+		prop.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
+		prop.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig = map[string]string{
+			"--horizontal-pod-autoscaler-downscale-stabilization":   "30s",
+			"--horizontal-pod-autoscaler-cpu-initialization-period": "30s",
+		}
+	}
+
 	return &Engine{
 		Config:            config,
 		ClusterDefinition: cs,

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -106,7 +106,7 @@ func CreateLinuxDeployDeleteIfExists(pattern, image, name, namespace, miscOpts s
 		return nil, err
 	}
 	for _, d := range deployments {
-		d.Delete(10)
+		d.Delete(util.DefaultDeleteRetries)
 	}
 	return CreateLinuxDeploy(image, name, namespace, miscOpts)
 }
@@ -164,7 +164,7 @@ func CreateWindowsDeployDeleteIfExist(pattern, image, name, namespace string, po
 		return nil, err
 	}
 	for _, d := range deployments {
-		d.Delete(10)
+		d.Delete(util.DefaultDeleteRetries)
 	}
 	return CreateWindowsDeploy(image, name, namespace, port, hostport)
 }
@@ -285,7 +285,7 @@ func (d *Deployment) ExposeDeleteIfExist(pattern, namespace, svcType string, tar
 		return err
 	}
 	for _, s := range services {
-		s.Delete(10)
+		s.Delete(util.DefaultDeleteRetries)
 	}
 	return d.Expose(svcType, targetPort, exposedPort)
 }
@@ -318,7 +318,7 @@ func (d *Deployment) CreateDeploymentHPA(cpuPercent, min, max int) error {
 func (d *Deployment) CreateDeploymentHPADeleteIfExist(cpuPercent, min, max int) error {
 	h, err := hpa.Get(d.Metadata.Name, d.Metadata.Namespace)
 	if err == nil {
-		err := h.Delete(10)
+		err := h.Delete(util.DefaultDeleteRetries)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -9,10 +9,13 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"time"
 
+	"github.com/Azure/aks-engine/test/e2e/kubernetes/hpa"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/pod"
+	"github.com/Azure/aks-engine/test/e2e/kubernetes/service"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/util"
 	"github.com/pkg/errors"
 )
@@ -96,6 +99,18 @@ func CreateLinuxDeployIfNotExist(image, name, namespace, miscOpts string) (*Depl
 	return deployment, nil
 }
 
+// CreateLinuxDeployDeleteIfExists will create a deployment, deleting any pre-existing deployment with the same name
+func CreateLinuxDeployDeleteIfExists(pattern, image, name, namespace, miscOpts string) (*Deployment, error) {
+	deployments, err := GetAllByPrefix(pattern, namespace)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range deployments {
+		d.Delete(10)
+	}
+	return CreateLinuxDeploy(image, name, namespace, miscOpts)
+}
+
 // RunLinuxDeploy will create a deployment that runs a bash command in a pod
 // --overrides=' "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
 func RunLinuxDeploy(image, name, namespace, command string, replicas int) (*Deployment, error) {
@@ -114,7 +129,7 @@ func RunLinuxDeploy(image, name, namespace, command string, replicas int) (*Depl
 	return d, nil
 }
 
-// CreateWindowsDeploy will crete a deployment for a given image with a name in a namespace
+// CreateWindowsDeploy will create a deployment for a given image with a name in a namespace
 func CreateWindowsDeploy(image, name, namespace string, port int, hostport int) (*Deployment, error) {
 	overrides := `{ "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}}}`
 	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--port", strconv.Itoa(port), "--hostport", strconv.Itoa(hostport), "--overrides", overrides)
@@ -129,6 +144,29 @@ func CreateWindowsDeploy(image, name, namespace string, port int, hostport int) 
 		return nil, err
 	}
 	return d, nil
+}
+
+// CreateWindowsDeployIfNotExist first checks if a deployment already exists, and return it if so
+// If not, we call CreateWindowsDeploy
+func CreateWindowsDeployIfNotExist(image, name, namespace string, port int, hostport int) (*Deployment, error) {
+	deployment, err := Get(name, namespace)
+	if err != nil {
+		return CreateWindowsDeploy(image, name, namespace, port, hostport)
+	}
+	return deployment, nil
+}
+
+// CreateWindowsDeployDeleteIfExist first checks if a deployment already exists according to a naming pattern
+// If a pre-existing deployment is found matching that pattern, it is deleted
+func CreateWindowsDeployDeleteIfExist(pattern, image, name, namespace string, port int, hostport int) (*Deployment, error) {
+	deployments, err := GetAllByPrefix(pattern, namespace)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range deployments {
+		d.Delete(10)
+	}
+	return CreateWindowsDeploy(image, name, namespace, port, hostport)
 }
 
 // Get returns a deployment from a name and namespace
@@ -146,6 +184,44 @@ func Get(name, namespace string) (*Deployment, error) {
 		return nil, err
 	}
 	return &d, nil
+}
+
+// GetAll will return all deployments in a given namespace
+func GetAll(namespace string) (*List, error) {
+	cmd := exec.Command("k", "get", "deployments", "-n", namespace, "-o", "json")
+	util.PrintCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error getting all deployments:\n")
+		return nil, err
+	}
+	dl := List{}
+	err = json.Unmarshal(out, &dl)
+	if err != nil {
+		log.Printf("Error unmarshalling deployments json:%s\n", err)
+		return nil, err
+	}
+	return &dl, nil
+}
+
+// GetAllByPrefix will return all pods in a given namespace that match a prefix
+func GetAllByPrefix(prefix, namespace string) ([]Deployment, error) {
+	dl, err := GetAll(namespace)
+	if err != nil {
+		return nil, err
+	}
+	deployments := []Deployment{}
+	for _, d := range dl.Deployments {
+		matched, err := regexp.MatchString(prefix+"-.*", d.Metadata.Name)
+		if err != nil {
+			log.Printf("Error trying to match deployment name:%s\n", err)
+			return nil, err
+		}
+		if matched {
+			deployments = append(deployments, d)
+		}
+	}
+	return deployments, nil
 }
 
 // Delete will delete a deployment in a given namespace
@@ -192,6 +268,28 @@ func (d *Deployment) Expose(svcType string, targetPort, exposedPort int) error {
 	return nil
 }
 
+// ExposeIfNotExist will create a load balancer and expose the deployment on a given port if the associated service doesn't already exist
+func (d *Deployment) ExposeIfNotExist(svcType string, targetPort, exposedPort int) error {
+	_, err := service.Get(d.Metadata.Name, d.Metadata.Namespace)
+	if err != nil {
+		return d.Expose(svcType, targetPort, exposedPort)
+	}
+	return nil
+}
+
+// ExposeDeleteIfExist will create a load balancer and expose the deployment on a given port
+// If a service matching the passed in pattern already exists, we'll delete it first
+func (d *Deployment) ExposeDeleteIfExist(pattern, namespace, svcType string, targetPort, exposedPort int) error {
+	services, err := service.GetAllByPrefix(pattern, namespace)
+	if err != nil {
+		return err
+	}
+	for _, s := range services {
+		s.Delete(10)
+	}
+	return d.Expose(svcType, targetPort, exposedPort)
+}
+
 // ScaleDeployment scales a deployment to n instancees
 func (d *Deployment) ScaleDeployment(n int) error {
 	cmd := exec.Command("k", "scale", fmt.Sprintf("--replicas=%d", n), "deployment", d.Metadata.Name)
@@ -214,6 +312,20 @@ func (d *Deployment) CreateDeploymentHPA(cpuPercent, min, max int) error {
 	}
 	d.Metadata.HasHPA = true
 	return nil
+}
+
+// CreateDeploymentHPADeleteIfExist applies autoscale characteristics to deployment, deleting any pre-existing HPA resource first
+func (d *Deployment) CreateDeploymentHPADeleteIfExist(cpuPercent, min, max int) error {
+	h, err := hpa.Get(d.Metadata.Name, d.Metadata.Namespace)
+	if err == nil {
+		err := h.Delete(10)
+		if err != nil {
+			return err
+		}
+		// Wait a minute before proceeding to create a new hpa w/ the same name
+		time.Sleep(1 * time.Minute)
+	}
+	return d.CreateDeploymentHPA(cpuPercent, min, max)
 }
 
 // Pods will return all pods related to a deployment

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -187,9 +187,9 @@ func WaitOnReady(jobPrefix, namespace string, sleep, duration time.Duration) (bo
 	for {
 		select {
 		case err := <-errCh:
-			pods, err := pod.GetAllByPrefix(jobPrefix, namespace)
-			if err != nil {
-				log.Printf("Error trying to get job pods: %s\n", err)
+			pods, getPodsErr := pod.GetAllByPrefix(jobPrefix, namespace)
+			if getPodsErr != nil {
+				log.Printf("Error trying to get job pods: %s\n", getPodsErr)
 			}
 			for _, p := range pods {
 				p.Logs()

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -187,6 +187,13 @@ func WaitOnReady(jobPrefix, namespace string, sleep, duration time.Duration) (bo
 	for {
 		select {
 		case err := <-errCh:
+			pods, err := pod.GetAllByPrefix(jobPrefix, namespace)
+			if err != nil {
+				log.Printf("Error trying to get job pods: %s\n", err)
+			}
+			for _, p := range pods {
+				p.Logs()
+			}
 			return false, err
 		case ready := <-readyCh:
 			return ready, nil

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -57,6 +57,20 @@ func CreateJobFromFile(filename, name, namespace string) (*Job, error) {
 	return job, nil
 }
 
+// CreateJobFromFileDeleteIfExists will create a Job from file, deleting any pre-existing job with the same name
+func CreateJobFromFileDeleteIfExists(filename, name, namespace string) (*Job, error) {
+	j, err := Get(name, namespace)
+	if err == nil {
+		err := j.Delete(10)
+		if err != nil {
+			return nil, err
+		}
+		// Wait a minute before proceeding to create a new job w/ the same name
+		time.Sleep(1 * time.Minute)
+	}
+	return CreateJobFromFile(filename, name, namespace)
+}
+
 // GetAll will return all jobs in a given namespace
 func GetAll(namespace string) (*List, error) {
 	cmd := exec.Command("k", "get", "jobs", "-n", namespace, "-o", "json")

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -61,7 +61,7 @@ func CreateJobFromFile(filename, name, namespace string) (*Job, error) {
 func CreateJobFromFileDeleteIfExists(filename, name, namespace string) (*Job, error) {
 	j, err := Get(name, namespace)
 	if err == nil {
-		err := j.Delete(10)
+		err := j.Delete(util.DefaultDeleteRetries)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -65,8 +65,10 @@ func CreateJobFromFileDeleteIfExists(filename, name, namespace string) (*Job, er
 		if err != nil {
 			return nil, err
 		}
-		// Wait a minute before proceeding to create a new job w/ the same name
-		time.Sleep(1 * time.Minute)
+		_, err = WaitOnDeleted(j.Metadata.Name, j.Metadata.Namespace, 5*time.Second, 1*time.Minute)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return CreateJobFromFile(filename, name, namespace)
 }
@@ -86,6 +88,26 @@ func GetAll(namespace string) (*List, error) {
 		return nil, err
 	}
 	return &jl, nil
+}
+
+// GetAllByPrefix will return all jobs in a given namespace that match a prefix
+func GetAllByPrefix(prefix, namespace string) ([]Job, error) {
+	jl, err := GetAll(namespace)
+	if err != nil {
+		return nil, err
+	}
+	jobs := []Job{}
+	for _, j := range jl.Jobs {
+		matched, err := regexp.MatchString(prefix+"-.*", j.Metadata.Name)
+		if err != nil {
+			log.Printf("Error trying to match pod name:%s\n", err)
+			return nil, err
+		}
+		if matched {
+			jobs = append(jobs, j)
+		}
+	}
+	return jobs, nil
 }
 
 // Get will return a job with a given name and namespace
@@ -193,4 +215,37 @@ func (j *Job) Delete(retries int) error {
 	}
 
 	return kubectlError
+}
+
+// WaitOnDeleted returns when a job is successfully deleted
+func WaitOnDeleted(jobPrefix, namespace string, sleep, duration time.Duration) (bool, error) {
+	succeededCh := make(chan bool, 1)
+	errCh := make(chan error)
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- errors.Errorf("Timeout exceeded (%s) while waiting for Jobs (%s) to be deleted in namespace (%s)", duration.String(), jobPrefix, namespace)
+			default:
+				p, err := GetAllByPrefix(jobPrefix, namespace)
+				if err != nil {
+					errCh <- errors.Errorf("Got error while getting Jobs with prefix \"%s\" in namespace \"%s\"", jobPrefix, namespace)
+				}
+				if len(p) == 0 {
+					succeededCh <- true
+				}
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case err := <-errCh:
+			return false, err
+		case deleted := <-succeededCh:
+			return deleted, nil
+		}
+	}
 }

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -631,7 +631,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring that we have functional DNS resolution from a windows container")
 				j, err = job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default")
 				Expect(err).NotTo(HaveOccurred())
-				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, validateDNSTimeout)
+				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
 				delErr = j.Delete(util.DefaultDeleteRetries)
 				if delErr != nil {
 					fmt.Printf("could not delete job %s\n", j.Metadata.Name)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1260,7 +1260,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				valid := iisService.Validate("(IIS Windows Server)", 10, 10*time.Second, cfg.Timeout)
+				valid := iisService.Validate("(IIS Windows Server)", 10, retryTimeWhenWaitingForPodReady, cfg.Timeout)
 				Expect(valid).To(BeTrue())
 
 				By("Checking that each pod can reach the internet")
@@ -1270,7 +1270,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).ToNot(BeZero())
 				for _, iisPod := range iisPods {
 					var pass bool
-					pass, err = iisPod.CheckWindowsOutboundConnection(10*time.Second, timeoutWhenWaitingForPodOutboundAccess)
+					pass, err = iisPod.CheckWindowsOutboundConnection(retryTimeWhenWaitingForPodReady, timeoutWhenWaitingForPodOutboundAccess)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pass).To(BeTrue())
 				}
@@ -1290,7 +1290,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).To(Equal(5))
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				valid = iisService.Validate("(IIS Windows Server)", 10, 10*time.Second, cfg.Timeout)
+				valid = iisService.Validate("(IIS Windows Server)", 10, retryTimeWhenWaitingForPodReady, cfg.Timeout)
 				Expect(valid).To(BeTrue())
 
 				By("Checking that each pod can reach the internet")
@@ -1299,7 +1299,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).ToNot(BeZero())
 				for _, iisPod := range iisPods {
 					var pass bool
-					pass, err = iisPod.CheckWindowsOutboundConnection(10*time.Second, timeoutWhenWaitingForPodOutboundAccess)
+					pass, err = iisPod.CheckWindowsOutboundConnection(retryTimeWhenWaitingForPodReady, timeoutWhenWaitingForPodOutboundAccess)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pass).To(BeTrue())
 				}
@@ -1321,7 +1321,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).To(Equal(2))
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				valid = iisService.Validate("(IIS Windows Server)", 10, 10*time.Second, cfg.Timeout)
+				valid = iisService.Validate("(IIS Windows Server)", 10, retryTimeWhenWaitingForPodReady, cfg.Timeout)
 				Expect(valid).To(BeTrue())
 
 				By("Checking that each pod can reach the internet")
@@ -1330,7 +1330,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).ToNot(BeZero())
 				for _, iisPod := range iisPods {
 					var pass bool
-					pass, err = iisPod.CheckWindowsOutboundConnection(10*time.Second, cfg.Timeout)
+					pass, err = iisPod.CheckWindowsOutboundConnection(retryTimeWhenWaitingForPodReady, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pass).To(BeTrue())
 				}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -40,7 +40,6 @@ const (
 	WorkloadDir                            = "workloads"
 	ScriptsDir                             = "scripts"
 	PolicyDir                              = "workloads/policies"
-	common.DefaultDeleteRetries                  = 10
 	retryCommandsTimeout                   = 5 * time.Minute
 	kubeSystemPodsReadinessChecks          = 6
 	retryTimeWhenWaitingForPodReady        = 1 * time.Minute

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -47,6 +47,7 @@ const (
 	stabilityCommandTimeout                = 5 * time.Second
 	windowsCommandTimeout                  = 1 * time.Minute
 	validateNetworkPolicyTimeout           = 3 * time.Minute
+	validateDNSTimeout                     = 2 * time.Minute
 )
 
 var (
@@ -617,7 +618,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			By("Ensuring that we have functional DNS resolution from a linux container")
 			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-linux.yaml"), "validate-dns-linux", "default")
 			Expect(err).NotTo(HaveOccurred())
-			ready, err := j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
+			ready, err := j.WaitOnReady(retryTimeWhenWaitingForPodReady, validateDNSTimeout)
 			delErr := j.Delete(util.DefaultDeleteRetries)
 			if delErr != nil {
 				fmt.Printf("could not delete job %s\n", j.Metadata.Name)
@@ -630,7 +631,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring that we have functional DNS resolution from a windows container")
 				j, err = job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default")
 				Expect(err).NotTo(HaveOccurred())
-				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
+				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, validateDNSTimeout)
 				delErr = j.Delete(util.DefaultDeleteRetries)
 				if delErr != nil {
 					fmt.Printf("could not delete job %s\n", j.Metadata.Name)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -568,8 +568,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			pods, err := phpApacheDeploy.Pods()
 			Expect(err).NotTo(HaveOccurred())
 			for _, p := range pods {
-				pass, err := p.CheckLinuxOutboundConnection(5*time.Second, cfg.Timeout)
-				Expect(err).NotTo(HaveOccurred())
+				pass, outboundErr := p.CheckLinuxOutboundConnection(5*time.Second, cfg.Timeout)
+				Expect(outboundErr).NotTo(HaveOccurred())
 				Expect(pass).To(BeTrue())
 			}
 

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -615,8 +615,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have functional container networking DNS", func() {
-			By("Ensuring that we have functional DNS resolution from a container")
-			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns.yaml"), "validate-dns", "default")
+			By("Ensuring that we have functional DNS resolution from a linux container")
+			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-linux.yaml"), "validate-dns-linux", "default")
 			Expect(err).NotTo(HaveOccurred())
 			ready, err := j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
 			delErr := j.Delete(deleteResourceRetries)
@@ -626,6 +626,20 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ready).To(Equal(true))
+
+			if eng.HasWindowsAgents() {
+				By("Ensuring that we have functional DNS resolution from a windows container")
+				j, err = job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default")
+				Expect(err).NotTo(HaveOccurred())
+				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
+				delErr = j.Delete(deleteResourceRetries)
+				if delErr != nil {
+					fmt.Printf("could not delete job %s\n", j.Metadata.Name)
+					fmt.Println(delErr)
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ready).To(Equal(true))
+			}
 
 			By("Ensuring that we have stable external DNS resolution as we recycle a bunch of pods")
 			name := fmt.Sprintf("alpine-%s", cfg.Name)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -40,7 +40,7 @@ const (
 	WorkloadDir                            = "workloads"
 	ScriptsDir                             = "scripts"
 	PolicyDir                              = "workloads/policies"
-	deleteResourceRetries                  = 10
+	common.DefaultDeleteRetries                  = 10
 	retryCommandsTimeout                   = 5 * time.Minute
 	kubeSystemPodsReadinessChecks          = 6
 	retryTimeWhenWaitingForPodReady        = 1 * time.Minute
@@ -619,7 +619,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-linux.yaml"), "validate-dns-linux", "default")
 			Expect(err).NotTo(HaveOccurred())
 			ready, err := j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
-			delErr := j.Delete(deleteResourceRetries)
+			delErr := j.Delete(common.DefaultDeleteRetries)
 			if delErr != nil {
 				fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 				fmt.Println(delErr)
@@ -632,7 +632,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				j, err = job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default")
 				Expect(err).NotTo(HaveOccurred())
 				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
-				delErr = j.Delete(deleteResourceRetries)
+				delErr = j.Delete(common.DefaultDeleteRetries)
 				if delErr != nil {
 					fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 					fmt.Println(delErr)
@@ -753,11 +753,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					}
 				}
 				By("Cleaning up after ourselves")
-				err = curlDeploy.Delete(deleteResourceRetries)
+				err = curlDeploy.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = deploy.Delete(deleteResourceRetries)
+				err = deploy.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = s.Delete(deleteResourceRetries)
+				err = s.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No linux agent was provisioned for this Cluster Definition")
@@ -840,7 +840,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Stopping load")
-				err = loadTestDeploy.Delete(deleteResourceRetries)
+				err = loadTestDeploy.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Ensuring we only have 1 apache-php pod after stopping load")
@@ -850,7 +850,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Deleting HPA configuration")
-				err = h.Delete(deleteResourceRetries)
+				err = h.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("This flavor/version of Kubernetes doesn't support hpa autoscale")
@@ -883,9 +883,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(valid).To(BeTrue())
 
 				By("Cleaning up after ourselves")
-				err = nginxDeploy.Delete(deleteResourceRetries)
+				err = nginxDeploy.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = s.Delete(deleteResourceRetries)
+				err = s.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No linux agent was provisioned for this Cluster Definition")
@@ -909,7 +909,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(pass).To(BeTrue())
 
 			By("Cleaning up after ourselves")
-			err = p.Delete(deleteResourceRetries)
+			err = p.Delete(common.DefaultDeleteRetries)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -927,7 +927,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "cuda-vector-add.yaml"), "cuda-vector-add", "default")
 					Expect(err).NotTo(HaveOccurred())
 					ready, err := j.WaitOnReady(30*time.Second, cfg.Timeout)
-					delErr := j.Delete(deleteResourceRetries)
+					delErr := j.Delete(common.DefaultDeleteRetries)
 					if delErr != nil {
 						fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 						fmt.Println(delErr)
@@ -938,7 +938,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "nvidia-smi.yaml"), "nvidia-smi", "default")
 					Expect(err).NotTo(HaveOccurred())
 					ready, err := j.WaitOnReady(30*time.Second, cfg.Timeout)
-					delErr := j.Delete(deleteResourceRetries)
+					delErr := j.Delete(common.DefaultDeleteRetries)
 					if delErr != nil {
 						fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 						fmt.Println(delErr)
@@ -1046,9 +1046,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(nodeZone == pvZone).To(Equal(true))
 
 				By("Cleaning up after ourselves")
-				err = testPod.Delete(deleteResourceRetries)
+				err = testPod.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = pvc.Delete(deleteResourceRetries)
+				err = pvc.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("Availability zones was not configured for this Cluster Definition")
@@ -1225,13 +1225,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 
 				By("Cleaning up after ourselves")
-				err = frontendProdDeployment.Delete(deleteResourceRetries)
+				err = frontendProdDeployment.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = frontendDevDeployment.Delete(deleteResourceRetries)
+				err = frontendDevDeployment.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = backendDeployment.Delete(deleteResourceRetries)
+				err = backendDeployment.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = nwpolicyDeployment.Delete(deleteResourceRetries)
+				err = nwpolicyDeployment.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 				err = namespaceDev.Delete()
 				Expect(err).NotTo(HaveOccurred())
@@ -1343,9 +1343,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 
 				By("Verifying pods & services can be deleted")
-				err = iisDeploy.Delete(deleteResourceRetries)
+				err = iisDeploy.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = iisService.Delete(deleteResourceRetries)
+				err = iisService.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No windows agent was provisioned for this Cluster Definition")
@@ -1413,13 +1413,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(successes).To(Equal(cfg.StabilityIterations))
 
 				By("Cleaning up after ourselves")
-				err = windowsIISDeployment.Delete(deleteResourceRetries)
+				err = windowsIISDeployment.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = linuxNginxDeploy.Delete(deleteResourceRetries)
+				err = linuxNginxDeploy.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = windowsService.Delete(deleteResourceRetries)
+				err = windowsService.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = linuxService.Delete(deleteResourceRetries)
+				err = linuxService.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No windows agent was provisioned for this Cluster Definition")
@@ -1513,9 +1513,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					Expect(valid).To(BeTrue())
 					Expect(err).NotTo(HaveOccurred())
 
-					err = iisPod.Delete(deleteResourceRetries)
+					err = iisPod.Delete(common.DefaultDeleteRetries)
 					Expect(err).NotTo(HaveOccurred())
-					err = pvc.Delete(deleteResourceRetries)
+					err = pvc.Delete(common.DefaultDeleteRetries)
 					Expect(err).NotTo(HaveOccurred())
 				} else {
 					Skip("Kubernetes version needs to be 1.8 and up for Azure File test")
@@ -1536,7 +1536,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(running).To(Equal(true))
 				restarts := pod.Status.ContainerStatuses[0].RestartCount
 				if cfg.SoakClusterName == "" {
-					err = pod.Delete(deleteResourceRetries)
+					err = pod.Delete(common.DefaultDeleteRetries)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(restarts).To(Equal(0))
 				} else {
@@ -1586,9 +1586,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				s, err := service.Get(longRunningApacheDeploymentName, "default")
 				Expect(err).NotTo(HaveOccurred())
 
-				err = s.Delete(deleteResourceRetries)
+				err = s.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = phpApacheDeploy.Delete(deleteResourceRetries)
+				err = phpApacheDeploy.Delete(common.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("Keep long-running php-apache workloads running for soak clusters")

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1468,7 +1468,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.HasWindowsAgents() {
 				if eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion == "1.11.0" {
 					// Failure in 1.11.0 - https://github.com/kubernetes/kubernetes/issues/65845, fixed in 1.11.1
-					Skip("Kubernetes 1.11.0 has a known issue creating Azure PersistentVolumeClaims")
+					Skip("Kubernetes 1.11.0 has a known issue creating Azure PersistentVolumeClaim")
 				} else if common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.8.0") {
 					windowsImages, err := eng.GetWindowsTestImages()
 					Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -618,7 +618,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-linux.yaml"), "validate-dns-linux", "default")
 			Expect(err).NotTo(HaveOccurred())
 			ready, err := j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
-			delErr := j.Delete(common.DefaultDeleteRetries)
+			delErr := j.Delete(util.DefaultDeleteRetries)
 			if delErr != nil {
 				fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 				fmt.Println(delErr)
@@ -631,7 +631,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				j, err = job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default")
 				Expect(err).NotTo(HaveOccurred())
 				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
-				delErr = j.Delete(common.DefaultDeleteRetries)
+				delErr = j.Delete(util.DefaultDeleteRetries)
 				if delErr != nil {
 					fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 					fmt.Println(delErr)
@@ -752,11 +752,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					}
 				}
 				By("Cleaning up after ourselves")
-				err = curlDeploy.Delete(common.DefaultDeleteRetries)
+				err = curlDeploy.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = deploy.Delete(common.DefaultDeleteRetries)
+				err = deploy.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = s.Delete(common.DefaultDeleteRetries)
+				err = s.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No linux agent was provisioned for this Cluster Definition")
@@ -839,7 +839,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Stopping load")
-				err = loadTestDeploy.Delete(common.DefaultDeleteRetries)
+				err = loadTestDeploy.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Ensuring we only have 1 apache-php pod after stopping load")
@@ -849,7 +849,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Deleting HPA configuration")
-				err = h.Delete(common.DefaultDeleteRetries)
+				err = h.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("This flavor/version of Kubernetes doesn't support hpa autoscale")
@@ -882,9 +882,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(valid).To(BeTrue())
 
 				By("Cleaning up after ourselves")
-				err = nginxDeploy.Delete(common.DefaultDeleteRetries)
+				err = nginxDeploy.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = s.Delete(common.DefaultDeleteRetries)
+				err = s.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No linux agent was provisioned for this Cluster Definition")
@@ -908,7 +908,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(pass).To(BeTrue())
 
 			By("Cleaning up after ourselves")
-			err = p.Delete(common.DefaultDeleteRetries)
+			err = p.Delete(util.DefaultDeleteRetries)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -926,7 +926,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "cuda-vector-add.yaml"), "cuda-vector-add", "default")
 					Expect(err).NotTo(HaveOccurred())
 					ready, err := j.WaitOnReady(30*time.Second, cfg.Timeout)
-					delErr := j.Delete(common.DefaultDeleteRetries)
+					delErr := j.Delete(util.DefaultDeleteRetries)
 					if delErr != nil {
 						fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 						fmt.Println(delErr)
@@ -937,7 +937,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "nvidia-smi.yaml"), "nvidia-smi", "default")
 					Expect(err).NotTo(HaveOccurred())
 					ready, err := j.WaitOnReady(30*time.Second, cfg.Timeout)
-					delErr := j.Delete(common.DefaultDeleteRetries)
+					delErr := j.Delete(util.DefaultDeleteRetries)
 					if delErr != nil {
 						fmt.Printf("could not delete job %s\n", j.Metadata.Name)
 						fmt.Println(delErr)
@@ -1045,9 +1045,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(nodeZone == pvZone).To(Equal(true))
 
 				By("Cleaning up after ourselves")
-				err = testPod.Delete(common.DefaultDeleteRetries)
+				err = testPod.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = pvc.Delete(common.DefaultDeleteRetries)
+				err = pvc.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("Availability zones was not configured for this Cluster Definition")
@@ -1224,13 +1224,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 
 				By("Cleaning up after ourselves")
-				err = frontendProdDeployment.Delete(common.DefaultDeleteRetries)
+				err = frontendProdDeployment.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = frontendDevDeployment.Delete(common.DefaultDeleteRetries)
+				err = frontendDevDeployment.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = backendDeployment.Delete(common.DefaultDeleteRetries)
+				err = backendDeployment.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = nwpolicyDeployment.Delete(common.DefaultDeleteRetries)
+				err = nwpolicyDeployment.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 				err = namespaceDev.Delete()
 				Expect(err).NotTo(HaveOccurred())
@@ -1342,9 +1342,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 
 				By("Verifying pods & services can be deleted")
-				err = iisDeploy.Delete(common.DefaultDeleteRetries)
+				err = iisDeploy.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = iisService.Delete(common.DefaultDeleteRetries)
+				err = iisService.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No windows agent was provisioned for this Cluster Definition")
@@ -1412,13 +1412,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(successes).To(Equal(cfg.StabilityIterations))
 
 				By("Cleaning up after ourselves")
-				err = windowsIISDeployment.Delete(common.DefaultDeleteRetries)
+				err = windowsIISDeployment.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = linuxNginxDeploy.Delete(common.DefaultDeleteRetries)
+				err = linuxNginxDeploy.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = windowsService.Delete(common.DefaultDeleteRetries)
+				err = windowsService.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = linuxService.Delete(common.DefaultDeleteRetries)
+				err = linuxService.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("No windows agent was provisioned for this Cluster Definition")
@@ -1512,9 +1512,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					Expect(valid).To(BeTrue())
 					Expect(err).NotTo(HaveOccurred())
 
-					err = iisPod.Delete(common.DefaultDeleteRetries)
+					err = iisPod.Delete(util.DefaultDeleteRetries)
 					Expect(err).NotTo(HaveOccurred())
-					err = pvc.Delete(common.DefaultDeleteRetries)
+					err = pvc.Delete(util.DefaultDeleteRetries)
 					Expect(err).NotTo(HaveOccurred())
 				} else {
 					Skip("Kubernetes version needs to be 1.8 and up for Azure File test")
@@ -1535,7 +1535,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(running).To(Equal(true))
 				restarts := pod.Status.ContainerStatuses[0].RestartCount
 				if cfg.SoakClusterName == "" {
-					err = pod.Delete(common.DefaultDeleteRetries)
+					err = pod.Delete(util.DefaultDeleteRetries)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(restarts).To(Equal(0))
 				} else {
@@ -1585,9 +1585,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				s, err := service.Get(longRunningApacheDeploymentName, "default")
 				Expect(err).NotTo(HaveOccurred())
 
-				err = s.Delete(common.DefaultDeleteRetries)
+				err = s.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
-				err = phpApacheDeploy.Delete(common.DefaultDeleteRetries)
+				err = phpApacheDeploy.Delete(util.DefaultDeleteRetries)
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Skip("Keep long-running php-apache workloads running for soak clusters")

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -564,7 +564,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(err).NotTo(HaveOccurred())
 			Expect(running).To(Equal(true))
 
-			By("Ensuing that the php-apache pod has outbound internet access")
+			By("Ensuring that the php-apache pod has outbound internet access")
 			pods, err := phpApacheDeploy.Pods()
 			Expect(err).NotTo(HaveOccurred())
 			for _, p := range pods {
@@ -822,12 +822,12 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				phpApacheDeploy, err := deployment.CreateLinuxDeployIfNotExist("deis/hpa-example", longRunningApacheDeploymentName, "default", "--requests=cpu=10m,memory=10M")
 				Expect(err).NotTo(HaveOccurred())
 
-				By("Ensuring that php-apache pod is running")
+				By("Ensuring that the php-apache pod is running")
 				running, err := pod.WaitOnReady(longRunningApacheDeploymentName, "default", 3, retryTimeWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
 
-				By("Ensuing that the php-apache pod has outbound internet access")
+				By("Ensuring that the php-apache pod has outbound internet access")
 				pods, err := phpApacheDeploy.Pods()
 				Expect(err).NotTo(HaveOccurred())
 				for _, p := range pods {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -544,9 +544,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should be able to launch a long-running container networking DNS liveness pod", func() {
 			if !eng.HasNetworkPolicy("calico") {
-				var err error
-				var p *pod.Pod
-				p, err = pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "dns-liveness.yaml"), "dns-liveness", "default", 1*time.Second, cfg.Timeout)
+				p, err := pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "dns-liveness.yaml"), "dns-liveness", "default", 1*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
 				running, err := p.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"regexp"
 	"time"
 
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/util"
@@ -17,8 +18,12 @@ import (
 
 const commandTimeout = 1 * time.Minute
 
-// PersistentVolumeClaims is used to parse data from kubectl get pvc
-type PersistentVolumeClaims struct {
+type List struct {
+	PersistentVolumeClaims []PersistentVolumeClaim `json:"items"`
+}
+
+// PersistentVolumeClaim is used to parse data from kubectl get pvc
+type PersistentVolumeClaim struct {
 	Metadata Metadata `json:"metadata"`
 	Spec     Spec     `json:"spec"`
 	Status   Status   `json:"status"`
@@ -28,7 +33,7 @@ type PersistentVolumeClaims struct {
 type Metadata struct {
 	CreatedAt time.Time `json:"creationTimestamp"`
 	Name      string    `json:"name"`
-	NameSpace string    `json:"namespace"`
+	Namespace string    `json:"namespace"`
 }
 
 // Spec holds information like storageClassName, volumeName
@@ -43,51 +48,90 @@ type Status struct {
 }
 
 // CreatePersistentVolumeClaimsFromFile will create a PVC from file with a name
-func CreatePersistentVolumeClaimsFromFile(filename, name, namespace string) (*PersistentVolumeClaims, error) {
+func CreatePersistentVolumeClaimsFromFile(filename, name, namespace string) (*PersistentVolumeClaim, error) {
 	cmd := exec.Command("k", "apply", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Printf("Error trying to create PersistentVolumeClaims %s in namespace %s:%s\n", name, namespace, string(out))
+		log.Printf("Error trying to create PersistentVolumeClaim %s in namespace %s:%s\n", name, namespace, string(out))
 		return nil, err
 	}
 	pvc, err := Get(name, namespace)
 	if err != nil {
-		log.Printf("Error while trying to fetch PersistentVolumeClaims %s in namespace %s:%s\n", name, namespace, err)
+		log.Printf("Error while trying to fetch PersistentVolumeClaim %s in namespace %s:%s\n", name, namespace, err)
 		return nil, err
 	}
 	return pvc, nil
 }
 
 // CreatePVCFromFileDeleteIfExist will create a PVC from file with a name
-func CreatePVCFromFileDeleteIfExist(filename, name, namespace string) (*PersistentVolumeClaims, error) {
+func CreatePVCFromFileDeleteIfExist(filename, name, namespace string) (*PersistentVolumeClaim, error) {
 	pvc, _ := Get(name, namespace)
 	if pvc != nil {
 		err := pvc.Delete(util.DefaultDeleteRetries)
 		if err != nil {
 			return nil, err
 		}
-		// Wait a minute before proceeding to create a new pvc w/ the same name
-		time.Sleep(1 * time.Minute)
+		_, err = WaitOnDeleted(pvc.Metadata.Name, pvc.Metadata.Namespace, 5*time.Second, 1*time.Minute)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return CreatePersistentVolumeClaimsFromFile(filename, name, namespace)
 }
 
-// Get will return a PersistentVolumeClaims with a given name and namespace
-func Get(pvcName, namespace string) (*PersistentVolumeClaims, error) {
+// Get will return a PersistentVolumeClaim with a given name and namespace
+func Get(pvcName, namespace string) (*PersistentVolumeClaim, error) {
 	cmd := exec.Command("k", "get", "pvc", pvcName, "-n", namespace, "-o", "json")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
-	pvc := PersistentVolumeClaims{}
+	pvc := PersistentVolumeClaim{}
 	err = json.Unmarshal(out, &pvc)
 	if err != nil {
-		log.Printf("Error unmarshalling PersistentVolumeClaims json:%s\n", err)
+		log.Printf("Error unmarshalling PersistentVolumeClaim json:%s\n", err)
 		return nil, err
 	}
 	return &pvc, nil
+}
+
+// GetAll will return all pvcs in a given namespace
+func GetAll(namespace string) (*List, error) {
+	cmd := exec.Command("k", "get", "pvc", "-n", namespace, "-o", "json")
+	util.PrintCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	pvcl := List{}
+	err = json.Unmarshal(out, &pvcl)
+	if err != nil {
+		log.Printf("Error unmarshalling pvc json:%s\n", err)
+		return nil, err
+	}
+	return &pvcl, nil
+}
+
+// GetAllByPrefix will return all jobs in a given namespace that match a prefix
+func GetAllByPrefix(prefix, namespace string) ([]PersistentVolumeClaim, error) {
+	pvcl, err := GetAll(namespace)
+	if err != nil {
+		return nil, err
+	}
+	pvcs := []PersistentVolumeClaim{}
+	for _, p := range pvcl.PersistentVolumeClaims {
+		matched, err := regexp.MatchString(prefix+"-.*", p.Metadata.Name)
+		if err != nil {
+			log.Printf("Error trying to match pod name:%s\n", err)
+			return nil, err
+		}
+		if matched {
+			pvcs = append(pvcs, p)
+		}
+	}
+	return pvcs, nil
 }
 
 // Describe gets the description for the given pvc and namespace.
@@ -103,15 +147,15 @@ func Describe(pvcName, namespace string) error {
 	return nil
 }
 
-// Delete will delete a PersistentVolumeClaims in a given namespace
-func (pvc *PersistentVolumeClaims) Delete(retries int) error {
+// Delete will delete a PersistentVolumeClaim in a given namespace
+func (pvc *PersistentVolumeClaim) Delete(retries int) error {
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {
-		cmd := exec.Command("k", "delete", "pvc", "-n", pvc.Metadata.NameSpace, pvc.Metadata.Name)
+		cmd := exec.Command("k", "delete", "pvc", "-n", pvc.Metadata.Namespace, pvc.Metadata.Name)
 		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd, commandTimeout)
 		if kubectlError != nil {
-			log.Printf("Error while trying to delete PVC %s in namespace %s:%s\n", pvc.Metadata.Name, pvc.Metadata.NameSpace, string(kubectlOutput))
+			log.Printf("Error while trying to delete PVC %s in namespace %s:%s\n", pvc.Metadata.Name, pvc.Metadata.Namespace, string(kubectlOutput))
 			continue
 		}
 		break
@@ -120,8 +164,8 @@ func (pvc *PersistentVolumeClaims) Delete(retries int) error {
 	return kubectlError
 }
 
-// WaitOnReady will block until PersistentVolumeClaims is available
-func (pvc *PersistentVolumeClaims) WaitOnReady(namespace string, sleep, duration time.Duration) (bool, error) {
+// WaitOnReady will block until PersistentVolumeClaim is available
+func (pvc *PersistentVolumeClaim) WaitOnReady(namespace string, sleep, duration time.Duration) (bool, error) {
 	readyCh := make(chan bool, 1)
 	errCh := make(chan error)
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
@@ -130,7 +174,7 @@ func (pvc *PersistentVolumeClaims) WaitOnReady(namespace string, sleep, duration
 		for {
 			select {
 			case <-ctx.Done():
-				errCh <- errors.Errorf("Timeout exceeded (%s) while waiting for PersistentVolumeClaims (%s) to become ready", duration.String(), pvc.Metadata.Name)
+				errCh <- errors.Errorf("Timeout exceeded (%s) while waiting for PersistentVolumeClaim (%s) to become ready", duration.String(), pvc.Metadata.Name)
 			default:
 				query, _ := Get(pvc.Metadata.Name, namespace)
 				if query != nil && query.Status.Phase == "Bound" {
@@ -148,6 +192,39 @@ func (pvc *PersistentVolumeClaims) WaitOnReady(namespace string, sleep, duration
 			return false, err
 		case ready := <-readyCh:
 			return ready, nil
+		}
+	}
+}
+
+// WaitOnDeleted returns when a pvc is successfully deleted
+func WaitOnDeleted(pvcPrefix, namespace string, sleep, duration time.Duration) (bool, error) {
+	succeededCh := make(chan bool, 1)
+	errCh := make(chan error)
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- errors.Errorf("Timeout exceeded (%s) while waiting for Jobs (%s) to be deleted in namespace (%s)", duration.String(), pvcPrefix, namespace)
+			default:
+				p, err := GetAllByPrefix(pvcPrefix, namespace)
+				if err != nil {
+					errCh <- errors.Errorf("Got error while getting Jobs with prefix \"%s\" in namespace \"%s\"", pvcPrefix, namespace)
+				}
+				if len(p) == 0 {
+					succeededCh <- true
+				}
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case err := <-errCh:
+			return false, err
+		case deleted := <-succeededCh:
+			return deleted, nil
 		}
 	}
 }

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -63,7 +63,7 @@ func CreatePersistentVolumeClaimsFromFile(filename, name, namespace string) (*Pe
 func CreatePVCFromFileDeleteIfExist(filename, name, namespace string) (*PersistentVolumeClaims, error) {
 	pvc, _ := Get(name, namespace)
 	if pvc != nil {
-		err := pvc.Delete(10)
+		err := pvc.Delete(util.DefaultDeleteRetries)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -42,7 +42,7 @@ type Status struct {
 	Phase string `json:"phase"`
 }
 
-// CreatePersistentVolumeClaimsFromFile will create a StorageClass from file with a name
+// CreatePersistentVolumeClaimsFromFile will create a PVC from file with a name
 func CreatePersistentVolumeClaimsFromFile(filename, name, namespace string) (*PersistentVolumeClaims, error) {
 	cmd := exec.Command("k", "apply", "-f", filename)
 	util.PrintCommand(cmd)
@@ -57,6 +57,20 @@ func CreatePersistentVolumeClaimsFromFile(filename, name, namespace string) (*Pe
 		return nil, err
 	}
 	return pvc, nil
+}
+
+// CreatePVCFromFileDeleteIfExist will create a PVC from file with a name
+func CreatePVCFromFileDeleteIfExist(filename, name, namespace string) (*PersistentVolumeClaims, error) {
+	pvc, _ := Get(name, namespace)
+	if pvc != nil {
+		err := pvc.Delete(10)
+		if err != nil {
+			return nil, err
+		}
+		// Wait a minute before proceeding to create a new pvc w/ the same name
+		time.Sleep(1 * time.Minute)
+	}
+	return CreatePersistentVolumeClaimsFromFile(filename, name, namespace)
 }
 
 // Get will return a PersistentVolumeClaims with a given name and namespace

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -168,12 +168,21 @@ func CreatePodFromFile(filename, name, namespace string, sleep, duration time.Du
 		log.Printf("Error trying to create Pod %s:%s\n", name, string(out))
 		return nil, err
 	}
-	pod, err := GetWithRetry(name, namespace, sleep, duration)
+	p, err := GetWithRetry(name, namespace, sleep, duration)
 	if err != nil {
 		log.Printf("Error while trying to fetch Pod %s:%s\n", name, err)
 		return nil, err
 	}
-	return pod, nil
+	return p, nil
+}
+
+// CreatePodFromFileIfNotExist will create a Pod from file with a name
+func CreatePodFromFileIfNotExist(filename, name, namespace string, sleep, duration time.Duration) (*Pod, error) {
+	p, err := Get("dns-liveness", "default")
+	if err != nil {
+		return CreatePodFromFile(filename, name, namespace, sleep, duration)
+	}
+	return p, nil
 }
 
 // RunLinuxPod will create a pod that runs a bash command
@@ -815,6 +824,7 @@ func (p *Pod) CheckWindowsOutboundConnection(sleep, duration time.Duration) (boo
 					matched := exp.MatchString(string(out))
 					if err == nil && matched {
 						readyCh <- true
+						break
 					} else {
 						if i == (len(urls) - 1) {
 							// if all are down let's say we don't have outbound internet access

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -263,7 +263,7 @@ func RunCommandMultipleTimes(podRunnerCmd podRunnerCmd, image, name, command str
 			log.Printf("%s\n", string(out))
 		}
 
-		err = p.Delete(3)
+		err = p.Delete(util.DefaultDeleteRetries)
 		if err != nil {
 			return successfulAttempts, err
 		}

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -241,7 +241,7 @@ func CreateServiceFromFile(filename, name, namespace string) (*Service, error) {
 func CreateServiceFromFileDeleteIfExist(filename, name, namespace string) (*Service, error) {
 	s, _ := Get(name, namespace)
 	if s != nil {
-		err := s.Delete(10)
+		err := s.Delete(util.DefaultDeleteRetries)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/kubernetes/util/util.go
+++ b/test/e2e/kubernetes/util/util.go
@@ -13,6 +13,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DefaultDeleteRetries defines a default retry count for resource deletion operations
+const DefaultDeleteRetries = 10
+
 // PrintCommand prints a command string
 func PrintCommand(cmd *exec.Cmd) {
 	fmt.Printf("\n$ %s\n", strings.Join(cmd.Args, " "))

--- a/test/e2e/kubernetes/workloads/ingress-nginx-elb.yaml
+++ b/test/e2e/kubernetes/workloads/ingress-nginx-elb.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ingress-nginx-ilb
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  name: ingress-nginx-elb
 spec:
   type: LoadBalancer
   ports:

--- a/test/e2e/kubernetes/workloads/validate-dns-linux.yaml
+++ b/test/e2e/kubernetes/workloads/validate-dns-linux.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: validate-dns
+  name: validate-dns-linux
 spec:
   template:
     spec:
@@ -14,4 +15,4 @@ spec:
         image: library/busybox
         command: ['sh', '-c', 'until nslookup google.com; do echo waiting for DNS resolution; sleep 1; done;']
       nodeSelector:
-        beta.kubernetes.io/os: linux 
+        beta.kubernetes.io/os: linux

--- a/test/e2e/kubernetes/workloads/validate-dns-windows-tcp.yaml
+++ b/test/e2e/kubernetes/workloads/validate-dns-windows-tcp.yaml
@@ -10,9 +10,9 @@ spec:
       containers:
       - name: validate-bing
         image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
-        command: ['powershell', 'Resolve-DnsName', '-Name', 'www.bing.com', '-DnsOnly', '-Type', 'CNAME']
+        command: ['powershell', 'Resolve-DnsName', '-Name', 'www.bing.com', '-DnsOnly', '-Type', 'CNAME', '-TcpOnly']
       - name: validate-google
         image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
-        command: ['powershell', 'Resolve-DnsName', '-Name', 'google.com', '-DnsOnly', '-Type', 'A']
+        command: ['powershell', 'Resolve-DnsName', '-Name', 'google.com', '-DnsOnly', '-Type', 'A', '-TcpOnly']
       nodeSelector:
         beta.kubernetes.io/os: windows

--- a/test/e2e/kubernetes/workloads/validate-dns-windows.yaml
+++ b/test/e2e/kubernetes/workloads/validate-dns-windows.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: validate-dns-windows
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: validate-bing
+        image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
+        command: ['powershell', 'Resolve-DnsName', '-Name', 'www.bing.com']
+      - name: validate-google
+        image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
+        command: ['powershell', 'Resolve-DnsName', '-Name', 'google.com']
+      nodeSelector:
+        beta.kubernetes.io/os: windows


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Includes several modifications to E2E test implementations, especially to accommodate soak test scenarios:

- detect pre-existing resources that may have been left around from a prior run, and delete them
- Windows-specific changes to aid in reliable test signal
  - now testing Windows DNS discretely
  - "outbound internet access" test is literally that — validate 8.8.8.8 TCP 43
- configures HPA to more responsively upscale and downscale; this saves 3-4 minutes per test run on average
- combines the "ILB" and "nginx" test into a single "LoadBalancers validation" test
- removes an unnecessary "deploy IIS" test, as the "deploy and scale IIS" test includes everything in it
- reduces retry time for pod Readiness waiting to 10 seconds from 1 minute

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
