### PR TITLE
feat: default AcceleratedNetworkingEnabledWindows to false if target platform is Azure Stack

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -565,7 +565,12 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool, cloudName 
 		}
 
 		if profile.AcceleratedNetworkingEnabledWindows == nil {
-			profile.AcceleratedNetworkingEnabledWindows = to.BoolPtr(DefaultAcceleratedNetworkingWindowsEnabled && !isUpgrade && !isScale && helpers.AcceleratedNetworkingSupported(profile.VMSize))
+			if p.IsAzureStackCloud() {
+				// Here we are using same default variable. We will change once we will start supporting AcceleratedNetworking feature in general.
+				profile.AcceleratedNetworkingEnabledWindows = to.BoolPtr(DefaultAzureStackAcceleratedNetworking)
+			} else {
+				profile.AcceleratedNetworkingEnabledWindows = to.BoolPtr(DefaultAcceleratedNetworkingWindowsEnabled && !isUpgrade && !isScale && helpers.AcceleratedNetworkingSupported(profile.VMSize))
+			}
 		}
 
 		if profile.VMSSOverProvisioningEnabled == nil {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2446,6 +2446,11 @@ func TestSetAgentProfileDefaultsOnAzureStack(t *testing.T) {
 			t.Fatalf("AcceleratedNetworkingEnabled did not have the expected value, got %t, expected %t",
 				(*pool.AcceleratedNetworkingEnabled), DefaultAzureStackAcceleratedNetworking)
 		}
+
+		if (*pool.AcceleratedNetworkingEnabledWindows) != DefaultAzureStackAcceleratedNetworking {
+			t.Fatalf("AcceleratedNetworkingEnabledWindows did not have the expected value, got %t, expected %t",
+				(*pool.AcceleratedNetworkingEnabledWindows), DefaultAzureStackAcceleratedNetworking)
+		}
 	}
 	// Check scenario where value is already set.
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{


### PR DESCRIPTION
**Reason for Change**:
PR update defaults to false for AcceleratedNetworkingEnabledWindows on Azure Stack as Accelerated Networking are not supported yet on linux or windows.


**Issue Fixed**:
Fixes #1567 


**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
