### PR TITLE
fix: do not set distro to VHD for US Gov and German cloud

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -39,16 +39,18 @@ func (cs *ContainerService) SetPropertiesDefaults(isUpgrade, isScale bool) (bool
 
 	cs.setOrchestratorDefaults(isUpgrade || isScale)
 
+	cloudName := cs.GetCloudSpecConfig().CloudName
+
 	// Set master profile defaults if this cluster configuration includes master node(s)
 	if cs.Properties.MasterProfile != nil {
-		properties.setMasterProfileDefaults(isUpgrade, isScale)
+		properties.setMasterProfileDefaults(isUpgrade, isScale, cloudName)
 	}
 	// Set VMSS Defaults for Masters
 	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.IsVirtualMachineScaleSets() {
 		properties.setVMSSDefaultsForMasters()
 	}
 
-	properties.setAgentProfileDefaults(isUpgrade, isScale)
+	properties.setAgentProfileDefaults(isUpgrade, isScale, cloudName)
 
 	properties.setStorageDefaults()
 	properties.setExtensionDefaults()
@@ -305,7 +307,7 @@ func (p *Properties) setExtensionDefaults() {
 	}
 }
 
-func (p *Properties) setMasterProfileDefaults(isUpgrade, isScale bool) {
+func (p *Properties) setMasterProfileDefaults(isUpgrade, isScale bool, cloudName string) {
 	if p.MasterProfile.Distro == "" {
 		if p.OrchestratorProfile.IsKubernetes() {
 			p.MasterProfile.Distro = AKSUbuntu1604
@@ -318,6 +320,11 @@ func (p *Properties) setMasterProfileDefaults(isUpgrade, isScale bool) {
 		} else if p.MasterProfile.Distro == AKS1804Deprecated {
 			p.MasterProfile.Distro = AKSUbuntu1804
 		}
+	}
+
+	// The AKS Distro is not available in US Governmnent Cloud and German Cloud.
+	if cloudName == AzureUSGovernmentCloud || cloudName == AzureGermanCloud {
+		p.MasterProfile.Distro = Ubuntu
 	}
 
 	// "--protect-kernel-defaults" is only true for VHD based VMs since the base Ubuntu distros don't have a /etc/sysctl.d/60-CIS.conf file.
@@ -459,7 +466,7 @@ func (p *Properties) setVMSSDefaultsForAgents() {
 	}
 }
 
-func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
+func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool, cloudName string) {
 	// configure the subnets if not in custom VNET
 	if p.MasterProfile != nil && !p.MasterProfile.IsCustomVNET() {
 		subnetCounter := 0
@@ -522,6 +529,10 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 				} else if profile.Distro == AKS1804Deprecated {
 					profile.Distro = AKSUbuntu1804
 				}
+			}
+			// The AKS Distro is not available in US Governmnent Cloud and German Cloud.
+			if cloudName == AzureUSGovernmentCloud || cloudName == AzureGermanCloud {
+				profile.Distro = Ubuntu
 			}
 		}
 

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1582,7 +1582,7 @@ func TestSetCertDefaults(t *testing.T) {
 	}
 
 	cs.setOrchestratorDefaults(false)
-	cs.Properties.setMasterProfileDefaults(false, false)
+	cs.Properties.setMasterProfileDefaults(false, false, AzurePublicCloud)
 	result, ips, err := cs.SetDefaultCerts()
 
 	if !result {
@@ -1648,7 +1648,7 @@ func TestSetCertDefaultsVMSS(t *testing.T) {
 	}
 
 	cs.setOrchestratorDefaults(false)
-	cs.Properties.setMasterProfileDefaults(false, false)
+	cs.Properties.setMasterProfileDefaults(false, false, AzurePublicCloud)
 	result, ips, err := cs.SetDefaultCerts()
 
 	if !result {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -553,7 +553,7 @@ func TestAuditDEnabled(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.12.7")
 	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	isUpgrade := true
-	mockCS.Properties.setAgentProfileDefaults(isUpgrade, false)
+	mockCS.Properties.setAgentProfileDefaults(isUpgrade, false, AzurePublicCloud)
 
 	// In upgrade scenario, nil AuditDEnabled should always render as false (i.e., we never turn on this feature on an existing vm that didn't have it before)
 	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {
@@ -563,7 +563,7 @@ func TestAuditDEnabled(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.12.7")
 	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	isScale := true
-	mockCS.Properties.setAgentProfileDefaults(false, isScale)
+	mockCS.Properties.setAgentProfileDefaults(false, isScale, AzurePublicCloud)
 
 	// In scale scenario, nil AuditDEnabled should always render as false (i.e., we never turn on this feature on an existing agent pool / vms that didn't have it before)
 	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {
@@ -572,7 +572,7 @@ func TestAuditDEnabled(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.12.7")
 	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
-	mockCS.Properties.setAgentProfileDefaults(false, false)
+	mockCS.Properties.setAgentProfileDefaults(false, false, AzurePublicCloud)
 
 	// In create scenario, nil AuditDEnabled should be the defaults
 	auditDEnabledEnabled := DefaultAuditDEnabled
@@ -583,7 +583,7 @@ func TestAuditDEnabled(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.10.8")
 	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled = to.BoolPtr(true)
-	mockCS.Properties.setAgentProfileDefaults(false, false)
+	mockCS.Properties.setAgentProfileDefaults(false, false, AzurePublicCloud)
 
 	// In create scenario with explicit true, AuditDEnabled should be true
 	if !to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {
@@ -593,7 +593,7 @@ func TestAuditDEnabled(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.10.8")
 	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled = to.BoolPtr(false)
-	mockCS.Properties.setAgentProfileDefaults(false, false)
+	mockCS.Properties.setAgentProfileDefaults(false, false, AzurePublicCloud)
 
 	// In create scenario with explicit false, AuditDEnabled should be false
 	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1087,6 +1087,8 @@ func TestDistroDefaults(t *testing.T) {
 		expectedAgentDistro    Distro // expected agent result default disto to be used
 		expectedMasterDistro   Distro // expected master result default disto to be used
 		isUpgrade              bool
+		isScale                bool
+		cloudName              string
 	}{
 		{
 			"default_kubernetes",
@@ -1098,6 +1100,21 @@ func TestDistroDefaults(t *testing.T) {
 			AKSUbuntu1604,
 			AKSUbuntu1604,
 			false,
+			false,
+			AzurePublicCloud,
+		},
+		{
+			"default_kubernetes_usgov",
+			OrchestratorProfile{
+				OrchestratorType: Kubernetes,
+			},
+			"",
+			"",
+			Ubuntu,
+			Ubuntu,
+			false,
+			false,
+			AzureUSGovernmentCloud,
 		},
 		{
 			"1804_upgrade_kubernetes",
@@ -1109,6 +1126,21 @@ func TestDistroDefaults(t *testing.T) {
 			AKSUbuntu1804,
 			AKSUbuntu1804,
 			true,
+			false,
+			AzurePublicCloud,
+		},
+		{
+			"default_kubernetes_usgov",
+			OrchestratorProfile{
+				OrchestratorType: Kubernetes,
+			},
+			AKS1604Deprecated,
+			AKS1604Deprecated,
+			Ubuntu,
+			Ubuntu,
+			true,
+			false,
+			AzureGermanCloud,
 		},
 		{
 			"deprecated_distro_kubernetes",
@@ -1120,6 +1152,8 @@ func TestDistroDefaults(t *testing.T) {
 			AKSUbuntu1604,
 			AKSUbuntu1604,
 			true,
+			false,
+			AzureChinaCloud,
 		},
 		{
 			"docker_engine_kubernetes",
@@ -1130,7 +1164,9 @@ func TestDistroDefaults(t *testing.T) {
 			AKSDockerEngine,
 			AKSUbuntu1604,
 			AKSUbuntu1604,
+			false,
 			true,
+			AzurePublicCloud,
 		},
 		{
 			"default_swarm",
@@ -1142,6 +1178,8 @@ func TestDistroDefaults(t *testing.T) {
 			Ubuntu,
 			Ubuntu,
 			false,
+			false,
+			AzurePublicCloud,
 		},
 		{
 			"default_swarmmode",
@@ -1153,6 +1191,8 @@ func TestDistroDefaults(t *testing.T) {
 			Ubuntu,
 			Ubuntu,
 			false,
+			false,
+			AzurePublicCloud,
 		},
 		{
 			"default_dcos",
@@ -1164,6 +1204,8 @@ func TestDistroDefaults(t *testing.T) {
 			Ubuntu,
 			Ubuntu,
 			false,
+			false,
+			AzurePublicCloud,
 		},
 	}
 
@@ -1174,8 +1216,8 @@ func TestDistroDefaults(t *testing.T) {
 		for _, agent := range mockAPI.AgentPoolProfiles {
 			agent.Distro = test.agentPoolProfileDistro
 		}
-		mockAPI.setMasterProfileDefaults(test.isUpgrade, false)
-		mockAPI.setAgentProfileDefaults(test.isUpgrade, false)
+		mockAPI.setMasterProfileDefaults(test.isUpgrade, test.isScale, test.cloudName)
+		mockAPI.setAgentProfileDefaults(test.isUpgrade, test.isScale, test.cloudName)
 		if mockAPI.MasterProfile.Distro != test.expectedMasterDistro {
 			t.Fatalf("setMasterProfileDefaults() test case %v did not return right Distro configurations %v != %v", test.name, mockAPI.MasterProfile.Distro, test.expectedMasterDistro)
 		}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13321,16 +13321,6 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
 {{ else }}
     sed -i "s|<etcdEndPointUri>|127.0.0.1|g" $a
 {{ end }}
-{{if IsAzureStackCloud}}
-    {{if IsMultiMasterCluster}}
-    masterLBIP=` + "`" + `getent hosts {{WrapAsVariable "masterPublicLbFQDN"}} | cut -d " " -f1` + "`" + `
-    sed -i "s|<advertiseAddr>|$masterLBIP|g" $a
-    {{else}}
-    sed -i "s|<advertiseAddr>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" $a
-    {{end}}
-{{else}}
-    sed -i "s|<advertiseAddr>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" $a
-{{end}}
     sed -i "s|<advertiseAddr>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" $a
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}|g" /etc/kubernetes/manifests/kube-controller-manager.yaml
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.SchedulerConfig}}|g" /etc/kubernetes/manifests/kube-scheduler.yaml
@@ -13726,15 +13716,7 @@ write_files:
     - name: localcluster
       cluster:
         certificate-authority: /etc/kubernetes/certs/ca.crt
-        {{if IsAzureStackCloud}}
-            {{if IsMultiMasterCluster}}
-        server: https://{{WrapAsVariable "masterPublicLbFQDN"}}:443
-            {{else}}
         server: https://{{WrapAsVariable "kubernetesAPIServerIP"}}:443
-            {{end}}
-        {{else}}
-        server: https://{{WrapAsVariable "kubernetesAPIServerIP"}}:443
-        {{end}}
     users:
     - name: client
       user:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The distro value needs to be set to `Ubuntu` for Azure clouds that don't support the VHD distros yet. Overriding the image value does not suffice since we do introspection on the distro value in the code to determine other cluster configurations (for example --protect-kernel-defaults kubelet flag).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#1291 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
