### PR TITLE
fix: remove outbound connectivity check on disconnected Azure Stacks

### DIFF
--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -276,7 +276,8 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.IsCoreOS() {
 		ncBinary = "ncat"
 	}
-	if !cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet") {
+	// TODO The AzureStack constraint has to be relaxed, it should only apply to *disconnected* instances
+	if !cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet") && !cs.Properties.IsAzureStackCloud() {
 		if cs.GetCloudSpecConfig().CloudName == api.AzureChinaCloud {
 			registry = `gcr.azk8s.cn 80`
 		} else {

--- a/pkg/engine/vmextensions.go
+++ b/pkg/engine/vmextensions.go
@@ -56,7 +56,8 @@ func CreateCustomScriptExtension(cs *api.ContainerService) VirtualMachineExtensi
 	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.IsCoreOS() {
 		ncBinary = "ncat"
 	}
-	if !cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet") {
+	// TODO The AzureStack constraint has to be relaxed, it should only apply to *disconnected* instances
+	if !cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet") && !cs.Properties.IsAzureStackCloud() {
 		if cs.GetCloudSpecConfig().CloudName == api.AzureChinaCloud {
 			registry = `gcr.azk8s.cn 80`
 		} else {
@@ -102,7 +103,8 @@ func createAgentVMASCustomScriptExtension(cs *api.ContainerService, profile *api
 	if profile.IsCoreOS() {
 		ncBinary = "ncat"
 	}
-	if !cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet") {
+	// TODO The AzureStack constraint has to be relaxed, it should only apply to *disconnected* instances
+	if !cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet") && !cs.Properties.IsAzureStackCloud() {
 		if cs.GetCloudSpecConfig().CloudName == api.AzureChinaCloud {
 			registry = `gcr.azk8s.cn 80`
 		} else {


### PR DESCRIPTION
**Reason for Change**:
If I deploy to a disconnected Azure Stack instance, I would like to skip outbound connectivity validations.

**Issue Fixed**:
Fixes #1249 

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I do not think we currently have a way of telling if the target Azure Stack is connected or disconnected.
For now, I am disabling the validation for all Azure Stack deployments. A subsequent PR will fix this.