### PR TITLE
feat: add support for Kubernetes 1.15.0-beta.1

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -124,6 +124,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.15.0-alpha.1": true,
 	"1.15.0-alpha.2": true,
 	"1.15.0-alpha.3": true,
+	"1.15.0-beta.1":  true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#changelog-since-v1150-alpha3

**Issue Fixed**:

**Requirements**:
- [x] Windows artifacts uploaded to acsmirror blob store
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
~~Requires #1369 to merge before this will pass.~~ *Merged*
CoreDNS was bumped to 1.5.0, but I think this may require configuration changes. I'll take a look at that next.
