### PR TITLE
fix: remove walinuxagent version pin

### DIFF
--- a/parts/k8s/cloud-init/artifacts/apt-preferences
+++ b/parts/k8s/cloud-init/artifacts/apt-preferences
@@ -1,3 +1,0 @@
-Package: walinuxagent
-Pin: version 2.2.32.2
-Pin-Priority: 550

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -10002,9 +10002,7 @@ func k8sArmparametersT() (*asset, error) {
 	return a, nil
 }
 
-var _k8sCloudInitArtifactsAptPreferences = []byte(`Package: walinuxagent
-Pin: version 2.2.32.2
-Pin-Priority: 550`)
+var _k8sCloudInitArtifactsAptPreferences = []byte(``)
 
 func k8sCloudInitArtifactsAptPreferencesBytes() ([]byte, error) {
 	return _k8sCloudInitArtifactsAptPreferences, nil


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Why remove this?
- This was added in https://github.com/Azure/aks-engine/pull/778 to "to further protect against runtime changes to the walinuxagent". #1471 proved that this does not actually work. 
- Different clouds/regions might different walinuxagent versions rolled out so pinning to one version might break sovereign clouds that don't have the latest version available.
- Having this setting introduces friction to have the latest walinuxagent version as we are not actively monitoring agent releases, which might lead us to run into bugs in the future that would have otherwise been fixed in the latest version. I would argue we should delegate walinuxagent version updates to the linux agent team and not override it.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
