### PR TITLE
feat: Support kubectl port-forward with k8s 1.15 on Windows nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ test/e2e/kubernetes/translations/
 
 # test outputs
 cmd/_test_output
+test/e2e/kubernetes/kubernetes.test
 
 # packer
 packer/settings.json

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,10 @@ ifneq ($(GIT_BASEDIR),)
 	LDFLAGS += -X github.com/Azure/aks-engine/pkg/test.JUnitOutDir=$(GIT_BASEDIR)/test/junit
 endif
 
-test: generate
+ginkgoBuild: generate
+	ginkgo build test/e2e/kubernetes
+
+test: generate ginkgoBuild
 	ginkgo -skipPackage test/e2e/dcos,test/e2e/kubernetes -failFast -r .
 
 .PHONY: test-style

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -159,7 +159,7 @@ New-InfraContainer {
     # Reference for these tags: curl -L https://mcr.microsoft.com/v2/k8s/core/pause/tags/list
     # Then docker run --rm mplatform/manifest-tool inspect mcr.microsoft.com/k8s/core/pause:<tag>
 
-    $defaultPauseImage = "mcr.microsoft.com/k8s/core/pause:1.1.0"
+    $defaultPauseImage = "mcr.microsoft.com/k8s/core/pause:1.2.0"
 
     switch ($computerInfo.WindowsVersion) {
         "1803" { docker pull $defaultPauseImage ; docker tag $defaultPauseImage $DestinationTag }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19298,7 +19298,7 @@ New-InfraContainer {
     # Reference for these tags: curl -L https://mcr.microsoft.com/v2/k8s/core/pause/tags/list
     # Then docker run --rm mplatform/manifest-tool inspect mcr.microsoft.com/k8s/core/pause:<tag>
 
-    $defaultPauseImage = "mcr.microsoft.com/k8s/core/pause:1.1.0"
+    $defaultPauseImage = "mcr.microsoft.com/k8s/core/pause:1.2.0"
 
     switch ($computerInfo.WindowsVersion) {
         "1803" { docker pull $defaultPauseImage ; docker tag $defaultPauseImage $DestinationTag }

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -4,7 +4,9 @@
 package kubernetes
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -446,6 +448,74 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 			} else {
 				Skip("This config is only available on VHD")
+			}
+		})
+
+		It("should be able to kubectl port-forward to a running pod on each node", func() {
+			deploymentNamespace := "default"
+
+			var deploy *deployment.Deployment
+			var err error
+			var pods []pod.Pod
+
+			testPortForward := func() {
+				pods, err = deploy.Pods()
+				Expect(err).NotTo(HaveOccurred())
+				for _, p := range pods {
+					By("Ensuring that the pod is running")
+					var running bool
+					running, err = p.WaitOnReady(retryTimeWhenWaitingForPodReady, cfg.Timeout)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(running).To(Equal(true))
+					By("Running kubectl port-forward")
+					proxyCmd := exec.Command("k", "port-forward", p.Metadata.Name, "8123:80")
+					var proxyStdout io.ReadCloser
+					proxyStdout, err = proxyCmd.StdoutPipe()
+					util.PrintCommand(proxyCmd)
+					err = proxyCmd.Start()
+					Expect(err).NotTo(HaveOccurred())
+					proxyStdoutReader := bufio.NewReader(proxyStdout)
+					var proxyOutStr string
+					proxyOutStr, err = proxyStdoutReader.ReadString('\n')
+					Expect(err).NotTo(HaveOccurred())
+					log.Printf("kubectl port-forward output: %s\n", proxyOutStr)
+					defer func() {
+						proxyCmd.Process.Signal(os.Interrupt)
+						proxyCmd.Wait()
+					}()
+					By("Running curl to access the forwarded port")
+					url := fmt.Sprintf("http://%s:%v", "localhost", 8123)
+					cmd := exec.Command("curl", "--max-time", "60", url)
+					util.PrintCommand(cmd)
+					var out []byte
+					out, err = cmd.CombinedOutput()
+					log.Printf("%s\n", out)
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+
+			if eng.AnyAgentIsLinux() {
+				By("Creating a Linux nginx deployment")
+				deploy, err = deployment.CreateLinuxDeployDeleteIfExists("fwdlinux", "library/nginx:latest", "fwdlinuxtest", deploymentNamespace, "")
+				Expect(err).NotTo(HaveOccurred())
+				testPortForward()
+				err = deploy.Delete(util.DefaultDeleteRetries)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			if eng.HasWindowsAgents() {
+				By("Creating a Windows IIS deployment")
+				if common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.15.0") {
+					windowsImages, err := eng.GetWindowsTestImages()
+					Expect(err).NotTo(HaveOccurred())
+					deploy, err = deployment.CreateWindowsDeployDeleteIfExist("fwdwindows", windowsImages.IIS, "fwdwindowstest", deploymentNamespace, "")
+					Expect(err).NotTo(HaveOccurred())
+					testPortForward()
+					err = deploy.Delete(util.DefaultDeleteRetries)
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					Skip("kubectl port-forward only works on Windows nodes with Kubernetes 1.15+")
+					// Reference: https://github.com/kubernetes/kubernetes/pull/75479
+				}
 			}
 		})
 
@@ -1383,7 +1453,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				deploymentPrefix := fmt.Sprintf("iis-%s", cfg.Name)
 				deploymentName := fmt.Sprintf("%s-%v", deploymentPrefix, r.Intn(99999))
 				By("Creating a deployment with 1 pod running IIS")
-				iisDeploy, err := deployment.CreateWindowsDeployDeleteIfExist(deploymentPrefix, windowsImages.IIS, deploymentName, "default", 80, -1)
+				iisDeploy, err := deployment.CreateWindowsDeployWithHostportDeleteIfExist(deploymentPrefix, windowsImages.IIS, deploymentName, "default", 80, -1)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Waiting on pod to be Ready")
@@ -1491,7 +1561,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				deploymentPrefix := fmt.Sprintf("iis-dns-%s", cfg.Name)
 				windowsDeploymentName := fmt.Sprintf("%s-%v", deploymentPrefix, r.Intn(99999))
 				By("Creating a deployment running IIS")
-				windowsIISDeployment, err := deployment.CreateWindowsDeployDeleteIfExist(deploymentPrefix, windowsImages.IIS, windowsDeploymentName, "default", 80, -1)
+				windowsIISDeployment, err := deployment.CreateWindowsDeployWithHostportDeleteIfExist(deploymentPrefix, windowsImages.IIS, windowsDeploymentName, "default", 80, -1)
 				Expect(err).NotTo(HaveOccurred())
 
 				deploymentPrefix = fmt.Sprintf("nginx-dns-%s", cfg.Name)


### PR DESCRIPTION
**Reason for Change**:
A new pause image is needed to make `kubectl port-forward` work for Windows pods in 1.15. This won't fix it for <= 1.14.

**Issue Fixed**:
resolves #1461 

cc @jchauncey