### PR TITLE
fix: don’t add etcd data disk in cosmos etcd scenario

### DIFF
--- a/pkg/engine/masterarmresources.go
+++ b/pkg/engine/masterarmresources.go
@@ -92,7 +92,7 @@ func createKubernetesMasterResourcesVMAS(cs *api.ContainerService) []interface{}
 		masterResources = append(masterResources, keyVaultStorageAccount, keyVault)
 	}
 
-	masterVM := CreateVirtualMachine(cs)
+	masterVM := CreateMasterVM(cs)
 	masterResources = append(masterResources, masterVM)
 
 	var useManagedIdentity, userAssignedIDEnabled bool

--- a/pkg/engine/virtualmachines_test.go
+++ b/pkg/engine/virtualmachines_test.go
@@ -114,8 +114,14 @@ func TestCreateVirtualMachines(t *testing.T) {
 	cs.Properties.MasterProfile.CosmosEtcd = to.BoolPtr(true)
 	actualVM = CreateMasterVM(cs)
 	expectedVM.StorageProfile.DataDisks = nil
+	expectedCustomDataStr = getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(cs))
+	expectedVM.VirtualMachine.VirtualMachineProperties.OsProfile.CustomData = to.StringPtr(expectedCustomDataStr)
 
 	diff = cmp.Diff(actualVM, expectedVM)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
 
 	// Now test with ManagedIdentity, Availability Zones, and StorageAccount
 
@@ -162,6 +168,9 @@ func TestCreateVirtualMachines(t *testing.T) {
 	expectedVM.VirtualMachine.Zones = &[]string{
 		"[string(parameters('availabilityZones')[mod(copyIndex(variables('masterOffset')), length(parameters('availabilityZones')))])]",
 	}
+
+	expectedCustomDataStr = getCustomDataFromJSON(tg.GetMasterCustomDataJSONObject(cs))
+	expectedVM.VirtualMachine.VirtualMachineProperties.OsProfile.CustomData = to.StringPtr(expectedCustomDataStr)
 
 	diff = cmp.Diff(actualVM, expectedVM)
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

In cosmos etcd scenario we should not add a data disk for local etcd.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1311

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
