### PR TITLE
fix: disable redundant cosmosdb regions

### DIFF
--- a/pkg/engine/cosmosdb.go
+++ b/pkg/engine/cosmosdb.go
@@ -26,10 +26,6 @@ func createCosmosDBAccount() map[string]interface{} {
 					"locationName":     "[resourceGroup().location]",
 					"failoverPriority": 0,
 				},
-				{
-					"locationName":     "[resourceGroup().location]",
-					"failoverPriority": 1,
-				},
 			},
 			"name":                             "[variables('cosmosAccountName')]",
 			"primaryClientCertificatePemBytes": "[variables('cosmosDBCertb64')]",

--- a/pkg/engine/cosmosdb_test.go
+++ b/pkg/engine/cosmosdb_test.go
@@ -33,10 +33,6 @@ func TestCreateCosmosDB(t *testing.T) {
 					"locationName":     "[resourceGroup().location]",
 					"failoverPriority": 0,
 				},
-				{
-					"locationName":     "[resourceGroup().location]",
-					"failoverPriority": 1,
-				},
 			},
 			"name":                             "[variables('cosmosAccountName')]",
 			"primaryClientCertificatePemBytes": "[variables('cosmosDBCertb64')]",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

multiple cosmosdb regions for a single customer is not currently supported by cosmosdb

See:

https://azure.microsoft.com/en-us/resources/videos/azure-cosmosdb-global-distribution/

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1400

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: