### PR TITLE
docs: aks-engine deploy tutorial errors out for auth method as CLI for linux container on windows

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -109,7 +109,6 @@ Finally, run `aks-engine deploy` with the appropriate arguments:
 
 ```console
 $ aks-engine deploy --subscription-id 51ac25de-afdg-9201-d923-8d8e8e8e8e8e \
-    --auth-method cli \
     --dns-prefix contoso-apple \
     --resource-group contoso-apple \
     --location westus2 \


### PR DESCRIPTION
If you try to run as per the documentation inside the container, it errors out because of auth-method as CLI when running it inside the linux container on windows.

Two probable solutions:
Either don't set the authentication method here
Or set the auth-method to client-secret 


**Reason for Change**:
Fixes the tutorial documentation for the case if running it inside the linux container on windows 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#1108 & #773 partially


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
