### PR TITLE
test: getTemplateFuncMap unit tests part 2

### DIFF
--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -271,3 +271,8 @@ func GetOrderedEscapedKeyValsString(config map[string]string) string {
 	}
 	return strings.TrimSuffix(buf.String(), ", ")
 }
+
+// SliceIntIsNonEmpty is a simple convenience to determine if a []int is non-empty
+func SliceIntIsNonEmpty(s []int) bool {
+	return len(s) > 0
+}

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -137,7 +137,8 @@ func TestGetMasterKubernetesLabels(t *testing.T) {
 	}
 }
 
-func TestGetK8sRuntimeConfigKeyVals(t *testing.T) {
+func TestGetOrderedEscapedKeyValsString(t *testing.T) {
+	alphabetizedString := `\"foo=bar\", \"yes=please\"`
 	cases := []struct {
 		input    map[string]string
 		expected string
@@ -151,14 +152,21 @@ func TestGetK8sRuntimeConfigKeyVals(t *testing.T) {
 				"foo": "bar",
 				"yes": "please",
 			},
-			expected: `\"foo=bar\", \"yes=please\"`,
+			expected: alphabetizedString,
+		},
+		{
+			input: map[string]string{
+				"yes": "please",
+				"foo": "bar",
+			},
+			expected: alphabetizedString,
 		},
 	}
 
 	for _, c := range cases {
 		ret := GetOrderedEscapedKeyValsString(c.input)
 		if ret != c.expected {
-			t.Fatalf("expected GetK8sRuntimeConfigKeyVals(%s) to return %s, but instead got %s", c.input, c.expected, ret)
+			t.Fatalf("expected GetOrderedEscapedKeyValsString(%s) to return %s, but instead got %s", c.input, c.expected, ret)
 		}
 	}
 }
@@ -194,5 +202,34 @@ func TestGetStorageAccountType(t *testing.T) {
 	result, err := GetStorageAccountType(invalidVMSize)
 	if err == nil {
 		t.Errorf("GetStorageAccountType() = (%s, nil), want error", result)
+	}
+}
+
+func TestSliceIntIsNonEmpty(t *testing.T) {
+	cases := []struct {
+		input    []int
+		expected bool
+	}{
+		{
+			input: []int{
+				1, 2, 3,
+			},
+			expected: true,
+		},
+		{
+			input:    []int{},
+			expected: false,
+		},
+		{
+			input:    nil,
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		ret := SliceIntIsNonEmpty(c.input)
+		if ret != c.expected {
+			t.Fatalf("expected SliceIntIsNonEmpty(%v) to return %t, but instead got %t", c.input, c.expected, ret)
+		}
 	}
 }

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -229,6 +229,8 @@ const (
 	DNSAutoscalerAddonName = "dns-autoscaler"
 	// DefaultUseCosmos determines if the cluster will use cosmos as etcd storage
 	DefaultUseCosmos = false
+	// etcdEndpointURIFmt is the name format for a typical etcd account uri
+	etcdEndpointURIFmt = "%sk8s.etcd.cosmosdb.azure.com"
 	// DefaultMaximumLoadBalancerRuleCount determines the default value of maximum allowed loadBalancer rule count according to
 	// https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#load-balancer.
 	DefaultMaximumLoadBalancerRuleCount = 250

--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -39,8 +39,7 @@ func (cs *ContainerService) setAPIServerConfig() {
 		"--v":                           "4",
 	}
 	// if using local etcd server then we need the ca file
-	/*this ugly if statement is made this way, because this function is used in a test that does not pass correct data structure */
-	if !(nil != cs.Properties && nil != cs.Properties.MasterProfile && to.Bool(cs.Properties.MasterProfile.CosmosEtcd)) {
+	if !(cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.HasCosmosEtcd()) {
 		staticAPIServerConfig["--etcd-cafile"] = "/etc/kubernetes/certs/ca.crt"
 	}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -436,6 +436,11 @@ type DcosConfig struct {
 	BootstrapProfile         *BootstrapProfile `json:"bootstrapProfile,omitempty"`
 }
 
+// HasPrivateRegistry returns if a private registry is specified
+func (d *DcosConfig) HasPrivateRegistry() bool {
+	return len(d.Registry) > 0
+}
+
 // MasterProfile represents the definition of the master cluster
 type MasterProfile struct {
 	Count                    int               `json:"count"`
@@ -1268,6 +1273,19 @@ func (m *MasterProfile) IsUbuntuNonVHD() bool {
 // HasMultipleNodes returns true if there are more than one master nodes
 func (m *MasterProfile) HasMultipleNodes() bool {
 	return m.Count > 1
+}
+
+// HasCosmosEtcd returns true if cosmos etcd configuration is enabled
+func (m *MasterProfile) HasCosmosEtcd() bool {
+	return to.Bool(m.CosmosEtcd)
+}
+
+// GetCosmosEndPointURI returns the URI string for the cosmos etcd endpoint
+func (m *MasterProfile) GetCosmosEndPointURI() string {
+	if m.HasCosmosEtcd() {
+		return fmt.Sprintf(etcdEndpointURIFmt, m.DNSPrefix)
+	}
+	return ""
 }
 
 // IsCustomVNET returns true if the customer brought their own VNET

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -73,7 +73,7 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 	hasStorageAccountDisks := cs.Properties.HasStorageAccountDisks()
 	isCustomVnet := cs.Properties.AreAgentProfilesCustomVNET()
 	hasAgentPool := len(profiles) > 0
-	hasCosmosEtcd := masterProfile != nil && to.Bool(masterProfile.CosmosEtcd)
+	hasCosmosEtcd := masterProfile != nil && masterProfile.HasCosmosEtcd()
 
 	kubernetesVersion := orchProfile.OrchestratorVersion
 	if cs.Properties.IsAzureStackCloud() {

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -226,25 +226,3 @@ const (
 	swarmWinAgentResourcesVMSS    = "swarm/swarmwinagentresourcesvmss.t"
 	windowsParams                 = "windowsparams.t"
 )
-
-// LBRuleBaseString is a raw string that represents a template that we will compose an LB rule from
-const LBRuleBaseString string = `	          {
-	"name": "LBRule%d",
-	"properties": {
-	  "backendAddressPool": {
-		"id": "[concat(variables('%sLbID'), '/backendAddressPools/', variables('%sLbBackendPoolName'))]"
-	  },
-	  "backendPort": %d,
-	  "enableFloatingIP": false,
-	  "frontendIPConfiguration": {
-		"id": "[variables('%sLbIPConfigID')]"
-	  },
-	  "frontendPort": %d,
-	  "idleTimeoutInMinutes": 5,
-	  "loadDistribution": "Default",
-	  "probe": {
-		"id": "[concat(variables('%sLbID'),'/probes/tcp%dProbe')]"
-	  },
-	  "protocol": "Tcp"
-	}
-  }`

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -110,8 +110,6 @@ const (
 	DefaultMasterEtcdClientPort = 2379
 	// etcdAccountNameFmt is the name format for a typical etcd account on Cosmos
 	etcdAccountNameFmt = "%sk8s"
-	// etcdEndpointURIFmt is the name format for a typical etcd account uri
-	etcdEndpointURIFmt = "%sk8s.etcd.cosmosdb.azure.com"
 )
 
 const (
@@ -228,3 +226,25 @@ const (
 	swarmWinAgentResourcesVMSS    = "swarm/swarmwinagentresourcesvmss.t"
 	windowsParams                 = "windowsparams.t"
 )
+
+// LBRuleBaseString is a raw string that represents a template that we will compose an LB rule from
+const LBRuleBaseString string = `	          {
+	"name": "LBRule%d",
+	"properties": {
+	  "backendAddressPool": {
+		"id": "[concat(variables('%sLbID'), '/backendAddressPools/', variables('%sLbBackendPoolName'))]"
+	  },
+	  "backendPort": %d,
+	  "enableFloatingIP": false,
+	  "frontendIPConfiguration": {
+		"id": "[variables('%sLbIPConfigID')]"
+	  },
+	  "frontendPort": %d,
+	  "idleTimeoutInMinutes": 5,
+	  "loadDistribution": "Default",
+	  "probe": {
+		"id": "[concat(variables('%sLbID'),'/probes/tcp%dProbe')]"
+	  },
+	  "protocol": "Tcp"
+	}
+  }`

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -447,26 +447,7 @@ func getVNETSubnets(properties *api.Properties, addNSG bool) string {
 }
 
 func getLBRule(name string, port int) string {
-	return fmt.Sprintf(`	          {
-            "name": "LBRule%d",
-            "properties": {
-              "backendAddressPool": {
-                "id": "[concat(variables('%sLbID'), '/backendAddressPools/', variables('%sLbBackendPoolName'))]"
-              },
-              "backendPort": %d,
-              "enableFloatingIP": false,
-              "frontendIPConfiguration": {
-                "id": "[variables('%sLbIPConfigID')]"
-              },
-              "frontendPort": %d,
-              "idleTimeoutInMinutes": 5,
-              "loadDistribution": "Default",
-              "probe": {
-                "id": "[concat(variables('%sLbID'),'/probes/tcp%dProbe')]"
-              },
-              "protocol": "Tcp"
-            }
-          }`, port, name, name, port, name, port, name, port)
+	return fmt.Sprintf(LBRuleBaseString, port, name, name, port, name, port, name, port)
 }
 
 func getLBRules(name string, ports []int) string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -447,7 +447,26 @@ func getVNETSubnets(properties *api.Properties, addNSG bool) string {
 }
 
 func getLBRule(name string, port int) string {
-	return fmt.Sprintf(LBRuleBaseString, port, name, name, port, name, port, name, port)
+	return fmt.Sprintf(`	          {
+            "name": "LBRule%d",
+            "properties": {
+              "backendAddressPool": {
+                "id": "[concat(variables('%sLbID'), '/backendAddressPools/', variables('%sLbBackendPoolName'))]"
+              },
+              "backendPort": %d,
+              "enableFloatingIP": false,
+              "frontendIPConfiguration": {
+                "id": "[variables('%sLbIPConfigID')]"
+              },
+              "frontendPort": %d,
+              "idleTimeoutInMinutes": 5,
+              "loadDistribution": "Default",
+              "probe": {
+                "id": "[concat(variables('%sLbID'),'/probes/tcp%dProbe')]"
+              },
+              "protocol": "Tcp"
+            }
+          }`, port, name, name, port, name, port, name, port)
 }
 
 func getLBRules(name string, ports []int) string {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -30,6 +30,28 @@ const (
 	TestAKSEngineVersion = "1.0.0"
 )
 
+// LBRuleBaseString is a raw string that represents a template that we will compose an LB rule from
+const LBRuleBaseString string = `	          {
+            "name": "LBRule%d",
+            "properties": {
+              "backendAddressPool": {
+                "id": "[concat(variables('%sLbID'), '/backendAddressPools/', variables('%sLbBackendPoolName'))]"
+              },
+              "backendPort": %d,
+              "enableFloatingIP": false,
+              "frontendIPConfiguration": {
+                "id": "[variables('%sLbIPConfigID')]"
+              },
+              "frontendPort": %d,
+              "idleTimeoutInMinutes": 5,
+              "loadDistribution": "Default",
+              "probe": {
+                "id": "[concat(variables('%sLbID'),'/probes/tcp%dProbe')]"
+              },
+              "protocol": "Tcp"
+            }
+          }`
+
 func TestExpected(t *testing.T) {
 	// Initialize locale for translation
 	locale := gotext.NewLocale(path.Join("..", "..", "translations"), "en_US")

--- a/pkg/engine/masterarmresources.go
+++ b/pkg/engine/masterarmresources.go
@@ -13,7 +13,7 @@ func createKubernetesMasterResourcesVMAS(cs *api.ContainerService) []interface{}
 
 	p := cs.Properties
 
-	if to.Bool(p.MasterProfile.CosmosEtcd) {
+	if p.MasterProfile.HasCosmosEtcd() {
 		masterResources = append(masterResources, createCosmosDBAccount())
 	}
 
@@ -126,7 +126,7 @@ func createKubernetesMasterResourcesVMAS(cs *api.ContainerService) []interface{}
 func createKubernetesMasterResourcesVMSS(cs *api.ContainerService) []interface{} {
 	var masterResources []interface{}
 
-	if to.Bool(cs.Properties.MasterProfile.CosmosEtcd) {
+	if cs.Properties.MasterProfile.HasCosmosEtcd() {
 		masterResources = append(masterResources, createCosmosDBAccount())
 	}
 

--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -14,19 +14,17 @@ import (
 func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 
 	var dependencies []string
-	if cs.Properties.MasterProfile.IsCustomVNET() {
+	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.IsCustomVNET() {
 		dependencies = append(dependencies, "[variables('nsgID')]")
 	} else {
 		dependencies = append(dependencies, "[variables('vnetID')]")
 	}
 
-	if cs.Properties.MasterProfile.HasMultipleNodes() {
+	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.HasMultipleNodes() {
 		dependencies = append(dependencies, "[variables('masterInternalLbName')]")
 	}
 
-	hasCosmosEtcd := nil != cs.Properties.MasterProfile && to.Bool(cs.Properties.MasterProfile.CosmosEtcd)
-
-	if hasCosmosEtcd {
+	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.HasCosmosEtcd() {
 		dependencies = append(dependencies, "[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmosAccountName'))]")
 	}
 
@@ -48,7 +46,7 @@ func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 		DependsOn: dependencies,
 	}
 
-	if cs.Properties.MasterProfile.HasMultipleNodes() {
+	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.HasMultipleNodes() {
 		internalLbPool := network.BackendAddressPool{
 			ID: to.StringPtr("[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
 		}
@@ -102,7 +100,7 @@ func CreateNetworkInterfaces(cs *api.ContainerService) NetworkInterfaceARM {
 		}
 	}
 
-	if cs.Properties.MasterProfile.IsCustomVNET() {
+	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.IsCustomVNET() {
 		nicProperties.NetworkSecurityGroup = &network.SecurityGroup{
 			ID: to.StringPtr("[variables('nsgID')]"),
 		}

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -293,7 +293,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"HasPrivateRegistry": func() bool {
 			if cs.Properties.OrchestratorProfile.DcosConfig != nil {
-				return len(cs.Properties.OrchestratorProfile.DcosConfig.Registry) > 0
+				return cs.Properties.OrchestratorProfile.DcosConfig.HasPrivateRegistry()
 			}
 			return false
 		},
@@ -304,19 +304,19 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.OrchestratorProfile.IsKubernetes()
 		},
 		"IsPublic": func(ports []int) bool {
-			return len(ports) > 0
+			return common.SliceIntIsNonEmpty(ports)
 		},
 		"IsAzureCNI": func() bool {
 			return cs.Properties.OrchestratorProfile.IsAzureCNI()
 		},
 		"HasCosmosEtcd": func() bool {
-			return nil != cs.Properties.MasterProfile && to.Bool(cs.Properties.MasterProfile.CosmosEtcd)
+			return cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.HasCosmosEtcd()
 		},
 		"GetCosmosEndPointUri": func() string {
-			if nil != cs.Properties.MasterProfile && to.Bool(cs.Properties.MasterProfile.CosmosEtcd) {
-				return fmt.Sprintf(etcdEndpointURIFmt, cs.Properties.MasterProfile.DNSPrefix)
+			if cs.Properties.MasterProfile != nil {
+				return cs.Properties.MasterProfile.GetCosmosEndPointURI()
 			}
-			return "" // This will apply on both during unit tests as !HasCosmosEtcd
+			return ""
 		},
 		"IsPrivateCluster": func() bool {
 			return cs.Properties.OrchestratorProfile.IsPrivateCluster()

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -54,6 +54,19 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		"GetKubeletConfigKeyVals",
 		"GetKubeletConfigKeyValsPsh",
 		"GetK8sRuntimeConfigKeyVals",
+		"HasPrivateRegistry",
+		"IsSwarmMode",
+		"IsKubernetes",
+		"IsPublic",
+		"IsAzureCNI",
+		"HasCosmosEtcd",
+		"GetCosmosEndPointUri",
+		"IsPrivateCluster",
+		"ProvisionJumpbox",
+		"UseManagedIdentity",
+		"NeedsKubeDNSWithExecHealthz",
+		"GetVNETSubnetDependencies",
+		"GetLBRules",
 		// TODO validate that the remaining func strings in getTemplateFuncMap are thinly wrapped and unit tested
 	}
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -9893,7 +9893,7 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 spec:
   privileged: true
   allowPrivilegeEscalation: true
@@ -9926,7 +9926,7 @@ metadata:
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  docker/default
     apparmor.security.beta.kubernetes.io/defaultProfileName:  runtime/default
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 spec:
   privileged: false
   allowPrivilegeEscalation: false
@@ -9965,7 +9965,7 @@ kind: ClusterRole
 metadata:
   name: psp:privileged
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
@@ -9978,7 +9978,7 @@ kind: ClusterRole
 metadata:
   name: psp:restricted
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
@@ -9991,7 +9991,7 @@ kind: ClusterRoleBinding
 metadata:
   name: default:restricted
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10007,7 +10007,7 @@ metadata:
   name: default:privileged
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -151,7 +151,7 @@ func CreateMasterVM(cs *api.ContainerService) VirtualMachineARM {
 	imageRef := cs.Properties.MasterProfile.ImageRef
 	useMasterCustomImage := imageRef != nil && len(imageRef.Name) > 0 && len(imageRef.ResourceGroup) > 0
 	etcdSizeGB, _ := strconv.Atoi(kubernetesConfig.EtcdDiskSizeGB)
-	if !to.Bool(cs.Properties.MasterProfile.CosmosEtcd) {
+	if !cs.Properties.MasterProfile.HasCosmosEtcd() {
 		dataDisk := compute.DataDisk{
 			CreateOption: compute.DiskCreateOptionTypesEmpty,
 			DiskSizeGB:   to.Int32Ptr(int32(etcdSizeGB)),

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -44,7 +44,7 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 		dependencies = append(dependencies, "[variables('masterInternalLbName')]")
 	}
 
-	if to.Bool(masterProfile.CosmosEtcd) {
+	if masterProfile.HasCosmosEtcd() {
 		dependencies = append(dependencies, "[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmosAccountName'))]")
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Ensures that the following `getTemplateFuncMap` function keys are thinly wrapped go functions with unit test coverage:

```
		"HasPrivateRegistry",
		"IsSwarmMode",
		"IsKubernetes",
		"IsPublic",
		"IsAzureCNI",
		"HasCosmosEtcd",
		"GetCosmosEndPointUri",
		"IsPrivateCluster",
		"ProvisionJumpbox",
		"UseManagedIdentity",
		"NeedsKubeDNSWithExecHealthz",
		"GetVNETSubnetDependencies",
		"GetLBRules",
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
