### PR TITLE
revert: Revert "feat: support CoreOS-like Linux distributions (#1560)"

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -53,7 +53,7 @@ ERR_CIS_ASSIGN_FILE_PERMISSION=112 # Error assigning permission to a file in CIS
 ERR_CIS_COPY_FILE=113 # Error writing a file to disk for CIS enforcement
 ERR_CIS_APPLY_PASSWORD_CONFIG=115 # Error applying CIS-recommended passwd configuration
 
-OS=$(sort -r /etc/*-release | gawk 'match($0, /^ID(|_LIKE)=(.*)/, a) { print toupper(a[2]); exit }')
+OS=$(cat /etc/*-release | grep ^ID= | tr -d 'ID="' | awk '{print toupper($0)}')
 UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"
 COREOS_OS_NAME="COREOS"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -11796,7 +11796,7 @@ ERR_CIS_ASSIGN_FILE_PERMISSION=112 # Error assigning permission to a file in CIS
 ERR_CIS_COPY_FILE=113 # Error writing a file to disk for CIS enforcement
 ERR_CIS_APPLY_PASSWORD_CONFIG=115 # Error applying CIS-recommended passwd configuration
 
-OS=$(sort -r /etc/*-release | gawk 'match($0, /^ID(|_LIKE)=(.*)/, a) { print toupper(a[2]); exit }')
+OS=$(cat /etc/*-release | grep ^ID= | tr -d 'ID="' | awk '{print toupper($0)}')
 UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"
 COREOS_OS_NAME="COREOS"


### PR DESCRIPTION
This reverts commit 31e804520e2839b823485ec8975a7a7da8b5722e.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
#1560 broke Ubuntu distro deployments.

Repro steps:

- deploy cluster with `"distro": "ubuntu"`: `{   "apiVersion": "vlabs",   "properties": {     "orchestratorProfile": {       "orchestratorType": "Kubernetes",       "orchestratorRelease": "1.14",   "kubernetesConfig": {         "networkPlugin": "azure", "addons": [           {             "name": "tiller",             "enabled": false           },           {             "name": "aci-connector",             "enabled": false           },           {             "name": "blobfuse-flexvolume",             "enabled": false           },           {             "name": "smb-flexvolume",             "enabled": false           },           {             "name": "keyvault-flexvolume",             "enabled": false           },           {             "name": "kubernetes-dashboard",             "enabled": false           },           {             "name": "azure-cni-networkmonitor",             "enabled": false           }         ]       }     },     "masterProfile": {       "count": 1,       "dnsPrefix": "",       "vmSize": "Standard_D2_v2",       "distro": "ubuntu"     },     "agentPoolProfiles": [       {         "name": "agentpool1",         "count": 2,         "vmSize": "Standard_D2_v2",         "distro": "ubuntu"       }     ],     "linuxProfile": {       "adminUsername": "azureuser",       "ssh": {         "publicKeys": [           {             "keyData": ""           }         ]       }     },     "servicePrincipalProfile": {       "clientId": "",       "secret": ""     }   } }`

The deployment fails with error:

```
Error from deployment for kubernetes-westus2-xxx in resource group kubernetes-westus2-xxx:exit status 1
2019/07/03 17:42:29 Command Output: ERROR: Deployment failed. Correlation ID: xxx. {
  "status": "Failed",
  "error": {
    "code": "ResourceDeploymentFailure",
    "message": "The resource operation completed with terminal provisioning state 'Failed'.",
    "details": [
      {
        "code": "VMExtensionProvisioningError",
        "message": "VM has reported a failure when processing extension 'cse-master-0'. Error message: \"Enable failed: failed to execute command: command terminated with exit status=4\n[stdout]\n\n[stderr]\nConnection to k8s.gcr.io 443 port [tcp/https] succeeded!\nConnection to gcr.io 443 port [tcp/https] succeeded!\nConnection to docker.io 443 port [tcp/https] succeeded!\n\"."
      }
    ]
  }
}
```

Reason for the breakage is that the "ubuntu" distro (Ubuntu 18.04-LTS image from Canonical) has `ID_LIKE` set to `debian`:

```
++ sort -r /etc/lsb-release /etc/os-release VERSION_ID="16.04" VERSION_CODENAME=xenial VERSION="16.04.6 LTS (Xenial Xerus)" UBUNTU_CODENAME=xenial SUPPORT_URL="http://help.ubuntu.com/" PRETTY_NAME="Ubuntu 16.04.6 LTS" NAME="Ubuntu" ID_LIKE=debian ID=ubuntu HOME_URL="http://www.ubuntu.com/" DISTRIB_RELEASE=16.04 DISTRIB_ID=Ubuntu DISTRIB_DESCRIPTION="Ubuntu 16.04.6 LTS" DISTRIB_CODENAME=xenial BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/" +++ gawk 'match($0, /^ID(|_LIKE)=(.*)/, a) { print toupper(a[2]); exit }' +++ sort -r /etc/lsb-release /etc/os-release ++ OS=DEBIAN
```

which results in `OS=DEBIAN` (the code expects `OS=UBUNTU` for the Ubuntu distro).

@invidian FYI

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Related to #1559

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
