### PR TITLE
refactor: run full validation for aks-engine deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -80,9 +80,11 @@ func newDeployCmd() *cobra.Command {
 				return errors.Wrap(err, "loading API model")
 			}
 			if dc.apiVersion == "vlabs" {
-				if err := dc.validateApimodel(); err != nil {
+				if err := dc.validateAPIModelAsVLabs(); err != nil {
 					return errors.Wrap(err, "validating API model after populating values")
 				}
+			} else {
+				log.Warnf("API model validation is only available for \"apiVersion\": \"vlabs\", skipping validation...")
 			}
 			return dc.run()
 		},
@@ -355,9 +357,9 @@ func autofillApimodel(dc *deployCmd) error {
 	return nil
 }
 
-func (dc *deployCmd) validateApimodel() error {
-	vlabsCS := api.ConvertContainerServiceToVLabs(dc.containerService)
-	return vlabsCS.Validate(false)
+// validateAPIModelAsVLabs converts the ContainerService object to a vlabs ContainerService object and validates it
+func (dc *deployCmd) validateAPIModelAsVLabs() error {
+	return api.ConvertContainerServiceToVLabs(dc.containerService).Validate(false)
 }
 
 func (dc *deployCmd) run() error {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/leonelquinteros/gotext"

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -80,7 +80,7 @@ func newDeployCmd() *cobra.Command {
 			if err := dc.loadAPIModel(); err != nil {
 				return errors.Wrap(err, "loading API model")
 			}
-			if _, _, err := dc.validateApimodel(); err != nil {
+			if err := dc.validateApimodel(); err != nil {
 				return errors.Wrap(err, "validating API model after populating values")
 			}
 			return dc.run()
@@ -354,28 +354,9 @@ func autofillApimodel(dc *deployCmd) error {
 	return nil
 }
 
-func (dc *deployCmd) validateApimodel() (*api.ContainerService, string, error) {
-	apiloader := &api.Apiloader{
-		Translator: &i18n.Translator{
-			Locale: dc.locale,
-		},
-	}
-
-	p := dc.containerService.Properties
-	if strings.ToLower(p.OrchestratorProfile.OrchestratorType) == "kubernetes" {
-		if p.ServicePrincipalProfile == nil || (p.ServicePrincipalProfile.ClientID == "" || (p.ServicePrincipalProfile.Secret == "" && p.ServicePrincipalProfile.KeyvaultSecretRef == nil)) {
-			if p.OrchestratorProfile.KubernetesConfig != nil && !p.OrchestratorProfile.KubernetesConfig.UseManagedIdentity {
-				return nil, "", errors.New("when using the kubernetes orchestrator, must either set useManagedIdentity in the kubernetes config or set --client-id and --client-secret or KeyvaultSecretRef of secret (also available in the API model)")
-			}
-		}
-	}
-
-	// This isn't terribly elegant, but it's the easiest way to go for now w/o duplicating a bunch of code
-	rawVersionedAPIModel, err := apiloader.SerializeContainerService(dc.containerService, dc.apiVersion)
-	if err != nil {
-		return nil, "", err
-	}
-	return apiloader.DeserializeContainerService(rawVersionedAPIModel, true, false, nil)
+func (dc *deployCmd) validateApimodel() error {
+	vlabsCS := api.ConvertContainerServiceToVLabs(dc.containerService)
+	return vlabsCS.Validate(false)
 }
 
 func (dc *deployCmd) run() error {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -79,8 +79,10 @@ func newDeployCmd() *cobra.Command {
 			if err := dc.loadAPIModel(); err != nil {
 				return errors.Wrap(err, "loading API model")
 			}
-			if err := dc.validateApimodel(); err != nil {
-				return errors.Wrap(err, "validating API model after populating values")
+			if dc.apiVersion == "vlabs" {
+				if err := dc.validateApimodel(); err != nil {
+					return errors.Wrap(err, "validating API model after populating values")
+				}
 			}
 			return dc.run()
 		},

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -490,7 +490,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 	// cleanup, since auto-populations creates dirs and saves the SSH private key that it might create
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
-	cs, _, err = deployCmd.validateApimodel()
+	err = deployCmd.validateApimodel()
 	if err != nil {
 		t.Fatalf("unexpected error validating apimodel after populating defaults: %s", err)
 	}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -490,7 +490,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 	// cleanup, since auto-populations creates dirs and saves the SSH private key that it might create
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
-	err = deployCmd.validateApimodel()
+	err = deployCmd.validateAPIModelAsVLabs()
 	if err != nil {
 		t.Fatalf("unexpected error validating apimodel after populating defaults: %s", err)
 	}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This is a simpler method of running cluster configuration validation during `aks-engine deploy`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
