### PR TITLE
fix: --anonymous-auth and --client-ca-file in insecure kubelet config

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -140,13 +140,6 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		o.KubernetesConfig.KubeletConfig[key] = val
 	}
 
-	// Remove secure kubelet flags, if configured
-	if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) {
-		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
-			delete(o.KubernetesConfig.KubeletConfig, key)
-		}
-	}
-
 	if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
 		hasSupportPodPidsLimitFeatureGate := strings.Contains(o.KubernetesConfig.KubeletConfig["--feature-gates"], "SupportPodPidsLimit=true")
 		podMaxPids, _ := strconv.Atoi(o.KubernetesConfig.KubeletConfig["--pod-max-pids"])

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -245,17 +245,20 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
 	cs.setKubeletConfig(false)
 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	if k["--anonymous-auth"] != "false" {
-		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
-			k["--anonymous-auth"])
-	}
-	if k["--authorization-mode"] != "Webhook" {
-		t.Fatalf("got unexpected '--authorization-mode' kubelet config value for EnableSecureKubelet=true: %s",
-			k["--authorization-mode"])
-	}
-	if k["--client-ca-file"] != "/etc/kubernetes/certs/ca.crt" {
-		t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
-			k["--client-ca-file"])
+	ka := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		if kubernetesConfig["--anonymous-auth"] != "false" {
+			t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
+				kubernetesConfig["--anonymous-auth"])
+		}
+		if kubernetesConfig["--authorization-mode"] != "Webhook" {
+			t.Fatalf("got unexpected '--authorization-mode' kubelet config value for EnableSecureKubelet=true: %s",
+				kubernetesConfig["--authorization-mode"])
+		}
+		if kubernetesConfig["--client-ca-file"] != "/etc/kubernetes/certs/ca.crt" {
+			t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
+				kubernetesConfig["--client-ca-file"])
+		}
 	}
 
 	// Test EnableSecureKubelet = false
@@ -263,10 +266,13 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
 	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
-		if _, ok := k[key]; ok {
-			t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
-				key, k[key])
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
+			if _, ok := kubernetesConfig[key]; ok {
+				t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
+					key, kubernetesConfig[key])
+			}
 		}
 	}
 
@@ -274,12 +280,16 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 1, false)
 	p := GetK8sDefaultProperties(true)
 	cs.Properties = p
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
 	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
-		if _, ok := k[key]; ok {
-			t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
-				key, k[key])
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
+			if _, ok := kubernetesConfig[key]; ok {
+				t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
+					key, kubernetesConfig[key])
+			}
 		}
 	}
 
@@ -290,10 +300,13 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
 	cs.setKubeletConfig(false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
-		if _, ok := k[key]; ok {
-			t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
-				key, k[key])
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
+			if _, ok := kubernetesConfig[key]; ok {
+				t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
+					key, kubernetesConfig[key])
+			}
 		}
 	}
 
@@ -303,16 +316,24 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	cs.Properties = p
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
 	cs.setKubeletConfig(false)
-	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	if k["--anonymous-auth"] != "false" {
+	kubernetesConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	kubernetesConfigWindowsAgentPool := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	if kubernetesConfig["--anonymous-auth"] != "false" {
 		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
-			k["--anonymous-auth"])
+			kubernetesConfig["--anonymous-auth"])
 	}
-	if k["--client-ca-file"] != "/etc/kubernetes/certs/ca.crt" {
+	if kubernetesConfig["--client-ca-file"] != "/etc/kubernetes/certs/ca.crt" {
 		t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
-			k["--client-ca-file"])
+			kubernetesConfig["--client-ca-file"])
 	}
-
+	if kubernetesConfigWindowsAgentPool["--anonymous-auth"] != "false" {
+		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
+			kubernetesConfig["--anonymous-auth"])
+	}
+	if kubernetesConfigWindowsAgentPool["--client-ca-file"] != "c:\\k\\ca.crt" {
+		t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
+			kubernetesConfig["--client-ca-file"])
+	}
 }
 
 func TestKubeletMaxPods(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

--anonymous-auth and --client-ca-file kubelet configuration enforcement is not responding to disabled EnableSecureKubelet properly

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: