### PR TITLE
chore(CIS):enable protect-kernel-defaults

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -81,11 +81,7 @@ func (cs *ContainerService) setKubeletConfig() {
 		"--streaming-connection-idle-timeout": "5m",
 	}
 
-	// "--protect-kernel-defaults" is true is currently only valid using base Ubuntu OS image
-	// until the changes are baked into a VHD
-	if cs.Properties.IsUbuntuDistroForAllNodes() {
-		defaultKubeletConfig["--protect-kernel-defaults"] = "true"
-	}
+	defaultKubeletConfig["--protect-kernel-defaults"] = "true"
 
 	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS
 	if !cs.Properties.IsIPMasqAgentEnabled() {

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -79,9 +79,8 @@ func (cs *ContainerService) setKubeletConfig() {
 		"--image-pull-progress-deadline":      "30m",
 		"--enforce-node-allocatable":          "pods",
 		"--streaming-connection-idle-timeout": "5m",
+		"--protect-kernel-defaults":           "true",
 	}
-
-	defaultKubeletConfig["--protect-kernel-defaults"] = "true"
 
 	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS
 	if !cs.Properties.IsIPMasqAgentEnabled() {

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -58,6 +58,7 @@ func (cs *ContainerService) setKubeletConfig() {
 	staticWindowsKubeletConfig["--image-pull-progress-deadline"] = "20m"
 	staticWindowsKubeletConfig["--resolv-conf"] = "\"\"\"\""
 	staticWindowsKubeletConfig["--eviction-hard"] = "\"\"\"\""
+	staticWindowsKubeletConfig["--protect-kernel-defaults"] = ""
 
 	// Default Kubelet config
 	defaultKubeletConfig := map[string]string{

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -57,21 +57,21 @@ func TestKubeletConfigDefaults(t *testing.T) {
 	for key, val := range kubeletConfig {
 		if expected[key] != val {
 			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
-				key, expected[key], val)
+				key, val, expected[key])
 		}
 	}
 	masterKubeletConfig := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
 	for key, val := range masterKubeletConfig {
 		if expected[key] != val {
 			t.Fatalf("got unexpected masterProfile kubelet config value for %s: %s, expected %s",
-				key, expected[key], val)
+				key, val, expected[key])
 		}
 	}
 	linuxProfileKubeletConfig := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
 	for key, val := range linuxProfileKubeletConfig {
 		if expected[key] != val {
 			t.Fatalf("got unexpected Linux agent profile kubelet config value for %s: %s, expected %s",
-				key, expected[key], val)
+				key, val, expected[key])
 		}
 	}
 	windowsProfileKubeletConfig := cs.Properties.AgentPoolProfiles[1].KubernetesConfig.KubeletConfig
@@ -88,10 +88,11 @@ func TestKubeletConfigDefaults(t *testing.T) {
 	expected["--resolv-conf"] = "\"\"\"\""
 	expected["--eviction-hard"] = "\"\"\"\""
 	delete(expected, "--pod-manifest-path")
+	delete(expected, "--protect-kernel-defaults")
 	for key, val := range windowsProfileKubeletConfig {
 		if expected[key] != val {
 			t.Fatalf("got unexpected Windows agent profile kubelet config value for %s: %s, expected %s",
-				key, expected[key], val)
+				key, val, expected[key])
 		}
 	}
 

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -49,6 +49,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--pod-manifest-path":                 "/etc/kubernetes/manifests",
 		"--pod-infra-container-image":         cs.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + K8sComponentsByVersionMap[cs.Properties.OrchestratorProfile.OrchestratorVersion]["pause"],
 		"--pod-max-pids":                      strconv.Itoa(DefaultKubeletPodMaxPIDs),
+		"--protect-kernel-defaults":           "true",
 		"--rotate-certificates":               "true",
 		"--streaming-connection-idle-timeout": "5m",
 		"--feature-gates":                     "PodPriority=true,RotateKubeletServerCertificate=true",
@@ -434,15 +435,15 @@ func TestProtectKernelDefaults(t *testing.T) {
 	cs := CreateMockContainerService("testcluster", "1.12.7", 3, 2, false)
 	cs.setKubeletConfig()
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	if k["--protect-kernel-defaults"] != "" {
+	if k["--protect-kernel-defaults"] != "true" {
 		t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
-			k["--protect-kernel-defaults"], "pods")
+			k["--protect-kernel-defaults"], "true")
 	}
 
-	// Validate that --protect-kernel-defaults is "true" by default for Ubuntu distros
+	// Validate that --protect-kernel-defaults is "true" by default for relevant distros
 	for _, distro := range DistroValues {
 		switch distro {
-		case Ubuntu, Ubuntu1804:
+		case Ubuntu, Ubuntu1804, AKS, AKS1804:
 			cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
 			cs.Properties.MasterProfile.Distro = distro
 			cs.Properties.AgentPoolProfiles[0].Distro = distro
@@ -469,10 +470,10 @@ func TestProtectKernelDefaults(t *testing.T) {
 			k["--protect-kernel-defaults"], "false")
 	}
 
-	// Validate that --protect-kernel-defaults is overridable for Ubuntu distros
+	// Validate that --protect-kernel-defaults is overridable for relevant distros
 	for _, distro := range DistroValues {
 		switch distro {
-		case Ubuntu, Ubuntu1804:
+		case Ubuntu, Ubuntu1804, AKS, AKS1804:
 			cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
 			cs.Properties.MasterProfile.Distro = "ubuntu"
 			cs.Properties.AgentPoolProfiles[0].Distro = "ubuntu"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
chore(CIS):enable protect-kernel-defaults
PR(https://github.com/Azure/aks-engine/pull/999) does not enable `--protect-kernel-defaults` completely, this PR fixes this issue since below latest Ubuntu image has already enabled the required kernel flags in the VHD image:
```
    "agentpoolosImageSKU": {
      "value": "aks-ubuntu-1604-201904"
    },
    "agentpoolosImageVersion": {
      "value": "2019.04.24"
    },
```
/assign @jackfrancis 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

/hold