### PR TITLE
fix: private cluster with VMSS masters, jumpbox

### DIFF
--- a/pkg/engine/masterarmresources.go
+++ b/pkg/engine/masterarmresources.go
@@ -146,9 +146,11 @@ func createKubernetesMasterResourcesVMSS(cs *api.ContainerService) []interface{}
 		masterResources = append(masterResources, internalLb)
 	}
 
-	publicIPAddress := CreatePublicIPAddress()
-	loadBalancer := CreateLoadBalancer(cs.Properties, true)
-	masterResources = append(masterResources, publicIPAddress, loadBalancer)
+	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
+		publicIPAddress := CreatePublicIPAddress()
+		loadBalancer := CreateLoadBalancer(cs.Properties, true)
+		masterResources = append(masterResources, publicIPAddress, loadBalancer)
+	}
 
 	kubernetesConfig := cs.Properties.OrchestratorProfile.KubernetesConfig
 

--- a/pkg/engine/masterarmresources_test.go
+++ b/pkg/engine/masterarmresources_test.go
@@ -429,7 +429,7 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 							Direction:                network.SecurityRuleDirectionInbound,
 							Priority:                 to.Int32Ptr(100),
 							Protocol:                 network.SecurityRuleProtocolTCP,
-							SourceAddressPrefix:      to.StringPtr("*"),
+							SourceAddressPrefix:      to.StringPtr("VirtualNetwork"),
 							SourcePortRange:          to.StringPtr("*"),
 						},
 					},

--- a/pkg/engine/masterarmresources_test.go
+++ b/pkg/engine/masterarmresources_test.go
@@ -35,6 +35,7 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 
 	actualResources := createKubernetesMasterResourcesVMAS(&cs)
 
+	var lbBackendAddressPools []network.BackendAddressPool
 	masterNIC := NetworkInterfaceARM{
 		ARMResource: ARMResource{
 			APIVersion: "[variables('apiVersionNetwork')]",
@@ -42,6 +43,57 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 				"count": "[sub(variables('masterCount'), variables('masterOffset'))]",
 				"name":  "nicLoopNode",
 			},
+			DependsOn: []string{
+				"[variables('vnetID')]",
+			},
+		},
+		Interface: network.Interface{
+			InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+				IPConfigurations: &[]network.InterfaceIPConfiguration{
+					{
+						InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+							LoadBalancerBackendAddressPools: &lbBackendAddressPools,
+							LoadBalancerInboundNatRules:     &[]network.InboundNatRule{},
+							PrivateIPAllocationMethod:       network.IPAllocationMethod("Static"),
+							PrivateIPAddress:                to.StringPtr("[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]"),
+							Subnet: &network.Subnet{
+								ID: to.StringPtr("[variables('vnetSubnetID')]"),
+							},
+							Primary: to.BoolPtr(true),
+						},
+						Name: to.StringPtr("ipconfig1"),
+					},
+					{
+						InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+							PrivateIPAllocationMethod: network.Dynamic,
+							Subnet: &network.Subnet{
+								ID: to.StringPtr("[variables('vnetSubnetID')]"),
+							},
+							Primary: to.BoolPtr(false),
+						},
+						Name: to.StringPtr("ipconfig2"),
+					},
+					{
+						InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+							PrivateIPAllocationMethod: network.Dynamic,
+							Subnet: &network.Subnet{
+								ID: to.StringPtr("[variables('vnetSubnetID')]"),
+							},
+							Primary: to.BoolPtr(false),
+						},
+						Name: to.StringPtr("ipconfig3"),
+					},
+				},
+			},
+			Name:     to.StringPtr("[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]"),
+			Type:     to.StringPtr("Microsoft.Network/networkInterfaces"),
+			Location: to.StringPtr("[variables('location')]"),
+		},
+	}
+
+	masterJumpboxNIC := NetworkInterfaceARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
 			DependsOn: []string{
 				"[concat('Microsoft.Network/publicIpAddresses/', variables('jumpboxPublicIpAddressName'))]",
 				"[concat('Microsoft.Network/networkSecurityGroups/', variables('jumpboxNetworkSecurityGroupName'))]",
@@ -55,21 +107,21 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 				},
 				IPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
+						Name: to.StringPtr("ipconfig1"),
 						InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-							PrivateIPAllocationMethod: network.IPAllocationMethod("Dynamic"),
 							Subnet: &network.Subnet{
 								ID: to.StringPtr("[variables('vnetSubnetID')]"),
 							},
-							Primary: to.BoolPtr(true),
+							Primary:                   to.BoolPtr(true),
+							PrivateIPAllocationMethod: network.Dynamic,
 							PublicIPAddress: &network.PublicIPAddress{
 								ID: to.StringPtr("[resourceId('Microsoft.Network/publicIpAddresses', variables('jumpboxPublicIpAddressName'))]"),
 							},
 						},
-						Name: to.StringPtr("ipconfig1"),
 					},
 				},
 			},
-			Name:     to.StringPtr("[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]"),
+			Name:     to.StringPtr("[variables('jumpboxNetworkInterfaceName')]"),
 			Type:     to.StringPtr("Microsoft.Network/networkInterfaces"),
 			Location: to.StringPtr("[variables('location')]"),
 		},
@@ -382,6 +434,7 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 		masterCSEExtension,
 		masterJumpboxVM,
 		masterJumpboxPublicIP,
+		masterJumpboxNIC,
 		masterJumpboxStorageAccount,
 		masterAVSet,
 		masterNSG,

--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -20,8 +20,6 @@ func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 		dependencies = append(dependencies, "[variables('vnetID')]")
 	}
 
-	dependencies = append(dependencies, "[variables('masterLbName')]")
-
 	if cs.Properties.MasterProfile.Count > 1 {
 		dependencies = append(dependencies, "[variables('masterInternalLbName')]")
 	}
@@ -32,6 +30,15 @@ func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 		dependencies = append(dependencies, "[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmosAccountName'))]")
 	}
 
+	lbBackendAddressPools := []network.BackendAddressPool{}
+	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
+		dependencies = append(dependencies, "[variables('masterLbName')]")
+		publicLbPool := network.BackendAddressPool{
+			ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+		}
+		lbBackendAddressPools = append(lbBackendAddressPools, publicLbPool)
+	}
+
 	armResource := ARMResource{
 		APIVersion: "[variables('apiVersionNetwork')]",
 		Copy: map[string]string{
@@ -39,12 +46,6 @@ func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 			"name":  "nicLoopNode",
 		},
 		DependsOn: dependencies,
-	}
-
-	lbBackendAddressPools := []network.BackendAddressPool{
-		{
-			ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
-		},
 	}
 
 	if cs.Properties.MasterProfile.Count > 1 {
@@ -58,18 +59,22 @@ func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 		Name: to.StringPtr("ipconfig1"),
 		InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 			LoadBalancerBackendAddressPools: &lbBackendAddressPools,
-			LoadBalancerInboundNatRules: &[]network.InboundNatRule{
-				{
-					ID: to.StringPtr("[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"),
-				},
-			},
-			PrivateIPAddress:          to.StringPtr("[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]"),
-			Primary:                   to.BoolPtr(true),
-			PrivateIPAllocationMethod: network.Static,
+			PrivateIPAddress:                to.StringPtr("[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]"),
+			Primary:                         to.BoolPtr(true),
+			PrivateIPAllocationMethod:       network.Static,
 			Subnet: &network.Subnet{
 				ID: to.StringPtr("[variables('vnetSubnetID')]"),
 			},
 		},
+	}
+
+	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() {
+		publicNatRules := []network.InboundNatRule{
+			{
+				ID: to.StringPtr("[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"),
+			},
+		}
+		loadBalancerIPConfig.LoadBalancerInboundNatRules = &publicNatRules
 	}
 
 	isAzureCNI := cs.Properties.OrchestratorProfile.IsAzureCNI()
@@ -228,11 +233,7 @@ func createJumpboxNetworkInterface(cs *api.ContainerService) NetworkInterfaceARM
 
 	armResource := ARMResource{
 		APIVersion: "[variables('apiVersionNetwork')]",
-		Copy: map[string]string{
-			"count": "[sub(variables('masterCount'), variables('masterOffset'))]",
-			"name":  "nicLoopNode",
-		},
-		DependsOn: dependencies,
+		DependsOn:  dependencies,
 	}
 
 	nicProperties := network.InterfacePropertiesFormat{
@@ -258,7 +259,7 @@ func createJumpboxNetworkInterface(cs *api.ContainerService) NetworkInterfaceARM
 
 	networkInterface := network.Interface{
 		Location:                  to.StringPtr("[variables('location')]"),
-		Name:                      to.StringPtr("[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]"),
+		Name:                      to.StringPtr("[variables('jumpboxNetworkInterfaceName')]"),
 		InterfacePropertiesFormat: &nicProperties,
 		Type:                      to.StringPtr("Microsoft.Network/networkInterfaces"),
 	}

--- a/pkg/engine/networkinterfaces_test.go
+++ b/pkg/engine/networkinterfaces_test.go
@@ -169,8 +169,8 @@ func TestCreateNIC(t *testing.T) {
 
 	expected.DependsOn = []string{
 		"[variables('nsgID')]",
-		"[variables('masterLbName')]",
 		"[variables('masterInternalLbName')]",
+		"[variables('masterLbName')]",
 	}
 
 	expected.IPConfigurations = &[]network.InterfaceIPConfiguration{
@@ -254,9 +254,9 @@ func TestCreateNIC(t *testing.T) {
 	nic = CreateNetworkInterfaces(cs)
 	expected.DependsOn = []string{
 		"[variables('nsgID')]",
-		"[variables('masterLbName')]",
 		"[variables('masterInternalLbName')]",
 		"[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmosAccountName'))]",
+		"[variables('masterLbName')]",
 	}
 	diff = cmp.Diff(nic, expected)
 
@@ -565,10 +565,6 @@ func TestCreateJumpboxNIC(t *testing.T) {
 	expected := NetworkInterfaceARM{
 		ARMResource: ARMResource{
 			APIVersion: "[variables('apiVersionNetwork')]",
-			Copy: map[string]string{
-				"count": "[sub(variables('masterCount'), variables('masterOffset'))]",
-				"name":  "nicLoopNode",
-			},
 			DependsOn: []string{
 				"[concat('Microsoft.Network/publicIpAddresses/', variables('jumpboxPublicIpAddressName'))]",
 				"[concat('Microsoft.Network/networkSecurityGroups/', variables('jumpboxNetworkSecurityGroupName'))]",
@@ -577,7 +573,7 @@ func TestCreateJumpboxNIC(t *testing.T) {
 		},
 		Interface: network.Interface{
 			Location: to.StringPtr("[variables('location')]"),
-			Name:     to.StringPtr("[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]"),
+			Name:     to.StringPtr("[variables('jumpboxNetworkInterfaceName')]"),
 			InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 				IPConfigurations: &[]network.InterfaceIPConfiguration{
 					{

--- a/pkg/engine/networksecuritygroups.go
+++ b/pkg/engine/networksecuritygroups.go
@@ -174,7 +174,7 @@ func createJumpboxNSG() NetworkSecurityGroupARM {
 	}
 	nsg := network.SecurityGroup{
 		Location: to.StringPtr("[variables('location')]"),
-		Name:     to.StringPtr("[variables('nsgName')]"),
+		Name:     to.StringPtr("[variables('jumpboxNetworkSecurityGroupName')]"),
 		Type:     to.StringPtr("Microsoft.Network/networkSecurityGroups"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &securityRules,

--- a/pkg/engine/networksecuritygroups.go
+++ b/pkg/engine/networksecuritygroups.go
@@ -44,6 +44,11 @@ func CreateNetworkSecurityGroup(cs *api.ContainerService) NetworkSecurityGroupAR
 		},
 	}
 
+	if cs.Properties.OrchestratorProfile.IsPrivateCluster() {
+		source := "VirtualNetwork"
+		kubeTLSRule.SourceAddressPrefix = &source
+	}
+
 	securityRules := []network.SecurityRule{
 		sshRule,
 		kubeTLSRule,

--- a/pkg/engine/networksecuritygroups_test.go
+++ b/pkg/engine/networksecuritygroups_test.go
@@ -157,7 +157,7 @@ func TestCreateJumpboxNSG(t *testing.T) {
 		},
 		SecurityGroup: network.SecurityGroup{
 			Location: to.StringPtr("[variables('location')]"),
-			Name:     to.StringPtr("[variables('nsgName')]"),
+			Name:     to.StringPtr("[variables('jumpboxNetworkSecurityGroupName')]"),
 			Type:     to.StringPtr("Microsoft.Network/networkSecurityGroups"),
 			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 				SecurityRules: &[]network.SecurityRule{

--- a/pkg/engine/networksecuritygroups_test.go
+++ b/pkg/engine/networksecuritygroups_test.go
@@ -16,6 +16,13 @@ import (
 func TestCreateNetworkSecurityGroup(t *testing.T) {
 	cs := &api.ContainerService{
 		Properties: &api.Properties{
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					PrivateCluster: &api.PrivateCluster{
+						Enabled: to.BoolPtr(true),
+					},
+				},
+			},
 			AgentPoolProfiles: []*api.AgentPoolProfile{
 				{
 					Name:   "fooAgent",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Private clusters do not currently deploy due to mixing of jumpbox and master resources, leading to variables absent or resources duplicated in the ARM templates. This PR separates and dedupes in the appropriate places, and fixes the corresponding tests to account for the behavior.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: