### PR TITLE
fix: remove "allow-privileged" in kubelet 1.15.0

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -186,6 +186,13 @@ func removeKubeletFlags(k map[string]string, v string) {
 		}
 	}
 
+	// Get rid of values not supported in v1.15 and up
+	if common.IsKubernetesVersionGe(v, "1.15.0-beta.1") {
+		for _, key := range []string{"--allow-privileged"} {
+			delete(k, key)
+		}
+	}
+
 	// Get rid of keys with empty string values
 	for key, val := range k {
 		if val == "" {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This PR remove `--allow-privileged` in kubelet config from k8s v1.15.0, since `--allow-privileged` is removed in this k8s upstream PR: https://github.com/kubernetes/kubernetes/pull/77820

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes#1368

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
