### PR TITLE
fix: --pod-max-pids upgrade to 1.14 scenarios

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -133,6 +133,12 @@ func (cs *ContainerService) setKubeletConfig() {
 		}
 	}
 
+	minVersionRequireSupportPodPidsLimitFeatureGate := "1.14.0"
+	podMaxPids, _ := strconv.Atoi(o.KubernetesConfig.KubeletConfig["--pod-max-pids"])
+	if podMaxPids > 0 {
+		addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, minVersionRequireSupportPodPidsLimitFeatureGate, "SupportPodPidsLimit=true")
+	}
+
 	removeKubeletFlags(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)
 
 	// Master-specific kubelet config changes go here

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/aks-engine/pkg/api/common"
 )
 
-func (cs *ContainerService) setKubeletConfig() {
+func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	o := cs.Properties.OrchestratorProfile
 	staticLinuxKubeletConfig := map[string]string{
 		"--address":                     "0.0.0.0",
@@ -133,10 +133,16 @@ func (cs *ContainerService) setKubeletConfig() {
 		}
 	}
 
-	minVersionRequireSupportPodPidsLimitFeatureGate := "1.14.0"
-	podMaxPids, _ := strconv.Atoi(o.KubernetesConfig.KubeletConfig["--pod-max-pids"])
-	if podMaxPids > 0 {
-		addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, minVersionRequireSupportPodPidsLimitFeatureGate, "SupportPodPidsLimit=true")
+	if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
+		hasSupportPodPidsLimitFeatureGate := strings.Contains(o.KubernetesConfig.KubeletConfig["--feature-gates"], "SupportPodPidsLimit=true")
+		podMaxPids, _ := strconv.Atoi(o.KubernetesConfig.KubeletConfig["--pod-max-pids"])
+		if podMaxPids > 0 {
+			// If we don't have an explicit SupportPodPidsLimit=true, disable --pod-max-pids by setting to -1
+			// To prevent older clusters from inheriting SupportPodPidsLimit=true implicitly starting w/ 1.14.0
+			if !hasSupportPodPidsLimitFeatureGate {
+				o.KubernetesConfig.KubeletConfig["--pod-max-pids"] = strconv.Itoa(-1)
+			}
+		}
 	}
 
 	removeKubeletFlags(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -20,7 +20,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 	winProfile.VMSize = "Standard_D2_v2"
 	winProfile.OSType = Windows
 	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, winProfile)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	kubeletConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	expected := map[string]string{
 		"--address":                           "0.0.0.0",
@@ -108,7 +108,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig = map[string]string{
 		"--azure-container-registry-config": overrideVal,
 	}
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	for key, val := range map[string]string{"--azure-container-registry-config": overrideVal} {
 		if k[key] != val {
@@ -126,7 +126,7 @@ func TestKubeletConfigDefaultsRemovals(t *testing.T) {
 	poolProfile.VMSize = "Standard_D2_v2"
 	poolProfile.OSType = Linux
 	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, poolProfile)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	kubeletConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	unexpected := []string{
 		"--cadvisor-port",
@@ -139,7 +139,7 @@ func TestKubeletConfigDefaultsRemovals(t *testing.T) {
 	}
 	cs = CreateMockContainerService("testcluster", "1.15.0-beta.1", 3, 2, false)
 	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, poolProfile)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	kubeletConfig = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	unexpected = []string{
 		"--allow-privileged",
@@ -157,7 +157,7 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 	// Test UseCloudControllerManager = true
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--cloud-provider"] != "external" {
 		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=true: %s",
@@ -167,7 +167,7 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 	// Test UseCloudControllerManager = false
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--cloud-provider"] != "azure" {
 		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=false: %s",
@@ -179,7 +179,7 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 func TestKubeletConfigCloudConfig(t *testing.T) {
 	// Test default value and custom value for --cloud-config
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--cloud-config"] != "/etc/kubernetes/azure.json" {
 		t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
@@ -188,7 +188,7 @@ func TestKubeletConfigCloudConfig(t *testing.T) {
 
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--cloud-config"] = "custom.json"
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--cloud-config"] != "custom.json" {
 		t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
@@ -199,7 +199,7 @@ func TestKubeletConfigCloudConfig(t *testing.T) {
 func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
 	// Test default value and custom value for --azure-container-registry-config
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--azure-container-registry-config"] != "/etc/kubernetes/azure.json" {
 		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
@@ -208,7 +208,7 @@ func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
 
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--azure-container-registry-config"] = "custom.json"
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--azure-container-registry-config"] != "custom.json" {
 		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
@@ -220,7 +220,7 @@ func TestKubeletConfigNetworkPlugin(t *testing.T) {
 	// Test NetworkPlugin = "kubenet"
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--network-plugin"] != NetworkPluginKubenet {
 		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPlugin=kubenet: %s",
@@ -230,7 +230,7 @@ func TestKubeletConfigNetworkPlugin(t *testing.T) {
 	// Test NetworkPlugin = "azure"
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--network-plugin"] != "cni" {
 		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPlugin=azure: %s",
@@ -243,7 +243,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	// Test EnableSecureKubelet = true
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--anonymous-auth"] != "false" {
 		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
@@ -261,7 +261,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	// Test EnableSecureKubelet = false
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
 		if _, ok := k[key]; ok {
@@ -274,7 +274,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 1, false)
 	p := GetK8sDefaultProperties(true)
 	cs.Properties = p
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
 		if _, ok := k[key]; ok {
@@ -288,7 +288,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	p = GetK8sDefaultProperties(true)
 	cs.Properties = p
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
 		if _, ok := k[key]; ok {
@@ -302,7 +302,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	p = GetK8sDefaultProperties(true)
 	cs.Properties = p
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--anonymous-auth"] != "false" {
 		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
@@ -318,7 +318,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 func TestKubeletMaxPods(t *testing.T) {
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--max-pods"] != strconv.Itoa(DefaultKubernetesMaxPodsVNETIntegrated) {
 		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
@@ -327,7 +327,7 @@ func TestKubeletMaxPods(t *testing.T) {
 
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--max-pods"] != strconv.Itoa(DefaultKubernetesMaxPods) {
 		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
@@ -338,7 +338,7 @@ func TestKubeletMaxPods(t *testing.T) {
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--max-pods"] = "99"
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--max-pods"] != "99" {
 		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
@@ -348,7 +348,7 @@ func TestKubeletMaxPods(t *testing.T) {
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--max-pods"] = "99"
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--max-pods"] != "99" {
 		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
@@ -359,7 +359,7 @@ func TestKubeletMaxPods(t *testing.T) {
 func TestKubeletCalico(t *testing.T) {
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyCalico
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--network-plugin"] != "cni" {
 		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPolicy=%s: %s",
@@ -382,7 +382,7 @@ func TestKubeletHostedMasterIPMasqAgentDisabled(t *testing.T) {
 		},
 	}
 
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--non-masquerade-cidr"] != subnet {
 		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
@@ -401,7 +401,7 @@ func TestKubeletHostedMasterIPMasqAgentDisabled(t *testing.T) {
 			Enabled: to.BoolPtr(true),
 		},
 	}
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--non-masquerade-cidr"] != DefaultNonMasqueradeCIDR {
 		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
@@ -417,7 +417,7 @@ func TestKubeletHostedMasterIPMasqAgentDisabled(t *testing.T) {
 			Enabled: to.BoolPtr(true),
 		},
 	}
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--non-masquerade-cidr"] != DefaultNonMasqueradeCIDR {
 		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
@@ -439,7 +439,7 @@ func TestKubeletIPMasqAgentEnabledOrDisabled(t *testing.T) {
 		},
 	}
 	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--non-masquerade-cidr"] != subnet {
 		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
@@ -458,7 +458,7 @@ func TestKubeletIPMasqAgentEnabledOrDisabled(t *testing.T) {
 		},
 	}
 	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--non-masquerade-cidr"] != DefaultNonMasqueradeCIDR {
 		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
@@ -469,7 +469,7 @@ func TestKubeletIPMasqAgentEnabledOrDisabled(t *testing.T) {
 func TestEnforceNodeAllocatable(t *testing.T) {
 	// Validate default
 	cs := CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--enforce-node-allocatable"] != "pods" {
 		t.Fatalf("got unexpected '--enforce-node-allocatable' kubelet config value %s, the expected value is %s",
@@ -483,7 +483,7 @@ func TestEnforceNodeAllocatable(t *testing.T) {
 			"--enforce-node-allocatable": "kube-reserved/system-reserved",
 		},
 	}
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--enforce-node-allocatable"] != "kube-reserved/system-reserved" {
 		t.Fatalf("got unexpected '--enforce-node-allocatable' kubelet config value %s, the expected value is %s",
@@ -628,7 +628,7 @@ func TestStaticWindowsConfig(t *testing.T) {
 	expected["--resolv-conf"] = "\"\"\"\""
 	expected["--eviction-hard"] = "\"\"\"\""
 
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	for _, profile := range cs.Properties.AgentPoolProfiles {
 		if profile.OSType == Windows {
 			for key, val := range expected {
@@ -643,7 +643,7 @@ func TestStaticWindowsConfig(t *testing.T) {
 
 func TestKubeletRotateCertificates(t *testing.T) {
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--rotate-certificates"] != "" {
 		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value for k8s version %s: %s",
@@ -652,7 +652,7 @@ func TestKubeletRotateCertificates(t *testing.T) {
 
 	// Test 1.11
 	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(Kubernetes, "1.11", "", false, false), 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--rotate-certificates"] != "true" {
 		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value for k8s version %s: %s",
@@ -661,7 +661,7 @@ func TestKubeletRotateCertificates(t *testing.T) {
 
 	// Test 1.14
 	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(Kubernetes, "1.14", "", false, false), 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--rotate-certificates"] != "true" {
 		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value for k8s version %s: %s",
@@ -672,7 +672,7 @@ func TestKubeletRotateCertificates(t *testing.T) {
 	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(Kubernetes, "1.14", "", false, false), 3, 2, false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	k["--rotate-certificates"] = "false"
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--rotate-certificates"] != "false" {
 		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value despite override value %s: %s",
@@ -682,7 +682,7 @@ func TestKubeletRotateCertificates(t *testing.T) {
 func TestKubeletConfigDefaultFeatureGates(t *testing.T) {
 	// test 1.7
 	cs := CreateMockContainerService("testcluster", "1.7.12", 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--feature-gates"] != "" {
 		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
@@ -691,7 +691,7 @@ func TestKubeletConfigDefaultFeatureGates(t *testing.T) {
 
 	// test 1.8
 	cs = CreateMockContainerService("testcluster", "1.8.15", 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--feature-gates"] != "PodPriority=true" {
 		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
@@ -700,7 +700,7 @@ func TestKubeletConfigDefaultFeatureGates(t *testing.T) {
 
 	// test 1.11
 	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(Kubernetes, "1.11", "", false, false), 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--feature-gates"] != "PodPriority=true,RotateKubeletServerCertificate=true" {
 		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
@@ -709,7 +709,7 @@ func TestKubeletConfigDefaultFeatureGates(t *testing.T) {
 
 	// test 1.14
 	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(Kubernetes, "1.14", "", false, false), 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--feature-gates"] != "PodPriority=true,RotateKubeletServerCertificate=true" {
 		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
@@ -720,7 +720,7 @@ func TestKubeletConfigDefaultFeatureGates(t *testing.T) {
 	cs = CreateMockContainerService("testcluster", "1.14.1", 3, 2, false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	k["--feature-gates"] = "DynamicKubeletConfig=true"
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	if k["--feature-gates"] != "DynamicKubeletConfig=true,PodPriority=true,RotateKubeletServerCertificate=true" {
 		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
 			k["--feature-gates"])
@@ -731,7 +731,7 @@ func TestKubeletStrongCipherSuites(t *testing.T) {
 	// Test allowed versions
 	for _, version := range []string{"1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0"} {
 		cs := CreateMockContainerService("testcluster", version, 3, 2, false)
-		cs.setKubeletConfig()
+		cs.setKubeletConfig(false)
 		k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 		if k["--tls-cipher-suites"] != TLSStrongCipherSuitesKubelet {
 			t.Fatalf("got unexpected default value for '--tls-cipher-suites' kubelet config for Kubernetes version %s: %s",
@@ -741,7 +741,7 @@ func TestKubeletStrongCipherSuites(t *testing.T) {
 
 	// Validate that 1.9.0 doesn't include --tls-cipher-suites at all
 	cs := CreateMockContainerService("testcluster", "1.9.0", 3, 2, false)
-	cs.setKubeletConfig()
+	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if _, ok := k["--tls-cipher-suites"]; ok {
 		t.Fatalf("got a value for '--tls-cipher-suites' kubelet config, which is not enabled in versions of Kubernetes prior to 1.10: %s",
@@ -755,7 +755,7 @@ func TestKubeletStrongCipherSuites(t *testing.T) {
 		cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig = map[string]string{
 			"--tls-cipher-suites": allSuites,
 		}
-		cs.setKubeletConfig()
+		cs.setKubeletConfig(false)
 		k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 		if k["--tls-cipher-suites"] != allSuites {
 			t.Fatalf("got unexpected default value for '--tls-cipher-suites' API server config for Kubernetes version %s: %s",
@@ -768,16 +768,17 @@ func TestSupportPodPidsLimitFeatureGate(t *testing.T) {
 	cases := []struct {
 		name                                   string
 		cs                                     *ContainerService
+		isUpgrade                              bool
 		expectedPodMaxPids                     string
 		expectedSupportPodPidsLimitFeatureGate bool
 	}{
 		{
-			name: "pre-1.14 with no --pod-max-pids defined",
+			name: "no --pod-max-pids defined",
 			cs: &ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{
 						OrchestratorType:    Kubernetes,
-						OrchestratorVersion: "1.13.6",
+						OrchestratorVersion: "1.14.0",
 						KubernetesConfig:    &KubernetesConfig{},
 					},
 				},
@@ -786,25 +787,7 @@ func TestSupportPodPidsLimitFeatureGate(t *testing.T) {
 			expectedSupportPodPidsLimitFeatureGate: false,
 		},
 		{
-			name: "pre-1.14 with --pod-max-pids defined",
-			cs: &ContainerService{
-				Properties: &Properties{
-					OrchestratorProfile: &OrchestratorProfile{
-						OrchestratorType:    Kubernetes,
-						OrchestratorVersion: "1.13.6",
-						KubernetesConfig: &KubernetesConfig{
-							KubeletConfig: map[string]string{
-								"--pod-max-pids": "100",
-							},
-						},
-					},
-				},
-			},
-			expectedPodMaxPids:                     "100",
-			expectedSupportPodPidsLimitFeatureGate: false,
-		},
-		{
-			name: "default",
+			name: "--pod-max-pids defined",
 			cs: &ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{
@@ -819,6 +802,192 @@ func TestSupportPodPidsLimitFeatureGate(t *testing.T) {
 				},
 			},
 			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "no --pod-max-pids defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig:    &KubernetesConfig{},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids": "100",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "100",
 			expectedSupportPodPidsLimitFeatureGate: true,
 		},
 	}
@@ -827,7 +996,7 @@ func TestSupportPodPidsLimitFeatureGate(t *testing.T) {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			c.cs.setKubeletConfig()
+			c.cs.setKubeletConfig(c.isUpgrade)
 			podMaxPids := c.cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--pod-max-pids"]
 			if podMaxPids != c.expectedPodMaxPids {
 				t.Fatalf("expected --pod-max-pids be equal to %s, got %s", c.expectedPodMaxPids, podMaxPids)

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -317,7 +317,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		// so it's critical to enforce default addons configuration first
 
 		// Configure kubelet
-		cs.setKubeletConfig()
+		cs.setKubeletConfig(isUpgrade)
 		// Configure controller-manager
 		cs.setControllerManagerConfig()
 		// Configure cloud-controller-manager

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -656,7 +656,7 @@ func TestKubeletFeatureGatesEnsureFeatureGatesOnAgentsFor1_6_0(t *testing.T) {
 	// so they will inherit the top-level config
 	properties.OrchestratorProfile.KubernetesConfig = getKubernetesConfigWithFeatureGates("TopLevel=true")
 
-	mockCS.setKubeletConfig()
+	mockCS.setKubeletConfig(false)
 
 	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
 	if agentFeatureGates != "TopLevel=true" {
@@ -680,7 +680,7 @@ func TestKubeletFeatureGatesEnsureMasterAndAgentConfigUsedFor1_6_0(t *testing.T)
 	properties.MasterProfile = &MasterProfile{KubernetesConfig: getKubernetesConfigWithFeatureGates("MasterLevel=true")}
 	properties.AgentPoolProfiles[0].KubernetesConfig = getKubernetesConfigWithFeatureGates("AgentLevel=true")
 
-	mockCS.setKubeletConfig()
+	mockCS.setKubeletConfig(false)
 
 	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
 	if agentFeatureGates != "AgentLevel=true" {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

When upgrading to 1.14 from older AKS Engine versions, the api model will declare a `--pod-max-pids` kubeletConfig value of 100. Because the required feature flag to actually enforce that setting was disabled by default *until* 1.14, in practice this means that upgraded clusters will suddenly have a reduced PIDs/pods operational configuration, which will likely break many workload scenarios.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1270

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
