### PR TITLE
test: update e2e api model definition

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -47,6 +47,14 @@
                 "memoryLimits": "200Mi"
               }
             ]
+          },
+          {
+            "name": "cluster-autoscaler",
+            "enabled": true
+          },
+          {
+            "name": "aad-pod-identity",
+            "enabled": true
           }
         ]
       }
@@ -62,7 +70,7 @@
     },
     "agentPoolProfiles": [
       {
-        "name": "agentmd",
+        "name": "pool1",
         "count": 3,
         "vmSize": "Standard_D2_v3",
         "OSDiskSizeGB": 200,
@@ -73,19 +81,7 @@
           128,
           128
         ],
-        "availabilityProfile": "AvailabilitySet",
-        "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
-      },
-      {
-        "name": "agentsa",
-        "count": 3,
-        "vmSize": "Standard_D2_v3",
-        "OSDiskSizeGB": 200,
-        "storageProfile": "StorageAccount",
-        "diskSizesGB": [
-          128
-        ],
-        "availabilityProfile": "AvailabilitySet",
+        "availabilityProfile": "VirtualMachineScaleSets",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
       }
     ],

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -8,45 +8,15 @@
         "addons": [
           {
             "name": "tiller",
-            "enabled": true,
-            "config": {
-              "max-history": "10"
-            },
-            "containers": [
-              {
-                "name": "tiller",
-                "cpuRequests": "1",
-                "memoryRequests": "1Gi",
-                "cpuLimits": "1",
-                "memoryLimits": "1Gi"
-              }
-            ]
+            "enabled": true
           },
           {
             "name": "kubernetes-dashboard",
-            "enabled": true,
-            "containers": [
-              {
-                "name": "kubernetes-dashboard",
-                "cpuRequests": "50m",
-                "memoryRequests": "512Mi",
-                "cpuLimits": "50m",
-                "memoryLimits": "512Mi"
-              }
-            ]
+            "enabled": true
           },
           {
             "name": "rescheduler",
-            "enabled": true,
-            "containers": [
-              {
-                "name": "rescheduler",
-                "cpuRequests": "20m",
-                "memoryRequests": "200Mi",
-                "cpuLimits": "20m",
-                "memoryLimits": "200Mi"
-              }
-            ]
+            "enabled": true
           },
           {
             "name": "cluster-autoscaler",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR proposes to update the cluster configuration definition used to validate basic Kubernetes on Azure functionality across k8s versions:

- changes from AvailabilitySet-backed VMs to VirtualMachineScaleSets-backed VMs
- removes the agent pool that tests non-managed disk
- enables cluster-autoscaler addon
  - E2E tests covering this addon to be added later
- enables aad-pod-identity addon
  - E2E tests covering this addon to be added later
- removes the addon configuration overrides for tiller, dashboard, and rescheduler
  - we should be regularly testing the default configuration to validate the configuration that we are delivering to most users, not using this cluster configuration definition to validate user-configurable addon functionality

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
