### PR TITLE
test: HPA scale down config only works if k8s >= 1.12

### DIFF
--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/api/vlabs"
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/aks-engine/pkg/i18n"
@@ -161,8 +162,16 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 		prop.ServicePrincipalProfile.ObjectID = config.ClientObjectID
 	}
 
-	if prop.OrchestratorProfile.KubernetesConfig == nil {
-		prop.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
+	var version string
+	if prop.OrchestratorProfile.OrchestratorRelease != "" {
+		version = prop.OrchestratorProfile.OrchestratorRelease + ".0"
+	} else if prop.OrchestratorProfile.OrchestratorVersion != "" {
+		version = prop.OrchestratorProfile.OrchestratorVersion
+	}
+	if common.IsKubernetesVersionGe(version, "1.12.0") {
+		if prop.OrchestratorProfile.KubernetesConfig == nil {
+			prop.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
+		}
 		prop.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig = map[string]string{
 			"--horizontal-pod-autoscaler-downscale-stabilization":   "30s",
 			"--horizontal-pod-autoscaler-cpu-initialization-period": "30s",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Two things:

- `--horizontal-pod-autoscaler-downscale-stabilization` and `--horizontal-pod-autoscaler-cpu-initialization-period` were introduced in k8s 1.12, so we can only set that value if the cluster is >= 1.12
- the way the runner is setting the config is only if the api model `KubernetesConfig` is empty, which in practice it rarely is

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
