### PR TITLE
fix: prune addon defaults if the addon is disabled

### DIFF
--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -352,6 +352,12 @@ func assignDefaultAddonVals(addon, defaults KubernetesAddon, isUpdate bool) Kube
 	if addon.Enabled == nil {
 		addon.Enabled = defaults.Enabled
 	}
+	if !to.Bool(addon.Enabled) {
+		return KubernetesAddon{
+			Name:    addon.Name,
+			Enabled: addon.Enabled,
+		}
+	}
 	for i := range defaults.Containers {
 		c := addon.GetAddonContainersIndexByName(defaults.Containers[i].Name)
 		if c < 0 {

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -316,7 +316,7 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 	}
 
 	for _, addon := range defaultAddons {
-		synthesizeAddonsConfig(o.KubernetesConfig.Addons, addon, false, isUpdate)
+		synthesizeAddonsConfig(o.KubernetesConfig.Addons, addon, isUpdate)
 	}
 
 	if len(o.KubernetesConfig.PodSecurityPolicyConfig) > 0 && isUpdate {
@@ -385,12 +385,10 @@ func assignDefaultAddonVals(addon, defaults KubernetesAddon, isUpdate bool) Kube
 	return addon
 }
 
-func synthesizeAddonsConfig(addons []KubernetesAddon, addon KubernetesAddon, enableIfNil bool, isUpdate bool) {
+func synthesizeAddonsConfig(addons []KubernetesAddon, addon KubernetesAddon, isUpdate bool) {
 	i := getAddonsIndexByName(addons, addon.Name)
 	if i >= 0 {
-		if addons[i].IsEnabled(enableIfNil) {
-			addons[i] = assignDefaultAddonVals(addons[i], addon, isUpdate)
-		}
+		addons[i] = assignDefaultAddonVals(addons[i], addon, isUpdate)
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Currently, we only set default addon values for addons when they are enabled but we still populate the defaults if the addon itself was omitted from the apimodel and is disabled by default. Although this has no functional impact, it is counter intuitive. As a user, when upgrading I would expect my addon Images to be refreshed, even if an addon is disabled or wasn't included in my input apimodel (since it will be included in the expanded apimodel). See #1372 for more details.

Steps to repro
- Deploy a cluster without specifying an addon that is disabled by default (eg. cluster-autoscaler)
- Note that the addon is added to the Addons section of the generated apimodel with `Enabled: false`.
- Upgrade the cluster with a more recent aks-engine version where the default addon image has changed.
The apimodel after the upgrade will still have the old image. This is purely cosmetic and has no effect on the cluster functionality since the addon is disabled. However, it might be confusing to users getting different images on different clusters using the same aks-engine version (one with the addon enabled, the other with the same addon disabled).

Before:
```
          {
            "name": "cluster-autoscaler",
            "enabled": false,
            "containers": [
              {
                "name": "cluster-autoscaler",
                "image": "k8s.gcr.io/cluster-autoscaler:v1.12.3",
                "cpuRequests": "100m",
                "memoryRequests": "300Mi",
                "cpuLimits": "100m",
                "memoryLimits": "300Mi"
              }
            ],
            "config": {
              "max-nodes": "5",
              "min-nodes": "1",
              "scan-interval": "10s"
            }
          }
```

After:

```
          {
            "name": "cluster-autoscaler",
            "enabled": false
          }
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Related to #1372 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
