### PR TITLE
feat: Make cordon drain timeout configurable with --upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -72,7 +72,7 @@ func newUpgradeCmd() *cobra.Command {
 	f.StringVar(&uc.deploymentDirectory, "deployment-dir", "", "the location of the output from `generate`")
 	f.StringVarP(&uc.upgradeVersion, "upgrade-version", "k", "", "desired kubernetes version (required)")
 	f.IntVar(&uc.timeoutInMinutes, "vm-timeout", -1, "how long to wait for each vm to be upgraded in minutes")
-	f.IntVar(&uc.cordonDrainTimeoutInMinutes, "cordon-drain-timeout", 20, "how long to wait for each vm to be cordoned in minutes")
+	f.IntVar(&uc.cordonDrainTimeoutInMinutes, "cordon-drain-timeout", -1, "how long to wait for each vm to be cordoned in minutes")
 	f.BoolVarP(&uc.force, "force", "f", false, "force upgrading the cluster to desired version. Allows same version upgrades and downgrades.")
 	addAuthFlags(uc.getAuthArgs(), f)
 
@@ -105,8 +105,10 @@ func (uc *upgradeCmd) validate(cmd *cobra.Command) error {
 		uc.timeout = &timeout
 	}
 
-	cordonDrainTimeout := time.Duration(uc.cordonDrainTimeoutInMinutes) * time.Minute
-	uc.cordonDrainTimeout = &cordonDrainTimeout
+	if uc.cordonDrainTimeoutInMinutes != -1 {
+		cordonDrainTimeout := time.Duration(uc.cordonDrainTimeoutInMinutes) * time.Minute
+		uc.cordonDrainTimeout = &cordonDrainTimeout
+	}
 
 	if uc.upgradeVersion == "" {
 		cmd.Usage()

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -33,13 +33,14 @@ type upgradeCmd struct {
 	authProvider
 
 	// user input
-	resourceGroupName   string
-	apiModelPath        string
-	deploymentDirectory string
-	upgradeVersion      string
-	location            string
-	timeoutInMinutes    int
-	force               bool
+	resourceGroupName           string
+	apiModelPath                string
+	deploymentDirectory         string
+	upgradeVersion              string
+	location                    string
+	timeoutInMinutes            int
+	cordonDrainTimeoutInMinutes int
+	force                       bool
 
 	// derived
 	containerService    *api.ContainerService
@@ -49,6 +50,7 @@ type upgradeCmd struct {
 	nameSuffix          string
 	agentPoolsToUpgrade map[string]bool
 	timeout             *time.Duration
+	cordonDrainTimeout  *time.Duration
 }
 
 func newUpgradeCmd() *cobra.Command {
@@ -70,6 +72,7 @@ func newUpgradeCmd() *cobra.Command {
 	f.StringVar(&uc.deploymentDirectory, "deployment-dir", "", "the location of the output from `generate`")
 	f.StringVarP(&uc.upgradeVersion, "upgrade-version", "k", "", "desired kubernetes version (required)")
 	f.IntVar(&uc.timeoutInMinutes, "vm-timeout", -1, "how long to wait for each vm to be upgraded in minutes")
+	f.IntVar(&uc.cordonDrainTimeoutInMinutes, "cordon-drain-timeout", 20, "how long to wait for each vm to be cordoned in minutes")
 	f.BoolVarP(&uc.force, "force", "f", false, "force upgrading the cluster to desired version. Allows same version upgrades and downgrades.")
 	addAuthFlags(uc.getAuthArgs(), f)
 
@@ -101,6 +104,9 @@ func (uc *upgradeCmd) validate(cmd *cobra.Command) error {
 		timeout := time.Duration(uc.timeoutInMinutes) * time.Minute
 		uc.timeout = &timeout
 	}
+
+	cordonDrainTimeout := time.Duration(uc.cordonDrainTimeoutInMinutes) * time.Minute
+	uc.cordonDrainTimeout = &cordonDrainTimeout
 
 	if uc.upgradeVersion == "" {
 		cmd.Usage()
@@ -238,9 +244,10 @@ func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 		Translator: &i18n.Translator{
 			Locale: uc.locale,
 		},
-		Logger:      log.NewEntry(log.New()),
-		Client:      uc.client,
-		StepTimeout: uc.timeout,
+		Logger:             log.NewEntry(log.New()),
+		Client:             uc.client,
+		StepTimeout:        uc.timeout,
+		CordonDrainTimeout: uc.cordonDrainTimeout,
 	}
 
 	upgradeCluster.ClusterTopology = kubernetesupgrade.ClusterTopology{}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -37,56 +37,61 @@ func TestUpgradeCommandShouldBeValidated(t *testing.T) {
 	}{
 		{
 			uc: &upgradeCmd{
-				resourceGroupName:   "",
-				apiModelPath:        "./not/used",
-				deploymentDirectory: "",
-				upgradeVersion:      "1.8.9",
-				location:            "centralus",
-				timeoutInMinutes:    60,
+				resourceGroupName:           "",
+				apiModelPath:                "./not/used",
+				deploymentDirectory:         "",
+				upgradeVersion:              "1.8.9",
+				location:                    "centralus",
+				timeoutInMinutes:            60,
+				cordonDrainTimeoutInMinutes: 60,
 			},
 			expectedErr: errors.New("--resource-group must be specified"),
 		},
 		{
 			uc: &upgradeCmd{
-				resourceGroupName:   "test",
-				apiModelPath:        "./not/used",
-				deploymentDirectory: "",
-				upgradeVersion:      "1.8.9",
-				location:            "",
-				timeoutInMinutes:    60,
+				resourceGroupName:           "test",
+				apiModelPath:                "./not/used",
+				deploymentDirectory:         "",
+				upgradeVersion:              "1.8.9",
+				location:                    "",
+				timeoutInMinutes:            60,
+				cordonDrainTimeoutInMinutes: 60,
 			},
 			expectedErr: errors.New("--location must be specified"),
 		},
 		{
 			uc: &upgradeCmd{
-				resourceGroupName:   "test",
-				apiModelPath:        "./not/used",
-				deploymentDirectory: "",
-				upgradeVersion:      "",
-				location:            "southcentralus",
-				timeoutInMinutes:    60,
+				resourceGroupName:           "test",
+				apiModelPath:                "./not/used",
+				deploymentDirectory:         "",
+				upgradeVersion:              "",
+				location:                    "southcentralus",
+				timeoutInMinutes:            60,
+				cordonDrainTimeoutInMinutes: 60,
 			},
 			expectedErr: errors.New("--upgrade-version must be specified"),
 		},
 		{
 			uc: &upgradeCmd{
-				resourceGroupName:   "test",
-				apiModelPath:        "",
-				deploymentDirectory: "",
-				upgradeVersion:      "1.9.0",
-				location:            "southcentralus",
-				timeoutInMinutes:    60,
+				resourceGroupName:           "test",
+				apiModelPath:                "",
+				deploymentDirectory:         "",
+				upgradeVersion:              "1.9.0",
+				location:                    "southcentralus",
+				timeoutInMinutes:            60,
+				cordonDrainTimeoutInMinutes: 60,
 			},
 			expectedErr: errors.New("--api-model must be specified"),
 		},
 		{
 			uc: &upgradeCmd{
-				resourceGroupName:   "test",
-				apiModelPath:        "./somefile",
-				deploymentDirectory: "aDir/anotherDir",
-				upgradeVersion:      "1.9.0",
-				location:            "southcentralus",
-				timeoutInMinutes:    60,
+				resourceGroupName:           "test",
+				apiModelPath:                "./somefile",
+				deploymentDirectory:         "aDir/anotherDir",
+				upgradeVersion:              "1.9.0",
+				location:                    "southcentralus",
+				timeoutInMinutes:            60,
+				cordonDrainTimeoutInMinutes: 60,
 			},
 			expectedErr: errors.New("ambiguous, please specify only one of --api-model and --deployment-dir"),
 		},
@@ -137,11 +142,12 @@ func TestUpgradeShouldFailForSameVersion(t *testing.T) {
 	})
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
-		resourceGroupName: "rg",
-		apiModelPath:      "./not/used",
-		upgradeVersion:    "1.10.13",
-		location:          "centralus",
-		timeoutInMinutes:  60,
+		resourceGroupName:           "rg",
+		apiModelPath:                "./not/used",
+		upgradeVersion:              "1.10.13",
+		location:                    "centralus",
+		timeoutInMinutes:            60,
+		cordonDrainTimeoutInMinutes: 60,
 
 		client: &armhelpers.MockAKSEngineClient{},
 	}
@@ -162,11 +168,12 @@ func TestUpgradeShouldFailForInvalidUpgradePath(t *testing.T) {
 	})
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
-		resourceGroupName: "rg",
-		apiModelPath:      "./not/used",
-		upgradeVersion:    "1.10.13",
-		location:          "centralus",
-		timeoutInMinutes:  60,
+		resourceGroupName:           "rg",
+		apiModelPath:                "./not/used",
+		upgradeVersion:              "1.10.13",
+		location:                    "centralus",
+		timeoutInMinutes:            60,
+		cordonDrainTimeoutInMinutes: 60,
 
 		client: &armhelpers.MockAKSEngineClient{},
 	}
@@ -186,11 +193,12 @@ func TestUpgradeShouldSuceedForValidUpgradePath(t *testing.T) {
 	})
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
-		resourceGroupName: "rg",
-		apiModelPath:      "./not/used",
-		upgradeVersion:    "1.10.13",
-		location:          "centralus",
-		timeoutInMinutes:  60,
+		resourceGroupName:           "rg",
+		apiModelPath:                "./not/used",
+		upgradeVersion:              "1.10.13",
+		location:                    "centralus",
+		timeoutInMinutes:            60,
+		cordonDrainTimeoutInMinutes: 60,
 
 		client: &armhelpers.MockAKSEngineClient{},
 	}
@@ -206,13 +214,14 @@ func TestUpgradeShouldSuceedForValidUpgradePath(t *testing.T) {
 func TestUpgradeFailWithPathWhenAzureDeployJsonIsInvalid(t *testing.T) {
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
-		resourceGroupName: "rg",
-		apiModelPath:      "./not/used",
-		upgradeVersion:    "1.13.3",
-		location:          "centralus",
-		timeoutInMinutes:  60,
-		force:             true,
-		client:            &armhelpers.MockAKSEngineClient{},
+		resourceGroupName:           "rg",
+		apiModelPath:                "./not/used",
+		upgradeVersion:              "1.13.3",
+		location:                    "centralus",
+		timeoutInMinutes:            60,
+		cordonDrainTimeoutInMinutes: 60,
+		force:                       true,
+		client:                      &armhelpers.MockAKSEngineClient{},
 	}
 
 	containerServiceMock := api.CreateMockContainerService("testcluster", "1.13.2", 3, 2, false)
@@ -228,11 +237,12 @@ func TestUpgradeForceSameVersionShouldSucceed(t *testing.T) {
 	})
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
-		resourceGroupName: "rg",
-		apiModelPath:      "./not/used",
-		upgradeVersion:    "1.10.13",
-		location:          "centralus",
-		timeoutInMinutes:  60,
+		resourceGroupName:           "rg",
+		apiModelPath:                "./not/used",
+		upgradeVersion:              "1.10.13",
+		location:                    "centralus",
+		timeoutInMinutes:            60,
+		cordonDrainTimeoutInMinutes: 60,
 
 		client: &armhelpers.MockAKSEngineClient{},
 	}
@@ -253,11 +263,12 @@ func TestUpgradeForceDowngradeShouldSetVersionOnContainerService(t *testing.T) {
 	})
 	g := NewGomegaWithT(t)
 	upgradeCmd := &upgradeCmd{
-		resourceGroupName: "rg",
-		apiModelPath:      "./not/used",
-		upgradeVersion:    "1.10.12",
-		location:          "centralus",
-		timeoutInMinutes:  60,
+		resourceGroupName:           "rg",
+		apiModelPath:                "./not/used",
+		upgradeVersion:              "1.10.12",
+		location:                    "centralus",
+		timeoutInMinutes:            60,
+		cordonDrainTimeoutInMinutes: 60,
 
 		client: &armhelpers.MockAKSEngineClient{},
 	}

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	interval           = time.Second * 1
-	retry              = time.Second * 5
-	cordonDrainTimeout = time.Minute * 20
+	interval = time.Second * 1
+	retry    = time.Second * 5
 )
 
 // Compiler to verify QueueMessageProcessor implements OperationsProcessor
@@ -42,6 +41,7 @@ type UpgradeAgentNode struct {
 	Client                  armhelpers.AKSEngineClient
 	kubeConfig              string
 	timeout                 time.Duration
+	cordonDrainTimeout      time.Duration
 }
 
 // DeleteNode takes state/resources of the master/agent node from ListNodeResources
@@ -69,7 +69,7 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 	}
 	// Cordon and drain the node
 	if drain {
-		err = operations.SafelyDrainNodeWithClient(client, kan.logger, nodeName, cordonDrainTimeout)
+		err = operations.SafelyDrainNodeWithClient(client, kan.logger, nodeName, kan.cordonDrainTimeout)
 		if err != nil {
 			kan.logger.Warningf("Error draining agent VM %s. Proceeding with deletion. Error: %v", *vmName, err)
 			// Proceed with deletion anyways

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -70,10 +70,11 @@ type UpgradeCluster struct {
 	Translator *i18n.Translator
 	Logger     *logrus.Entry
 	ClusterTopology
-	Client          armhelpers.AKSEngineClient
-	StepTimeout     *time.Duration
-	UpgradeWorkFlow UpgradeWorkFlow
-	Force           bool
+	Client             armhelpers.AKSEngineClient
+	StepTimeout        *time.Duration
+	CordonDrainTimeout *time.Duration
+	UpgradeWorkFlow    UpgradeWorkFlow
+	Force              bool
 }
 
 // MasterVMNamePrefix is the prefix for all master VM names for Kubernetes clusters
@@ -108,7 +109,7 @@ func (uc *UpgradeCluster) getUpgradeWorkflow(kubeConfig string, aksEngineVersion
 		return uc.UpgradeWorkFlow
 	}
 	u := &Upgrader{}
-	u.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, aksEngineVersion)
+	u.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, uc.CordonDrainTimeout, aksEngineVersion)
 	return u
 }
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
@@ -22,8 +21,6 @@ import (
 )
 
 const TestAKSEngineVersion = "1.0.0"
-
-var defaultTestCordonTimeOut = time.Minute * 20
 
 type fakeUpgradeWorkflow struct {
 	RunUpgradeError error
@@ -57,9 +54,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should succeed when cluster VMs are missing expected tags during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -84,9 +80,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to list VMs during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -111,9 +106,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to delete VMs during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -135,9 +129,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to deploy template during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -159,9 +152,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to get a virtual machine during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 6, false)
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -183,9 +175,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to get storage client during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 5, 1, false)
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -207,9 +198,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to delete network interface during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 3, 2, false)
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -233,9 +223,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -266,9 +255,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 			mockClient = armhelpers.MockAKSEngineClient{}
 			cs = api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
 			uc = UpgradeCluster{
-				Translator:         &i18n.Translator{},
-				Logger:             log.NewEntry(log.New()),
-				CordonDrainTimeout: &defaultTestCordonTimeOut,
+				Translator: &i18n.Translator{},
+				Logger:     log.NewEntry(log.New()),
 			}
 			mockClient.FakeListVirtualMachineScaleSetsResult = func() []compute.VirtualMachineScaleSet {
 				scalesetName := "scalesetName"
@@ -375,9 +363,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 			mockClient = armhelpers.MockAKSEngineClient{}
 			cs = api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
 			uc = UpgradeCluster{
-				Translator:         &i18n.Translator{},
-				Logger:             log.NewEntry(log.New()),
-				CordonDrainTimeout: &defaultTestCordonTimeOut,
+				Translator: &i18n.Translator{},
+				Logger:     log.NewEntry(log.New()),
 			}
 			mockClient.FakeListVirtualMachineScaleSetsResult = func() []compute.VirtualMachineScaleSet {
 				windowsScalesetName := "akswinpoo"
@@ -450,9 +437,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 			mockClient = armhelpers.MockAKSEngineClient{}
 			cs = api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
 			uc = UpgradeCluster{
-				Translator:         &i18n.Translator{},
-				Logger:             log.NewEntry(log.New()),
-				CordonDrainTimeout: &defaultTestCordonTimeOut,
+				Translator: &i18n.Translator{},
+				Logger:     log.NewEntry(log.New()),
 			}
 
 			uc.Client = &mockClient
@@ -560,9 +546,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
 		uc := UpgradeCluster{
-			Translator:         &i18n.Translator{},
-			Logger:             log.NewEntry(log.New()),
-			CordonDrainTimeout: &defaultTestCordonTimeOut,
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -605,7 +590,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		}
 
 		u := &Upgrader{}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
 
 		vmname, err := u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal("aks-agentnode1-123456-vmss000005"))
@@ -619,7 +604,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 				mockClient.MakeFakeVirtualMachineScaleSetVMWithGivenName("Kubernetes:1.9.10", ""),
 			}
 		}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
 
 		vmname, err = u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal(""))
@@ -628,7 +613,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
 			return []compute.VirtualMachineScaleSetVM{}
 		}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
 
 		vmname, err = u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal(""))
@@ -641,7 +626,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		mockClient := &armhelpers.MockAKSEngineClient{MockKubernetesClient: &armhelpers.MockKubernetesClient{}}
 		mockClient.MockKubernetesClient.FailGetNode = true
 
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, nil, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, nil, "", nil, nil, TestAKSEngineVersion)
 		err := u.copyCustomPropertiesToNewNode(mockClient.MockKubernetesClient, "oldNodeName", "newNodeName")
 		Expect(err).Should(HaveOccurred())
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -590,7 +590,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		}
 
 		u := &Upgrader{}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
 
 		vmname, err := u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal("aks-agentnode1-123456-vmss000005"))
@@ -604,7 +604,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 				mockClient.MakeFakeVirtualMachineScaleSetVMWithGivenName("Kubernetes:1.9.10", ""),
 			}
 		}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
 
 		vmname, err = u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal(""))
@@ -613,7 +613,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
 			return []compute.VirtualMachineScaleSetVM{}
 		}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
 
 		vmname, err = u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal(""))
@@ -626,7 +626,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		mockClient := &armhelpers.MockAKSEngineClient{MockKubernetesClient: &armhelpers.MockKubernetesClient{}}
 		mockClient.MockKubernetesClient.FailGetNode = true
 
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, nil, "", nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, nil, "", nil, nil, TestAKSEngineVersion)
 		err := u.copyCustomPropertiesToNewNode(mockClient.MockKubernetesClient, "oldNodeName", "newNodeName")
 		Expect(err).Should(HaveOccurred())
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
@@ -21,6 +22,8 @@ import (
 )
 
 const TestAKSEngineVersion = "1.0.0"
+
+var defaultTestCordonTimeOut = time.Minute * 20
 
 type fakeUpgradeWorkflow struct {
 	RunUpgradeError error
@@ -54,8 +57,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should succeed when cluster VMs are missing expected tags during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -80,8 +84,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to list VMs during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -106,8 +111,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to delete VMs during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -129,8 +135,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to deploy template during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 1, false)
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -152,8 +159,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to get a virtual machine during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 1, 6, false)
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -175,8 +183,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to get storage client during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 5, 1, false)
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -198,8 +207,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	It("Should return error message when failing to delete network interface during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.9.11", 3, 2, false)
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -223,8 +233,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -255,8 +266,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 			mockClient = armhelpers.MockAKSEngineClient{}
 			cs = api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
 			uc = UpgradeCluster{
-				Translator: &i18n.Translator{},
-				Logger:     log.NewEntry(log.New()),
+				Translator:         &i18n.Translator{},
+				Logger:             log.NewEntry(log.New()),
+				CordonDrainTimeout: &defaultTestCordonTimeOut,
 			}
 			mockClient.FakeListVirtualMachineScaleSetsResult = func() []compute.VirtualMachineScaleSet {
 				scalesetName := "scalesetName"
@@ -363,8 +375,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 			mockClient = armhelpers.MockAKSEngineClient{}
 			cs = api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
 			uc = UpgradeCluster{
-				Translator: &i18n.Translator{},
-				Logger:     log.NewEntry(log.New()),
+				Translator:         &i18n.Translator{},
+				Logger:             log.NewEntry(log.New()),
+				CordonDrainTimeout: &defaultTestCordonTimeOut,
 			}
 			mockClient.FakeListVirtualMachineScaleSetsResult = func() []compute.VirtualMachineScaleSet {
 				windowsScalesetName := "akswinpoo"
@@ -437,8 +450,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 			mockClient = armhelpers.MockAKSEngineClient{}
 			cs = api.CreateMockContainerService("testcluster", "1.9.10", 3, 3, false)
 			uc = UpgradeCluster{
-				Translator: &i18n.Translator{},
-				Logger:     log.NewEntry(log.New()),
+				Translator:         &i18n.Translator{},
+				Logger:             log.NewEntry(log.New()),
+				CordonDrainTimeout: &defaultTestCordonTimeOut,
 			}
 
 			uc.Client = &mockClient
@@ -546,8 +560,9 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
 		uc := UpgradeCluster{
-			Translator: &i18n.Translator{},
-			Logger:     log.NewEntry(log.New()),
+			Translator:         &i18n.Translator{},
+			Logger:             log.NewEntry(log.New()),
+			CordonDrainTimeout: &defaultTestCordonTimeOut,
 		}
 
 		mockClient := armhelpers.MockAKSEngineClient{}
@@ -590,7 +605,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		}
 
 		u := &Upgrader{}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
 
 		vmname, err := u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal("aks-agentnode1-123456-vmss000005"))
@@ -604,7 +619,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 				mockClient.MakeFakeVirtualMachineScaleSetVMWithGivenName("Kubernetes:1.9.10", ""),
 			}
 		}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
 
 		vmname, err = u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal(""))
@@ -613,7 +628,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		mockClient.FakeListVirtualMachineScaleSetVMsResult = func() []compute.VirtualMachineScaleSetVM {
 			return []compute.VirtualMachineScaleSetVM{}
 		}
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, &mockClient, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
 
 		vmname, err = u.getLastVMNameInVMSS(ctx, "resourcegroup", "scalesetName")
 		Expect(vmname).To(Equal(""))
@@ -626,7 +641,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		mockClient := &armhelpers.MockAKSEngineClient{MockKubernetesClient: &armhelpers.MockKubernetesClient{}}
 		mockClient.MockKubernetesClient.FailGetNode = true
 
-		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, nil, "", nil, nil, TestAKSEngineVersion)
+		u.Init(&i18n.Translator{}, log.NewEntry(log.New()), ClusterTopology{}, nil, "", nil, &defaultTestCordonTimeOut, TestAKSEngineVersion)
 		err := u.copyCustomPropertiesToNewNode(mockClient.MockKubernetesClient, "oldNodeName", "newNodeName")
 		Expect(err).Should(HaveOccurred())
 

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -505,8 +505,10 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 
 			ku.logger.Infof("Successfully set capacity for VMSS %s", vmssToUpgrade.Name)
 
-			cordonDrainTimeout := defaultCordonDrainTimeout
-			if ku.cordonDrainTimeout != nil {
+			var cordonDrainTimeout time.Duration
+			if ku.cordonDrainTimeout == nil {
+				cordonDrainTimeout = defaultCordonDrainTimeout
+			} else {
 				cordonDrainTimeout = *ku.cordonDrainTimeout
 			}
 

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -507,7 +507,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 
 			cordonDrainTimeout := defaultCordonDrainTimeout
 			if ku.cordonDrainTimeout != nil {
-				cordonDrainTimeout = defaultCordonDrainTimeout
+				cordonDrainTimeout = *ku.cordonDrainTimeout
 			}
 
 			// Before we can delete the node we should safely and responsibly drain it

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -40,6 +40,7 @@ type vmStatus int
 
 const (
 	defaultTimeout                     = time.Minute * 20
+	defaultCordonDrainTimeout          = time.Minute * 20
 	nodePropertiesCopyTimeout          = time.Minute * 5
 	vmStatusUpgraded          vmStatus = iota
 	vmStatusNotUpgraded
@@ -265,7 +266,11 @@ func (ku *Upgrader) upgradeAgentPools(ctx context.Context) error {
 		} else {
 			upgradeAgentNode.timeout = *ku.stepTimeout
 		}
-		upgradeAgentNode.cordonDrainTimeout = *ku.cordonDrainTimeout
+		if ku.cordonDrainTimeout == nil {
+			upgradeAgentNode.cordonDrainTimeout = defaultCordonDrainTimeout
+		} else {
+			upgradeAgentNode.cordonDrainTimeout = *ku.cordonDrainTimeout
+		}
 
 		agentVMs := make(map[int]*vmInfo)
 		// Go over upgraded VMs and verify provisioning state

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -505,8 +505,13 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 
 			ku.logger.Infof("Successfully set capacity for VMSS %s", vmssToUpgrade.Name)
 
+			cordonDrainTimeout := defaultCordonDrainTimeout
+			if ku.cordonDrainTimeout != nil {
+				cordonDrainTimeout = defaultCordonDrainTimeout
+			}
+
 			// Before we can delete the node we should safely and responsibly drain it
-			client, err := ku.getKubernetesClient(*ku.cordonDrainTimeout)
+			client, err := ku.getKubernetesClient(cordonDrainTimeout)
 			if err != nil {
 				ku.logger.Errorf("Error getting Kubernetes client: %v", err)
 				return err
@@ -517,7 +522,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 				client,
 				ku.logger,
 				strings.ToLower(vmToUpgrade.Name),
-				*ku.cordonDrainTimeout,
+				cordonDrainTimeout,
 			)
 			if err != nil {
 				ku.logger.Errorf("Error draining VM in VMSS: %v", err)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Make the cordon drain timeout value configurable in `--upgrade` command.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #950

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
