### PR TITLE
test: getTemplateFuncMap unit tests part 3

### DIFF
--- a/parts/dcos/bstrap/bootstrapparams.t
+++ b/parts/dcos/bstrap/bootstrapparams.t
@@ -12,22 +12,6 @@
       "type": "securestring"
       },
     {{end}}
-{{if IsHostedBootstrap}}
-    "bootstrapSubnet": {
-      "defaultValue": "{{.HostedBootstrapProfile.Subnet}}",
-      "metadata": {
-        "description": "Sets the subnet for the VMs in the cluster."
-      },
-      "type": "string"
-    },
-    "bootstrapEndpoint": {
-      "defaultValue": "{{.HostedBootstrapProfile.FQDN}}",
-      "metadata": {
-        "description": "Sets the static IP of the first bootstrap"
-      },
-      "type": "string"
-    },
-{{else}}
     "bootstrapStaticIP": {
       "metadata": {
         "description": "Sets the static IP of the first bootstrap"
@@ -41,7 +25,6 @@
       },
       "type": "string"
     },
-{{end}}
     "sshRSAPublicKey": {
       "metadata": {
         "description": "SSH public key used for auth to all Linux machines.  Not Required.  If not set, you must provide a password key."

--- a/parts/dcos/bstrap/bootstrapresources.t
+++ b/parts/dcos/bstrap/bootstrapresources.t
@@ -1,14 +1,3 @@
-{{if HasBootstrapPublicIP}}
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "bootstrapPublicIP",
-      "properties": {
-        "publicIPAllocationMethod": "Dynamic"
-      },
-      "type": "Microsoft.Network/publicIPAddresses"
-    },
-{{end}}
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
@@ -53,9 +42,6 @@
 {{if not .MasterProfile.IsCustomVNET}}
         "[variables('vnetID')]",
 {{end}}
-{{if HasBootstrapPublicIP}}
-        "bootstrapPublicIP",
-{{end}}
         "[variables('bootstrapNSGID')]"
       ],
       "location": "[variables('location')]",
@@ -67,11 +53,6 @@
             "properties": {
               "privateIPAddress": "[variables('bootstrapStaticIP')]",
               "privateIPAllocationMethod": "Static",
-{{if HasBootstrapPublicIP}}
-              "publicIpAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIpAddresses', 'bootstrapPublicIP')]"
-              },
-{{end}}
               "subnet": {
                 "id": "[variables('masterVnetSubnetID')]"
               }

--- a/parts/dcos/bstrap/dcosmasterresources.t
+++ b/parts/dcos/bstrap/dcosmasterresources.t
@@ -266,9 +266,7 @@
         "[variables('masterStorageAccountName')]",
 {{end}}
         "[variables('masterStorageAccountExhibitorName')]"
-{{if not IsHostedBootstrap}}
        ,"[concat('Microsoft.Compute/virtualMachines/', variables('bootstrapVMName'), '/extensions/bootstrapready')]"
-{{end}}
       ],
       "tags":
       {

--- a/parts/dcos/dcosagentresourcesvmas.t
+++ b/parts/dcos/dcosagentresourcesvmas.t
@@ -175,7 +175,7 @@
 {{end}}
         "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
         "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
-{{if and HasBootstrap (not IsHostedBootstrap)}}
+{{if HasBootstrap}}
        ,"[concat('Microsoft.Compute/virtualMachines/', variables('bootstrapVMName'), /extensions/bootstrapready')]"
 {{end}}
       ],

--- a/parts/dcos/dcosagentresourcesvmss.t
+++ b/parts/dcos/dcosagentresourcesvmss.t
@@ -96,7 +96,7 @@
 {{if IsPublic .Ports}}
        ,"[concat('Microsoft.Network/loadBalancers/', variables('{{.Name}}LbName'))]"
 {{end}}
-{{if and HasBootstrap (not IsHostedBootstrap)}}
+{{if HasBootstrap}}
        ,"[concat('Microsoft.Compute/virtualMachines/', variables('bootstrapVMName'), '/extensions/bootstrapready')]"
 {{end}}
       ],

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -441,6 +441,11 @@ func (d *DcosConfig) HasPrivateRegistry() bool {
 	return len(d.Registry) > 0
 }
 
+// HasBootstrap returns if a bootstrap profile is specified
+func (d *DcosConfig) HasBootstrap() bool {
+	return d.BootstrapProfile != nil
+}
+
 // MasterProfile represents the definition of the master cluster
 type MasterProfile struct {
 	Count                    int               `json:"count"`

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -5235,3 +5235,37 @@ func TestDcosConfigHasPrivateRegistry(t *testing.T) {
 		}
 	}
 }
+
+func TestDcosConfigHasBootstrap(t *testing.T) {
+	cases := []struct {
+		p        Properties
+		expected bool
+	}{
+		{
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: DCOS,
+					DcosConfig:       &DcosConfig{},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: DCOS,
+					DcosConfig: &DcosConfig{
+						BootstrapProfile: &BootstrapProfile{},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		if c.p.OrchestratorProfile.DcosConfig.HasBootstrap() != c.expected {
+			t.Fatalf("expected HasBootstrap() to return %t but instead got %t", c.expected, c.p.OrchestratorProfile.DcosConfig.HasBootstrap())
+		}
+	}
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1199,7 +1199,6 @@ func TestGetDataDisks(t *testing.T) {
             }`
 	cases := []struct {
 		p        *api.AgentPoolProfile
-		addNSG   bool
 		expected string
 	}{
 		{

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -355,13 +355,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return getDataDisks(profile)
 		},
 		"HasBootstrap": func() bool {
-			return cs.Properties.OrchestratorProfile.DcosConfig != nil && cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile != nil
-		},
-		"HasBootstrapPublicIP": func() bool {
-			return false
-		},
-		"IsHostedBootstrap": func() bool {
-			return false
+			return cs.Properties.OrchestratorProfile.DcosConfig != nil && cs.Properties.OrchestratorProfile.DcosConfig.HasBootstrap()
 		},
 		"GetDCOSBootstrapCustomData": func() string {
 			masterIPList := generateIPList(cs.Properties.MasterProfile.Count, cs.Properties.MasterProfile.FirstConsecutiveStaticIP)

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -67,6 +67,13 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		"NeedsKubeDNSWithExecHealthz",
 		"GetVNETSubnetDependencies",
 		"GetLBRules",
+		"GetProbes",
+		"GetSecurityRules",
+		"GetUniqueNameSuffix",
+		"GetVNETAddressPrefixes",
+		"GetVNETSubnets",
+		"GetDataDisks",
+		"HasBootstrap",
 		// TODO validate that the remaining func strings in getTemplateFuncMap are thinly wrapped and unit tested
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Ensures that the following `getTemplateFuncMap` function keys are thinly wrapped go functions with unit test coverage:

```
		"GetProbes",
		"GetSecurityRules",
		"GetUniqueNameSuffix",
		"GetVNETAddressPrefixes",
		"GetVNETSubnets",
		"GetDataDisks",
		"HasBootstrap",
```

Also removed the entirely unnecessary `HasBootstrapPublicIP` and `IsHostedBootstrap` static `return false` template functions.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
