### PR TITLE
feat: Adding Windows Server version 1903 support

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -645,7 +645,7 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 | windowsSku                       | no       | SKU usedto find Windows VM to deploy from marketplace. Default: `Datacenter-Core-1809-with-Containers-smalldisk` |
 | imageVersion                     | no       | Specific image version to deploy from marketplace.  Default: `latest` |
 | windowsImageSourceURL            | no       | Path to an existing Azure storage blob with a sysprepped VHD. This is used to test pre-release or customized VHD files that you have uploaded to Azure. If provided, the above 4 parameters are ignored. |
-| sshEnabled                       | no       | If set to `true`, OpenSSH will be installed on windows nodes to allow for ssh remoting. **Only for Windows version 1809 or 2019** . The same SSH authorized public key(s) will be added from [linuxProfile.ssh.publicKeys](#linuxProfile) |
+| sshEnabled                       | no       | If set to `true`, OpenSSH will be installed on windows nodes to allow for ssh remoting. **Only for Windows version 1809/2019 or later** . The same SSH authorized public key(s) will be added from [linuxProfile.ssh.publicKeys](#linuxProfile) |
 
 
 #### Choosing a Windows version
@@ -661,10 +661,12 @@ $ az vm image list --publisher MicrosoftWindowsServer --all -o table
 Offer                    Publisher                      Sku                                             Urn                                                                                                            Version
 -----------------------  -----------------------------  ----------------------------------------------  -------------------------------------------------------------------------------------------------------------  -----------------
 ...
-WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1709-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1709-with-Containers-smalldisk:1709.0.20181017  1709.0.20181017
-WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20181017  1803.0.20181017
-WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1809-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1809-with-Containers-smalldisk:1809.0.20181107  1809.0.20181107
-WindowsServer            MicrosoftWindowsServer         2019-Datacenter-Core-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:2019.0.20181107            2019.0.20181107
+WindowsServer              MicrosoftWindowsServer         2019-Datacenter-with-Containers                 MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers:2019.0.20190603                           2019.0.20190603
+WindowsServer              MicrosoftWindowsServer         2019-Datacenter-with-Containers-smalldisk       MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers-smalldisk:2019.0.20190603                 2019.0.20190603
+WindowsServer              MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20190603            1803.0.20190603
+WindowsServer              MicrosoftWindowsServer         Datacenter-Core-1809-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1809-with-Containers-smalldisk:1809.0.20190603            1809.0.20190603
+WindowsServer              MicrosoftWindowsServer         Datacenter-Core-1903-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:1903.0.20190603            1903.0.20190603
+...
 ```
 
 If you wanted to use the last one in the list above, then set:

--- a/examples/windows/kubernetes-windows-1903.json
+++ b/examples/windows/kubernetes-windows-1903.json
@@ -1,0 +1,46 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.15"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool2",
+        "count": 2,
+        "vmSize": "Standard_D2_v3",
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "osType": "Windows"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "sshEnabled": true,
+      "windowsPublisher": "MicrosoftWindowsServer",
+      "windowsOffer": "WindowsServer",
+      "windowsSku": "Datacenter-Core-1903-with-Containers-smalldisk",
+      "imageVersion": "1903.0.20190603"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/parts/k8s/windowsinstallopensshfunc.ps1
+++ b/parts/k8s/windowsinstallopensshfunc.ps1
@@ -34,6 +34,8 @@ Install-OpenSSH {
     Write-Host "Setting required permissions..."
     icacls $adminpath\$adminfile /remove "NT AUTHORITY\Authenticated Users"
     icacls $adminpath\$adminfile /inheritance:r
+    icacls $adminpath\$adminfile /grant SYSTEM:`(F`)
+    icacls $adminpath\$adminfile /grant BUILTIN\Administrators:`(F`)
 
     Write-Host "Restarting sshd service..."
     Restart-Service sshd

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -140,8 +140,7 @@ Build-PauseContainer {
     # Future work: This needs to build wincat - see https://github.com/Azure/aks-engine/issues/1461
     "FROM $($WindowsBase)" | Out-File -encoding ascii -FilePath Dockerfile
     "CMD cmd /c ping -t localhost" | Out-File -encoding ascii -FilePath Dockerfile -Append
-    docker build -t $containerTag .
-    return $containerTag
+    docker build -t $DestinationTag .
 }
 
 function
@@ -157,7 +156,7 @@ New-InfraContainer {
     # Reference for these tags: curl -L https://mcr.microsoft.com/v2/k8s/core/pause/tags/list
     # Then docker run --rm mplatform/manifest-tool inspect mcr.microsoft.com/k8s/core/pause:<tag>
 
-    $windowsBase = switch ($computerInfo.WindowsVersion) {
+    switch ($computerInfo.WindowsVersion) {
         "1803" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
         "1809" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
         "1903" { Build-PauseContainer -WindowsBase "mcr.microsoft.com/windows/nanoserver:1903" -DestinationTag $DestinationTag}

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -131,29 +131,38 @@ users:
 }
 
 function
+Build-PauseContainer {
+    Param(
+        [Parameter(Mandatory = $true)][string]
+        $WindowsBase,
+        $DestinationTag
+    )
+    # Future work: This needs to build wincat - see https://github.com/Azure/aks-engine/issues/1461
+    "FROM $($WindowsBase)" | Out-File -encoding ascii -FilePath Dockerfile
+    "CMD cmd /c ping -t localhost" | Out-File -encoding ascii -FilePath Dockerfile -Append
+    docker build -t $containerTag .
+    return $containerTag
+}
+
+function
 New-InfraContainer {
     Param(
         [Parameter(Mandatory = $true)][string]
-        $KubeDir
+        $KubeDir,
+        $DestinationTag = "kubletwin/pause"
     )
     cd $KubeDir
     $computerInfo = Get-ComputerInfo
-    $windowsBase = if ($computerInfo.WindowsVersion -eq "1709") {
-        "microsoft/nanoserver:1709"
-    }
-    elseif ($computerInfo.WindowsVersion -eq "1803") {
-        "microsoft/nanoserver:1803"
-    }
-    elseif ($computerInfo.WindowsVersion -eq "1809") {
-        "mcr.microsoft.com/windows/nanoserver:1809"
-    }
-    else {
-        "mcr.microsoft.com/nanoserver-insider"
-    }
 
-    "FROM $($windowsBase)" | Out-File -encoding ascii -FilePath Dockerfile
-    "CMD cmd /c ping -t localhost" | Out-File -encoding ascii -FilePath Dockerfile -Append
-    docker build -t kubletwin/pause .
+    # Reference for these tags: curl -L https://mcr.microsoft.com/v2/k8s/core/pause/tags/list
+    # Then docker run --rm mplatform/manifest-tool inspect mcr.microsoft.com/k8s/core/pause:<tag>
+
+    $windowsBase = switch ($computerInfo.WindowsVersion) {
+        "1803" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
+        "1809" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
+        "1903" { Build-PauseContainer -WindowsBase "mcr.microsoft.com/windows/nanoserver:1903" -DestinationTag $DestinationTag}
+        default { Build-PauseContainer -WindowsBase "mcr.microsoft.com/nanoserver-insider" -DestinationTag $DestinationTag}
+    }
 }
 
 
@@ -185,11 +194,6 @@ Get-KubeBinaries {
         [Parameter(Mandatory = $true)][string]
         $KubeBinariesURL
     )
-
-    if ($computerInfo.WindowsVersion -eq "1709") {
-        Write-Log "Server version 1709 does not support using kubernetes binaries in tar file."
-        return
-    }
 
     $tempdir = New-TemporaryDirectory
     $binaryPackage = "$tempdir\k.tar.gz"

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -156,9 +156,11 @@ New-InfraContainer {
     # Reference for these tags: curl -L https://mcr.microsoft.com/v2/k8s/core/pause/tags/list
     # Then docker run --rm mplatform/manifest-tool inspect mcr.microsoft.com/k8s/core/pause:<tag>
 
+    $defaultPauseImage = "mcr.microsoft.com/k8s/core/pause:1.1.0"
+
     switch ($computerInfo.WindowsVersion) {
-        "1803" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
-        "1809" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
+        "1803" { docker pull $defaultPauseImage ; docker tag $defaultPauseImage $DestinationTag }
+        "1809" { docker pull $defaultPauseImage ; docker tag $defaultPauseImage $DestinationTag }
         "1903" { Build-PauseContainer -WindowsBase "mcr.microsoft.com/windows/nanoserver:1903" -DestinationTag $DestinationTag}
         default { Build-PauseContainer -WindowsBase "mcr.microsoft.com/nanoserver-insider" -DestinationTag $DestinationTag}
     }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19259,8 +19259,7 @@ Build-PauseContainer {
     # Future work: This needs to build wincat - see https://github.com/Azure/aks-engine/issues/1461
     "FROM $($WindowsBase)" | Out-File -encoding ascii -FilePath Dockerfile
     "CMD cmd /c ping -t localhost" | Out-File -encoding ascii -FilePath Dockerfile -Append
-    docker build -t $containerTag .
-    return $containerTag
+    docker build -t $DestinationTag .
 }
 
 function
@@ -19276,7 +19275,7 @@ New-InfraContainer {
     # Reference for these tags: curl -L https://mcr.microsoft.com/v2/k8s/core/pause/tags/list
     # Then docker run --rm mplatform/manifest-tool inspect mcr.microsoft.com/k8s/core/pause:<tag>
 
-    $windowsBase = switch ($computerInfo.WindowsVersion) {
+    switch ($computerInfo.WindowsVersion) {
         "1803" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
         "1809" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
         "1903" { Build-PauseContainer -WindowsBase "mcr.microsoft.com/windows/nanoserver:1903" -DestinationTag $DestinationTag}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19275,9 +19275,11 @@ New-InfraContainer {
     # Reference for these tags: curl -L https://mcr.microsoft.com/v2/k8s/core/pause/tags/list
     # Then docker run --rm mplatform/manifest-tool inspect mcr.microsoft.com/k8s/core/pause:<tag>
 
+    $defaultPauseImage = "mcr.microsoft.com/k8s/core/pause:1.1.0"
+
     switch ($computerInfo.WindowsVersion) {
-        "1803" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
-        "1809" { docker pull "mcr.microsoft.com/k8s/core/pause" ; docker tag "mcr.microsoft.com/k8s/core/pause" $DestinationTag }
+        "1803" { docker pull $defaultPauseImage ; docker tag $defaultPauseImage $DestinationTag }
+        "1809" { docker pull $defaultPauseImage ; docker tag $defaultPauseImage $DestinationTag }
         "1903" { Build-PauseContainer -WindowsBase "mcr.microsoft.com/windows/nanoserver:1903" -DestinationTag $DestinationTag}
         default { Build-PauseContainer -WindowsBase "mcr.microsoft.com/nanoserver-insider" -DestinationTag $DestinationTag}
     }

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -226,15 +226,20 @@ func (e *Engine) GetWindowsTestImages() (*WindowsTestImages, error) {
 	}
 
 	windowsSku := e.ExpandedDefinition.Properties.WindowsProfile.GetWindowsSku()
+	// tip: curl -L https://mcr.microsoft.com/v2/windows/servercore/tags/list
+	//      curl -L https://mcr.microsoft.com/v2/windows/servercore/iis/tags/list
 	switch {
+	case strings.Contains(windowsSku, "1903"):
+		return &WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-1903",
+			ServerCore: "mcr.microsoft.com/windows/servercore:1903"}, nil
 	case strings.Contains(windowsSku, "1809"), strings.Contains(windowsSku, "2019"):
 		return &WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",
-			ServerCore: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"}, nil
+			ServerCore: "mcr.microsoft.com/windows/servercore:ltsc2019"}, nil
 	case strings.Contains(windowsSku, "1803"):
-		return &WindowsTestImages{IIS: "microsoft/iis:windowsservercore-1803",
-			ServerCore: "microsoft/iis:windowsservercore-1803"}, nil
+		return &WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-1803",
+			ServerCore: "mcr.microsoft.com/windows/servercore:1803"}, nil
 	case strings.Contains(windowsSku, "1709"):
-		return nil, errors.New("Windows Server version 1709 hasn't been tested in a long time and is deprecated")
+		return nil, errors.New("Windows Server version 1709 is out of support")
 	}
 	return nil, errors.New("Unknown Windows version. GetWindowsSku() = " + windowsSku)
 }

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -693,7 +693,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 			if eng.HasWindowsAgents() {
 				By("Ensuring that we have functional DNS resolution from a windows container")
-				j, err = job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default")
+				windowsImages, imgErr := eng.GetWindowsTestImages()
+				Expect(imgErr).NotTo(HaveOccurred())
+				j, err = job.CreateWindowsJobFromTemplateDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default", windowsImages)
 				Expect(err).NotTo(HaveOccurred())
 				ready, err = j.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
 				delErr = j.Delete(util.DefaultDeleteRetries)

--- a/test/e2e/kubernetes/workloads/validate-dns-windows.yaml
+++ b/test/e2e/kubernetes/workloads/validate-dns-windows.yaml
@@ -9,10 +9,10 @@ spec:
       restartPolicy: Never
       containers:
       - name: validate-bing
-        image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
+        image: {{ .ServerCore }}
         command: ['powershell', 'Resolve-DnsName', '-Name', 'www.bing.com', '-DnsOnly', '-Type', 'CNAME']
       - name: validate-google
-        image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
+        image: {{ .ServerCore }}
         command: ['powershell', 'Resolve-DnsName', '-Name', 'google.com', '-DnsOnly', '-Type', 'A']
       nodeSelector:
         beta.kubernetes.io/os: windows


### PR DESCRIPTION
**Reason for Change**:

This adds support for Windows Server version 1903, along with a sample and brief update to clusterdefinition.md. I also cleaned up the container version references and added comments to help identify what containers to use with the next Windows OS version change.

**Issue Fixed**:

resolves #1462

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
