### PR TITLE
ci: swap ensure-generated and test-style tasks

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -52,11 +52,11 @@ jobs:
   - script: make validate-dependencies
     displayName: Check if imports, Gopkg.toml, and Gopkg.lock are in sync
     workingDirectory: $(modulePath)
-  - script: make generate test-style
-    displayName: Run linting rules
-    workingDirectory: $(modulePath)
   - script: make ensure-generated
     displayName: Check if generated code is up to date
+    workingDirectory: $(modulePath)
+  - script: make generate test-style
+    displayName: Run linting rules
     workingDirectory: $(modulePath)
   - script: make build-cross
     displayName: Build cross-architectural binaries


### PR DESCRIPTION
**Reason for Change**:
The `Check if generated code is up to date` Azure DevOps task would always succeed because `make generate` had just been run in the previous `Run linting rules` task. This swaps them as a simple workaround.

Seems to work, as proved by #1406. 😅 

**Issue Fixed**:
Fixes #1318

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
