### PR TITLE
chore: CoreDNS configmap is not updated during upgrades

### DIFF
--- a/parts/k8s/addons/coredns.yaml
+++ b/parts/k8s/addons/coredns.yaml
@@ -56,7 +56,7 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-      addonmanager.kubernetes.io/mode: EnsureExists
+      addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
     .:53 {


### PR DESCRIPTION
Upgrading clusters from previous versions to the current CoreDNS version break when this ConfigMap isn't also updated

/cc @mboersma