### PR TITLE
test: test for missing kubelet configs as well

### DIFF
--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -51,25 +51,26 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--pod-max-pids":                      strconv.Itoa(DefaultKubeletPodMaxPIDs),
 		"--rotate-certificates":               "true",
 		"--streaming-connection-idle-timeout": "5m",
+		"--feature-gates":                     "PodPriority=true,RotateKubeletServerCertificate=true",
 	}
-	for key, val := range expected {
-		if kubeletConfig[key] != val {
+	for key, val := range kubeletConfig {
+		if expected[key] != val {
 			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
-				key, kubeletConfig[key], val)
+				key, expected[key], val)
 		}
 	}
 	masterKubeletConfig := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
-	for key, val := range expected {
-		if masterKubeletConfig[key] != val {
-			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
-				key, masterKubeletConfig[key], val)
+	for key, val := range masterKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected masterProfile kubelet config value for %s: %s, expected %s",
+				key, expected[key], val)
 		}
 	}
 	linuxProfileKubeletConfig := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
-	for key, val := range expected {
-		if linuxProfileKubeletConfig[key] != val {
-			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
-				key, linuxProfileKubeletConfig[key], val)
+	for key, val := range linuxProfileKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected Linux agent profile kubelet config value for %s: %s, expected %s",
+				key, expected[key], val)
 		}
 	}
 	windowsProfileKubeletConfig := cs.Properties.AgentPoolProfiles[1].KubernetesConfig.KubeletConfig
@@ -86,10 +87,10 @@ func TestKubeletConfigDefaults(t *testing.T) {
 	expected["--resolv-conf"] = "\"\"\"\""
 	expected["--eviction-hard"] = "\"\"\"\""
 	delete(expected, "--pod-manifest-path")
-	for key, val := range expected {
-		if windowsProfileKubeletConfig[key] != val {
-			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
-				key, windowsProfileKubeletConfig[key], val)
+	for key, val := range windowsProfileKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected Windows agent profile kubelet config value for %s: %s, expected %s",
+				key, expected[key], val)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow-up from #1244 

We need to enumerate through the actual kubelet config keys to ensure that our expected set doesn't *exclude* anything. In other words, this change will fail unit tests if there's an additional config key that we aren't expecting.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
