### PR TITLE
fix: old VMSS AKS cluster cannot be upgraded after April 2

### DIFF
--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -688,6 +688,7 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 		}
 
 		if cs.Properties.IsHostedMasterProfile() {
+			aksBillingExtension.Name = to.StringPtr(fmt.Sprintf("[concat(variables('%sVMNamePrefix'), '-AksLinuxBilling')]", profile.Name))
 			if profile.IsWindows() {
 				aksBillingExtension.Type = to.StringPtr("Compute.AKS.Windows.Billing")
 			} else {

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -688,10 +688,11 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 		}
 
 		if cs.Properties.IsHostedMasterProfile() {
-			aksBillingExtension.Name = to.StringPtr(fmt.Sprintf("[concat(variables('%sVMNamePrefix'), '-AksLinuxBilling')]", profile.Name))
 			if profile.IsWindows() {
+				aksBillingExtension.Name = to.StringPtr(fmt.Sprintf("[concat(variables('%sVMNamePrefix'), '-AKSWindowsBilling')]", profile.Name))
 				aksBillingExtension.Type = to.StringPtr("Compute.AKS.Windows.Billing")
 			} else {
+				aksBillingExtension.Name = to.StringPtr(fmt.Sprintf("[concat(variables('%sVMNamePrefix'), '-AKSLinuxBilling')]", profile.Name))
 				aksBillingExtension.Type = to.StringPtr("Compute.AKS.Linux.Billing")
 			}
 		} else {

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -550,7 +550,7 @@ func TestCreateAgentVMSSHostedMasterProfile(t *testing.T) {
 									Settings:                map[string]interface{}{},
 									ProtectedSettings: map[string]interface{}{
 										"commandToExecute": `[concat('retrycmd_if_failure() { r=$1; w=$2; t=$3; shift && shift && shift; for i in $(seq 1 $r); do timeout $t ${@}; [ $? -eq 0  ] && break || if [ $i -eq $r ]; then return 1; else sleep $w; fi; done }; ERR_OUTBOUND_CONN_FAIL=50; retrycmd_if_failure 50 1 3 nc -vz k8s.gcr.io 443 && retrycmd_if_failure 50 1 3 nc -vz gcr.io 443 && retrycmd_if_failure 50 1 3 nc -vz docker.io 443 || exit $ERR_OUTBOUND_CONN_FAIL; for i in $(seq 1 1200); do if [ -f /opt/azure/containers/provision.sh ]; then break; fi; if [ $i -eq 1200 ]; then exit 100; else sleep 1; fi; done; ', variables('provisionScriptParametersCommon'),` + generateUserAssignedIdentityClientIDParameter(userAssignedIDEnabled) + `,' GPU_NODE=false SGX_NODE=false AUDITD_ENABLED=false /usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1"')]`}}}, {
-								Name: to.StringPtr("[concat(variables('agentpool1VMNamePrefix'), '-computeAksLinuxBilling')]"),
+								Name: to.StringPtr("[concat(variables('agentpool1VMNamePrefix'), '-AKSLinuxBilling')]"),
 								VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
 									Publisher:               to.StringPtr("Microsoft.AKS"),
 									Type:                    to.StringPtr("Compute.AKS.Linux.Billing"),
@@ -609,7 +609,7 @@ func TestCreateAgentVMSSHostedMasterProfile(t *testing.T) {
 				},
 			},
 			{
-				Name: to.StringPtr("[concat(variables('agentpool1VMNamePrefix'), '-computeAksLinuxBilling')]"),
+				Name: to.StringPtr("[concat(variables('agentpool1VMNamePrefix'), '-AKSWindowsBilling')]"),
 				VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
 					Publisher:               to.StringPtr("Microsoft.AKS"),
 					Type:                    to.StringPtr("Compute.AKS.Windows.Billing"),


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Old VMSS AKS cluster cannot be upgraded after April 2

AKS-Engine changed AKS billing extension type from Compute.AKS-Engine.Linux.Billing to Compute.AKS.Linux.Billing in this PR (https://github.com/Azure/aks-engine/commit/bc462f1c49d5fc9bd93b9b7910504019853e4db9). The change was vendored into AKS on Apr. 2nd.  So any VMSS cluster created before the change will hit this problem during upgrade. New clusters should be fine.

**Issue Fixed**:
Rename the billing extension to make the ARM deployment happy


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
