### PR TITLE
fix: use explicit spec.Selector with apps/v1 api manifests

### DIFF
--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -45,6 +45,10 @@ metadata:
     app: flannel
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: flannel
   template:
     metadata:
       labels:

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -8,6 +8,10 @@ metadata:
   name: kube-proxy
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      component: kube-proxy
+      tier: node
   template:
     metadata:
       labels:

--- a/parts/k8s/containeraddons/1.16/ip-masq-agent.yaml
+++ b/parts/k8s/containeraddons/1.16/ip-masq-agent.yaml
@@ -9,6 +9,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     tier: node
 spec:
+  selector:
+    matchLabels:
+      k8s-app: azure-ip-masq-agent
+      tier: node
   template:
     metadata:
       labels:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -94,6 +94,10 @@ metadata:
   name: nmi
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      component: nmi
+      tier: node
   template:
     metadata:
       labels:
@@ -194,6 +198,9 @@ metadata:
   name: mic
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      component: mic
   template:
     metadata:
       labels:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-aci-connector-deployment.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-aci-connector-deployment.yaml
@@ -73,6 +73,9 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: aci-connector
   template:
     metadata:
       labels:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-calico-daemonset.yaml
@@ -349,6 +349,9 @@ spec:
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
   replicas: 1
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:
@@ -656,6 +659,9 @@ metadata:
     addonmanager.kubernetes.io/mode: "Reconcile"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha-autoscaler
   template:
     metadata:
       labels:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -8,6 +8,9 @@ metadata:
   name: keyvault-flexvolume
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: keyvault-flexvolume
   template:
     metadata:
       labels:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-tiller-deployment.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-tiller-deployment.yaml
@@ -54,6 +54,10 @@ metadata:
   name: tiller-deploy
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: helm
+      name: tiller
   template:
     metadata:
       labels:

--- a/parts/k8s/containeraddons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/containeraddons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -349,6 +349,9 @@ spec:
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
   replicas: 1
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:
@@ -718,7 +721,7 @@ subjects:
   namespace: kube-system
 ---
 
-# Typha Horizontal Autoscaler Role 
+# Typha Horizontal Autoscaler Role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -764,4 +767,3 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -6995,6 +6995,10 @@ metadata:
     app: flannel
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: flannel
   template:
     metadata:
       labels:
@@ -7358,6 +7362,10 @@ metadata:
   name: kube-proxy
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      component: kube-proxy
+      tier: node
   template:
     metadata:
       labels:
@@ -15089,6 +15097,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     tier: node
 spec:
+  selector:
+    matchLabels:
+      k8s-app: azure-ip-masq-agent
+      tier: node
   template:
     metadata:
       labels:
@@ -15264,6 +15276,10 @@ metadata:
   name: nmi
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      component: nmi
+      tier: node
   template:
     metadata:
       labels:
@@ -15364,6 +15380,9 @@ metadata:
   name: mic
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      component: mic
   template:
     metadata:
       labels:
@@ -15484,6 +15503,9 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: aci-connector
   template:
     metadata:
       labels:
@@ -16078,6 +16100,9 @@ spec:
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
   replicas: 1
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:
@@ -16385,6 +16410,9 @@ metadata:
     addonmanager.kubernetes.io/mode: "Reconcile"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha-autoscaler
   template:
     metadata:
       labels:
@@ -16758,6 +16786,9 @@ metadata:
   name: keyvault-flexvolume
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: keyvault-flexvolume
   template:
     metadata:
       labels:
@@ -17652,6 +17683,10 @@ metadata:
   name: tiller-deploy
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: helm
+      name: tiller
   template:
     metadata:
       labels:
@@ -19318,6 +19353,9 @@ spec:
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
   replicas: 1
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:
@@ -19687,7 +19725,7 @@ subjects:
   namespace: kube-system
 ---
 
-# Typha Horizontal Autoscaler Role 
+# Typha Horizontal Autoscaler Role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -19733,7 +19771,6 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-
 `)
 
 func k8sContaineraddonsKubernetesmasteraddonsCalicoDaemonsetYamlBytes() ([]byte, error) {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Adds an explicit `selector:` to Deployment and DaemonSet manifests using apps/v1 (not -beta). This is no longer implicit in Kubernetes 1.16.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1573 


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Most `apps/v1` manifests already had an explicit selector, so this just updates those that didn't.