### PR TITLE
feat: remove azurefile storage class for Azure Stack

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml
@@ -1,0 +1,39 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: default
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: managed-premium
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Premium_LRS
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: managed-standard
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+  cachingmode: ReadOnly

--- a/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml
@@ -1,0 +1,37 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: default
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: unmanaged-premium
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: shared
+  storageaccounttype: Premium_LRS
+  cachingmode: ReadOnly
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: unmanaged-standard
+  annotations:
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: shared
+  storageaccounttype: Standard_LRS
+  cachingmode: ReadOnly

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -199,14 +199,28 @@ func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSet
 			kubernetesFeatureSetting{
 				"kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml",
 				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks,
+				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks && !profile.IsAzureStackCloud(),
 				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
 			})
 		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
 			kubernetesFeatureSetting{
 				"kubernetesmasteraddons-managed-azure-storage-classes.yaml",
 				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks,
+				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks && !profile.IsAzureStackCloud(),
+				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
+			})
+		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
+			kubernetesFeatureSetting{
+				"kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml",
+				"azure-storage-classes.yaml",
+				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks && profile.IsAzureStackCloud(),
+				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
+			})
+		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
+			kubernetesFeatureSetting{
+				"kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml",
+				"azure-storage-classes.yaml",
+				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks && profile.IsAzureStackCloud(),
 				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
 			})
 	}

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -193,10 +193,10 @@ func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSet
 			profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultELBSVCAddonName),
 		},
 	}
-	
+
 	unmanagedStorageClassYaml := "kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml"
 	managedStorageClassYaml := "kubernetesmasteraddons-managed-azure-storage-classes.yaml"
-	
+
 	if profile.IsAzureStackCloud() {
 		unmanagedStorageClassYaml = "kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml"
 		managedStorageClassYaml = "kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml"
@@ -224,7 +224,7 @@ func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSet
 
 func kubernetesManifestSettingsInit(profile *api.Properties) []kubernetesFeatureSetting {
 	kubeControllerManagerYaml := "kubernetesmaster-kube-controller-manager.yaml"
-	
+
 	if profile.IsAzureStackCloud() {
 		kubeControllerManagerYaml = "kubernetesmaster-kube-controller-manager-custom.yaml"
 	}

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -193,34 +193,28 @@ func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSet
 			profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultELBSVCAddonName),
 		},
 	}
+	
+	unmanagedStorageClassYaml := "kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml"
+	managedStorageClassYaml := "kubernetesmasteraddons-managed-azure-storage-classes.yaml"
+	
+	if profile.IsAzureStackCloud() {
+		unmanagedStorageClassYaml = "kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml"
+		managedStorageClassYaml = "kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml"
+	}
 
 	if len(profile.AgentPoolProfiles) > 0 {
 		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
 			kubernetesFeatureSetting{
-				"kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml",
+				unmanagedStorageClassYaml,
 				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks && !profile.IsAzureStackCloud(),
+				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks,
 				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
 			})
 		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
 			kubernetesFeatureSetting{
-				"kubernetesmasteraddons-managed-azure-storage-classes.yaml",
+				managedStorageClassYaml,
 				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks && !profile.IsAzureStackCloud(),
-				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
-			})
-		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
-			kubernetesFeatureSetting{
-				"kubernetesmasteraddons-unmanaged-azure-storage-classes-custom.yaml",
-				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks && profile.IsAzureStackCloud(),
-				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
-			})
-		kubernetesFeatureSettings = append(kubernetesFeatureSettings,
-			kubernetesFeatureSetting{
-				"kubernetesmasteraddons-managed-azure-storage-classes-custom.yaml",
-				"azure-storage-classes.yaml",
-				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks && profile.IsAzureStackCloud(),
+				profile.AgentPoolProfiles[0].StorageProfile == api.ManagedDisks,
 				profile.OrchestratorProfile.KubernetesConfig.GetAddonScript(DefaultAzureStorageClassesAddonName),
 			})
 	}
@@ -229,6 +223,12 @@ func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSet
 }
 
 func kubernetesManifestSettingsInit(profile *api.Properties) []kubernetesFeatureSetting {
+	kubeControllerManagerYaml := "kubernetesmaster-kube-controller-manager.yaml"
+	
+	if profile.IsAzureStackCloud() {
+		kubeControllerManagerYaml = "kubernetesmaster-kube-controller-manager-custom.yaml"
+	}
+
 	return []kubernetesFeatureSetting{
 		{
 			"kubernetesmaster-kube-scheduler.yaml",
@@ -237,15 +237,9 @@ func kubernetesManifestSettingsInit(profile *api.Properties) []kubernetesFeature
 			profile.OrchestratorProfile.KubernetesConfig.SchedulerConfig["data"],
 		},
 		{
-			"kubernetesmaster-kube-controller-manager.yaml",
+			kubeControllerManagerYaml,
 			"kube-controller-manager.yaml",
-			!profile.IsAzureStackCloud(),
-			profile.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig["data"],
-		},
-		{
-			"kubernetesmaster-kube-controller-manager-custom.yaml",
-			"kube-controller-manager.yaml",
-			profile.IsAzureStackCloud(),
+			true,
 			profile.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig["data"],
 		},
 		{


### PR DESCRIPTION
**Reason for Change**:
Remove azurefile as a valid storage class for Azure Stack deployments

**Issue Fixed**:
#1220

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
