### PR TITLE
Fix issue 1049: Windows Kublet issues error due to unsupported config

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -164,14 +164,12 @@ func (cs *ContainerService) setKubeletConfig() {
 		}
 
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
-
-		// The previous call may have copied values from the orchestartor profile, which are not valid
-		// for Windows. We have to fix that 
+		// The previous call may have copied values from the orchestartor profile, which are not valid on Windows
 		if profile.OSType == Windows {
-			delete(profile.KubernetesConfig.KubeletConfig,"--pod-manifest-path")
+			delete(profile.KubernetesConfig.KubeletConfig, "--pod-manifest-path")
 		}
 
-			// For N Series (GPU) VMs
+		// For N Series (GPU) VMs
 		if strings.Contains(profile.VMSize, "Standard_N") {
 			if !cs.Properties.IsNVIDIADevicePluginEnabled() && !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.11.0") {
 				// enabling accelerators for Kubernetes >= 1.6 to <= 1.9

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -165,7 +165,13 @@ func (cs *ContainerService) setKubeletConfig() {
 
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 
-		// For N Series (GPU) VMs
+		// The previous call may have copied values from the orchestartor profile, which are not valid
+		// for Windows. We have to fix that 
+		if profile.OSType == Windows {
+			delete(profile.KubernetesConfig.KubeletConfig,"--pod-manifest-path")
+		}
+
+			// For N Series (GPU) VMs
 		if strings.Contains(profile.VMSize, "Standard_N") {
 			if !cs.Properties.IsNVIDIADevicePluginEnabled() && !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.11.0") {
 				// enabling accelerators for Kubernetes >= 1.6 to <= 1.9


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Undefined Kubelet config values are populated from the Orchestrator profile,
which is always a Linux profile. Unsupported config keys for Windows must
be deleted after that step.

**Issue Fixed**:
Fixes #1049

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
