### PR TITLE
fix: Proper permission on the HOME dir for user on jumpbox VM

### DIFF
--- a/parts/k8s/cloud-init/jumpboxcustomdata.yml
+++ b/parts/k8s/cloud-init/jumpboxcustomdata.yml
@@ -11,7 +11,7 @@ write_files:
 
 - path: "/home/{{WrapAsParameter "jumpboxUsername"}}/.kube/config"
   permissions: "0644"
-  owner: "root"
+  owner: "{{WrapAsParameter "jumpboxUsername"}}"
   content: |
 {{WrapAsVariable "kubeconfig"}}
 
@@ -20,3 +20,7 @@ runcmd:
 - retrycmd_if_failure 10 5 10 curl -LO https://storage.googleapis.com/kubernetes-release/release/v{{.OrchestratorProfile.OrchestratorVersion}}/bin/linux/amd64/kubectl
 - chmod +x ./kubectl
 - sudo mv ./kubectl /usr/local/bin/kubectl
+- chown -R "{{WrapAsParameter "jumpboxUsername"}}" "/home/{{WrapAsParameter "jumpboxUsername"}}"
+- chgrp -R "{{WrapAsParameter "jumpboxUsername"}}" "/home/{{WrapAsParameter "jumpboxUsername"}}"
+- chown -R root "/home/{{WrapAsParameter "jumpboxUsername"}}/.kube"
+- chgrp -R root "/home/{{WrapAsParameter "jumpboxUsername"}}/.kube"


### PR DESCRIPTION
**Reason for Change**:
The cloud init yml for the jumpbox VM in private clusters resulted in root permissions for the default user. Fixed this in a foolproof way to ensure correct permissions.

**Issue Fixed**:
Fixes #725

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
No unit test, as in general testing on the jumpbox in private clusters is currently lacking some testing and this PR is not going to cure that.