### PR TITLE
fix: Ensure etcd starts after disk is mounted (#1515)

### DIFF
--- a/parts/k8s/cloud-init/artifacts/etcd.service
+++ b/parts/k8s/cloud-init/artifacts/etcd.service
@@ -4,6 +4,7 @@ Documentation=https://github.com/coreos/etcd
 Documentation=man:etcd
 After=network.target
 Wants=network-online.target
+RequiresMountsFor=/var/lib/etcddisk
 [Service]
 Environment=DAEMON_ARGS=
 Environment=ETCD_NAME=%H

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -11896,6 +11896,7 @@ Documentation=https://github.com/coreos/etcd
 Documentation=man:etcd
 After=network.target
 Wants=network-online.target
+RequiresMountsFor=/var/lib/etcddisk
 [Service]
 Environment=DAEMON_ARGS=
 Environment=ETCD_NAME=%H


### PR DESCRIPTION
There is currenlty no ordering specified that the disk
`/var/lib/etcddisk` is available before etcd starts.

Predominately this is the case but on a hypervisor crash that disk
gets fscked and may not be available until later. Etcd will try for a
little while but will give up eventually leaving the master node
offline :-(

This patch tells systemd to add the ordering commands such that
etcd.service won't start till the disk is mounted.

Fixes #1515 

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
