### PR TITLE
feat: support for Application Gateway Ingress Controller

### DIFF
--- a/examples/addons/appgw-ingress/README.md
+++ b/examples/addons/appgw-ingress/README.md
@@ -1,0 +1,78 @@
+# AppGW Ingress Add-on
+
+This add-on will deploy an Application Gateway and dependency resources with your new Kubernetes cluster.
+
+Following resources are deployed:
+
+1) Azure Application Gateway v2
+2) Public IP Address
+3) AppGw Subnet in the shared vnet.
+4) User Assigned Identity to initialize the aad-pod-identity service and ingress controller.
+5) Set required RBACs.
+
+Supported `Config` options:
+| Option | Required | Default | Description |
+|--|--|--|--|
+| appgw-subnet | true | N/A | CIDR of the Application Gateway subnet. This should not overlap with master/agent subnets. |
+| appgw-sku | false | WAF_v2 | SKU of the Application Gateway. (Standard_v2/WAF_v2) |
+| appgw-private-ip | false | null | Private IP assigned to the Application Gateway from subnet. |
+
+Once, the infrastructure is deployed, please follow the instructions to deploy the [Application Gateway  Ingress controller](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/install-new.md#setting-up-application-gateway-ingress-controller-on-aks)
+
+> Note: Adding the add-on multiple times will not create multiple applicaiton gateways.
+
+```json
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPlugin": "azure",
+        "addons": [
+          {
+            "name": "appgw-ingress",
+            "enabled": true,
+            "config": {
+              "appgw-subnet": "<subnet CIDR>",
+              "appgw-sku": "WAF_v2"
+            }
+          }
+        ]
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_DS2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool",
+        "count": 3,
+        "vmSize": "Standard_DS2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": "",
+      "objectId": "<>"
+    }
+  }
+}
+```
+
+## Supported Orchestrators
+
+Kubernetes

--- a/examples/addons/appgw-ingress/README.md
+++ b/examples/addons/appgw-ingress/README.md
@@ -10,12 +10,13 @@ Following resources are deployed:
 4) User Assigned Identity to initialize the aad-pod-identity service and ingress controller.
 5) Set required RBACs.
 
-Supported `Config` options:
+Supported Add-on `Config` options:
+
 | Option | Required | Default | Description |
 |--|--|--|--|
-| appgw-subnet | true | N/A | CIDR of the Application Gateway subnet. This should not overlap with master/agent subnets. |
-| appgw-sku | false | WAF_v2 | SKU of the Application Gateway. (Standard_v2/WAF_v2) |
-| appgw-private-ip | false | null | Private IP assigned to the Application Gateway from subnet. |
+| `appgw-subnet` | true | N/A | CIDR of the Application Gateway subnet. This should not overlap with master/agent subnets. |
+| `appgw-sku` | false | `WAF_v2` | SKU of the Application Gateway. (`Standard_v2`/`WAF_v2`) |
+| `appgw-private-ip` | false | null | Private IP assigned to the Application Gateway from subnet. |
 
 Once, the infrastructure is deployed, please follow the instructions to deploy the [Application Gateway  Ingress controller](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/install-new.md#setting-up-application-gateway-ingress-controller-on-aks)
 

--- a/examples/addons/appgw-ingress/kubernetes-appgw-ingress.json
+++ b/examples/addons/appgw-ingress/kubernetes-appgw-ingress.json
@@ -3,13 +3,14 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.12",
       "kubernetesConfig": {
+        "networkPlugin": "azure",
         "addons": [
           {
             "name": "appgw-ingress",
             "enabled": true,
             "config": {
+              "appgw-subnet": "<subnet CIDR>",
               "appgw-sku": "WAF_v2"
             }
           }
@@ -18,13 +19,13 @@
     },
     "masterProfile": {
       "count": 1,
-      "vmSize": "Standard_DS2_v2",
-      "DNSPrefix": ""
+      "dnsPrefix": "",
+      "vmSize": "Standard_DS2_v2"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool",
-        "count": 2,
+        "count": 3,
         "vmSize": "Standard_DS2_v2",
         "availabilityProfile": "AvailabilitySet"
       }
@@ -40,6 +41,8 @@
       }
     },
     "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": "",
       "objectId": "<>"
     }
   }

--- a/examples/addons/appgw-ingress/kubernetes-appgw-ingress.json
+++ b/examples/addons/appgw-ingress/kubernetes-appgw-ingress.json
@@ -1,0 +1,46 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.12",
+      "kubernetesConfig": {
+        "addons": [
+          {
+            "name": "appgw-ingress",
+            "enabled": true,
+            "config": {
+              "appgw-sku": "WAF_v2"
+            }
+          }
+        ]
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "vmSize": "Standard_DS2_v2",
+      "DNSPrefix": ""
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool",
+        "count": 2,
+        "vmSize": "Standard_DS2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "objectId": "<>"
+    }
+  }
+}

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -599,6 +599,7 @@
       "type": "string"
     }
  {{end}}
+ {{if .OrchestratorProfile.KubernetesConfig.IsAppGWIngressEnabled}}
     ,"appGwSubnet": {
       "metadata": {
         "description": "Sets the subnet of the Application Gateway"
@@ -611,3 +612,4 @@
       },
       "type": "string"
     }
+  {{end}}

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -599,3 +599,15 @@
       "type": "string"
     }
  {{end}}
+    ,"appGwSubnet": {
+      "metadata": {
+        "description": "Sets the subnet of the Application Gateway"
+      },
+      "type": "string"
+    }
+    ,"appGwSku": {
+      "metadata": {
+        "description": "Sets the subnet of the Application Gateway"
+      },
+      "type": "string"
+    }

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -612,4 +612,4 @@
       },
       "type": "string"
     }
-  {{end}}
+ {{end}}

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -321,6 +321,16 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 		},
 	}
 
+	defaultAppGwAddonsConfig := KubernetesAddon{
+		Name:    AppGwIngressAddonName,
+		Enabled: to.BoolPtr(DefaultAppGwIngressAddonEnabled),
+		Config: map[string]string{
+			"appgw-subnet":     "",
+			"appgw-sku":        "WAF_v2",
+			"appgw-private-ip": "",
+		},
+	}
+
 	defaultAddons := []KubernetesAddon{
 		defaultsHeapsterAddonsConfig,
 		defaultTillerAddonsConfig,
@@ -340,6 +350,7 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 		defaultDNSAutoScalerAddonsConfig,
 		defaultsCalicoDaemonSetAddonsConfig,
 		defaultsAADPodIdentityAddonsConfig,
+		defaultAppGwAddonsConfig,
 	}
 	// Add default addons specification, if no user-provided spec exists
 	if o.KubernetesConfig.Addons == nil {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -132,6 +132,8 @@ const (
 	DefaultAADPodIdentityAddonEnabled = false
 	// DefaultACIConnectorAddonEnabled determines the aks-engine provided default for enabling aci connector addon
 	DefaultACIConnectorAddonEnabled = false
+	// DefaultAppGwIngressAddonEnabled determines the aks-engine provided default for enabling appgw ingress addon
+	DefaultAppGwIngressAddonEnabled = false
 	// DefaultClusterAutoscalerAddonEnabled determines the aks-engine provided default for enabling cluster autoscaler addon
 	DefaultClusterAutoscalerAddonEnabled = false
 	// DefaultBlobfuseFlexVolumeAddonEnabled determines the aks-engine provided default for enabling blobfuse flexvolume addon
@@ -176,6 +178,8 @@ const (
 	AADPodIdentityAddonName = "aad-pod-identity"
 	// ACIConnectorAddonName is the name of the aci-connector addon deployment
 	ACIConnectorAddonName = "aci-connector"
+	// AppGwIngressAddonName appgw addon
+	AppGwIngressAddonName = "appgw-ingress"
 	// ClusterAutoscalerAddonName is the name of the cluster autoscaler addon deployment
 	ClusterAutoscalerAddonName = "cluster-autoscaler"
 	// BlobfuseFlexVolumeAddonName is the name of the blobfuse flexvolume addon

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -256,7 +256,7 @@ func TestAssignDefaultAddonImages(t *testing.T) {
 			mockCS.setOrchestratorDefaults(c.isUpdate, c.isUpdate)
 			resultAddons := mockCS.Properties.OrchestratorProfile.KubernetesConfig.Addons
 			for _, result := range resultAddons {
-				if result.Containers[0].Image != c.expectedImages[result.Name] {
+				if len(result.Containers) > 0 && result.Containers[0].Image != c.expectedImages[result.Name] {
 					t.Errorf("expected setDefaults to set Image to \"%s\" in addon %s, but got \"%s\"", c.expectedImages[result.Name], result.Name, result.Containers[0].Image)
 				}
 			}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1606,6 +1606,11 @@ func (k *KubernetesConfig) IsClusterAutoscalerEnabled() bool {
 	return k.IsAddonEnabled(ClusterAutoscalerAddonName)
 }
 
+// IsAppGWIngressEnabled checks if the appgw ingress addon is enabled
+func (k *KubernetesConfig) IsAppGWIngressEnabled() bool {
+	return k.IsAddonEnabled(AppGwIngressAddonName)
+}
+
 // IsIPMasqAgentEnabled checks if the ip-masq-agent addon is enabled
 func (k *KubernetesConfig) IsIPMasqAgentEnabled() bool {
 	return k.IsAddonEnabled(IPMASQAgentAddonName)

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -617,6 +617,16 @@ func (a *Properties) validateAddons() error {
 				if to.Bool(addon.Enabled) && a.HasCoreOS() {
 					return errors.New("flexvolume add-ons not currently supported on coreos distro. Please use Ubuntu")
 				}
+			case "appgw-ingress":
+				if to.Bool(addon.Enabled) {
+					if a.OrchestratorProfile.KubernetesConfig.NetworkPlugin != "azure" {
+						return errors.New("appgw-ingress add-ons can only be used with Network Plugin as 'azure'")
+					}
+
+					if len(addon.Config["appgw-subnet"]) == 0 {
+						return errors.New("appgw-ingress add-ons requires 'appgw-subnet' in the Config. It is used to provision the subnet for Application Gateway in the vnet")
+					}
+				}
 			}
 		}
 	}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -619,6 +619,11 @@ func (a *Properties) validateAddons() error {
 				}
 			case "appgw-ingress":
 				if to.Bool(addon.Enabled) {
+					if (a.ServicePrincipalProfile == nil || len(a.ServicePrincipalProfile.ObjectID) == 0) &&
+						!a.OrchestratorProfile.KubernetesConfig.UseManagedIdentity {
+						return errors.New("appgw-ingress add-ons requires 'objectID' to be specified or UseManagedIdentity to be true")
+					}
+
 					if a.OrchestratorProfile.KubernetesConfig.NetworkPlugin != "azure" {
 						return errors.New("appgw-ingress add-ons can only be used with Network Plugin as 'azure'")
 					}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1475,6 +1475,62 @@ func Test_Properties_ValidateAddons(t *testing.T) {
 			"should error using incompatible addon with coreos (blobfuse-flexvolume)",
 		)
 	}
+
+	p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		NetworkPlugin: "azure",
+		Addons: []KubernetesAddon{
+			{
+				Name:    "appgw-ingress",
+				Enabled: to.BoolPtr(true),
+				Config: map[string]string{
+					"appgw-subnet": "10.0.0.0/16",
+				},
+			},
+		},
+	}
+
+	if err := p.validateAddons(); err != nil {
+		t.Error(
+			"should not error for correct config.",
+			err,
+		)
+	}
+
+	p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		NetworkPlugin: "kubelet",
+		Addons: []KubernetesAddon{
+			{
+				Name:    "appgw-ingress",
+				Enabled: to.BoolPtr(true),
+				Config: map[string]string{
+					"appgw-subnet": "10.0.0.0/16",
+				},
+			},
+		},
+	}
+
+	if err := p.validateAddons(); err == nil {
+		t.Errorf(
+			"should error using when not using 'azure' for Network Plugin",
+		)
+	}
+
+	p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		NetworkPlugin: "azure",
+		Addons: []KubernetesAddon{
+			{
+				Name:    "appgw-ingress",
+				Enabled: to.BoolPtr(true),
+				Config:  map[string]string{},
+			},
+		},
+	}
+
+	if err := p.validateAddons(); err == nil {
+		t.Errorf(
+			"should error when missing the subnet for Application Gateway",
+		)
+	}
 }
 
 func TestWindowsVersions(t *testing.T) {

--- a/pkg/engine/applicationgateway.go
+++ b/pkg/engine/applicationgateway.go
@@ -29,7 +29,7 @@ func createApplicationGateway(prop *api.Properties) ApplicationGatewayARM {
 					Capacity: to.Int32Ptr(2),
 				},
 				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
-					network.ApplicationGatewayIPConfiguration{
+					{
 						Name: to.StringPtr("gatewayIP"),
 						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
 							Subnet: &network.SubResource{
@@ -39,7 +39,7 @@ func createApplicationGateway(prop *api.Properties) ApplicationGatewayARM {
 					},
 				},
 				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
-					network.ApplicationGatewayFrontendIPConfiguration{
+					{
 						Name: to.StringPtr("frontendIP"),
 						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 							PublicIPAddress: &network.SubResource{
@@ -49,7 +49,7 @@ func createApplicationGateway(prop *api.Properties) ApplicationGatewayARM {
 					},
 				},
 				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
-					network.ApplicationGatewayFrontendPort{
+					{
 						Name: to.StringPtr("httpPort"),
 						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
 							Port: to.Int32Ptr(80),
@@ -57,7 +57,7 @@ func createApplicationGateway(prop *api.Properties) ApplicationGatewayARM {
 					},
 				},
 				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
-					network.ApplicationGatewayBackendAddressPool{
+					{
 						Name: to.StringPtr("pool"),
 						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
@@ -65,7 +65,7 @@ func createApplicationGateway(prop *api.Properties) ApplicationGatewayARM {
 					},
 				},
 				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
-					network.ApplicationGatewayHTTPListener{
+					{
 						Name: to.StringPtr("httpListener"),
 						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
 							Protocol: network.HTTP,
@@ -79,7 +79,7 @@ func createApplicationGateway(prop *api.Properties) ApplicationGatewayARM {
 					},
 				},
 				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
-					network.ApplicationGatewayBackendHTTPSettings{
+					{
 						Name: to.StringPtr("setting"),
 						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 							Port:     to.Int32Ptr(80),

--- a/pkg/engine/applicationgateway.go
+++ b/pkg/engine/applicationgateway.go
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package engine
+
+import (
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func createApplicationGateway(prop *api.Properties) ApplicationGatewayARM {
+
+	applicationGateway := ApplicationGatewayARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIPAddressName'))]",
+				"[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+			},
+		},
+		ApplicationGateway: network.ApplicationGateway{
+			Location: to.StringPtr("[variables('location')]"),
+			Name:     to.StringPtr("[variables('appGwName')]"),
+			ApplicationGatewayPropertiesFormat: &network.ApplicationGatewayPropertiesFormat{
+				Sku: &network.ApplicationGatewaySku{
+					Name:     network.ApplicationGatewaySkuName("[parameters('appGwSku')]"),
+					Tier:     network.ApplicationGatewayTier("[parameters('appGwSku')]"),
+					Capacity: to.Int32Ptr(2),
+				},
+				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
+					network.ApplicationGatewayIPConfiguration{
+						Name: to.StringPtr("gatewayIP"),
+						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
+							Subnet: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('vnetID'),'/subnets/',variables('appGwSubnetName'))]"),
+							},
+						},
+					},
+				},
+				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
+					network.ApplicationGatewayFrontendIPConfiguration{
+						Name: to.StringPtr("frontendIP"),
+						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &network.SubResource{
+								ID: to.StringPtr("[resourceId('Microsoft.Network/publicIpAddresses',variables('appGwPublicIPAddressName'))]"),
+							},
+						},
+					},
+				},
+				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
+					network.ApplicationGatewayFrontendPort{
+						Name: to.StringPtr("httpPort"),
+						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+							Port: to.Int32Ptr(80),
+						},
+					},
+				},
+				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
+					network.ApplicationGatewayBackendAddressPool{
+						Name: to.StringPtr("pool"),
+						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
+							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
+						},
+					},
+				},
+				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
+					network.ApplicationGatewayHTTPListener{
+						Name: to.StringPtr("httpListener"),
+						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
+							Protocol: network.HTTP,
+							FrontendPort: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendPorts/httpPort')]"),
+							},
+							FrontendIPConfiguration: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendIPConfigurations/frontendIP')]"),
+							},
+						},
+					},
+				},
+				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
+					network.ApplicationGatewayBackendHTTPSettings{
+						Name: to.StringPtr("setting"),
+						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
+							Port:     to.Int32Ptr(80),
+							Protocol: network.HTTP,
+						},
+					},
+				},
+				RequestRoutingRules: &[]network.ApplicationGatewayRequestRoutingRule{
+					{
+						Name: to.StringPtr("rule"),
+						ApplicationGatewayRequestRoutingRulePropertiesFormat: &network.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+							HTTPListener: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/httpListeners/httpListener')]"),
+							},
+							BackendAddressPool: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendAddressPools/pool')]"),
+							},
+							BackendHTTPSettings: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendHttpSettingsCollection/setting')]"),
+							},
+						},
+					},
+				},
+			},
+			Type: to.StringPtr("Microsoft.Network/applicationGateways"),
+		},
+	}
+
+	if prop.OrchestratorProfile.KubernetesConfig.GetAddonByName(AppGwIngressAddonName).Config["appgw-sku"] == "WAF_v2" {
+		applicationGateway.ApplicationGateway.ApplicationGatewayPropertiesFormat.WebApplicationFirewallConfiguration = &network.ApplicationGatewayWebApplicationFirewallConfiguration{
+			Enabled:      to.BoolPtr(true),
+			FirewallMode: network.Detection,
+		}
+	}
+
+	privateIP := prop.OrchestratorProfile.KubernetesConfig.GetAddonByName(AppGwIngressAddonName).Config["appgw-private-ip"]
+	if privateIP != "" {
+		frontendIPConfigurations := append(
+			*applicationGateway.ApplicationGateway.ApplicationGatewayPropertiesFormat.FrontendIPConfigurations,
+			network.ApplicationGatewayFrontendIPConfiguration{
+				Name: to.StringPtr("privateIp"),
+				ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+					PrivateIPAddress: to.StringPtr(privateIP),
+				},
+			})
+		applicationGateway.ApplicationGateway.ApplicationGatewayPropertiesFormat.FrontendIPConfigurations = &frontendIPConfigurations
+	}
+
+	return applicationGateway
+}

--- a/pkg/engine/applicationgateway_test.go
+++ b/pkg/engine/applicationgateway_test.go
@@ -42,7 +42,7 @@ func TestCreateApplicationGateway(t *testing.T) {
 					Capacity: to.Int32Ptr(2),
 				},
 				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
-					network.ApplicationGatewayIPConfiguration{
+					{
 						Name: to.StringPtr("gatewayIP"),
 						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
 							Subnet: &network.SubResource{
@@ -52,7 +52,7 @@ func TestCreateApplicationGateway(t *testing.T) {
 					},
 				},
 				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
-					network.ApplicationGatewayFrontendIPConfiguration{
+					{
 						Name: to.StringPtr("frontendIP"),
 						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 							PublicIPAddress: &network.SubResource{
@@ -62,7 +62,7 @@ func TestCreateApplicationGateway(t *testing.T) {
 					},
 				},
 				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
-					network.ApplicationGatewayFrontendPort{
+					{
 						Name: to.StringPtr("httpPort"),
 						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
 							Port: to.Int32Ptr(80),
@@ -70,7 +70,7 @@ func TestCreateApplicationGateway(t *testing.T) {
 					},
 				},
 				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
-					network.ApplicationGatewayBackendAddressPool{
+					{
 						Name: to.StringPtr("pool"),
 						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
@@ -78,7 +78,7 @@ func TestCreateApplicationGateway(t *testing.T) {
 					},
 				},
 				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
-					network.ApplicationGatewayHTTPListener{
+					{
 						Name: to.StringPtr("httpListener"),
 						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
 							Protocol: network.HTTP,
@@ -92,7 +92,7 @@ func TestCreateApplicationGateway(t *testing.T) {
 					},
 				},
 				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
-					network.ApplicationGatewayBackendHTTPSettings{
+					{
 						Name: to.StringPtr("setting"),
 						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 							Port:     to.Int32Ptr(80),
@@ -167,7 +167,7 @@ func TestCreateApplicationGatewayWAF(t *testing.T) {
 					Capacity: to.Int32Ptr(2),
 				},
 				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
-					network.ApplicationGatewayIPConfiguration{
+					{
 						Name: to.StringPtr("gatewayIP"),
 						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
 							Subnet: &network.SubResource{
@@ -177,7 +177,7 @@ func TestCreateApplicationGatewayWAF(t *testing.T) {
 					},
 				},
 				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
-					network.ApplicationGatewayFrontendIPConfiguration{
+					{
 						Name: to.StringPtr("frontendIP"),
 						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 							PublicIPAddress: &network.SubResource{
@@ -187,7 +187,7 @@ func TestCreateApplicationGatewayWAF(t *testing.T) {
 					},
 				},
 				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
-					network.ApplicationGatewayFrontendPort{
+					{
 						Name: to.StringPtr("httpPort"),
 						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
 							Port: to.Int32Ptr(80),
@@ -195,7 +195,7 @@ func TestCreateApplicationGatewayWAF(t *testing.T) {
 					},
 				},
 				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
-					network.ApplicationGatewayBackendAddressPool{
+					{
 						Name: to.StringPtr("pool"),
 						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
@@ -203,7 +203,7 @@ func TestCreateApplicationGatewayWAF(t *testing.T) {
 					},
 				},
 				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
-					network.ApplicationGatewayHTTPListener{
+					{
 						Name: to.StringPtr("httpListener"),
 						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
 							Protocol: network.HTTP,
@@ -217,7 +217,7 @@ func TestCreateApplicationGatewayWAF(t *testing.T) {
 					},
 				},
 				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
-					network.ApplicationGatewayBackendHTTPSettings{
+					{
 						Name: to.StringPtr("setting"),
 						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 							Port:     to.Int32Ptr(80),
@@ -296,7 +296,7 @@ func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
 					Capacity: to.Int32Ptr(2),
 				},
 				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
-					network.ApplicationGatewayIPConfiguration{
+					{
 						Name: to.StringPtr("gatewayIP"),
 						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
 							Subnet: &network.SubResource{
@@ -306,7 +306,7 @@ func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
 					},
 				},
 				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
-					network.ApplicationGatewayFrontendIPConfiguration{
+					{
 						Name: to.StringPtr("frontendIP"),
 						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 							PublicIPAddress: &network.SubResource{
@@ -314,7 +314,7 @@ func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
 							},
 						},
 					},
-					network.ApplicationGatewayFrontendIPConfiguration{
+					{
 						Name: to.StringPtr("privateIp"),
 						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 							PrivateIPAddress: to.StringPtr("10.0.0.1"),
@@ -322,7 +322,7 @@ func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
 					},
 				},
 				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
-					network.ApplicationGatewayFrontendPort{
+					{
 						Name: to.StringPtr("httpPort"),
 						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
 							Port: to.Int32Ptr(80),
@@ -330,7 +330,7 @@ func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
 					},
 				},
 				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
-					network.ApplicationGatewayBackendAddressPool{
+					{
 						Name: to.StringPtr("pool"),
 						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
@@ -338,7 +338,7 @@ func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
 					},
 				},
 				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
-					network.ApplicationGatewayHTTPListener{
+					{
 						Name: to.StringPtr("httpListener"),
 						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
 							Protocol: network.HTTP,
@@ -352,7 +352,7 @@ func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
 					},
 				},
 				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
-					network.ApplicationGatewayBackendHTTPSettings{
+					{
 						Name: to.StringPtr("setting"),
 						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 							Port:     to.Int32Ptr(80),

--- a/pkg/engine/applicationgateway_test.go
+++ b/pkg/engine/applicationgateway_test.go
@@ -1,0 +1,390 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/Azure/aks-engine/pkg/api"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func TestCreateApplicationGateway(t *testing.T) {
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{},
+			},
+		},
+	}
+	actual := createApplicationGateway(cs.Properties)
+
+	expected := ApplicationGatewayARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIPAddressName'))]",
+				"[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+			},
+		},
+		ApplicationGateway: network.ApplicationGateway{
+			Location: to.StringPtr("[variables('location')]"),
+			Name:     to.StringPtr("[variables('appGwName')]"),
+			ApplicationGatewayPropertiesFormat: &network.ApplicationGatewayPropertiesFormat{
+				Sku: &network.ApplicationGatewaySku{
+					Name:     network.ApplicationGatewaySkuName("[parameters('appGwSku')]"),
+					Tier:     network.ApplicationGatewayTier("[parameters('appGwSku')]"),
+					Capacity: to.Int32Ptr(2),
+				},
+				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
+					network.ApplicationGatewayIPConfiguration{
+						Name: to.StringPtr("gatewayIP"),
+						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
+							Subnet: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('vnetID'),'/subnets/',variables('appGwSubnetName'))]"),
+							},
+						},
+					},
+				},
+				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
+					network.ApplicationGatewayFrontendIPConfiguration{
+						Name: to.StringPtr("frontendIP"),
+						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &network.SubResource{
+								ID: to.StringPtr("[resourceId('Microsoft.Network/publicIpAddresses',variables('appGwPublicIPAddressName'))]"),
+							},
+						},
+					},
+				},
+				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
+					network.ApplicationGatewayFrontendPort{
+						Name: to.StringPtr("httpPort"),
+						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+							Port: to.Int32Ptr(80),
+						},
+					},
+				},
+				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
+					network.ApplicationGatewayBackendAddressPool{
+						Name: to.StringPtr("pool"),
+						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
+							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
+						},
+					},
+				},
+				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
+					network.ApplicationGatewayHTTPListener{
+						Name: to.StringPtr("httpListener"),
+						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
+							Protocol: network.HTTP,
+							FrontendPort: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendPorts/httpPort')]"),
+							},
+							FrontendIPConfiguration: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendIPConfigurations/frontendIP')]"),
+							},
+						},
+					},
+				},
+				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
+					network.ApplicationGatewayBackendHTTPSettings{
+						Name: to.StringPtr("setting"),
+						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
+							Port:     to.Int32Ptr(80),
+							Protocol: network.HTTP,
+						},
+					},
+				},
+				RequestRoutingRules: &[]network.ApplicationGatewayRequestRoutingRule{
+					{
+						Name: to.StringPtr("rule"),
+						ApplicationGatewayRequestRoutingRulePropertiesFormat: &network.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+							HTTPListener: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/httpListeners/httpListener')]"),
+							},
+							BackendAddressPool: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendAddressPools/pool')]"),
+							},
+							BackendHTTPSettings: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendHttpSettingsCollection/setting')]"),
+							},
+						},
+					},
+				},
+			},
+			Type: to.StringPtr("Microsoft.Network/applicationGateways"),
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing application gateways: %s", diff)
+	}
+
+}
+
+func TestCreateApplicationGatewayWAF(t *testing.T) {
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					Addons: []api.KubernetesAddon{
+						{
+							Name:    AppGwIngressAddonName,
+							Enabled: to.BoolPtr(true),
+							Config: map[string]string{
+								"appgw-sku": "WAF_v2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	actual := createApplicationGateway(cs.Properties)
+
+	expected := ApplicationGatewayARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIPAddressName'))]",
+				"[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+			},
+		},
+		ApplicationGateway: network.ApplicationGateway{
+			Location: to.StringPtr("[variables('location')]"),
+			Name:     to.StringPtr("[variables('appGwName')]"),
+			ApplicationGatewayPropertiesFormat: &network.ApplicationGatewayPropertiesFormat{
+				Sku: &network.ApplicationGatewaySku{
+					Name:     network.ApplicationGatewaySkuName("[parameters('appGwSku')]"),
+					Tier:     network.ApplicationGatewayTier("[parameters('appGwSku')]"),
+					Capacity: to.Int32Ptr(2),
+				},
+				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
+					network.ApplicationGatewayIPConfiguration{
+						Name: to.StringPtr("gatewayIP"),
+						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
+							Subnet: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('vnetID'),'/subnets/',variables('appGwSubnetName'))]"),
+							},
+						},
+					},
+				},
+				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
+					network.ApplicationGatewayFrontendIPConfiguration{
+						Name: to.StringPtr("frontendIP"),
+						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &network.SubResource{
+								ID: to.StringPtr("[resourceId('Microsoft.Network/publicIpAddresses',variables('appGwPublicIPAddressName'))]"),
+							},
+						},
+					},
+				},
+				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
+					network.ApplicationGatewayFrontendPort{
+						Name: to.StringPtr("httpPort"),
+						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+							Port: to.Int32Ptr(80),
+						},
+					},
+				},
+				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
+					network.ApplicationGatewayBackendAddressPool{
+						Name: to.StringPtr("pool"),
+						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
+							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
+						},
+					},
+				},
+				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
+					network.ApplicationGatewayHTTPListener{
+						Name: to.StringPtr("httpListener"),
+						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
+							Protocol: network.HTTP,
+							FrontendPort: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendPorts/httpPort')]"),
+							},
+							FrontendIPConfiguration: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendIPConfigurations/frontendIP')]"),
+							},
+						},
+					},
+				},
+				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
+					network.ApplicationGatewayBackendHTTPSettings{
+						Name: to.StringPtr("setting"),
+						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
+							Port:     to.Int32Ptr(80),
+							Protocol: network.HTTP,
+						},
+					},
+				},
+				RequestRoutingRules: &[]network.ApplicationGatewayRequestRoutingRule{
+					{
+						Name: to.StringPtr("rule"),
+						ApplicationGatewayRequestRoutingRulePropertiesFormat: &network.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+							HTTPListener: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/httpListeners/httpListener')]"),
+							},
+							BackendAddressPool: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendAddressPools/pool')]"),
+							},
+							BackendHTTPSettings: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendHttpSettingsCollection/setting')]"),
+							},
+						},
+					},
+				},
+				WebApplicationFirewallConfiguration: &network.ApplicationGatewayWebApplicationFirewallConfiguration{
+					Enabled:      to.BoolPtr(true),
+					FirewallMode: network.Detection,
+				},
+			},
+			Type: to.StringPtr("Microsoft.Network/applicationGateways"),
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing application gateways: %s", diff)
+	}
+
+}
+
+func TestCreateApplicationGatewayPrivateIP(t *testing.T) {
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					Addons: []api.KubernetesAddon{
+						{
+							Name:    AppGwIngressAddonName,
+							Enabled: to.BoolPtr(true),
+							Config: map[string]string{
+								"appgw-private-ip": "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	actual := createApplicationGateway(cs.Properties)
+
+	expected := ApplicationGatewayARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIPAddressName'))]",
+				"[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+			},
+		},
+		ApplicationGateway: network.ApplicationGateway{
+			Location: to.StringPtr("[variables('location')]"),
+			Name:     to.StringPtr("[variables('appGwName')]"),
+			ApplicationGatewayPropertiesFormat: &network.ApplicationGatewayPropertiesFormat{
+				Sku: &network.ApplicationGatewaySku{
+					Name:     network.ApplicationGatewaySkuName("[parameters('appGwSku')]"),
+					Tier:     network.ApplicationGatewayTier("[parameters('appGwSku')]"),
+					Capacity: to.Int32Ptr(2),
+				},
+				GatewayIPConfigurations: &[]network.ApplicationGatewayIPConfiguration{
+					network.ApplicationGatewayIPConfiguration{
+						Name: to.StringPtr("gatewayIP"),
+						ApplicationGatewayIPConfigurationPropertiesFormat: &network.ApplicationGatewayIPConfigurationPropertiesFormat{
+							Subnet: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('vnetID'),'/subnets/',variables('appGwSubnetName'))]"),
+							},
+						},
+					},
+				},
+				FrontendIPConfigurations: &[]network.ApplicationGatewayFrontendIPConfiguration{
+					network.ApplicationGatewayFrontendIPConfiguration{
+						Name: to.StringPtr("frontendIP"),
+						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &network.SubResource{
+								ID: to.StringPtr("[resourceId('Microsoft.Network/publicIpAddresses',variables('appGwPublicIPAddressName'))]"),
+							},
+						},
+					},
+					network.ApplicationGatewayFrontendIPConfiguration{
+						Name: to.StringPtr("privateIp"),
+						ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+							PrivateIPAddress: to.StringPtr("10.0.0.1"),
+						},
+					},
+				},
+				FrontendPorts: &[]network.ApplicationGatewayFrontendPort{
+					network.ApplicationGatewayFrontendPort{
+						Name: to.StringPtr("httpPort"),
+						ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+							Port: to.Int32Ptr(80),
+						},
+					},
+				},
+				BackendAddressPools: &[]network.ApplicationGatewayBackendAddressPool{
+					network.ApplicationGatewayBackendAddressPool{
+						Name: to.StringPtr("pool"),
+						ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
+							BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
+						},
+					},
+				},
+				HTTPListeners: &[]network.ApplicationGatewayHTTPListener{
+					network.ApplicationGatewayHTTPListener{
+						Name: to.StringPtr("httpListener"),
+						ApplicationGatewayHTTPListenerPropertiesFormat: &network.ApplicationGatewayHTTPListenerPropertiesFormat{
+							Protocol: network.HTTP,
+							FrontendPort: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendPorts/httpPort')]"),
+							},
+							FrontendIPConfiguration: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/frontendIPConfigurations/frontendIP')]"),
+							},
+						},
+					},
+				},
+				BackendHTTPSettingsCollection: &[]network.ApplicationGatewayBackendHTTPSettings{
+					network.ApplicationGatewayBackendHTTPSettings{
+						Name: to.StringPtr("setting"),
+						ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
+							Port:     to.Int32Ptr(80),
+							Protocol: network.HTTP,
+						},
+					},
+				},
+				RequestRoutingRules: &[]network.ApplicationGatewayRequestRoutingRule{
+					{
+						Name: to.StringPtr("rule"),
+						ApplicationGatewayRequestRoutingRulePropertiesFormat: &network.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+							HTTPListener: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/httpListeners/httpListener')]"),
+							},
+							BackendAddressPool: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendAddressPools/pool')]"),
+							},
+							BackendHTTPSettings: &network.SubResource{
+								ID: to.StringPtr("[concat(variables('appGwId'), '/backendHttpSettingsCollection/setting')]"),
+							},
+						},
+					},
+				},
+			},
+			Type: to.StringPtr("Microsoft.Network/applicationGateways"),
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing application gateways: %s", diff)
+	}
+
+}

--- a/pkg/engine/armoutputs.go
+++ b/pkg/engine/armoutputs.go
@@ -69,8 +69,23 @@ func GetKubernetesOutputs(cs *api.ContainerService) map[string]interface{} {
 				"value": fmt.Sprintf("[variables('%sSubnetName')]", agentName),
 			}
 		}
-
 	}
+
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(AppGwIngressAddonName) {
+		outputs["applicationGatewayName"] = map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('appGwName')]",
+		}
+		outputs["appGwIdentityResourceId"] = map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('appGwICIdentityId')]",
+		}
+		outputs["appGwIdentityClientId"] = map[string]interface{}{
+			"type":  "string",
+			"value": "[reference(variables('appGwICIdentityId'), variables('apiVersionManagedIdentity')).clientId]",
+		}
+	}
+
 	return outputs
 }
 

--- a/pkg/engine/armoutputs_test.go
+++ b/pkg/engine/armoutputs_test.go
@@ -191,3 +191,119 @@ func TestK8sOutputsWithAvSets(t *testing.T) {
 		t.Errorf("unexpected error while comparing output maps: %s", diff)
 	}
 }
+
+func TestK8sOutputsWithAppGwIngressAddon(t *testing.T) {
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+				ClientID: "barClientID",
+				Secret:   "bazSecret",
+			},
+			MasterProfile: &api.MasterProfile{
+				Count:     1,
+				DNSPrefix: "blueorange",
+				VMSize:    "Standard_D2_v2",
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{
+					Addons: []api.KubernetesAddon{
+						api.KubernetesAddon{
+							Name:    AppGwIngressAddonName,
+							Enabled: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			LinuxProfile: &api.LinuxProfile{},
+			AgentPoolProfiles: []*api.AgentPoolProfile{
+				{
+					Name:                "agentpool1",
+					VMSize:              "Standard_D2_v2",
+					Count:               2,
+					AvailabilityProfile: api.AvailabilitySet,
+					StorageProfile:      api.StorageAccount,
+				},
+			},
+		},
+	}
+
+	outputMap := GetKubernetesOutputs(cs)
+
+	expected := map[string]interface{}{
+		"resourceGroup": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('resourceGroup')]",
+		},
+		"vnetResourceGroup": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('virtualNetworkResourceGroupName')]",
+		},
+		"subnetName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('subnetName')]",
+		},
+		"securityGroupName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('nsgName')]",
+		},
+		"virtualNetworkName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('virtualNetworkName')]",
+		},
+		"routeTableName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('routeTableName')]",
+		},
+		"primaryAvailabilitySetName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('primaryAvailabilitySetName')]",
+		},
+		"primaryScaleSetName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('primaryScaleSetName')]",
+		},
+		"masterFQDN": map[string]interface{}{
+			"type":  "string",
+			"value": "[reference(concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))).dnsSettings.fqdn]",
+		},
+		"agentpool1StorageAccountOffset": map[string]interface{}{
+			"type":  "int",
+			"value": "[variables('agentpool1StorageAccountOffset')]",
+		},
+		"agentpool1StorageAccountCount": map[string]interface{}{
+			"type":  "int",
+			"value": "[variables('agentpool1StorageAccountsCount')]",
+		},
+		"agentpool1SubnetName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('agentpool1SubnetName')]",
+		},
+		"agentStorageAccountSuffix": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('storageAccountBaseName')]",
+		},
+		"agentStorageAccountPrefixes": map[string]interface{}{
+			"type":  "array",
+			"value": "[variables('storageAccountPrefixes')]",
+		},
+		"applicationGatewayName": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('appGwName')]",
+		},
+		"appGwIdentityResourceId": map[string]interface{}{
+			"type":  "string",
+			"value": "[variables('appGwICIdentityId')]",
+		},
+		"appGwIdentityClientId": map[string]interface{}{
+			"type":  "string",
+			"value": "[reference(variables('appGwICIdentityId'), variables('apiVersionManagedIdentity')).clientId]",
+		},
+	}
+
+	diff := cmp.Diff(outputMap, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected error while comparing output maps: %s", diff)
+	}
+}

--- a/pkg/engine/armoutputs_test.go
+++ b/pkg/engine/armoutputs_test.go
@@ -208,7 +208,7 @@ func TestK8sOutputsWithAppGwIngressAddon(t *testing.T) {
 				OrchestratorType: api.Kubernetes,
 				KubernetesConfig: &api.KubernetesConfig{
 					Addons: []api.KubernetesAddon{
-						api.KubernetesAddon{
+						{
 							Name:    AppGwIngressAddonName,
 							Enabled: to.BoolPtr(true),
 						},

--- a/pkg/engine/armresources.go
+++ b/pkg/engine/armresources.go
@@ -73,7 +73,15 @@ func GenerateARMResources(cs *api.ContainerService) []interface{} {
 		}
 
 		armResources = append(armResources, masterResources...)
+	}
 
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(AppGwIngressAddonName) {
+		armResources = append(armResources, createAppGwPublicIPAddress())
+		armResources = append(armResources, createAppGwUserAssignedIdentities())
+		armResources = append(armResources, createApplicationGateway(cs.Properties))
+		armResources = append(armResources, createAppGwIdentityApplicationGatewayWriteSysRoleAssignment())
+		armResources = append(armResources, createKubernetesSpAppGIdentityOperatorAccessRoleAssignment(cs.Properties))
+		armResources = append(armResources, createAppGwIdentityResourceGroupReadSysRoleAssignment())
 	}
 
 	return armResources

--- a/pkg/engine/armtype.go
+++ b/pkg/engine/armtype.go
@@ -149,6 +149,12 @@ type LoadBalancerARM struct {
 	network.LoadBalancer
 }
 
+// ApplicationGatewayARM embeds the ARMResource type in network.ApplicationGateway.
+type ApplicationGatewayARM struct {
+	ARMResource
+	network.ApplicationGateway
+}
+
 // NetworkInterfaceARM embeds the ARMResource type in network.Interface.
 type NetworkInterfaceARM struct {
 	ARMResource

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -455,6 +455,9 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 	masterVars["subscriptionId"] = "[subscription().subscriptionId]"
 	masterVars["contributorRoleDefinitionId"] = "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]"
 	masterVars["readerRoleDefinitionId"] = "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]"
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(AppGwIngressAddonName) {
+		masterVars["managedIdentityOperatorRoleDefinitionId"] = "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]"
+	}
 	masterVars["scope"] = "[resourceGroup().id]"
 	masterVars["tenantId"] = "[subscription().tenantId]"
 	masterVars["singleQuote"] = "'"
@@ -467,6 +470,15 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		masterVars["clusterKeyVaultName"] = "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"
 	} else {
 		masterVars["clusterKeyVaultName"] = ""
+	}
+
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(AppGwIngressAddonName) {
+		masterVars["appGwName"] = "[concat(parameters('orchestratorName'), '-appgw-', parameters('nameSuffix'))]"
+		masterVars["appGwSubnetName"] = "appgw-subnet"
+		masterVars["appGwPublicIPAddressName"] = "[concat(parameters('orchestratorName'), '-appgw-ip-', parameters('nameSuffix'))]"
+		masterVars["appGwICIdentityName"] = "[concat(parameters('orchestratorName'), '-appgw-ic-identity-', parameters('nameSuffix'))]"
+		masterVars["appGwId"] = "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]"
+		masterVars["appGwICIdentityId"] = "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('appGwICIdentityName'))]"
 	}
 
 	return masterVars, nil

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -646,6 +646,32 @@ func TestK8sVars(t *testing.T) {
 		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
 	}
 
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    AppGwIngressAddonName,
+			Enabled: to.BoolPtr(true),
+			Config: map[string]string{
+				"appgw-sku": "WAF_v2",
+			},
+		},
+	}
+
+	varMap, err = GetKubernetesVariables(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedMap["managedIdentityOperatorRoleDefinitionId"] = "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]"
+	expectedMap["appGwName"] = "[concat(parameters('orchestratorName'), '-appgw-', parameters('nameSuffix'))]"
+	expectedMap["appGwSubnetName"] = "appgw-subnet"
+	expectedMap["appGwPublicIPAddressName"] = "[concat(parameters('orchestratorName'), '-appgw-ip-', parameters('nameSuffix'))]"
+	expectedMap["appGwICIdentityName"] = "[concat(parameters('orchestratorName'), '-appgw-ic-identity-', parameters('nameSuffix'))]"
+	expectedMap["appGwId"] = "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]"
+	expectedMap["appGwICIdentityId"] = "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('appGwICIdentityName'))]"
+	diff = cmp.Diff(varMap, expectedMap)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
 }
 
 func TestK8sVarsMastersOnly(t *testing.T) {

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -72,6 +72,8 @@ const (
 	AADPodIdentityAddonName = "aad-pod-identity"
 	// ACIConnectorAddonName is the name of the aci-connector addon deployment
 	ACIConnectorAddonName = "aci-connector"
+	// AppGwIngressAddonName appgw addon
+	AppGwIngressAddonName = "appgw-ingress"
 	// DashboardAddonName is the name of the kubernetes-dashboard addon deployment
 	DashboardAddonName = "kubernetes-dashboard"
 	// ClusterAutoscalerAddonName is the name of the autoscaler addon deployment

--- a/pkg/engine/ipaddresses.go
+++ b/pkg/engine/ipaddresses.go
@@ -30,6 +30,25 @@ func CreatePublicIPAddress() PublicIPAddressARM {
 	}
 }
 
+func createAppGwPublicIPAddress() PublicIPAddressARM {
+	return PublicIPAddressARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+		},
+		PublicIPAddress: network.PublicIPAddress{
+			Location: to.StringPtr("[variables('location')]"),
+			Name:     to.StringPtr("[variables('appGwPublicIPAddressName')]"),
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				PublicIPAllocationMethod: network.Static,
+			},
+			Sku: &network.PublicIPAddressSku{
+				Name: "Standard",
+			},
+			Type: to.StringPtr("Microsoft.Network/publicIPAddresses"),
+		},
+	}
+}
+
 func createJumpboxPublicIPAddress() PublicIPAddressARM {
 	return PublicIPAddressARM{
 		ARMResource: ARMResource{

--- a/pkg/engine/ipaddresses_test.go
+++ b/pkg/engine/ipaddresses_test.go
@@ -126,3 +126,30 @@ func TestCreateClusterPublicIPv6Address(t *testing.T) {
 		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
 	}
 }
+
+func TestCreateAppGwPublicIPAddress(t *testing.T) {
+	expected := PublicIPAddressARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+		},
+		PublicIPAddress: network.PublicIPAddress{
+			Location: to.StringPtr("[variables('location')]"),
+			Name:     to.StringPtr("[variables('appGwPublicIPAddressName')]"),
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				PublicIPAllocationMethod: network.Static,
+			},
+			Sku: &network.PublicIPAddressSku{
+				Name: "Standard",
+			},
+			Type: to.StringPtr("Microsoft.Network/publicIPAddresses"),
+		},
+	}
+
+	actual := createAppGwPublicIPAddress()
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
+}

--- a/pkg/engine/masterarmresources.go
+++ b/pkg/engine/masterarmresources.go
@@ -72,7 +72,6 @@ func createKubernetesMasterResourcesVMAS(cs *api.ContainerService) []interface{}
 			jumpboxPublicIP := createJumpboxPublicIPAddress()
 			masterResources = append(masterResources, jumpboxNSG, jumpboxNIC, jumpboxPublicIP)
 		}
-
 	}
 
 	if p.MasterProfile.HasMultipleNodes() {

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -261,5 +261,10 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 				addValue(parametersMap, "aadAdminGroupId", properties.AADProfile.AdminGroupID)
 			}
 		}
+
+		if kubernetesConfig != nil && kubernetesConfig.IsAddonEnabled(AppGwIngressAddonName) {
+			addValue(parametersMap, "appGwSku", kubernetesConfig.GetAddonByName(AppGwIngressAddonName).Config["appgw-sku"])
+			addValue(parametersMap, "appGwSubnet", kubernetesConfig.GetAddonByName(AppGwIngressAddonName).Config["appgw-subnet"])
+		}
 	}
 }

--- a/pkg/engine/roleassignments.go
+++ b/pkg/engine/roleassignments.go
@@ -4,6 +4,7 @@
 package engine
 
 import (
+	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/to"
 )
@@ -33,6 +34,77 @@ func createMSIRoleAssignment(identityRoleDefinition IdentityRoleDefinition) Role
 				PrincipalID:      to.StringPtr("[reference(concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))).principalId]"),
 				PrincipalType:    authorization.ServicePrincipal,
 				Scope:            to.StringPtr("[resourceGroup().id]"),
+			},
+		},
+	}
+}
+
+func createKubernetesSpAppGIdentityOperatorAccessRoleAssignment(prop *api.Properties) RoleAssignmentARM {
+	kubernetesSpObjectID := ""
+	if prop.OrchestratorProfile.KubernetesConfig.UseManagedIdentity {
+		kubernetesSpObjectID = "[reference(concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))).principalId]"
+	} else if prop.ServicePrincipalProfile.ObjectID != "" {
+		kubernetesSpObjectID = prop.ServicePrincipalProfile.ObjectID
+	}
+
+	return RoleAssignmentARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionAuthorizationSystem')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/applicationgateways/', variables('appGwName'))]",
+				"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('appGwICIdentityName'))]",
+			},
+		},
+		RoleAssignment: authorization.RoleAssignment{
+			Type: to.StringPtr("Microsoft.ManagedIdentity/userAssignedIdentities/providers/roleAssignments"),
+			Name: to.StringPtr("[concat(variables('appGwICIdentityName'), '/Microsoft.Authorization/', guid(resourceGroup().id, 'aksidentityaccess'))]"),
+			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
+				RoleDefinitionID: to.StringPtr("[variables('managedIdentityOperatorRoleDefinitionId')]"),
+				PrincipalID:      to.StringPtr(kubernetesSpObjectID),
+				PrincipalType:    authorization.ServicePrincipal,
+				Scope:            to.StringPtr("[variables('appGwICIdentityId')]"),
+			},
+		},
+	}
+}
+
+func createAppGwIdentityResourceGroupReadSysRoleAssignment() RoleAssignmentARM {
+	return RoleAssignmentARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionAuthorizationSystem')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/applicationgateways/', variables('appGwName'))]",
+				"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('appGwICIdentityName'))]",
+			},
+		},
+		RoleAssignment: authorization.RoleAssignment{
+			Type: to.StringPtr("Microsoft.Authorization/roleAssignments"),
+			Name: to.StringPtr("[guid(resourceGroup().id, 'identityrgaccess')]"),
+			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
+				RoleDefinitionID: to.StringPtr("[variables('readerRoleDefinitionId')]"),
+				PrincipalID:      to.StringPtr("[reference(variables('appGwICIdentityId'), variables('apiVersionManagedIdentity')).principalId]"),
+				Scope:            to.StringPtr("[resourceGroup().id]"),
+			},
+		},
+	}
+}
+
+func createAppGwIdentityApplicationGatewayWriteSysRoleAssignment() RoleAssignmentARM {
+	return RoleAssignmentARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionAuthorizationSystem')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/applicationgateways/', variables('appGwName'))]",
+				"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('appGwICIdentityName'))]",
+			},
+		},
+		RoleAssignment: authorization.RoleAssignment{
+			Type: to.StringPtr("Microsoft.Network/applicationgateways/providers/roleAssignments"),
+			Name: to.StringPtr("[concat(variables('appGwName'), '/Microsoft.Authorization/', guid(resourceGroup().id, 'identityappgwaccess'))]"),
+			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
+				RoleDefinitionID: to.StringPtr("[variables('contributorRoleDefinitionId')]"),
+				PrincipalID:      to.StringPtr("[reference(variables('appGwICIdentityId'), variables('apiVersionManagedIdentity')).principalId]"),
+				Scope:            to.StringPtr("[variables('appGwId')]"),
 			},
 		},
 	}

--- a/pkg/engine/roleassignments_test.go
+++ b/pkg/engine/roleassignments_test.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"testing"
 
+	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
@@ -61,6 +62,138 @@ func TestCreateMSIRoleAssignment(t *testing.T) {
 	}
 
 	diff = cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while comparing: %s", diff)
+	}
+}
+
+func TestCreateKubernetesSpAppGIdentityOperatorAccessRoleAssignment(t *testing.T) {
+	// using service principal
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+				ObjectID: "xxxx",
+			},
+		},
+	}
+
+	actual := createKubernetesSpAppGIdentityOperatorAccessRoleAssignment(cs.Properties)
+	expected := RoleAssignmentARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionAuthorizationSystem')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/applicationgateways/', variables('appGwName'))]",
+				"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('appGwICIdentityName'))]",
+			},
+		},
+		RoleAssignment: authorization.RoleAssignment{
+			Type: to.StringPtr("Microsoft.ManagedIdentity/userAssignedIdentities/providers/roleAssignments"),
+			Name: to.StringPtr("[concat(variables('appGwICIdentityName'), '/Microsoft.Authorization/', guid(resourceGroup().id, 'aksidentityaccess'))]"),
+			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
+				RoleDefinitionID: to.StringPtr(string(IdentityManagedIdentityOperatorRole)),
+				PrincipalID:      to.StringPtr("xxxx"),
+				PrincipalType:    authorization.ServicePrincipal,
+				Scope:            to.StringPtr("[variables('appGwICIdentityId')]"),
+			},
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while comparing: %s", diff)
+	}
+
+	// using managed identity
+	cs = &api.ContainerService{
+		Properties: &api.Properties{
+			OrchestratorProfile: &api.OrchestratorProfile{
+				KubernetesConfig: &api.KubernetesConfig{
+					UseManagedIdentity: true,
+				},
+			},
+		},
+	}
+
+	actual = createKubernetesSpAppGIdentityOperatorAccessRoleAssignment(cs.Properties)
+	expected = RoleAssignmentARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionAuthorizationSystem')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/applicationgateways/', variables('appGwName'))]",
+				"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('appGwICIdentityName'))]",
+			},
+		},
+		RoleAssignment: authorization.RoleAssignment{
+			Type: to.StringPtr("Microsoft.ManagedIdentity/userAssignedIdentities/providers/roleAssignments"),
+			Name: to.StringPtr("[concat(variables('appGwICIdentityName'), '/Microsoft.Authorization/', guid(resourceGroup().id, 'aksidentityaccess'))]"),
+			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
+				RoleDefinitionID: to.StringPtr(string(IdentityManagedIdentityOperatorRole)),
+				PrincipalID:      to.StringPtr("[reference(concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))).principalId]"),
+				PrincipalType:    authorization.ServicePrincipal,
+				Scope:            to.StringPtr("[variables('appGwICIdentityId')]"),
+			},
+		},
+	}
+
+	diff = cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while comparing: %s", diff)
+	}
+}
+
+func TestCreateAppGwIdentityResourceGroupReadSysRoleAssignment(t *testing.T) {
+	actual := createAppGwIdentityResourceGroupReadSysRoleAssignment()
+	expected := RoleAssignmentARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionAuthorizationSystem')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/applicationgateways/', variables('appGwName'))]",
+				"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('appGwICIdentityName'))]",
+			},
+		},
+		RoleAssignment: authorization.RoleAssignment{
+			Type: to.StringPtr("Microsoft.Authorization/roleAssignments"),
+			Name: to.StringPtr("[guid(resourceGroup().id, 'identityrgaccess')]"),
+			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
+				RoleDefinitionID: to.StringPtr(string(IdentityReaderRole)),
+				PrincipalID:      to.StringPtr("[reference(variables('appGwICIdentityId'), variables('apiVersionManagedIdentity')).principalId]"),
+				Scope:            to.StringPtr("[resourceGroup().id]"),
+			},
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while comparing: %s", diff)
+	}
+}
+
+func TestCreateAppGwIdentityApplicationGatewayWriteSysRoleAssignment(t *testing.T) {
+	actual := createAppGwIdentityApplicationGatewayWriteSysRoleAssignment()
+	expected := RoleAssignmentARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionAuthorizationSystem')]",
+			DependsOn: []string{
+				"[concat('Microsoft.Network/applicationgateways/', variables('appGwName'))]",
+				"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('appGwICIdentityName'))]",
+			},
+		},
+		RoleAssignment: authorization.RoleAssignment{
+			Type: to.StringPtr("Microsoft.Network/applicationgateways/providers/roleAssignments"),
+			Name: to.StringPtr("[concat(variables('appGwName'), '/Microsoft.Authorization/', guid(resourceGroup().id, 'identityappgwaccess'))]"),
+			RoleAssignmentPropertiesWithScope: &authorization.RoleAssignmentPropertiesWithScope{
+				RoleDefinitionID: to.StringPtr(string(IdentityContributorRole)),
+				PrincipalID:      to.StringPtr("[reference(variables('appGwICIdentityId'), variables('apiVersionManagedIdentity')).principalId]"),
+				Scope:            to.StringPtr("[variables('appGwId')]"),
+			},
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
 
 	if diff != "" {
 		t.Errorf("unexpected diff while comparing: %s", diff)

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -21673,6 +21673,7 @@ var _k8sKubernetesparamsT = []byte(`{{if .HasAadProfile}}
       "type": "string"
     }
  {{end}}
+ {{if .OrchestratorProfile.KubernetesConfig.IsAppGWIngressEnabled}}
     ,"appGwSubnet": {
       "metadata": {
         "description": "Sets the subnet of the Application Gateway"
@@ -21684,7 +21685,8 @@ var _k8sKubernetesparamsT = []byte(`{{if .HasAadProfile}}
         "description": "Sets the subnet of the Application Gateway"
       },
       "type": "string"
-    }`)
+    }
+ {{end}}`)
 
 func k8sKubernetesparamsTBytes() ([]byte, error) {
 	return _k8sKubernetesparamsT, nil

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -21673,7 +21673,18 @@ var _k8sKubernetesparamsT = []byte(`{{if .HasAadProfile}}
       "type": "string"
     }
  {{end}}
-`)
+    ,"appGwSubnet": {
+      "metadata": {
+        "description": "Sets the subnet of the Application Gateway"
+      },
+      "type": "string"
+    }
+    ,"appGwSku": {
+      "metadata": {
+        "description": "Sets the subnet of the Application Gateway"
+      },
+      "type": "string"
+    }`)
 
 func k8sKubernetesparamsTBytes() ([]byte, error) {
 	return _k8sKubernetesparamsT, nil

--- a/pkg/engine/userassignedidentities.go
+++ b/pkg/engine/userassignedidentities.go
@@ -20,3 +20,16 @@ func createUserAssignedIdentities() UserAssignedIdentitiesARM {
 		},
 	}
 }
+
+func createAppGwUserAssignedIdentities() UserAssignedIdentitiesARM {
+	return UserAssignedIdentitiesARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionManagedIdentity')]",
+		},
+		Identity: msi.Identity{
+			Type:     "Microsoft.ManagedIdentity/userAssignedIdentities",
+			Name:     to.StringPtr("[variables('appGwICIdentityName')]"),
+			Location: to.StringPtr("[variables('location')]"),
+		},
+	}
+}

--- a/pkg/engine/userassignedidentities_test.go
+++ b/pkg/engine/userassignedidentities_test.go
@@ -32,3 +32,24 @@ func TestCreateUserAssignedIdentities(t *testing.T) {
 		t.Errorf("unexpected diff while comparing structs: %s", diff)
 	}
 }
+
+func TestCreateAppGwUserAssignedIdentities(t *testing.T) {
+	expectedAssignedIdentity := UserAssignedIdentitiesARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionManagedIdentity')]",
+		},
+		Identity: msi.Identity{
+			Type:     "Microsoft.ManagedIdentity/userAssignedIdentities",
+			Name:     to.StringPtr("[variables('appGwICIdentityName')]"),
+			Location: to.StringPtr("[variables('location')]"),
+		},
+	}
+
+	actual := createAppGwUserAssignedIdentities()
+
+	diff := cmp.Diff(expectedAssignedIdentity, actual)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while comparing structs: %s", diff)
+	}
+}

--- a/pkg/engine/virtualnetworks.go
+++ b/pkg/engine/virtualnetworks.go
@@ -69,6 +69,18 @@ func CreateVirtualNetwork(cs *api.ContainerService) VirtualNetworkARM {
 		},
 	}
 
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(AppGwIngressAddonName) {
+		subnetAppGw := network.Subnet{
+			Name: to.StringPtr("[variables('appGwSubnetName')]"),
+			SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+				AddressPrefix: to.StringPtr("[parameters('appGwSubnet')]"),
+			},
+		}
+
+		subnets := append(*virtualNetwork.VirtualNetworkPropertiesFormat.Subnets, subnetAppGw)
+		virtualNetwork.VirtualNetworkPropertiesFormat.Subnets = &subnets
+	}
+
 	return VirtualNetworkARM{
 		ARMResource:    armResource,
 		VirtualNetwork: virtualNetwork,
@@ -149,6 +161,18 @@ func createVirtualNetworkVMSS(cs *api.ContainerService) VirtualNetworkARM {
 				subnetAgent,
 			},
 		},
+	}
+
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(AppGwIngressAddonName) {
+		subnetAppGw := network.Subnet{
+			Name: to.StringPtr("[variables('appGwSubnetName')]"),
+			SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+				AddressPrefix: to.StringPtr("[parameters('appGwSubnet')]"),
+			},
+		}
+
+		subnets := append(*virtualNetwork.VirtualNetworkPropertiesFormat.Subnets, subnetAppGw)
+		virtualNetwork.VirtualNetworkPropertiesFormat.Subnets = &subnets
 	}
 
 	return VirtualNetworkARM{


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
This PR adds support to deploy `Application Gateway` with the Kubernetes cluster to provide `ingress` support.
1) Azure `Application Gateway` is Azure's native layer-7 loadbalancer which additionally provides support for SSL Offload, WAF, Autoscaling, Private Ip, Redirects, etc.
2) [**Skipping adding ingress controller section, as discussed with Sean**] Ingress Controller is a controller that looks for `Ingress/Service/Endpoint/Pod` related changes on the cluster and configures the loadbalancer with the updated routing rules.
Ref: [Application Gateway Ingress Controller](https://github.com/Azure/application-gateway-kubernetes-ingress).

**Add-on Description**
This add-on will deploy an Application Gateway and dependency resources with your new Kubernetes cluster.

Supported Add-on `Config` options:

| Option | Required | Default | Description |
|--|--|--|--|
| `appgw-subnet` | true | N/A | CIDR of the Application Gateway subnet. This should not overlap with master/agent subnets. |
| `appgw-sku` | false | `WAF_v2` | SKU of the Application Gateway. (`Standard_v2`/`WAF_v2`) |
| `appgw-private-ip` | false | null | Private IP assigned to the Application Gateway from subnet. |

Once, the infrastructure is deployed, please follow the instructions to deploy the [Application Gateway  Ingress controller](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/install-new.md#setting-up-application-gateway-ingress-controller-on-aks)

***Additions to ARM resources:***
1) Azure Virtual Network with a subnet specifically for `AppGw`.
2) Azure Application Gateway
3) User Assigned Identity to initialize the aad-pod-identity service and ingress controller.
4) Set required RBACs.

Result
![image](https://user-images.githubusercontent.com/5294363/59072483-8ed01c80-8877-11e9-9af3-940bfd669a3c.png)

[**Skipping adding ingress controller section, as discussed with Sean**] ***Additions to Kubernetes deployment:***
1) Deploy Ingress Controller `deployment/pod`
2) Deploy `AAD-Pod-indentity` for token required by the controller to talk to ARM

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
