### PR TITLE
fix: ensure calico is properly enabled during upgrade

### DIFF
--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -363,6 +363,17 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 			o.KubernetesConfig.Addons = appendAddonIfNotPresent(o.KubernetesConfig.Addons, pspAddonsConfig)
 		}
 	}
+
+	// Specific back-compat business logic for calico addon
+	// Ensure addon is set to Enabled w/ proper containers config no matter what if NetworkPolicy == calico
+	if o.KubernetesConfig.NetworkPolicy == NetworkPolicyCalico && isUpdate {
+		i := getAddonsIndexByName(o.KubernetesConfig.Addons, CalicoAddonName)
+		j := getAddonsIndexByName(defaultAddons, CalicoAddonName)
+		if i > -1 {
+			o.KubernetesConfig.Addons[i].Enabled = to.BoolPtr(true)
+			o.KubernetesConfig.Addons[i] = assignDefaultAddonVals(o.KubernetesConfig.Addons[i], defaultAddons[j], isUpdate)
+		}
+	}
 }
 
 func appendAddonIfNotPresent(addons []KubernetesAddon, addon KubernetesAddon) []KubernetesAddon {

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -366,13 +366,13 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 
 	// Specific back-compat business logic for calico addon
 	// Ensure addon is set to Enabled w/ proper containers config no matter what if NetworkPolicy == calico
-	if o.KubernetesConfig.NetworkPolicy == NetworkPolicyCalico && isUpdate {
-		i := getAddonsIndexByName(o.KubernetesConfig.Addons, CalicoAddonName)
+	i := getAddonsIndexByName(o.KubernetesConfig.Addons, CalicoAddonName)
+	if isUpdate && o.KubernetesConfig.NetworkPolicy == NetworkPolicyCalico && i > -1 && o.KubernetesConfig.Addons[i].Enabled != to.BoolPtr(true) {
 		j := getAddonsIndexByName(defaultAddons, CalicoAddonName)
-		if i > -1 {
-			o.KubernetesConfig.Addons[i].Enabled = to.BoolPtr(true)
-			o.KubernetesConfig.Addons[i] = assignDefaultAddonVals(o.KubernetesConfig.Addons[i], defaultAddons[j], isUpdate)
-		}
+		// Ensure calico is statically set to enabled
+		o.KubernetesConfig.Addons[i].Enabled = to.BoolPtr(true)
+		// Assume addon configuration was pruned due to an inherited enabled=false, so re-apply default values
+		o.KubernetesConfig.Addons[i] = assignDefaultAddonVals(o.KubernetesConfig.Addons[i], defaultAddons[j], isUpdate)
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

For a very brief period of time we shipped a calico addon with functional configuration, but with a misleading `Enabled` value of `false`. See:

https://github.com/Azure/aks-engine/pull/1089/files#diff-d42c7f77841d06173c357c09c3ccbbf9R269

This PR anticipates this in an update scenario, sets the value of `Enabled` to true if `networkPolicy` == `calico`, and applies the appropriate defaults.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1492

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
