### PR TITLE
feat: Add defaults for useInstanceMetadata and AcceleratedNetworkingEnabled on Azure Stack

### DIFF
--- a/docs/topics/azure-stack.md
+++ b/docs/topics/azure-stack.md
@@ -81,10 +81,10 @@ Unless otherwise specified down below, standard [cluster definition](../../docs/
 | Name                            | Required | Description                          |
 | ------------------------------- | -------- | ------------------------------------ |
 | addons                          | no       | A few addons are not supported on Azure Stack. See the [complete list](#unsupported-addons) down below.|
-| kubernetesImageBase             | yes      | Specifies the default image base URL to be used for all Kubernetes-related containers such as hyperkube, cloud-controller-manager, pause, addon-manager, etc. This property should be set to `"msazurestackdocker/"`. |
+| kubernetesImageBase             | yes      | Specifies the default image base URL to be used for all Kubernetes-related containers such as hyperkube, cloud-controller-manager, pause, addon-manager, etc. This property should be set to `"mcr.microsoft.com/k8s/azurestack/core"`. |
 | networkPlugin                   | yes      | Specifies the network plugin implementation for the cluster. Valid values are `"kubenet"` for Kubernetes software networking implementation, and `"flannel"` to use CoreOS Flannel. |
 | networkPolicy                   | no       | Network policies can be enforced using [Canal](https://docs.projectcalico.org/v3.7/getting-started/kubernetes/installation/flannel). |
-| useInstanceMetadata             | yes      | Use the Azure cloud provider instance metadata service for appropriate resource discovery operations. This property should be always set to `"false"`. |
+| useInstanceMetadata             | no      | Use the Azure cloud provider instance metadata service for appropriate resource discovery operations. This property should be always set to `"false"`. |
 
 ### customCloudProfile
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -242,6 +242,18 @@ const (
 	DefaultEnableVMSSNodePublicIP = false
 )
 
+// AzureStackCloud Specific Defaults
+const (
+	// DefaultUseInstanceMetadata set to false as Azure Stack today doesn't support instance metadata service
+	DefaultAzureStackUseInstanceMetadata = false
+
+	// DefaultAzureStackAcceleratedNetworking set to false as Azure Stack today doesn't support accelerated networking
+	DefaultAzureStackAcceleratedNetworking = false
+
+	// DefaultAzureStackFaultDomainCount set to 3 as Azure Stack today has minimum 4 node deployment.
+	DefaultAzureStackFaultDomainCount = 3
+)
+
 // WindowsProfile defaults
 const (
 	// DefaultWindowsPublisher sets the default WindowsPublisher value in WindowsProfile

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -627,7 +627,7 @@ func TestK8sVars(t *testing.T) {
 		"subscriptionId":                            "[subscription().subscriptionId]",
 		"tenantId":                                  "[subscription().tenantId]",
 		"truncatedResourceGroup":                    "[take(replace(replace(resourceGroup().name, '(', '-'), ')', '-'), 63)]",
-		"useInstanceMetadata":                       "true",
+		"useInstanceMetadata":                       "false",
 		"useManagedIdentityExtension":               "false",
 		"userAssignedClientID":                      "",
 		"userAssignedID":                            "",


### PR DESCRIPTION
**Reason for Change**:
PR update defaults to false for useInstanceMetadata and AcceleratedNetworkingEnabled on Azure Stack as both Instance service and Accelerated Networking are not supported yet.

**Issue Fixed**:
Fixes #1378 #1380 

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
