### PR TITLE
fix: update etcd and containerd versions during upgrade

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -118,7 +118,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpdate bool) {
 		if o.KubernetesConfig.KubernetesImageBase == "" {
 			o.KubernetesConfig.KubernetesImageBase = cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase
 		}
-		if o.KubernetesConfig.EtcdVersion == "" {
+		if o.KubernetesConfig.EtcdVersion == "" || isUpdate {
 			o.KubernetesConfig.EtcdVersion = DefaultEtcdVersion
 		}
 
@@ -140,7 +140,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpdate bool) {
 				o.KubernetesConfig.MobyVersion = DefaultMobyVersion
 			}
 		case Containerd, ClearContainers, KataContainers:
-			if o.KubernetesConfig.ContainerdVersion == "" {
+			if o.KubernetesConfig.ContainerdVersion == "" || isUpdate {
 				o.KubernetesConfig.ContainerdVersion = DefaultContainerdVersion
 			}
 		}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -770,11 +770,11 @@ func TestNetworkPolicyDefaults(t *testing.T) {
 
 func TestContainerRuntime(t *testing.T) {
 
-	for _, version := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5"} {
+	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5"} {
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
 		properties.OrchestratorProfile.OrchestratorType = Kubernetes
-		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = version
+		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
 		mockCS.setOrchestratorDefaults(true)
 		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Docker {
 			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
@@ -785,25 +785,25 @@ func TestContainerRuntime(t *testing.T) {
 				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, DefaultMobyVersion)
 		}
 		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
-			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
 				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
 		}
 
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
 		properties.OrchestratorProfile.OrchestratorType = Kubernetes
-		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = version
+		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
 		mockCS.setOrchestratorDefaults(false)
 		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Docker {
 			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
 				properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, Docker)
 		}
-		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != version {
+		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != mobyVersion {
 			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
-				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, version)
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, mobyVersion)
 		}
 		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
-			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
 				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
 		}
 	}
@@ -821,7 +821,7 @@ func TestContainerRuntime(t *testing.T) {
 			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, DefaultMobyVersion)
 	}
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
-		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
 	}
 
@@ -839,7 +839,7 @@ func TestContainerRuntime(t *testing.T) {
 			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
 	}
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
-		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, DefaultContainerdVersion)
 	}
 
@@ -857,7 +857,7 @@ func TestContainerRuntime(t *testing.T) {
 			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
 	}
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
-		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, DefaultContainerdVersion)
 	}
 
@@ -875,27 +875,49 @@ func TestContainerRuntime(t *testing.T) {
 			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
 	}
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
-		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, DefaultContainerdVersion)
 	}
 
-	mockCS = getMockBaseContainerService("1.10.13")
-	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
-	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
-	properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = "1.1.6"
-	mockCS.setOrchestratorDefaults(false)
-	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Containerd {
-		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
-			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, Containerd)
-	}
-	if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
-		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
-			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
-	}
-	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "1.1.6" {
-		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
-			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "1.1.6")
+	for _, containerdVersion := range []string{"1.1.2", "1.1.4", "1.1.5"} {
+
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
+		properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = containerdVersion
+		mockCS.setOrchestratorDefaults(true)
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Containerd {
+			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, Containerd)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, DefaultContainerdVersion)
+		}
+
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
+		properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = containerdVersion
+		mockCS.setOrchestratorDefaults(false)
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Containerd {
+			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, Containerd)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != containerdVersion {
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, containerdVersion)
+		}
 	}
 }
 

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -906,9 +906,9 @@ func TestEtcdVersion(t *testing.T) {
 		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(true)
-		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
-			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
-				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, etcdVersion)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != DefaultEtcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, DefaultEtcdVersion)
 		}
 
 		mockCS = getMockBaseContainerService("1.10.13")
@@ -916,9 +916,9 @@ func TestEtcdVersion(t *testing.T) {
 		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(false)
-		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != DefaultEtcdVersion {
-			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
-				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, DefaultEtcdVersion)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, etcdVersion)
 		}
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -829,7 +829,7 @@ func TestContainerRuntime(t *testing.T) {
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
-	mockCS.setOrchestratorDefaults(true)
+	mockCS.setOrchestratorDefaults(false)
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Containerd {
 		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, Containerd)
@@ -847,7 +847,7 @@ func TestContainerRuntime(t *testing.T) {
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = ClearContainers
-	mockCS.setOrchestratorDefaults(true)
+	mockCS.setOrchestratorDefaults(false)
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != ClearContainers {
 		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, ClearContainers)
@@ -865,7 +865,7 @@ func TestContainerRuntime(t *testing.T) {
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = KataContainers
-	mockCS.setOrchestratorDefaults(true)
+	mockCS.setOrchestratorDefaults(false)
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != KataContainers {
 		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, KataContainers)
@@ -884,7 +884,7 @@ func TestContainerRuntime(t *testing.T) {
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
 	properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = "1.1.6"
-	mockCS.setOrchestratorDefaults(true)
+	mockCS.setOrchestratorDefaults(false)
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Containerd {
 		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, Containerd)
@@ -896,6 +896,30 @@ func TestContainerRuntime(t *testing.T) {
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "1.1.6" {
 		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "1.1.6")
+	}
+}
+
+func TestEtcdVersion(t *testing.T) {
+	for _, etcdVersion := range []string{"2.2.5", "3.2.24", "3.2.25", "3.3.0"} {
+		mockCS := getMockBaseContainerService("1.10.13")
+		properties := mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(true)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, etcdVersion)
+		}
+
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(false)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != DefaultEtcdVersion {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, DefaultEtcdVersion)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
When a cluster is upgraded or scaled currently, the etcd version and containerd version in. the apimodel get persisted instead of getting bumped to the latest. This PR changes the behavior to match other components by updating the version of etcd and containerd during update operations.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
