### PR TITLE
docs: changed accelerated networking example VMs

### DIFF
--- a/examples/kubernetes-config/kubernetes-accelerated-network.json
+++ b/examples/kubernetes-config/kubernetes-accelerated-network.json
@@ -13,7 +13,7 @@
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v3",
+        "vmSize": "Standard_D4_v3",
         "acceleratedNetworkingEnabled": true
       }
     ],


### PR DESCRIPTION
Due to Standard_D2_v3 not being supported with accelerated network due to 2 vCPUs, the example should use standard_D4_v3 instead.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Standard_D2_v3 is not supported with accelerated networking due to 2 vCPUs, changing to D4_v3 on the example makes the example valid. 


**Issue Fixed**:
Fixes #1531 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
