### PR TITLE
test: getTemplateFuncMap unit tests part 1

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -4,12 +4,14 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"math/rand"
 	"net"
 	neturl "net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1369,6 +1371,26 @@ func (a *AgentPoolProfile) IsUbuntuNonVHD() bool {
 	return a.IsUbuntu() && !a.IsVHDDistro()
 }
 
+// GetKubernetesLabels returns a k8s API-compliant labels string for nodes in this profile
+func (a *AgentPoolProfile) GetKubernetesLabels(rg string) string {
+	var buf bytes.Buffer
+	buf.WriteString("node-role.kubernetes.io/agent=")
+	buf.WriteString(fmt.Sprintf(",kubernetes.io/role=agent,agentpool=%s", a.Name))
+	if a.StorageProfile == ManagedDisks {
+		storagetier, _ := common.GetStorageAccountType(a.VMSize)
+		buf.WriteString(fmt.Sprintf(",storageprofile=managed,storagetier=%s", storagetier))
+	}
+	if common.IsNvidiaEnabledSKU(a.VMSize) {
+		accelerator := "nvidia"
+		buf.WriteString(fmt.Sprintf(",accelerator=%s", accelerator))
+	}
+	buf.WriteString(fmt.Sprintf(",kubernetes.azure.com/cluster=%s", rg))
+	for k, v := range a.CustomNodeLabels {
+		buf.WriteString(fmt.Sprintf(",%s=%s", k, v))
+	}
+	return buf.String()
+}
+
 // HasSecrets returns true if the customer specified secrets to install
 func (w *WindowsProfile) HasSecrets() bool {
 	return len(w.Secrets) > 0
@@ -1441,6 +1463,13 @@ func (o *OrchestratorProfile) IsKubernetes() bool {
 // IsDCOS returns true if this template is for DCOS orchestrator
 func (o *OrchestratorProfile) IsDCOS() bool {
 	return o.OrchestratorType == DCOS
+}
+
+// IsDCOS19 returns true if this is a DCOS 1.9 orchestrator using the latest version
+func (o *OrchestratorProfile) IsDCOS19() bool {
+	return o.OrchestratorType == DCOS &&
+		(o.OrchestratorVersion == common.DCOSVersion1Dot9Dot0 ||
+			o.OrchestratorVersion == common.DCOSVersion1Dot9Dot8)
 }
 
 // IsAzureCNI returns true if Azure CNI network plugin is enabled
@@ -1606,12 +1635,40 @@ func (k *KubernetesConfig) GetUserAssignedID() string {
 	return ""
 }
 
-// GetUserAssignedClientID returns the user assigned client ID if it is enabled.
+// GetUserAssignedClientID returns the user assigned client ID if it is enabled.v
 func (k *KubernetesConfig) GetUserAssignedClientID() string {
 	if k.UserAssignedClientIDEnabled() {
 		return k.UserAssignedClientID
 	}
 	return ""
+}
+
+// GetOrderedKubeletConfigString returns an ordered string of key/val pairs
+func (k *KubernetesConfig) GetOrderedKubeletConfigString() string {
+	keys := []string{}
+	for key := range k.KubeletConfig {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for _, key := range keys {
+		buf.WriteString(fmt.Sprintf("%s=%s ", key, k.KubeletConfig[key]))
+	}
+	return buf.String()
+}
+
+// GetOrderedKubeletConfigStringForPowershell returns an ordered string of key/val pairs for Powershell script consumption
+func (k *KubernetesConfig) GetOrderedKubeletConfigStringForPowershell() string {
+	keys := []string{}
+	for key := range k.KubeletConfig {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for _, key := range keys {
+		buf.WriteString(fmt.Sprintf("\"%s=%s\", ", key, k.KubeletConfig[key]))
+	}
+	return strings.TrimSuffix(buf.String(), ", ")
 }
 
 // IsNSeriesSKU returns true if the agent pool contains an N-series (NVIDIA GPU) VM

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1635,7 +1635,7 @@ func (k *KubernetesConfig) GetUserAssignedID() string {
 	return ""
 }
 
-// GetUserAssignedClientID returns the user assigned client ID if it is enabled.v
+// GetUserAssignedClientID returns the user assigned client ID if it is enabled.
 func (k *KubernetesConfig) GetUserAssignedClientID() string {
 	if k.UserAssignedClientIDEnabled() {
 		return k.UserAssignedClientID

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3280,7 +3280,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 					OrchestratorType: Kubernetes,
 					KubernetesConfig: &KubernetesConfig{
 						Addons: []KubernetesAddon{
-							KubernetesAddon{
+							{
 								Name: IPMASQAgentAddonName,
 								Containers: []KubernetesContainerSpec{
 									{
@@ -3301,7 +3301,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 					OrchestratorType: Kubernetes,
 					KubernetesConfig: &KubernetesConfig{
 						Addons: []KubernetesAddon{
-							KubernetesAddon{
+							{
 								Name:    IPMASQAgentAddonName,
 								Enabled: to.BoolPtr(false),
 								Containers: []KubernetesContainerSpec{
@@ -3323,7 +3323,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 					OrchestratorType: Kubernetes,
 					KubernetesConfig: &KubernetesConfig{
 						Addons: []KubernetesAddon{
-							KubernetesAddon{
+							{
 								Name:    IPMASQAgentAddonName,
 								Enabled: to.BoolPtr(false),
 								Containers: []KubernetesContainerSpec{
@@ -3348,7 +3348,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 					OrchestratorType: Kubernetes,
 					KubernetesConfig: &KubernetesConfig{
 						Addons: []KubernetesAddon{
-							KubernetesAddon{
+							{
 								Name:    IPMASQAgentAddonName,
 								Enabled: to.BoolPtr(true),
 								Containers: []KubernetesContainerSpec{
@@ -3373,7 +3373,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 					OrchestratorType: Kubernetes,
 					KubernetesConfig: &KubernetesConfig{
 						Addons: []KubernetesAddon{
-							KubernetesAddon{
+							{
 								Name:    IPMASQAgentAddonName,
 								Enabled: to.BoolPtr(true),
 								Containers: []KubernetesContainerSpec{

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -167,19 +167,6 @@ func addSecret(m paramsMap, k string, v interface{}, encode bool) {
 	addKeyvaultReference(m, k, parts[1], parts[2], parts[4])
 }
 
-// getStorageAccountType returns the support managed disk storage tier for a give VM size
-func getStorageAccountType(sizeName string) (string, error) {
-	spl := strings.Split(sizeName, "_")
-	if len(spl) < 2 {
-		return "", errors.Errorf("Invalid sizeName: %s", sizeName)
-	}
-	capability := spl[1]
-	if strings.Contains(strings.ToLower(capability), "s") {
-		return "Premium_LRS", nil
-	}
-	return "Standard_LRS", nil
-}
-
 func makeMasterExtensionScriptCommands(cs *api.ContainerService) string {
 	return makeExtensionScriptCommands(cs.Properties.MasterProfile.PreprovisionExtension,
 		cs.Properties.ExtensionProfiles)

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -326,40 +326,6 @@ func addTestCertificateProfile(api *api.CertificateProfile) {
 	api.EtcdPeerPrivateKeys = []string{"etcdPeerPrivateKey0"}
 }
 
-func TestGetStorageAccountType(t *testing.T) {
-	validPremiumVMSize := "Standard_DS2_v2"
-	validStandardVMSize := "Standard_D2_v2"
-	expectedPremiumTier := "Premium_LRS"
-	expectedStandardTier := "Standard_LRS"
-	invalidVMSize := "D2v2"
-
-	// test premium VMSize returns premium managed disk tier
-	premiumTier, err := getStorageAccountType(validPremiumVMSize)
-	if err != nil {
-		t.Fatalf("Invalid sizeName: %s", err)
-	}
-
-	if premiumTier != expectedPremiumTier {
-		t.Fatalf("premium VM did no match premium managed storage tier")
-	}
-
-	// test standard VMSize returns standard managed disk tier
-	standardTier, err := getStorageAccountType(validStandardVMSize)
-	if err != nil {
-		t.Fatalf("Invalid sizeName: %s", err)
-	}
-
-	if standardTier != expectedStandardTier {
-		t.Fatalf("standard VM did no match standard managed storage tier")
-	}
-
-	// test invalid VMSize
-	result, err := getStorageAccountType(invalidVMSize)
-	if err == nil {
-		t.Errorf("getStorageAccountType() = (%s, nil), want error", result)
-	}
-}
-
 type TestARMTemplate struct {
 	Outputs map[string]OutputElement `json:"outputs"`
 	//Parameters *json.RawMessage `json:"parameters"`

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -41,18 +41,26 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		t.Errorf("unexpected error while unmarshalling the apiModel JSON: %s", err.Error())
 	}
 	funcmap := tg.getTemplateFuncMap(cs)
-	cases := []struct {
-		key string
-	}{
-		{
-			key: "IsMultiMasterCluster",
-		},
+	cases := []string{
+		"IsAzureStackCloud",
+		"IsMultiMasterCluster",
+		"IsMasterVirtualMachineScaleSets",
+		"IsHostedMaster",
+		"IsIPMasqAgentEnabled",
+		"IsKubernetesVersionGe",
+		"IsKubernetesVersionLt",
+		"GetMasterKubernetesLabels",
+		"GetAgentKubernetesLabels",
+		"GetKubeletConfigKeyVals",
+		"GetKubeletConfigKeyValsPsh",
+		"GetK8sRuntimeConfigKeyVals",
+		// TODO validate that the remaining func strings in getTemplateFuncMap are thinly wrapped and unit tested
 	}
 
 	for _, c := range cases {
-		_, ok := funcmap[c.key]
+		_, ok := funcmap[c]
 		if !ok {
-			t.Fatalf("Didn't find expected funcmap key %s.", c.key)
+			t.Fatalf("Didn't find expected funcmap key %s.", c)
 		}
 	}
 }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13727,11 +13727,11 @@ write_files:
       cluster:
         certificate-authority: /etc/kubernetes/certs/ca.crt
         {{if IsAzureStackCloud}}
-        {{if IsMultiMasterCluster}}
+            {{if IsMultiMasterCluster}}
         server: https://{{WrapAsVariable "masterPublicLbFQDN"}}:443
-        {{else}}
+            {{else}}
         server: https://{{WrapAsVariable "kubernetesAPIServerIP"}}:443
-        {{end}}
+            {{end}}
         {{else}}
         server: https://{{WrapAsVariable "kubernetesAPIServerIP"}}:443
         {{end}}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Ensures that the following `getTemplateFuncMap` function keys are thinly wrapped go functions with unit test coverage:

```
		"IsAzureStackCloud",
		"IsMasterVirtualMachineScaleSets",
		"IsHostedMaster",
		"IsIPMasqAgentEnabled",
		"IsKubernetesVersionGe",
		"IsKubernetesVersionLt",
		"GetMasterKubernetesLabels",
		"GetAgentKubernetesLabels",
		"GetKubeletConfigKeyVals",
		"GetKubeletConfigKeyValsPsh",
		"GetK8sRuntimeConfigKeyVals",
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
