### PR TITLE
chore: include https://fqdn:443 for AKS upgrade

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -52,7 +52,7 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 	var kubeAPIServerURL string
 
 	if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
-		kubeAPIServerURL = kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN
+		kubeAPIServerURL = "https://" + kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN + ":443"
 	} else {
 		kubeAPIServerURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
 	}
@@ -122,7 +122,7 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 	kan.logger.Infof("Validating %s", nodeName)
 	var masterURL string
 	if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
-		masterURL = kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN
+		masterURL = "https://" + kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN + ":443"
 	} else {
 		masterURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
 	}

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -52,7 +52,8 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 	var kubeAPIServerURL string
 
 	if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
-		kubeAPIServerURL = "https://" + kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN + ":443"
+		apiServerListeningPort := 443
+		kubeAPIServerURL = fmt.Sprintf("https://%s:%d", kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN, apiServerListeningPort)
 	} else {
 		kubeAPIServerURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
 	}
@@ -122,7 +123,8 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 	kan.logger.Infof("Validating %s", nodeName)
 	var masterURL string
 	if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
-		masterURL = "https://" + kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN + ":443"
+		apiServerListeningPort := 443
+		masterURL = fmt.Sprintf("https://%s:%d", kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN, apiServerListeningPort)
 	} else {
 		masterURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
 	}

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -757,9 +757,14 @@ func (ku *Upgrader) copyCustomNodeProperties(client armhelpers.KubernetesClient,
 }
 
 func (ku *Upgrader) getKubernetesClient(timeout time.Duration) (armhelpers.KubernetesClient, error) {
+	apiserverURL := ku.DataModel.Properties.GetMasterFQDN()
+	if ku.DataModel.Properties.HostedMasterProfile != nil {
+		apiServerListeningPort := 443
+		apiserverURL = fmt.Sprintf("https://%s:%d", apiserverURL, apiServerListeningPort)
+	}
 
 	return ku.Client.GetKubernetesClient(
-		ku.DataModel.Properties.GetMasterFQDN(),
+		apiserverURL,
 		ku.kubeConfig,
 		interval,
 		timeout)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Tests suggest that AKS upgrade implementation is failing after client-go update to v10 because the k8s api client object isn't aware that its apiserver is listening on SSL + TCP 443

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
