### PR TITLE
chore: move examples VM SKUs from Standard_D2_v2 to Standard_D2_v3

### DIFF
--- a/examples/agents-only.json
+++ b/examples/agents-only.json
@@ -9,7 +9,7 @@
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/azure-cni/k8s-scaledown.json
+++ b/examples/azure-cni/k8s-scaledown.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/azure-cni/k8s-scaleup.json
+++ b/examples/azure-cni/k8s-scaleup.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/azure-cni/k8s-vnet-scaledown.json
+++ b/examples/azure-cni/k8s-vnet-scaledown.json
@@ -10,7 +10,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
       "firstConsecutiveStaticIP": "10.239.255.239",
       "vnetCidr": "10.239.0.0/16"
@@ -19,7 +19,7 @@
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
       }

--- a/examples/azure-cni/k8s-vnet-scaleup.json
+++ b/examples/azure-cni/k8s-vnet-scaleup.json
@@ -10,7 +10,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
       "firstConsecutiveStaticIP": "10.239.255.239",
       "vnetCidr": "10.239.0.0/16"
@@ -19,7 +19,7 @@
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
       }

--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -19,14 +19,14 @@
             "distro": "ubuntu",
             "osDiskSizeGB": 200,
             "count": 1,
-            "vmSize": "Standard_D2_v2"
+            "vmSize": "Standard_D2_v3"
         },
         "agentPoolProfiles": [
             {
                 "name": "linuxpool",
                 "osDiskSizeGB": 200,
                 "count": 3,
-                "vmSize": "Standard_D2_v2",
+                "vmSize": "Standard_D2_v3",
                 "distro": "ubuntu",
                 "availabilityProfile": "AvailabilitySet",
                 "AcceleratedNetworkingEnabled": false

--- a/examples/coreos/kubernetes-coreos-hybrid.json
+++ b/examples/coreos/kubernetes-coreos-hybrid.json
@@ -10,35 +10,35 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "distro": "coreos"
     },
     "agentPoolProfiles": [
       {
         "name": "ubuntupool",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "distro": "ubuntu"
       },
       {
         "name": "coreospool",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "distro": "coreos"
       },
       {
         "name": "windowspool",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       },
       {
         "name": "ubuntupool2",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/coreos/kubernetes-coreos.json
+++ b/examples/coreos/kubernetes-coreos.json
@@ -10,14 +10,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "distro": "coreos"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "distro": "coreos"
       }

--- a/examples/cosmos-etcd/kubernetes-3-masters-cosmos.json
+++ b/examples/cosmos-etcd/kubernetes-3-masters-cosmos.json
@@ -10,14 +10,14 @@
         "masterProfile": {
             "count": 3,
             "dnsPrefix": "",
-            "vmSize": "Standard_D2_v2",
+            "vmSize": "Standard_D2_v3",
             "cosmosEtcd" : true
         },
         "agentPoolProfiles": [
             {
                 "name": "agent",
                 "count": 3,
-                "vmSize": "Standard_D2_v2",
+                "vmSize": "Standard_D2_v3",
                 "availabilityProfile": "AvailabilitySet"
             }
         ],

--- a/examples/custom-image.json
+++ b/examples/custom-image.json
@@ -11,7 +11,7 @@
       },
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
@@ -21,7 +21,7 @@
           "name": "stretch",
           "resourceGroup": "debian"
         },
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/disks-managed/kubernetes-preAttachedDisks-vmas.json
+++ b/examples/disks-managed/kubernetes-preAttachedDisks-vmas.json
@@ -7,13 +7,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agent",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "storageProfile" : "ManagedDisks",
         "diskSizesGB": [128, 128, 128, 128],
         "availabilityProfile": "AvailabilitySet"

--- a/examples/disks-managed/kubernetes-vmas.json
+++ b/examples/disks-managed/kubernetes-vmas.json
@@ -7,14 +7,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200
     },
     "agentPoolProfiles": [
       {
         "name": "agent",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "OSDiskSizeGB": 200,
         "storageProfile" : "ManagedDisks",
         "availabilityProfile": "AvailabilitySet"

--- a/examples/disks-storageaccount/kubernetes-master-sa.json
+++ b/examples/disks-storageaccount/kubernetes-master-sa.json
@@ -7,14 +7,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "storageProfile": "StorageAccount"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/disks-storageaccount/kubernetes.json
+++ b/examples/disks-storageaccount/kubernetes.json
@@ -7,14 +7,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "OSDiskSizeGB": 200,
         "availabilityProfile": "AvailabilitySet",
         "storageProfile": "StorageAccount",
@@ -23,7 +23,7 @@
       {
         "name": "agentpool2",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "storageProfile": "StorageAccount",
         "diskSizesGB": [10, 10, 10, 10]

--- a/examples/e2e-tests/kubernetes/coreos/coreos.json
+++ b/examples/e2e-tests/kubernetes/coreos/coreos.json
@@ -70,7 +70,7 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200,
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
       "firstConsecutiveStaticIP": "10.239.255.239",
@@ -82,7 +82,7 @@
         "name": "agentmd",
         "count": 3,
         "distro": "coreos",
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "OSDiskSizeGB": 200,
         "storageProfile": "ManagedDisks",
         "diskSizesGB": [

--- a/examples/e2e-tests/kubernetes/gpu-enabled/definition.json
+++ b/examples/e2e-tests/kubernetes/gpu-enabled/definition.json
@@ -8,7 +8,7 @@
       "masterProfile": {
         "count": 1,
         "dnsPrefix": "",
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       },
       "agentPoolProfiles": [
         {

--- a/examples/e2e-tests/kubernetes/kubernetes-config/addons-disabled.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/addons-disabled.json
@@ -47,13 +47,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/e2e-tests/kubernetes/kubernetes-config/addons-enabled.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/addons-enabled.json
@@ -48,13 +48,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       }
     ],
     "linuxProfile": {

--- a/examples/e2e-tests/kubernetes/kubernetes-config/clear-containers.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/clear-containers.json
@@ -12,7 +12,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {

--- a/examples/e2e-tests/kubernetes/kubernetes-config/network-plugin-kubenet.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/network-plugin-kubenet.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/e2e-tests/kubernetes/kubernetes-config/rbac-disabled.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/rbac-disabled.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/e2e-tests/kubernetes/node-count/50-nodes/definition.json
+++ b/examples/e2e-tests/kubernetes/node-count/50-nodes/definition.json
@@ -8,14 +8,14 @@
     "masterProfile": {
       "count": 5,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 50,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "osType": "Linux",
         "availabilityProfile": "AvailabilitySet"
       }

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -54,7 +54,7 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200,
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
       "firstConsecutiveStaticIP": "10.239.255.239",
@@ -64,7 +64,7 @@
       {
         "name": "agentmd",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "OSDiskSizeGB": 200,
         "storageProfile": "ManagedDisks",
         "diskSizesGB": [
@@ -79,7 +79,7 @@
       {
         "name": "agentsa",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "OSDiskSizeGB": 200,
         "storageProfile": "StorageAccount",
         "diskSizesGB": [

--- a/examples/e2e-tests/kubernetes/windows/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/definition.json
@@ -7,13 +7,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentwin",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       }

--- a/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
@@ -7,19 +7,19 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentwin",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       }

--- a/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas-multimaster.json
+++ b/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas-multimaster.json
@@ -12,14 +12,14 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "availabilityProfile": "AvailabilitySet"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas.json
+++ b/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas.json
@@ -12,14 +12,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "availabilityProfile": "AvailabilitySet"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
+++ b/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
@@ -12,14 +12,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "availabilityProfile": "VirtualMachineScaleSets"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "VirtualMachineScaleSets"
       }
     ],

--- a/examples/extensions/kubernetes.json
+++ b/examples/extensions/kubernetes.json
@@ -7,9 +7,9 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "extensions": [
-        { 
+        {
           "name": "hello-world-k8s"
         }
      ]
@@ -18,7 +18,7 @@
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],
@@ -33,8 +33,8 @@
       }
     },
     "extensionProfiles": [
-      { 
-        "name": "hello-world-k8s", 
+      {
+        "name": "hello-world-k8s",
         "version": "v1"
       }
     ],

--- a/examples/extensions/kubernetes.oms.json
+++ b/examples/extensions/kubernetes.oms.json
@@ -7,9 +7,9 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "extensions": [
-        { 
+        {
           "name": "microsoft-oms-agent-k8s"
         }
      ]
@@ -18,7 +18,7 @@
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],
@@ -33,9 +33,9 @@
       }
     },
     "extensionProfiles": [
-      { 
-        "name": "microsoft-oms-agent-k8s", 
-        "version": "v1", 
+      {
+        "name": "microsoft-oms-agent-k8s",
+        "version": "v1",
         "extensionParameters": ""
       }
     ],

--- a/examples/extensions/kubernetes.preprovision.json
+++ b/examples/extensions/kubernetes.preprovision.json
@@ -7,7 +7,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "preProvisionExtension": {
         "name": "hello-world",
         "singleOrAll": "All"
@@ -17,7 +17,7 @@
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "preProvisionExtension": {
             "name": "hello-world",

--- a/examples/feature-gates/kubernetes-featuresgates.json
+++ b/examples/feature-gates/kubernetes-featuresgates.json
@@ -16,13 +16,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/ipvs/kubernetes-msi.json
+++ b/examples/ipvs/kubernetes-msi.json
@@ -12,13 +12,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ]

--- a/examples/k8s-upgrade/v1.7.7.json
+++ b/examples/k8s-upgrade/v1.7.7.json
@@ -8,19 +8,19 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpool2",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/k8s-upgrade/v1.7.9-hybrid.json
+++ b/examples/k8s-upgrade/v1.7.9-hybrid.json
@@ -8,20 +8,20 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "windowspool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       },
       {
         "name": "agentpool2",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/k8s-upgrade/v1.7.9-win.json
+++ b/examples/k8s-upgrade/v1.7.9-win.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "windowspool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "storageProfile": "StorageAccount",
         "osType": "Windows"
@@ -22,7 +22,7 @@
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       }

--- a/examples/k8s-upgrade/v1.7.9.json
+++ b/examples/k8s-upgrade/v1.7.9.json
@@ -8,20 +8,20 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "storageProfile": "StorageAccount"
       },
       {
         "name": "agentpool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/k8s-upgrade/v1.8.4.json
+++ b/examples/k8s-upgrade/v1.8.4.json
@@ -8,19 +8,19 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpool2",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/keyvault-params/kubernetes.json
+++ b/examples/keyvault-params/kubernetes.json
@@ -7,19 +7,19 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpool2",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/keyvaultcerts/kubernetes.json
+++ b/examples/keyvaultcerts/kubernetes.json
@@ -7,13 +7,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-clear-containers.json
+++ b/examples/kubernetes-clear-containers.json
@@ -22,7 +22,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {

--- a/examples/kubernetes-config/kubernetes-accelerated-network.json
+++ b/examples/kubernetes-config/kubernetes-accelerated-network.json
@@ -7,13 +7,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "acceleratedNetworkingEnabled": true
       }
     ],

--- a/examples/kubernetes-config/kubernetes-cloud-controller-manager.json
+++ b/examples/kubernetes-config/kubernetes-cloud-controller-manager.json
@@ -11,13 +11,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-clustersubnet.json
+++ b/examples/kubernetes-config/kubernetes-clustersubnet.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-data-encryption-at-rest.json
+++ b/examples/kubernetes-config/kubernetes-data-encryption-at-rest.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-dockerbridgesubnet.json
+++ b/examples/kubernetes-config/kubernetes-dockerbridgesubnet.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-etcd-storage-size.json
+++ b/examples/kubernetes-config/kubernetes-etcd-storage-size.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-gc.json
+++ b/examples/kubernetes-config/kubernetes-gc.json
@@ -11,13 +11,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-keyvault-encryption.json
+++ b/examples/kubernetes-config/kubernetes-keyvault-encryption.json
@@ -12,13 +12,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-maxpods.json
+++ b/examples/kubernetes-config/kubernetes-maxpods.json
@@ -12,13 +12,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-no-dashboard.json
+++ b/examples/kubernetes-config/kubernetes-no-dashboard.json
@@ -15,13 +15,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-private-cluster-single-master.json
+++ b/examples/kubernetes-config/kubernetes-private-cluster-single-master.json
@@ -8,7 +8,7 @@
           "enabled": true,
           "jumpboxProfile": {
             "name": "my-jb",
-            "vmSize": "Standard_D2_v2",
+            "vmSize": "Standard_D2_v3",
             "osDiskSizeGB": 30,
             "username": "azureuser",
             "publicKey": ""
@@ -19,13 +19,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-private-cluster.json
+++ b/examples/kubernetes-config/kubernetes-private-cluster.json
@@ -8,7 +8,7 @@
           "enabled": true,
           "jumpboxProfile": {
             "name": "my-jb",
-            "vmSize": "Standard_D2_v2",
+            "vmSize": "Standard_D2_v3",
             "osDiskSizeGB": 30,
             "username": "azureuser",
             "publicKey": ""
@@ -19,13 +19,13 @@
       "masterProfile": {
         "count": 3,
         "dnsPrefix": "",
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       },
       "agentPoolProfiles": [
         {
           "name": "linuxpool1",
           "count": 3,
-          "vmSize": "Standard_D2_v2",
+          "vmSize": "Standard_D2_v3",
           "availabilityProfile": "AvailabilitySet"
         }
       ],

--- a/examples/kubernetes-config/kubernetes-rescheduler.json
+++ b/examples/kubernetes-config/kubernetes-rescheduler.json
@@ -15,13 +15,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-config/kubernetes-standardlb.json
+++ b/examples/kubernetes-config/kubernetes-standardlb.json
@@ -12,13 +12,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "VirtualMachineScaleSets"
       }
     ],

--- a/examples/kubernetes-containerd.json
+++ b/examples/kubernetes-containerd.json
@@ -22,7 +22,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {

--- a/examples/kubernetes-gpu/kubernetes.json
+++ b/examples/kubernetes-gpu/kubernetes.json
@@ -7,7 +7,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {

--- a/examples/kubernetes-kata-containers.json
+++ b/examples/kubernetes-kata-containers.json
@@ -12,7 +12,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {

--- a/examples/kubernetes-labels/README.md
+++ b/examples/kubernetes-labels/README.md
@@ -12,7 +12,7 @@ The definition below adds 2 labels `"bar"` and `"baz"` to all nodes in the `firs
       {
         "name": "firstpool",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "customNodeLabels": {
           "bar": "lulz",

--- a/examples/kubernetes-labels/kubernetes.json
+++ b/examples/kubernetes-labels/kubernetes.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "my-cluster",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "firstpool",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "customNodeLabels": {
           "bar": "lulz",

--- a/examples/kubernetes-msi-userassigned/kube-vma.json
+++ b/examples/kubernetes-msi-userassigned/kube-vma.json
@@ -11,13 +11,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "storageProfile": "ManagedDisks"
       }

--- a/examples/kubernetes-msi-userassigned/kube-vmss.json
+++ b/examples/kubernetes-msi-userassigned/kube-vmss.json
@@ -11,13 +11,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "VirtualMachineScaleSets",
         "storageProfile": "ManagedDisks"
       }

--- a/examples/kubernetes-releases/kubernetes1.10.json
+++ b/examples/kubernetes-releases/kubernetes1.10.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-releases/kubernetes1.11.json
+++ b/examples/kubernetes-releases/kubernetes1.11.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-releases/kubernetes1.12.json
+++ b/examples/kubernetes-releases/kubernetes1.12.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       }
     ],
     "linuxProfile": {

--- a/examples/kubernetes-releases/kubernetes1.13.json
+++ b/examples/kubernetes-releases/kubernetes1.13.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       }
     ],
     "linuxProfile": {

--- a/examples/kubernetes-releases/kubernetes1.6.json
+++ b/examples/kubernetes-releases/kubernetes1.6.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-releases/kubernetes1.7.json
+++ b/examples/kubernetes-releases/kubernetes1.7.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-releases/kubernetes1.8.json
+++ b/examples/kubernetes-releases/kubernetes1.8.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-releases/kubernetes1.9.json
+++ b/examples/kubernetes-releases/kubernetes1.9.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/kubernetes-vmss-low-priority/kubernetes.json
+++ b/examples/kubernetes-vmss-low-priority/kubernetes.json
@@ -11,13 +11,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "VirtualMachineScaleSets",
         "scaleSetPriority": "Low",
         "scaleSetEvictionPolicy": "Delete",

--- a/examples/kubernetes-vmss-master/kubernetes.json
+++ b/examples/kubernetes-vmss-master/kubernetes.json
@@ -8,14 +8,14 @@
       "masterProfile": {
         "count": 1,
         "dnsPrefix": "",
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "VirtualMachineScaleSets"
       },
       "agentPoolProfiles": [
         {
           "name": "agentpool1",
           "count": 3,
-          "vmSize": "Standard_D2_v2",
+          "vmSize": "Standard_D2_v3",
           "availabilityProfile": "VirtualMachineScaleSets",
           "storageProfile": "ManagedDisks"
         }

--- a/examples/kubernetes-vmss-master/windows.json
+++ b/examples/kubernetes-vmss-master/windows.json
@@ -8,20 +8,20 @@
       "masterProfile": {
         "count": 1,
         "dnsPrefix": "",
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "VirtualMachineScaleSets"
       },
       "agentPoolProfiles": [
         {
           "name": "linuxpool1",
           "count": 1,
-          "vmSize": "Standard_D2_v2",
+          "vmSize": "Standard_D2_v3",
           "availabilityProfile": "VirtualMachineScaleSets"
         },
         {
           "name": "agentwin",
           "count": 2,
-          "vmSize": "Standard_D2_v2",
+          "vmSize": "Standard_D2_v3",
           "availabilityProfile": "VirtualMachineScaleSets",
           "osType": "Windows"
         }

--- a/examples/kubernetes-vmss/kubernetes.json
+++ b/examples/kubernetes-vmss/kubernetes.json
@@ -11,13 +11,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "VirtualMachineScaleSets",
         "storageProfile": "ManagedDisks"
       }

--- a/examples/kubernetes.json
+++ b/examples/kubernetes.json
@@ -7,13 +7,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       }
     ],
     "linuxProfile": {

--- a/examples/managed-identity/kubernetes-msi.json
+++ b/examples/managed-identity/kubernetes-msi.json
@@ -11,19 +11,19 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       }

--- a/examples/multiple-masters/kubernetes-3-masters.json
+++ b/examples/multiple-masters/kubernetes-3-masters.json
@@ -7,13 +7,13 @@
         "masterProfile": {
             "count": 3,
             "dnsPrefix": "",
-            "vmSize": "Standard_D2_v2"
+            "vmSize": "Standard_D2_v3"
         },
         "agentPoolProfiles": [
             {
                 "name": "agent",
                 "count": 3,
-                "vmSize": "Standard_D2_v2",
+                "vmSize": "Standard_D2_v3",
                 "availabilityProfile": "AvailabilitySet"
             }
         ],

--- a/examples/multiple-masters/kubernetes-5-masters.json
+++ b/examples/multiple-masters/kubernetes-5-masters.json
@@ -7,13 +7,13 @@
         "masterProfile": {
             "count": 5,
             "dnsPrefix": "",
-            "vmSize": "Standard_D2_v2"
+            "vmSize": "Standard_D2_v3"
         },
         "agentPoolProfiles": [
             {
                 "name": "agent",
                 "count": 3,
-                "vmSize": "Standard_D2_v2",
+                "vmSize": "Standard_D2_v3",
                 "availabilityProfile": "AvailabilitySet"
             }
         ],

--- a/examples/multiple-nodepools/README.md
+++ b/examples/multiple-nodepools/README.md
@@ -11,7 +11,7 @@ A complete example is contained in the `multipool.json` apimodel in this directo
       {
         "name": "workerpool",
         "count": 2,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       },
       {
         "name": "gpupool",

--- a/examples/multiple-nodepools/multipool.json
+++ b/examples/multiple-nodepools/multipool.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "workerpool",
         "count": 2,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       },
       {
         "name": "gpupool",

--- a/examples/networkplugin/kubernetes-azure.json
+++ b/examples/networkplugin/kubernetes-azure.json
@@ -10,19 +10,19 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpool2",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/networkpolicy/kubernetes-cilium.json
+++ b/examples/networkpolicy/kubernetes-cilium.json
@@ -21,13 +21,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/examples/ubuntu-1604/kubernetes.json
+++ b/examples/ubuntu-1604/kubernetes.json
@@ -10,14 +10,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "distro": "aks-ubuntu-16.04"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "distro": "aks-ubuntu-16.04"
       }
     ],

--- a/examples/ubuntu-1804/kubernetes.json
+++ b/examples/ubuntu-1804/kubernetes.json
@@ -10,14 +10,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "distro": "aks-ubuntu-18.04"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "distro": "aks-ubuntu-18.04"
       }
     ],

--- a/examples/v20160930/kubernetes.json
+++ b/examples/v20160930/kubernetes.json
@@ -12,12 +12,12 @@
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       },
       {
         "name": "agentpool2",
         "count": 3,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       }
     ],
     "linuxProfile": {

--- a/examples/v20170131/kubernetes.json
+++ b/examples/v20170131/kubernetes.json
@@ -12,12 +12,12 @@
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       },
       {
         "name": "agentpool2",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "osType": "Windows"
       }
     ],

--- a/examples/v20170701/kubernetes.json
+++ b/examples/v20170701/kubernetes.json
@@ -8,13 +8,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v3"
       },
       {
         "name": "agentpool2",

--- a/examples/vnet/kubernetesvnet-azure-cni.json
+++ b/examples/vnet/kubernetesvnet-azure-cni.json
@@ -7,7 +7,7 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "test",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
       "firstConsecutiveStaticIP": "10.239.255.239",
       "vnetCidr": "10.239.0.0/16"
@@ -16,14 +16,14 @@
       {
         "name": "agentpri",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpri2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       }

--- a/examples/vnet/kubernetesvnet-customsearchdomain.json
+++ b/examples/vnet/kubernetesvnet-customsearchdomain.json
@@ -10,22 +10,22 @@
       "masterProfile": {
         "count": 1,
         "dnsPrefix": "test",
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
-        "firstConsecutiveStaticIP": "10.239.255.239" 
+        "firstConsecutiveStaticIP": "10.239.255.239"
       },
       "agentPoolProfiles": [
         {
           "name": "agentpri",
           "count": 2,
-          "vmSize": "Standard_D2_v2",
+          "vmSize": "Standard_D2_v3",
           "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
           "availabilityProfile": "AvailabilitySet"
         },
         {
           "name": "agentpri2",
           "count": 2,
-          "vmSize": "Standard_D2_v2",
+          "vmSize": "Standard_D2_v3",
           "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
           "availabilityProfile": "AvailabilitySet"
         }

--- a/examples/vnet/kubernetesvnet.json
+++ b/examples/vnet/kubernetesvnet.json
@@ -10,22 +10,22 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "test",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
-      "firstConsecutiveStaticIP": "10.239.255.239" 
+      "firstConsecutiveStaticIP": "10.239.255.239"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpri",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpri2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       }

--- a/examples/vnet/kubernetesvnet1.5.json
+++ b/examples/vnet/kubernetesvnet1.5.json
@@ -8,22 +8,22 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
-      "firstConsecutiveStaticIP": "10.239.255.239" 
+      "firstConsecutiveStaticIP": "10.239.255.239"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpri",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpri2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       }

--- a/examples/vnet/kubernetesvnet1.6.json
+++ b/examples/vnet/kubernetesvnet1.6.json
@@ -8,22 +8,22 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
-      "firstConsecutiveStaticIP": "10.239.255.239" 
+      "firstConsecutiveStaticIP": "10.239.255.239"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpri",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpri2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityProfile": "AvailabilitySet"
       }

--- a/examples/windows/kubernetes-custom-image.json
+++ b/examples/windows/kubernetes-custom-image.json
@@ -7,13 +7,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       }

--- a/examples/windows/kubernetes-hybrid.json
+++ b/examples/windows/kubernetes-hybrid.json
@@ -7,19 +7,19 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "linuxpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       }

--- a/examples/windows/kubernetes-manageddisks.json
+++ b/examples/windows/kubernetes-manageddisks.json
@@ -7,14 +7,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200
     },
     "agentPoolProfiles": [
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "storageProfile" : "ManagedDisks",
         "availabilityProfile": "AvailabilitySet",
         "OSDiskSizeGB": 200,

--- a/examples/windows/kubernetes-master-sa.json
+++ b/examples/windows/kubernetes-master-sa.json
@@ -7,14 +7,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "storageProfile": "StorageAccount"
     },
     "agentPoolProfiles": [
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows"
       }

--- a/examples/windows/kubernetes-sadisks.json
+++ b/examples/windows/kubernetes-sadisks.json
@@ -7,14 +7,14 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200
     },
     "agentPoolProfiles": [
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "storageProfile": "StorageAccount",
         "OSDiskSizeGB": 200,

--- a/examples/windows/kubernetes-wincni.json
+++ b/examples/windows/kubernetes-wincni.json
@@ -10,13 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "agentwin",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D2_v3",
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",
         "osDiskSizeGB": 128,


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Replace `Standard_D2_v2` with `Standard_D2_v3` in example cluster configurations, to reflect that it is probably a better "default" choice for folks wishing to test cluster examples. `Standard_D2_v3` represents a roughly 20% price savings compared to `Standard_D2_v2` for comparable "general purpose" performance.

Reference:

https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-general

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
