### PR TITLE
Update hyperkube command in manifests for k8s components.

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - command:
         - /hyperkube
-        - proxy
+        - kube-proxy
         - --kubeconfig=/var/lib/kubelet/kubeconfig
         - --cluster-cidr=<CIDR>
         - --feature-gates=ExperimentalCriticalPodAnnotation=true

--- a/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -12,7 +12,7 @@ spec:
     - name: kube-apiserver
       image: <img>
       imagePullPolicy: IfNotPresent
-      command: ["/hyperkube", "apiserver"]
+      command: ["/hyperkube", "kube-apiserver"]
       args: [<args>]
       volumeMounts:
         - name: etc-kubernetes

--- a/parts/k8s/manifests/kubernetesmaster-kube-controller-manager-custom.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-controller-manager-custom.yaml
@@ -12,7 +12,7 @@ spec:
     - name: kube-controller-manager
       image: <img>
       imagePullPolicy: IfNotPresent
-      command: ["/hyperkube", "controller-manager"]
+      command: ["/hyperkube", "kube-controller-manager"]
       args: [<args>]
       env:
       - name: AZURE_ENVIRONMENT_FILEPATH

--- a/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
@@ -12,7 +12,7 @@ spec:
     - name: kube-controller-manager
       image: <img>
       imagePullPolicy: IfNotPresent
-      command: ["/hyperkube", "controller-manager"]
+      command: ["/hyperkube", "kube-controller-manager"]
       args: [<args>]
       volumeMounts:
         - name: etc-kubernetes

--- a/parts/k8s/manifests/kubernetesmaster-kube-scheduler.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-scheduler.yaml
@@ -12,7 +12,7 @@ spec:
     - name: kube-scheduler
       image: <img>
       imagePullPolicy: IfNotPresent
-      command: ["/hyperkube", "scheduler"]
+      command: ["/hyperkube", "kube-scheduler"]
       args: [<args>]
       volumeMounts:
         - name: etc-kubernetes


### PR DESCRIPTION
In k8s 1.15 this PR : https://github.com/kubernetes/kubernetes/pull/76953
removed aliases for k8s binaries in hyperkube ( i.e proxy alias for kube-proxy ).

This PR changes the commands in all manifests that invoke hyperkube
to use the full name of the binaries.

**Reason for Change**:

PR https://github.com/kubernetes/kubernetes/pull/76953 in kubernetes/kubernetes removed aliases for hyperkube binaries ( apiserver, proxy etc. ), thus the binaries have to be invoked by their full name ( kube-apiserver, kube-proxy etc. ).

This issue has been observed in upstream windows testing for k8s ( https://testgrid.k8s.io/sig-windows#aks-engine-azure-windows-master ).

NOTE: 
- It does not affect aks-engine as it is now, as it only supports k8s 1.15.0-alpha.3 ( Change merged after this ) however it may pose a problem in future releases.
- the full binary name,  kube- , is supported in all k8s versions thus there shouldn't be any backwards compatibility issues.
