### PR TITLE
docs: correct "--auth-method" arguments in help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,7 +118,7 @@ func addAuthFlags(authArgs *authArgs, f *flag.FlagSet) {
 	f.StringVarP(&authArgs.rawSubscriptionID, "subscription-id", "s", "", "azure subscription id (required)")
 	f.StringVar(&authArgs.AuthMethod, "auth-method", "client_secret", "auth method (default:`client_secret`, `cli`, `client_certificate`, `device`)")
 	f.StringVar(&authArgs.rawClientID, "client-id", "", "client id (used with --auth-method=[client_secret|client_certificate])")
-	f.StringVar(&authArgs.ClientSecret, "client-secret", "", "client secret (used with --auth-mode=client_secret)")
+	f.StringVar(&authArgs.ClientSecret, "client-secret", "", "client secret (used with --auth-method=client_secret)")
 	f.StringVar(&authArgs.CertificatePath, "certificate-path", "", "path to client certificate (used with --auth-method=client_certificate)")
 	f.StringVar(&authArgs.PrivateKeyPath, "private-key-path", "", "path to private key (used with --auth-method=client_certificate)")
 	f.StringVar(&authArgs.IdentitySystem, "identity-system", "azure_ad", "identity system (default:`azure_ad`, `adfs`)")

--- a/docs/topics/scale.md
+++ b/docs/topics/scale.md
@@ -39,5 +39,5 @@ This command will re-use the `apimodel.json` file inside the output directory as
 |--node-pool|depends|Required if there is more than one node pool. Which node pool should be scaled.|
 |--new-node-count|yes|Desired number of nodes in the node pool.|
 |--master-FQDN|depends|When scaling down a kubernetes cluster this is required. The master FDQN so that the nodes can be cordoned and drained before removal. This should be output as part of the create template or it can be found by looking at the public ip addresses in the resource group.|
-|--auth-method|no|The authentication method used. Default value is 'client_secret'. Other supported values are: 'device' and 'client_certificate'.|
+|--auth-method|no|The authentication method used. Default value is `client_secret`. Other supported values are: `cli`, `client_certificate`, and `device`.|
 |--language|no|Language to return error message in. Default value is "en-us").|


### PR DESCRIPTION
**Reason for Change**:
Just a couple of typo fixes.

**Issue Fixed**:

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
