### PR TITLE
fix: vhd pre-pulls expected flannel images tag

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -351,7 +351,7 @@ FLANNEL_VERSIONS="
 0.8.0
 "
 for FLANNEL_VERSION in ${FLANNEL_VERSIONS}; do
-    CONTAINER_IMAGE="quay.io/coreos/flannel:v${FLANNEL_VERSION}"
+    CONTAINER_IMAGE="quay.io/coreos/flannel:v${FLANNEL_VERSION}-amd64"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${RELEASE_NOTES_FILEPATH}
 done


### PR DESCRIPTION
**Reason for Change**:
There is a mismatch between the [pre-pulled flannel image](https://github.com/Azure/aks-engine/blob/master/packer/install-dependencies.sh#L349) and [flannel's DS template](https://github.com/Azure/aks-engine/blob/bf4861fe098ab5114c892cbe09122574f0b972a9/parts/k8s/addons/kubernetesmasteraddons-flannel-daemonset.yaml#L93)

This is breaking air-gapped deployments that rely on the VHD containing all dependencies.
