### PR TITLE
docs: make build before make clean in release docs

### DIFF
--- a/docs/community/release-checklist.md
+++ b/docs/community/release-checklist.md
@@ -87,7 +87,7 @@ Save the markdown that it prints so it can be pasted into the GitHub release.
 Make sure your repository has no local changes, then build the aks-engine distribution archives:
 
 ```
-$ make build && make info  # check that the git tree state is clean after a build, and that the tag is correct
+$ make generate && make info  # check that the git tree state is clean after a build, and that the tag is correct
 $ make clean dist
 ```
 

--- a/docs/community/release-checklist.md
+++ b/docs/community/release-checklist.md
@@ -87,7 +87,7 @@ Save the markdown that it prints so it can be pasted into the GitHub release.
 Make sure your repository has no local changes, then build the aks-engine distribution archives:
 
 ```
-$ make info  # check that the git tree state is clean and the tag is correct
+$ make build && make info  # check that the git tree state is clean after a build, and that the tag is correct
 $ make clean dist
 ```
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

We should run `make build && make clean` before cutting a release to validate that the release branch we're cutting from has rationalized generated files.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
