### PR TITLE
feat: Add checks for Metadata, AcceleratedNetworking and etcdDiskSizeGB on Azure Stack to fail fast.

### DIFF
--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -134,6 +134,8 @@ const (
 const (
 	// AzureStackCloud is a const string reference identifier for Azure Stack cloud
 	AzureStackCloud = "AzureStackCloud"
+	// MaxAzureStackManagedDiskSize is max etcd disk size supported on AzureStackCloud
+	MaxAzureStackManagedDiskSize = 1023
 )
 
 const (

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -303,12 +303,14 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 						return errors.New("useInstanceMetadata shouldn't be set to true as feature not yet supported on Azure Stack")
 					}
 
-					etcdDiskSizeGB, err := strconv.Atoi(o.KubernetesConfig.EtcdDiskSizeGB)
-					if err != nil {
-						return errors.Errorf("could not convert EtcdDiskSizeGB to int")
-					}
-					if etcdDiskSizeGB > MaxAzureStackManagedDiskSize {
-						return errors.Errorf("EtcdDiskSizeGB max size supported on Azure Stack is %d", MaxAzureStackManagedDiskSize)
+					if o.KubernetesConfig.EtcdDiskSizeGB != "" {
+						etcdDiskSizeGB, err := strconv.Atoi(o.KubernetesConfig.EtcdDiskSizeGB)
+						if err != nil {
+							return errors.Errorf("could not convert EtcdDiskSizeGB to int")
+						}
+						if etcdDiskSizeGB > MaxAzureStackManagedDiskSize {
+							return errors.Errorf("EtcdDiskSizeGB max size supported on Azure Stack is %d", MaxAzureStackManagedDiskSize)
+						}
 					}
 				}
 			}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -296,6 +297,20 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 				if o.KubernetesConfig.MaximumLoadBalancerRuleCount < 0 {
 					return errors.New("maximumLoadBalancerRuleCount shouldn't be less than 0")
 				}
+
+				if a.IsAzureStackCloud() {
+					if to.Bool(o.KubernetesConfig.UseInstanceMetadata) {
+						return errors.New("useInstanceMetadata shouldn't be set to true as feature not yet supported on Azure Stack")
+					}
+
+					etcdDiskSizeGB, err := strconv.Atoi(o.KubernetesConfig.EtcdDiskSizeGB)
+					if err != nil {
+						return errors.Errorf("could not convert EtcdDiskSizeGB to int")
+					}
+					if etcdDiskSizeGB > MaxAzureStackManagedDiskSize {
+						return errors.Errorf("EtcdDiskSizeGB max size supported on Azure Stack is %d", MaxAzureStackManagedDiskSize)
+					}
+				}
 			}
 		default:
 			return errors.Errorf("OrchestratorProfile has unknown orchestrator: %s", o.OrchestratorType)
@@ -428,7 +443,9 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 		}
 
 		if to.Bool(agentPoolProfile.AcceleratedNetworkingEnabled) || to.Bool(agentPoolProfile.AcceleratedNetworkingEnabledWindows) {
-			if e := validatePoolAcceleratedNetworking(agentPoolProfile.VMSize); e != nil {
+			if a.IsAzureStackCloud() {
+				return errors.Errorf("AcceleratedNetworkingEnabled or AcceleratedNetworkingEnabledWindows shouldn't be set to true as feature is not yet supported on Azure Stack")
+			} else if e := validatePoolAcceleratedNetworking(agentPoolProfile.VMSize); e != nil {
 				return e
 			}
 		}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -2941,6 +2941,27 @@ func TestValidateLocation(t *testing.T) {
 			expectedErr: errors.Errorf("EtcdDiskSizeGB max size supported on Azure Stack is %d", MaxAzureStackManagedDiskSize),
 		},
 		{
+			name:          "AzureStack EtcdDiskSizeGB is 1024",
+			location:      "local",
+			propertiesnil: false,
+			cs: &ContainerService{
+				Location: "local",
+				Properties: &Properties{
+					CustomCloudProfile: &CustomCloudProfile{
+						PortalURL: "https://portal.local.cotoso.com",
+					},
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.11.10",
+						KubernetesConfig: &KubernetesConfig{
+							EtcdDiskSizeGB: "1024GB",
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("could not convert EtcdDiskSizeGB to int"),
+		},
+		{
 			name:          "AzureStack AcceleratedNetworking is true",
 			location:      "local",
 			propertiesnil: false,


### PR DESCRIPTION
**Reason for Change**:
On Azure Stack we dont support certain flags and expected to be in certain value or range.
This change add validation so that proper error is returned early and fail fast.


**Issue Fixed**:
Fixes #1563 


**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
