### PR TITLE
test: add subnets to route table in E2E for custom vnet + kubenet

### DIFF
--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/aks-engine/pkg/api"
-
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/aks-engine/test/e2e/azure"

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -132,7 +132,14 @@ func (cli *CLIProvisioner) provision() error {
 	agentSubnetID := ""
 	agentSubnetIDs := []string{}
 	subnets := []string{}
-	var cs *api.VlabsARMContainerService
+	config, err := engine.ParseConfig(cli.Config.CurrentWorkingDir, cli.Config.ClusterDefinition, cli.Config.Name)
+	if err != nil {
+		log.Printf("Error while trying to build Engine Configuration:%s\n", err)
+	}
+	cs, err := engine.ParseInput(config.ClusterDefinitionPath)
+	if err != nil {
+		return err
+	}
 
 	if cli.CreateVNET {
 		if cli.MasterVMSS {
@@ -154,16 +161,6 @@ func (cli *CLIProvisioner) provision() error {
 			agentSubnetID = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s", cli.Account.SubscriptionID, cli.Account.ResourceGroup.Name, vnetName, agentSubnetName)
 
 		} else {
-			var config *engine.Config
-			config, err = engine.ParseConfig(cli.Config.CurrentWorkingDir, cli.Config.ClusterDefinition, cli.Config.Name)
-			if err != nil {
-				log.Printf("Error while trying to build Engine Configuration:%s\n", err)
-			}
-
-			cs, err = engine.ParseInput(config.ClusterDefinitionPath)
-			if err != nil {
-				return err
-			}
 			err = cli.Account.CreateVnet(vnetName, "10.239.0.0/16")
 			if err != nil {
 				return errors.Errorf("Error trying to create vnet:%s", err.Error())

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -131,6 +131,7 @@ func (cli *CLIProvisioner) provision() error {
 	masterSubnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s", cli.Account.SubscriptionID, cli.Account.ResourceGroup.Name, vnetName, masterSubnetName)
 	agentSubnetID := ""
 	agentSubnetIDs := []string{}
+	subnets := []string{}
 
 	if cli.CreateVNET {
 		if cli.MasterVMSS {
@@ -143,12 +144,14 @@ func (cli *CLIProvisioner) provision() error {
 			if err != nil {
 				return errors.Errorf("Error trying to create subnet:%s", err.Error())
 			}
+			subnets = append(subnets, masterSubnetName)
 			err = cli.Account.CreateSubnet(vnetName, agentSubnetName, "10.239.128.0/17")
 			if err != nil {
 				return errors.Errorf("Error trying to create subnet in subnet:%s", err.Error())
 			}
-
+			subnets = append(subnets, agentSubnetName)
 			agentSubnetID = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s", cli.Account.SubscriptionID, cli.Account.ResourceGroup.Name, vnetName, agentSubnetName)
+
 		} else {
 			var config *engine.Config
 			config, err = engine.ParseConfig(cli.Config.CurrentWorkingDir, cli.Config.ClusterDefinition, cli.Config.Name)
@@ -168,12 +171,14 @@ func (cli *CLIProvisioner) provision() error {
 			if err != nil {
 				return errors.Errorf("Error trying to create subnet:%s", err.Error())
 			}
+			subnets = append(subnets, masterSubnetName)
 			for i, pool := range cs.ContainerService.Properties.AgentPoolProfiles {
 				subnetName := fmt.Sprintf("%sCustomSubnet", pool.Name)
 				err = cli.Account.CreateSubnet(vnetName, subnetName, fmt.Sprintf("10.239.%d.0/24", i+1))
 				if err != nil {
 					return errors.Errorf("Error trying to create subnet:%s", err.Error())
 				}
+				subnets = append(subnets, subnetName)
 				subnetID = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s", cli.Account.SubscriptionID, cli.Account.ResourceGroup.Name, vnetName, subnetName)
 				agentSubnetIDs = append(agentSubnetIDs, subnetID)
 			}
@@ -202,6 +207,17 @@ func (cli *CLIProvisioner) provision() error {
 	err = cli.generateAndDeploy()
 	if err != nil {
 		return errors.Wrap(err, "Error in generateAndDeploy:%s")
+	}
+
+	if cli.CreateVNET {
+		routeTable, err := cli.Account.GetRGRouteTable(10 * time.Minute)
+		if err != nil {
+			return errors.Errorf("Error trying to get route table in VNET: %s", err.Error())
+		}
+		err = cli.Account.AddSubnetsToRouteTable(*routeTable.ID, vnetName, subnets)
+		if err != nil {
+			return errors.Errorf("Error trying to add subnets to route table %s in VNET: %s", *routeTable.ID, err.Error())
+		}
 	}
 
 	if cli.Config.IsKubernetes() {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

As a convenience, add subnets to route table in E2E "custom VNET" test scenarios.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
