### PR TITLE
chore: Add support for Kubernetes 1.13.7 and 1.14.3 on Azure Stack

### DIFF
--- a/docs/topics/azure-stack.md
+++ b/docs/topics/azure-stack.md
@@ -173,9 +173,9 @@ If you need to expose more than 5 services, then the recommendation is to route 
 
 These are the Kubernetes versions that you can deploy to Azure Stack using AKS Engine:
 
-<!-- - 1.14.3 build and push to mcr -->
-<!-- - 1.13.7 build and push to mcr -->
+- 1.14.3
 - 1.14.1
+- 1.13.7
 - 1.13.5
 - 1.12.8
 - 1.12.7

--- a/docs/topics/azure-stack.md
+++ b/docs/topics/azure-stack.md
@@ -178,7 +178,6 @@ These are the Kubernetes versions that you can deploy to Azure Stack using AKS E
 - 1.13.7
 - 1.13.5
 - 1.12.8
-- 1.12.7
 - 1.11.10
 - 1.11.9
 

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -362,9 +362,11 @@ echo "  - busybox" >> ${RELEASE_NOTES_FILEPATH}
 K8S_VERSIONS="
 1.15.0
 1.14.3
+1.14.3-azs
 1.14.1
 1.14.1-azs
 1.13.7
+1.13.7-azs
 1.13.5
 1.13.5-azs
 1.12.9


### PR DESCRIPTION
**Reason for Change**:
Adding 1.13.7 and 1.14.3 K8s images to be supported on Azure Stack.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1373 

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
