### PR TITLE
fix: kubeconfig incorrectly escape characters for azuredeploy.json

### DIFF
--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -365,7 +365,7 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 				if err != nil {
 					panic(err)
 				}
-				masterVars["kubeconfig"] = strings.Replace(kubeConfig,"\n", "", -1)
+				masterVars["kubeconfig"] = kubeConfig
 
 				isJumpboxManagedDisks := kubernetesConfig.PrivateJumpboxProvision() &&
 					kubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile == api.ManagedDisks

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -365,7 +365,7 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 				if err != nil {
 					panic(err)
 				}
-				masterVars["kubeconfig"] = escapeSingleLine(kubeConfig)
+				masterVars["kubeconfig"] = strings.Replace(kubeConfig,"\n", "", -1)
 
 				isJumpboxManagedDisks := kubernetesConfig.PrivateJumpboxProvision() &&
 					kubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile == api.ManagedDisks


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
The kubeconfig generated in azuredeploy.json is incorrectly escaped which makes config invalid in jumpbox when doing `kubectl get pods` for example


**Issue Fixed**:
Fixes #1552 


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
![image](https://user-images.githubusercontent.com/5923107/60680873-f84a4780-9e84-11e9-8f06-afa2c2f780d6.png)
