### PR TITLE
fix: Get VMSS node version from K8s API instead of tags for old instances

### DIFF
--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -73,6 +73,7 @@ type MockKubernetesClient struct {
 	FailListServiceAccounts  bool
 	FailGetNode              bool
 	UpdateNodeFunc           func(*v1.Node) (*v1.Node, error)
+	GetNodeFunc              func(name string) (*v1.Node, error)
 	FailUpdateNode           bool
 	FailDeleteNode           bool
 	FailDeleteServiceAccount bool
@@ -335,6 +336,9 @@ func (mkc *MockKubernetesClient) ListServiceAccounts(namespace string) (*v1.Serv
 
 //GetNode returns details about node with passed in name
 func (mkc *MockKubernetesClient) GetNode(name string) (*v1.Node, error) {
+	if mkc.GetNodeFunc != nil {
+		return mkc.GetNodeFunc(name)
+	}
 	if mkc.FailGetNode {
 		return nil, errors.New("GetNode failed")
 	}
@@ -622,12 +626,14 @@ func (mc *MockAKSEngineClient) MakeFakeVirtualMachineScaleSetVMWithGivenName(orc
 		tags = nil
 	}
 
+	trueVar := true
 	return compute.VirtualMachineScaleSetVM{
 		Name:       &vm1Name,
 		Tags:       tags,
 		InstanceID: &instanceID,
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-			OsProfile: &compute.OSProfile{ComputerName: &computerName},
+			LatestModelApplied: &trueVar,
+			OsProfile:          &compute.OSProfile{ComputerName: &computerName},
 			StorageProfile: &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
 					Vhd: &compute.VirtualHardDisk{

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -558,7 +558,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 				}
 
 				ku.logger.Infof("Copying custom annotations, labels, taints from old node %s to new node %s...", vmToUpgrade.Name, newNodeName)
-				err = ku.copyCustomPropertiesToNewNode(client, vmToUpgrade.Name, newNodeName)
+				err = ku.copyCustomPropertiesToNewNode(client, strings.ToLower(vmToUpgrade.Name), strings.ToLower(newNodeName))
 				if err != nil {
 					ku.logger.Warningf("Failed to copy custom annotations, labels, taints from old node %s to new node %s: %v", vmToUpgrade.Name, newNodeName, err)
 				}


### PR DESCRIPTION
Get VMSS node version from K8S API for instances with old model. Also adding back a missed lower case conversion

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
All instances in Azure VMSS share the same tags. So in case of partial agent pool upgrade failures, we will end up with nodes on both new model and old model. Yet, the tags of all nodes are of the new model. So retry upgrade in this situation ends up doing nothing. With this fix we will check whether each instance has the latest model applied before checking the tags. If not, we will use K8s API to get node version.

Also, adding back toLower to newnode name when copying node properties. 

<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
