### PR TITLE
docs: Link to more details on Windows images

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -652,7 +652,7 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 
 If you want to choose a specific Windows image, but automatically use the latest - set `windowsPublisher`, `windowsOffer`, and `windowsSku`. If you need a specific version, then add `agentWindowsVersion` too.
 
-You can find all available images with `az vm image list`
+You can find all available images with `az vm image list`, and the contents of these images are described in the knowledge base article [Windows Server release on Azure Marketplace update history](https://support.microsoft.com/en-us/help/4497947).
 
 
 ```bash


### PR DESCRIPTION
**Reason for Change**:

There's a new document describing what Windows Server images have been published to Azure. Let's link to it!

They're planning to add more details (offer/sku/version) to this doc over time so maybe people won't have to run `az vm list ...` and guess on which one to use in the future :)
