### PR TITLE
test: Switch Windows test passes to VMSS by default to match AKS

### DIFF
--- a/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
@@ -14,13 +14,13 @@
         "name": "linuxpool1",
         "count": 1,
         "vmSize": "Standard_D2_v3",
-        "availabilityProfile": "AvailabilitySet"
+        "availabilityProfile": "VirtualMachineScaleSets"
       },
       {
         "name": "agentwin",
         "count": 2,
         "vmSize": "Standard_D2_v3",
-        "availabilityProfile": "AvailabilitySet",
+        "availabilityProfile": "VirtualMachineScaleSets",
         "osType": "Windows"
       }
     ],


### PR DESCRIPTION
**Reason for Change**:
`VirtualMachineScaleSets` has been the recommended default for k8s > 1.10 per https://github.com/Azure/aks-engine/blob/windows-vmss/docs/topics/clusterdefinitions.md#L530 , but the PR test passes are using `AvailabilitySet`

