### PR TITLE
fix: check for nil masterProfile when setting FD count

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1867,7 +1867,9 @@ func (cs *ContainerService) GetAzureProdFQDN() string {
 // SetPlatformFaultDomainCount sets the fault domain count value for all VMASes in a cluster.
 func (cs *ContainerService) SetPlatformFaultDomainCount(count int) {
 	// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
-	cs.Properties.MasterProfile.PlatformFaultDomainCount = &count
+	if cs.Properties.MasterProfile != nil {
+		cs.Properties.MasterProfile.PlatformFaultDomainCount = &count
+	}
 	for _, pool := range cs.Properties.AgentPoolProfiles {
 		pool.PlatformFaultDomainCount = &count
 	}

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -5099,6 +5099,30 @@ func TestSetPlatformFaultDomainCount(t *testing.T) {
 	}
 }
 
+func TestSetPlatformFaultDomainCountNoMasters(t *testing.T) {
+	// check that the default value is nil
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 1, 3, false)
+	cs.Properties.MasterProfile = nil
+	for _, pool := range cs.Properties.AgentPoolProfiles {
+		if pool.PlatformFaultDomainCount != nil {
+			t.Errorf("expected agent platformFaultDomainCount to be nil, not %v", pool.PlatformFaultDomainCount)
+		}
+	}
+
+	// check that pfdc can be set to legal values
+	for i := 1; i <= 3; i++ {
+		cs.SetPlatformFaultDomainCount(i)
+		if cs.Properties.MasterProfile != nil {
+			t.Error("expected MasterProfile to stay nil")
+		}
+		for _, pool := range cs.Properties.AgentPoolProfiles {
+			if *pool.PlatformFaultDomainCount != i {
+				t.Errorf("expected agent platformFaultDomainCount to be %d, not %v", i, pool.PlatformFaultDomainCount)
+			}
+		}
+	}
+}
+
 func TestAnyAgentUsesAvailabilitySets(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
**Reason for Change**:
Adds a `nil` check to fix upgrading with no masters and a test to prevent regression. Verified that the test panics without the fix.

**Issue Fixed**:

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This bug was found by an AKS unit test when vendoring in the aks-engine v0.37.1 release.