### PR TITLE
feat: remove azurefile storage class for Azure Stack

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml
@@ -1,0 +1,39 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: default
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: managed-premium
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Premium_LRS
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: managed-standard
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+  cachingmode: ReadOnly

--- a/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml
@@ -1,0 +1,37 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: default
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: unmanaged-premium
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: shared
+  storageaccounttype: Premium_LRS
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: unmanaged-standard
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: shared
+  storageaccounttype: Standard_LRS
+  cachingmode: ReadOnly

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -199,14 +199,28 @@ func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSet
 			kubernetesFeatureSetting{
 				"kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml",
 				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks,
+				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks && !profile.IsAzureStackCloud(),
 				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
 			})
 		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
 			kubernetesFeatureSetting{
 				"kubernetesmasteraddons-managed-azure-storage-classes.yaml",
 				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks,
+				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks && !profile.IsAzureStackCloud(),
+				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
+			})
+		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
+			kubernetesFeatureSetting{
+				"kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml",
+				"azure-storage-classes.yaml",
+				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks && profile.IsAzureStackCloud(),
+				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
+			})
+		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
+			kubernetesFeatureSetting{
+				"kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml",
+				"azure-storage-classes.yaml",
+				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks && profile.IsAzureStackCloud(),
 				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
 			})
 	}


### PR DESCRIPTION
**Reason for Change**:
Remove `azurefile` as a valid storage class for Azure Stack deployments

**Issue Fixed**:
#1220

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
