### PR TITLE
chore: Change Windows default image to Jun 2019

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -641,9 +641,9 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 | adminUsername                    | yes      | Username for the Windows adminstrator account created on each Windows node |
 | adminPassword                    | yes      | Password for the Windows adminstrator account created on each Windows node |
 | windowsPublisher                 | no       | Publisher used to find Windows VM to deploy from marketplace. Default: `MicrosoftWindowsServer` |
-| windowsOffer                     | no       | Offer used to find Windows VM to deploy from marketplace. Default: `WindowsServerSemiAnnual` |
+| windowsOffer                     | no       | Offer used to find Windows VM to deploy from marketplace. Default: `WindowsServer` |
 | windowsSku                       | no       | SKU usedto find Windows VM to deploy from marketplace. Default: `Datacenter-Core-1809-with-Containers-smalldisk` |
-| imageVersion                     | no       | Specific image version to deploy from marketplace.  Default: `latest` |
+| imageVersion                     | no       | Specific image version to deploy from marketplace.  Default: `17763.557.20190604`. This default is incremented as new versions are tested to avoid unexpected breaks. |
 | windowsImageSourceURL            | no       | Path to an existing Azure storage blob with a sysprepped VHD. This is used to test pre-release or customized VHD files that you have uploaded to Azure. If provided, the above 4 parameters are ignored. |
 | sshEnabled                       | no       | If set to `true`, OpenSSH will be installed on windows nodes to allow for ssh remoting. **Only for Windows version 1809 or 2019** . The same SSH authorized public key(s) will be added from [linuxProfile.ssh.publicKeys](#linuxProfile) |
 
@@ -667,7 +667,7 @@ WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1809-wit
 WindowsServer            MicrosoftWindowsServer         2019-Datacenter-Core-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:2019.0.20181107            2019.0.20181107
 ```
 
-If you wanted to use the last one in the list above, then set:
+If you want to use a specific image then `windowsPublisher`, `windowsOffer`, `windowsSku`, and `imageVersion` must all be set:
 
 ```json
 "windowsProfile": {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -247,11 +247,11 @@ const (
 	// DefaultWindowsPublisher sets the default WindowsPublisher value in WindowsProfile
 	DefaultWindowsPublisher = "MicrosoftWindowsServer"
 	// DefaultWindowsOffer sets the default WindowsOffer value in WindowsProfile
-	DefaultWindowsOffer = "WindowsServerSemiAnnual"
+	DefaultWindowsOffer = "WindowsServer"
 	// DefaultWindowsSku sets the default WindowsSku value in WindowsProfile
 	DefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 	// DefaultImageVersion sets the default ImageVersion value in WindowsProfile
-	DefaultImageVersion = "1809.0.20190314"
+	DefaultImageVersion = "17763.557.20190604"
 )
 
 const (


### PR DESCRIPTION
**Reason for Change**:

This updates the last-known-good image to the latest Windows patch release. There were some issues that could break DNS in April/May cumulative updates. 

**Issue Fixed**:


**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

/hold
I was expecting this to have a date on or after the 2nd Tuesday which is June 10, not June 4. I need to make sure this is the right one before merge.