### PR TITLE
chore: Allow pod to wireserver communication

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -13,9 +13,9 @@ jobs:
     maxParallel: 0
   pool:
     vmImage: ubuntu-16.04
-  
+
   container: dev1
-  
+
   variables:
     GOBIN:  '$(GOPATH)/bin' # Go binaries path
     GOROOT: '/usr/local/go' # Go installation path
@@ -30,6 +30,7 @@ jobs:
     RETAIN_SSH: false
     ENABLE_KMS_ENCRYPTION: true
     SUBSCRIPTION_ID: '$(SUBSCRIPTION_ID_E2E_KUBERNETES)'
+    STABILITY_ITERATIONS: '3'
 
   steps:
     - template: e2e-step-template.yaml

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -342,7 +342,7 @@ write_files:
 {{end}}
 {{if not IsIPMasqAgentEnabled}}
     {{if IsAzureCNI}}
-    iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsParameter "vnetCidr"}} -j MASQUERADE
+    iptables -t nat -A POSTROUTING -m addrtype ! --dst-type local ! -d {{WrapAsParameter "vnetCidr"}} -j MASQUERADE
     {{end}}
 {{end}}
 {{if HasLinuxProfile}}{{if HasCustomSearchDomain}}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -646,6 +646,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(successes).To(Equal(cfg.StabilityIterations))
 		})
 
+		It("should have stable pod to wireserver connectivity", func() {
+			name := fmt.Sprintf("alpine-%s", cfg.Name)
+			command := fmt.Sprintf("nc -vz 168.63.129.16 80")
+			successes, err := pod.RunCommandMultipleTimes(pod.RunLinuxPod, "alpine", name, command, cfg.StabilityIterations, 1*time.Second, retryCommandsTimeout, stabilityCommandTimeout)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(successes).To(Equal(cfg.StabilityIterations))
+		})
+
 		It("should have stable pod-to-pod networking", func() {
 			if eng.HasLinuxAgents() {
 				By("Creating a test php-apache deployment")


### PR DESCRIPTION
Snat wireserver traffic from pod
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This PR allows pod to communicate with wireserver running in azure host.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
