### PR TITLE
chore: add k8s 1.14.1 for Azure Stack to VHD script

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -363,6 +363,7 @@ echo "  - busybox" >> ${RELEASE_NOTES_FILEPATH}
 K8S_VERSIONS="
 1.14.3
 1.14.1
+1.14.1-azs
 1.13.7
 1.13.5
 1.13.5-azs


### PR DESCRIPTION
**Reason for Change**:
Adds hyperkube support for Kubernetes 1.14.1 on Azure Stack to the VHD image script.

**Issue Fixed**:
This was prompted by the docs changes in #1482.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
