### PR TITLE
feat: Set PlatformFaultDomainCount value as 3 for Azure Stack

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -549,7 +549,7 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool, cloudName 
 			faultDomainCount := 3
 			profile.PlatformFaultDomainCount = &faultDomainCount
 		}
-		
+
 		// Accelerated Networking is supported on most general purpose and compute-optimized instance sizes with 2 or more vCPUs.
 		// These supported series are: D/DSv2 and F/Fs // All the others are not supported
 		// On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs.

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -483,6 +483,12 @@ func (p *Properties) setMasterProfileDefaults(isUpgrade, isScale bool, cloudName
 	if nil == p.MasterProfile.CosmosEtcd {
 		p.MasterProfile.CosmosEtcd = to.BoolPtr(DefaultUseCosmos)
 	}
+
+	// Update fault domain value to 3 for Azure Stack
+	if p.IsAzureStackCloud() && p.MasterProfile.PlatformFaultDomainCount == nil {
+		faultDomainCount := 3
+		p.MasterProfile.PlatformFaultDomainCount = &faultDomainCount
+	}
 }
 
 // setVMSSDefaultsForMasters
@@ -538,6 +544,12 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool, cloudName 
 			profile.OSType = Linux
 		}
 
+		// Update fault domain value to 3 for Azure Stack
+		if p.IsAzureStackCloud() && profile.PlatformFaultDomainCount == nil {
+			faultDomainCount := 3
+			profile.PlatformFaultDomainCount = &faultDomainCount
+		}
+		
 		// Accelerated Networking is supported on most general purpose and compute-optimized instance sizes with 2 or more vCPUs.
 		// These supported series are: D/DSv2 and F/Fs // All the others are not supported
 		// On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs.

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2359,18 +2359,13 @@ func TestSetMasterProfileDefaultsOnAzureStack(t *testing.T) {
 		},
 	)
 
-	_, err = mockCS.SetPropertiesDefaults(false, false)
-	if err != nil {
-		t.Errorf("Failed to test setMasterProfileDefaults with portal url - %s", err)
-	}
-
-	if mockCS.Properties.MasterProfile.PlatformFaultDomainCount != faultDomainCount {
-		t.Fatalf("Master profile did not have the expected default configuration of PlatformFaultDomainCount, got %s, expected %s",
-			mockCS.Properties.MasterProfile.PlatformFaultDomainCount, faultDomainCount)
+	mockCS.SetPropertiesDefaults(false, false)
+	if (*mockCS.Properties.MasterProfile.PlatformFaultDomainCount) != faultDomainCount {
+		t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+			(*mockCS.Properties.MasterProfile.PlatformFaultDomainCount), faultDomainCount)
 	}
 
 	// Check scenario where value is already set.
-	mockCS := getMockBaseContainerService("1.11.6")
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
 		PortalURL: "https://portal.testlocation.contoso.com",
 	}
@@ -2386,14 +2381,11 @@ func TestSetMasterProfileDefaultsOnAzureStack(t *testing.T) {
 			return resp, nil
 		},
 	)
-	_, err = mockCS.SetPropertiesDefaults(false, false)
-	if err != nil {
-		t.Errorf("Failed to test setMasterProfileDefaults with portal url - %s", err)
-	}
 
-	if mockCS.Properties.MasterProfile.PlatformFaultDomainCount != oldFaultDomainCount {
-		t.Fatalf("Master profile did not have the expected default configuration of PlatformFaultDomainCount, got %s, expected %s",
-			mockCS.Properties.MasterProfile.PlatformFaultDomainCount, oldFaultDomainCount)
+	mockCS.SetPropertiesDefaults(false, false)
+	if (*mockCS.Properties.MasterProfile.PlatformFaultDomainCount) != oldFaultDomainCount {
+		t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+			(*mockCS.Properties.MasterProfile.PlatformFaultDomainCount), oldFaultDomainCount)
 	}
 }
 
@@ -2419,24 +2411,22 @@ func TestSetAgentProfileDefaultsOnAzureStack(t *testing.T) {
 		},
 	)
 
-	_, err = mockCS.SetPropertiesDefaults(false, false)
-	if err != nil {
-		t.Errorf("Failed to test setMasterProfileDefaults with portal url - %s", err)
+	mockCS.SetPropertiesDefaults(false, false)
+	for _, pool := range mockCS.Properties.AgentPoolProfiles {
+		if (*pool.PlatformFaultDomainCount) != faultDomainCount {
+			t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+				(*pool.PlatformFaultDomainCount), faultDomainCount)
+		}
 	}
-
-	if mockCS.Properties.AgentPoolProfiles[0].PlatformFaultDomainCount != faultDomainCount {
-		t.Fatalf("Agent profile did not have the expected default configuration of PlatformFaultDomainCount, got %s, expected %s",
-			mockCS.Properties.MasterProfile.PlatformFaultDomainCount, faultDomainCount)
-	}
-
 	// Check scenario where value is already set.
-	mockCS := getMockBaseContainerService("1.11.6")
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
 		PortalURL: "https://portal.testlocation.contoso.com",
 	}
 	mockCS.Properties.MasterProfile.AvailabilityProfile = ""
 	mockCS.Properties.MasterProfile.Count = 1
-	mockCS.Properties.AgentPoolProfiles[0].PlatformFaultDomainCount = &oldFaultDomainCount
+	for _, pool := range mockCS.Properties.AgentPoolProfiles {
+		pool.PlatformFaultDomainCount = &oldFaultDomainCount
+	}
 	mockCS.Location = location
 
 	httpmock.DeactivateAndReset()
@@ -2447,14 +2437,13 @@ func TestSetAgentProfileDefaultsOnAzureStack(t *testing.T) {
 			return resp, nil
 		},
 	)
-	_, err = mockCS.SetPropertiesDefaults(false, false)
-	if err != nil {
-		t.Errorf("Failed to test setMasterProfileDefaults with portal url - %s", err)
-	}
 
-	if mockCS.Properties.AgentPoolProfiles[0].PlatformFaultDomainCount != oldFaultDomainCount {
-		t.Fatalf("Agent profile did not have the expected default configuration of PlatformFaultDomainCount, got %s, expected %s",
-			mockCS.Properties.MasterProfile.PlatformFaultDomainCount, oldFaultDomainCount)
+	mockCS.SetPropertiesDefaults(false, false)
+	for _, pool := range mockCS.Properties.AgentPoolProfiles {
+		if (*pool.PlatformFaultDomainCount) != oldFaultDomainCount {
+			t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+				(*pool.PlatformFaultDomainCount), oldFaultDomainCount)
+		}
 	}
 }
 


### PR DESCRIPTION
**Reason for Change**:
Currently fault domain count value is set using location condition based on the region. 
But in Azure Stack location value is not constant so we can't derive based on that.
Hence we setting PlatformFaultDomainCount value in SetAzureStackCloudSpec

**Issue Fixed**:
Fixes #1528 


**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
