### PR TITLE
test: getTemplateFuncMap unit tests part 4

### DIFF
--- a/parts/agentparams.t
+++ b/parts/agentparams.t
@@ -41,7 +41,7 @@
     },
     {{end}}
     "{{.Name}}VMSize": {
-      {{GetAgentAllowedSizes}}
+      {{GetKubernetesAllowedVMSKUs}}
       "defaultValue": "{{.VMSize}}",
       "metadata": {
         "description": "The size of the Virtual Machine."

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -961,3 +961,24 @@ func getSwarmVersions(orchestratorVersion, dockerComposeVersion string) string {
 func wrapAsVariableObject(o, v string) string {
 	return fmt.Sprintf("',variables('%s').%s,'", o, v)
 }
+
+func getSSHPublicKeysPowerShell(linuxProfile *api.LinuxProfile) string {
+	str := ""
+	if linuxProfile != nil {
+		lastItem := len(linuxProfile.SSH.PublicKeys) - 1
+		for i, publicKey := range linuxProfile.SSH.PublicKeys {
+			str += `"` + strings.TrimSpace(publicKey.KeyData) + `"`
+			if i < lastItem {
+				str += ", "
+			}
+		}
+	}
+	return str
+}
+
+func getWindowsMasterSubnetARMParam(masterProfile *api.MasterProfile) string {
+	if masterProfile != nil && masterProfile.IsCustomVNET() {
+		return fmt.Sprintf("',parameters('vnetCidr'),'")
+	}
+	return fmt.Sprintf("',parameters('masterSubnet'),'")
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1298,3 +1298,185 @@ func TestGenerateConsecutiveIPsList(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateProfileOptedForExtension(t *testing.T) {
+	cases := []struct {
+		extensions          []api.Extension
+		name                string
+		expectedEnabled     bool
+		expectedSingleOrAll string
+	}{
+		{
+			extensions: []api.Extension{
+				{
+					Name:        "foo",
+					SingleOrAll: "single",
+				},
+			},
+			name:                "foo",
+			expectedEnabled:     true,
+			expectedSingleOrAll: "single",
+		},
+		{
+			extensions: []api.Extension{
+				{
+					Name:        "foo",
+					SingleOrAll: "All",
+				},
+			},
+			name:                "foo",
+			expectedEnabled:     true,
+			expectedSingleOrAll: "All",
+		},
+		{
+			extensions: []api.Extension{
+				{
+					Name: "foo",
+				},
+			},
+			name:                "foo",
+			expectedEnabled:     true,
+			expectedSingleOrAll: "",
+		},
+		{
+			extensions: []api.Extension{
+				{
+					Name: "foo",
+				},
+			},
+			name:                "bar",
+			expectedEnabled:     false,
+			expectedSingleOrAll: "",
+		},
+	}
+
+	for _, c := range cases {
+		enabled, singleOrAll := validateProfileOptedForExtension(c.name, c.extensions)
+		if enabled != c.expectedEnabled {
+			t.Fatalf("expected validateProfileOptedForExtension(%s, %v) to return %t but instead got %t", c.name, c.extensions, c.expectedEnabled, enabled)
+		}
+		if singleOrAll != c.expectedSingleOrAll {
+			t.Fatalf("expected validateProfileOptedForExtension(%s, %v) to return %s but instead got %s", c.name, c.extensions, c.expectedSingleOrAll, singleOrAll)
+		}
+	}
+}
+
+func TestGetMasterLinkedTemplateText(t *testing.T) {
+	cases := []struct {
+		orchestrator     string
+		extensionProfile *api.ExtensionProfile
+		singleOrAll      string
+		expected         string
+		expectedErr      error
+	}{
+		{
+			orchestrator: api.Kubernetes,
+			extensionProfile: &api.ExtensionProfile{
+				Name:    "winrm",
+				Version: "v1",
+				RootURL: "https://raw.githubusercontent.com/Azure/aks-engine/master/",
+			},
+			singleOrAll: "single",
+			expected: `{
+	"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), 'winrm')]",
+	"type": "Microsoft.Resources/deployments",
+	"apiVersion": "[variables('apiVersionDeployments')]",
+	"dependsOn": [
+		"[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '/extensions/cse', '-master-', copyIndex(variables('masterOffset')))]"
+	],
+	"copy": {
+		"count": 1,
+		"name": "winrmExtensionLoop"
+	},
+	"properties": {
+		"mode": "Incremental",
+		"templateLink": {
+			"uri": "https://raw.githubusercontent.com/Azure/aks-engine/master/extensions/winrm/v1/template.json",
+			"contentVersion": "1.0.0.0"
+		},
+		"parameters": {
+			"artifactsLocation": {
+				"value": "https://raw.githubusercontent.com/Azure/aks-engine/master/"
+			},
+			"apiVersionDeployments": {
+				"value": "[variables('apiVersionDeployments')]"
+			},
+			"targetVMName": {
+				"value": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]"
+			},
+			"targetVMType": {
+				"value": "master"
+			},
+			"extensionParameters": {
+				"value": "[parameters('winrmParameters')]"
+			},
+			"vmIndex":{
+				"value": "[copyIndex(variables('masterOffset'))]"
+			}
+		}
+	}
+}`,
+			expectedErr: nil,
+		},
+		{
+			orchestrator: api.Kubernetes,
+			extensionProfile: &api.ExtensionProfile{
+				Name:    "winrm",
+				Version: "v1",
+				RootURL: "https://raw.githubusercontent.com/Azure/aks-engine/master/",
+			},
+			expected: `{
+	"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), 'winrm')]",
+	"type": "Microsoft.Resources/deployments",
+	"apiVersion": "[variables('apiVersionDeployments')]",
+	"dependsOn": [
+		"[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '/extensions/cse', '-master-', copyIndex(variables('masterOffset')))]"
+	],
+	"copy": {
+		"count": "[sub(variables('masterCount'), variables('masterOffset'))]",
+		"name": "winrmExtensionLoop"
+	},
+	"properties": {
+		"mode": "Incremental",
+		"templateLink": {
+			"uri": "https://raw.githubusercontent.com/Azure/aks-engine/master/extensions/winrm/v1/template.json",
+			"contentVersion": "1.0.0.0"
+		},
+		"parameters": {
+			"artifactsLocation": {
+				"value": "https://raw.githubusercontent.com/Azure/aks-engine/master/"
+			},
+			"apiVersionDeployments": {
+				"value": "[variables('apiVersionDeployments')]"
+			},
+			"targetVMName": {
+				"value": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]"
+			},
+			"targetVMType": {
+				"value": "master"
+			},
+			"extensionParameters": {
+				"value": "[parameters('winrmParameters')]"
+			},
+			"vmIndex":{
+				"value": "[copyIndex(variables('masterOffset'))]"
+			}
+		}
+	}
+}`,
+			expectedErr: nil,
+		},
+	}
+
+	for _, c := range cases {
+		ret, err := getMasterLinkedTemplateText(c.orchestrator, c.extensionProfile, c.singleOrAll)
+		ret = strings.Join(strings.Fields(ret), " ")
+		expected := strings.Join(strings.Fields(c.expected), " ")
+		if ret != expected {
+			t.Fatalf("expected getMasterLinkedTemplateText(%s, %v, %s) to return %s but instead got %s", c.orchestrator, c.extensionProfile, c.singleOrAll, expected, ret)
+		}
+		if err != c.expectedErr {
+			t.Fatalf("expected getMasterLinkedTemplateText(%s, %v, %s) to return %s but instead got %s", c.orchestrator, c.extensionProfile, c.singleOrAll, c.expectedErr, err)
+		}
+	}
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1564,3 +1564,68 @@ func TestGetAgentPoolLinkedTemplateText(t *testing.T) {
 		}
 	}
 }
+
+func TestGetSSHPublicKeysPowerShell(t *testing.T) {
+	cases := []struct {
+		publicKeys []api.PublicKey
+		expected   string
+	}{
+		{
+			publicKeys: []api.PublicKey{
+				{
+					KeyData: "foo   ",
+				},
+			},
+			expected: "\"foo\"",
+		},
+		{
+			publicKeys: []api.PublicKey{
+				{
+					KeyData: "  foo",
+				},
+				{
+					KeyData: " bar   ",
+				},
+			},
+			expected: "\"foo\", \"bar\"",
+		},
+	}
+
+	for _, c := range cases {
+		linuxProfile := &api.LinuxProfile{}
+		linuxProfile.SSH.PublicKeys = c.publicKeys
+		ret := getSSHPublicKeysPowerShell(linuxProfile)
+		if ret != c.expected {
+			t.Fatalf("expected getSSHPublicKeysPowerShell(%v) to return %s but instead got %s", linuxProfile, c.expected, ret)
+		}
+	}
+}
+
+func TestGetWindowsMasterSubnetARMParam(t *testing.T) {
+	cases := []struct {
+		m        *api.MasterProfile
+		expected string
+	}{
+		{
+			m:        &api.MasterProfile{},
+			expected: "',parameters('masterSubnet'),'",
+		},
+		{
+			m:        nil,
+			expected: "',parameters('masterSubnet'),'",
+		},
+		{
+			m: &api.MasterProfile{
+				VnetSubnetID: "/my/subnet",
+			},
+			expected: "',parameters('vnetCidr'),'",
+		},
+	}
+
+	for _, c := range cases {
+		ret := getWindowsMasterSubnetARMParam(c.m)
+		if ret != c.expected {
+			t.Fatalf("expected getWindowsMasterSubnetARMParam(%v) to return %s but instead got %s", c.m, c.expected, ret)
+		}
+	}
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1480,3 +1480,87 @@ func TestGetMasterLinkedTemplateText(t *testing.T) {
 		}
 	}
 }
+
+func TestGetAgentPoolLinkedTemplateText(t *testing.T) {
+	cases := []struct {
+		orchestrator     string
+		agentPoolProfile *api.AgentPoolProfile
+		extensionProfile *api.ExtensionProfile
+		singleOrAll      string
+		expected         string
+		expectedErr      error
+	}{
+		{
+			orchestrator: api.Kubernetes,
+			agentPoolProfile: &api.AgentPoolProfile{
+				Name:                "foo",
+				AvailabilityProfile: "AvailabilitySet",
+			},
+			extensionProfile: &api.ExtensionProfile{
+				Name:    "winrm",
+				Version: "v1",
+				RootURL: "https://raw.githubusercontent.com/Azure/aks-engine/master/",
+			},
+			singleOrAll: "single",
+			expected:    `{ "name": "[concat(variables('fooVMNamePrefix'), copyIndex(variables('fooOffset')), 'winrm')]", "type": "Microsoft.Resources/deployments", "apiVersion": "[variables('apiVersionDeployments')]", "dependsOn": [ "[concat('Microsoft.Compute/virtualMachines/', variables('fooVMNamePrefix'), copyIndex(variables('fooOffset')), '/extensions/cse', '-agent-', copyIndex(variables('fooOffset')))]" ], "copy": { "count": 1, "name": "winrmExtensionLoop" }, "properties": { "mode": "Incremental", "templateLink": { "uri": "https://raw.githubusercontent.com/Azure/aks-engine/master/extensions/winrm/v1/template.json", "contentVersion": "1.0.0.0" }, "parameters": { "artifactsLocation": { "value": "https://raw.githubusercontent.com/Azure/aks-engine/master/" }, "apiVersionDeployments": { "value": "[variables('apiVersionDeployments')]" }, "targetVMName": { "value": "[concat(variables('fooVMNamePrefix'), copyIndex(variables('fooOffset')))]" }, "targetVMType": { "value": "agent" }, "extensionParameters": { "value": "[parameters('winrmParameters')]" }, "vmIndex":{ "value": "[copyIndex(variables('fooOffset'))]" } } } }`,
+			expectedErr: nil,
+		},
+		{
+			orchestrator: api.Kubernetes,
+			agentPoolProfile: &api.AgentPoolProfile{
+				Name:                "foo",
+				AvailabilityProfile: "VirtualMachineScaleSets",
+			},
+			extensionProfile: &api.ExtensionProfile{
+				Name:    "winrm",
+				Version: "v1",
+				RootURL: "https://raw.githubusercontent.com/Azure/aks-engine/master/",
+			},
+			singleOrAll: "single",
+			expected:    `{ "name": "[concat(variables('fooVMNamePrefix'), copyIndex(), 'winrm')]", "type": "Microsoft.Resources/deployments", "apiVersion": "[variables('apiVersionDeployments')]", "dependsOn": [ "[concat('Microsoft.Compute/virtualMachines/', variables('fooVMNamePrefix'), copyIndex(), '/extensions/cse', '-agent-', copyIndex())]" ], "copy": { "count": 1, "name": "winrmExtensionLoop" }, "properties": { "mode": "Incremental", "templateLink": { "uri": "https://raw.githubusercontent.com/Azure/aks-engine/master/extensions/winrm/v1/template.json", "contentVersion": "1.0.0.0" }, "parameters": { "artifactsLocation": { "value": "https://raw.githubusercontent.com/Azure/aks-engine/master/" }, "apiVersionDeployments": { "value": "[variables('apiVersionDeployments')]" }, "targetVMName": { "value": "[concat(variables('fooVMNamePrefix'), copyIndex())]" }, "targetVMType": { "value": "agent" }, "extensionParameters": { "value": "[parameters('winrmParameters')]" }, "vmIndex":{ "value": "[copyIndex()]" } } } }`,
+			expectedErr: nil,
+		},
+		{
+			orchestrator: api.Kubernetes,
+			agentPoolProfile: &api.AgentPoolProfile{
+				Name:                "foo",
+				AvailabilityProfile: "VirtualMachineScaleSets",
+			},
+			extensionProfile: &api.ExtensionProfile{
+				Name:    "winrm",
+				Version: "v1",
+				RootURL: "https://raw.githubusercontent.com/Azure/aks-engine/master/",
+			},
+			singleOrAll: "All",
+			expected:    `{ "name": "[concat(variables('fooVMNamePrefix'), copyIndex(), 'winrm')]", "type": "Microsoft.Resources/deployments", "apiVersion": "[variables('apiVersionDeployments')]", "dependsOn": [ "[concat('Microsoft.Compute/virtualMachines/', variables('fooVMNamePrefix'), copyIndex(), '/extensions/cse', '-agent-', copyIndex())]" ], "copy": { "count": "[variables('fooCount'))]", "name": "winrmExtensionLoop" }, "properties": { "mode": "Incremental", "templateLink": { "uri": "https://raw.githubusercontent.com/Azure/aks-engine/master/extensions/winrm/v1/template.json", "contentVersion": "1.0.0.0" }, "parameters": { "artifactsLocation": { "value": "https://raw.githubusercontent.com/Azure/aks-engine/master/" }, "apiVersionDeployments": { "value": "[variables('apiVersionDeployments')]" }, "targetVMName": { "value": "[concat(variables('fooVMNamePrefix'), copyIndex())]" }, "targetVMType": { "value": "agent" }, "extensionParameters": { "value": "[parameters('winrmParameters')]" }, "vmIndex":{ "value": "[copyIndex()]" } } } }`,
+			expectedErr: nil,
+		},
+		{
+			orchestrator: api.Kubernetes,
+			agentPoolProfile: &api.AgentPoolProfile{
+				Name:                "foo",
+				AvailabilityProfile: "AvailabilitySet",
+			},
+			extensionProfile: &api.ExtensionProfile{
+				Name:    "winrm",
+				Version: "v1",
+				RootURL: "https://raw.githubusercontent.com/Azure/aks-engine/master/",
+			},
+			singleOrAll: "All",
+			expected:    `{ "name": "[concat(variables('fooVMNamePrefix'), copyIndex(variables('fooOffset')), 'winrm')]", "type": "Microsoft.Resources/deployments", "apiVersion": "[variables('apiVersionDeployments')]", "dependsOn": [ "[concat('Microsoft.Compute/virtualMachines/', variables('fooVMNamePrefix'), copyIndex(variables('fooOffset')), '/extensions/cse', '-agent-', copyIndex(variables('fooOffset')))]" ], "copy": { "count": "[sub(variables('fooCount'), variables('fooOffset'))]", "name": "winrmExtensionLoop" }, "properties": { "mode": "Incremental", "templateLink": { "uri": "https://raw.githubusercontent.com/Azure/aks-engine/master/extensions/winrm/v1/template.json", "contentVersion": "1.0.0.0" }, "parameters": { "artifactsLocation": { "value": "https://raw.githubusercontent.com/Azure/aks-engine/master/" }, "apiVersionDeployments": { "value": "[variables('apiVersionDeployments')]" }, "targetVMName": { "value": "[concat(variables('fooVMNamePrefix'), copyIndex(variables('fooOffset')))]" }, "targetVMType": { "value": "agent" }, "extensionParameters": { "value": "[parameters('winrmParameters')]" }, "vmIndex":{ "value": "[copyIndex(variables('fooOffset'))]" } } } }`,
+			expectedErr: nil,
+		},
+	}
+
+	for _, c := range cases {
+		ret, err := getAgentPoolLinkedTemplateText(c.agentPoolProfile, c.orchestrator, c.extensionProfile, c.singleOrAll)
+		ret = strings.Join(strings.Fields(ret), " ")
+		expected := strings.Join(strings.Fields(c.expected), " ")
+		if ret != expected {
+			t.Fatalf("expected getAgentPoolLinkedTemplateText(%v, %s, %v, %s) to return %s but instead got %s", c.agentPoolProfile, c.orchestrator, c.extensionProfile, c.singleOrAll, expected, ret)
+		}
+		if err != c.expectedErr {
+			t.Fatalf("expected getAgentPoolLinkedTemplateText(%v, %s, %v, %s) to return %s but instead got %s", c.agentPoolProfile, c.orchestrator, c.extensionProfile, c.singleOrAll, c.expectedErr, err)
+		}
+	}
+}

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -381,13 +381,13 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			if cs.Properties.OrchestratorProfile.OrchestratorType == api.DCOS {
 				return helpers.GetDCOSMasterAllowedSizes()
 			}
-			return helpers.GetKubernetesAllowedSizes()
+			return helpers.GetKubernetesAllowedVMSKUs()
 		},
 		"GetDefaultVNETCIDR": func() string {
 			return DefaultVNETCIDR
 		},
-		"GetAgentAllowedSizes": func() string {
-			return helpers.GetKubernetesAllowedSizes()
+		"GetKubernetesAllowedVMSKUs": func() string {
+			return helpers.GetKubernetesAllowedVMSKUs()
 		},
 		"getSwarmVersions": func() string {
 			return getSwarmVersions(api.SwarmVersion, api.SwarmDockerComposeVersion)

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -399,8 +399,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return helpers.GetSizeMap()
 		},
 		"WriteLinkedTemplatesForExtensions": func() string {
-			extensions := getLinkedTemplatesForExtensions(cs.Properties)
-			return extensions
+			return getLinkedTemplatesForExtensions(cs.Properties)
 		},
 		"GetSshPublicKeysPowerShell": func() string {
 			str := ""

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -402,24 +402,10 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return getLinkedTemplatesForExtensions(cs.Properties)
 		},
 		"GetSshPublicKeysPowerShell": func() string {
-			str := ""
-			linuxProfile := cs.Properties.LinuxProfile
-			if linuxProfile != nil {
-				lastItem := len(linuxProfile.SSH.PublicKeys) - 1
-				for i, publicKey := range linuxProfile.SSH.PublicKeys {
-					str += `"` + strings.TrimSpace(publicKey.KeyData) + `"`
-					if i < lastItem {
-						str += ", "
-					}
-				}
-			}
-			return str
+			return getSSHPublicKeysPowerShell(cs.Properties.LinuxProfile)
 		},
 		"GetWindowsMasterSubnetARMParam": func() string {
-			if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.IsCustomVNET() {
-				return fmt.Sprintf("',parameters('vnetCidr'),'")
-			}
-			return fmt.Sprintf("',parameters('masterSubnet'),'")
+			return getWindowsMasterSubnetARMParam(cs.Properties.MasterProfile)
 		},
 		"GetKubernetesMasterPreprovisionYaml": func() string {
 			str := ""

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/aks-engine/pkg/api"
@@ -74,13 +75,26 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		"GetVNETSubnets",
 		"GetDataDisks",
 		"HasBootstrap",
+		"GetMasterAllowedSizes",
+		"GetDefaultVNETCIDR",
+		"GetKubernetesAllowedVMSKUs",
+		"GetSizeMap",
 		// TODO validate that the remaining func strings in getTemplateFuncMap are thinly wrapped and unit tested
 	}
 
 	for _, c := range cases {
-		_, ok := funcmap[c]
+		f, ok := funcmap[c]
+		v := reflect.ValueOf(f)
 		if !ok {
 			t.Fatalf("Didn't find expected funcmap key %s.", c)
+		}
+		switch c {
+		case "GetDefaultVNETCIDR":
+			rargs := make([]reflect.Value, 0)
+			ret := v.Call(rargs)
+			if ret[0].Interface() != DefaultVNETCIDR {
+				t.Fatalf("Got unexpected default VNET CIDR")
+			}
 		}
 	}
 }

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -79,6 +79,9 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		"GetDefaultVNETCIDR",
 		"GetKubernetesAllowedVMSKUs",
 		"GetSizeMap",
+		"WriteLinkedTemplatesForExtensions",
+		"GetSshPublicKeysPowerShell",
+		"GetWindowsMasterSubnetARMParam",
 		// TODO validate that the remaining func strings in getTemplateFuncMap are thinly wrapped and unit tested
 	}
 

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -98,6 +98,12 @@ func TestGetTemplateFuncMap(t *testing.T) {
 			if ret[0].Interface() != DefaultVNETCIDR {
 				t.Fatalf("Got unexpected default VNET CIDR")
 			}
+		case "IsMultiMasterCluster":
+			rargs := make([]reflect.Value, 0)
+			ret := v.Call(rargs)
+			if ret[0].Interface() != false {
+				t.Fatalf("Got unexpected IsMultiMasterCluster response")
+			}
 		}
 	}
 }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -267,7 +267,7 @@ var _agentparamsT = []byte(`    "{{.Name}}Count": {
     },
     {{end}}
     "{{.Name}}VMSize": {
-      {{GetAgentAllowedSizes}}
+      {{GetKubernetesAllowedVMSKUs}}
       "defaultValue": "{{.VMSize}}",
       "metadata": {
         "description": "The size of the Virtual Machine."

--- a/pkg/helpers/azureconst.go
+++ b/pkg/helpers/azureconst.go
@@ -263,8 +263,8 @@ func GetDCOSMasterAllowedSizes() string {
 `
 }
 
-// GetKubernetesAllowedSizes returns the allowed sizes for Kubernetes agent
-func GetKubernetesAllowedSizes() string {
+// GetKubernetesAllowedVMSKUs returns the allowed sizes for Kubernetes agent
+func GetKubernetesAllowedVMSKUs() string {
 	return `      "allowedValues": [
         "Standard_A0",
         "Standard_A1",

--- a/pkg/helpers/azureconst_test.go
+++ b/pkg/helpers/azureconst_test.go
@@ -279,9 +279,9 @@ func TestGetDCOSMasterAllowedSizes(t *testing.T) {
 }
 
 func TestKubernetesAllowedSizes(t *testing.T) {
-	sizes := GetKubernetesAllowedSizes()
+	sizes := GetKubernetesAllowedVMSKUs()
 	if len(sizes) == 0 {
-		t.Errorf("expected GetKubernetesAllowedSizes to return a non empty string")
+		t.Errorf("expected GetKubernetesAllowedVMSKUs to return a non empty string")
 	}
 
 	expectedSizes := []string{

--- a/pkg/helpers/generate_azure_constants.py
+++ b/pkg/helpers/generate_azure_constants.py
@@ -121,8 +121,8 @@ func GetDCOSMasterAllowedSizes() string {
 `
 }
 
-// GetKubernetesAllowedSizes returns the allowed sizes for Kubernetes agent
- func GetKubernetesAllowedSizes() string {
+// GetKubernetesAllowedVMSKUs returns the allowed sizes for Kubernetes agent
+ func GetKubernetesAllowedVMSKUs() string {
         return `      "allowedValues": [
 """
     kubernetes_agent_map_keys = sorted(kubernetes_size_map.keys())


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Ensures that the following `getTemplateFuncMap` function keys are thinly wrapped go functions with unit test coverage:

```
		"GetMasterAllowedSizes",
		"GetDefaultVNETCIDR",
		"GetKubernetesAllowedVMSKUs",
		"GetSizeMap",
		"WriteLinkedTemplatesForExtensions",
		"GetSshPublicKeysPowerShell",
		"GetWindowsMasterSubnetARMParam"
```

`GetKubernetesAllowedVMSKUs` is a rename of `GetAgentAllowedSizes` to more clearly express what it is.

Also includes unit test coverage of extention convenienc functions.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
