### PR TITLE
feat: support CoreOS-like Linux distributions

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -53,7 +53,7 @@ ERR_CIS_ASSIGN_FILE_PERMISSION=112 # Error assigning permission to a file in CIS
 ERR_CIS_COPY_FILE=113 # Error writing a file to disk for CIS enforcement
 ERR_CIS_APPLY_PASSWORD_CONFIG=115 # Error applying CIS-recommended passwd configuration
 
-OS=$(cat /etc/*-release | grep ^ID= | tr -d 'ID="' | awk '{print toupper($0)}')
+OS=$(sort -r /etc/*-release | gawk 'match($0, /^ID(|_LIKE)=(.*)/, a) { print toupper(a[2]); exit }')
 UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"
 COREOS_OS_NAME="COREOS"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -11796,7 +11796,7 @@ ERR_CIS_ASSIGN_FILE_PERMISSION=112 # Error assigning permission to a file in CIS
 ERR_CIS_COPY_FILE=113 # Error writing a file to disk for CIS enforcement
 ERR_CIS_APPLY_PASSWORD_CONFIG=115 # Error applying CIS-recommended passwd configuration
 
-OS=$(cat /etc/*-release | grep ^ID= | tr -d 'ID="' | awk '{print toupper($0)}')
+OS=$(sort -r /etc/*-release | gawk 'match($0, /^ID(|_LIKE)=(.*)/, a) { print toupper(a[2]); exit }')
 UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"
 COREOS_OS_NAME="COREOS"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Distributions like Flatcar Linux sets `ID_LIKE=coreos` in `/etc/os-release` file.

This PR changes the way we set OS variable.

`sort -r` is used to always prefer ID_LIKE over ID, since `gawk` only
prints first line.

`/^ID(|_LIKE)=(.*)/` matches both `ID=` and `ID_LIKE=` and extracts the
value after `=` sign.

`print toupper(a[2]); exit` prints uppercased value and exits, so only
first line is always printed.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Closes #1559 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>