### PR TITLE
fix: honor master VMAS fault domain count in scale

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1241,7 +1241,7 @@ func (m *MasterProfile) IsVHDDistro() bool {
 
 // IsAvailabilitySets returns true if the customer specified disks
 func (m *MasterProfile) IsAvailabilitySets() bool {
-	return m.AvailabilityProfile == AvailabilitySet
+	return !m.IsVirtualMachineScaleSets()
 }
 
 // IsVirtualMachineScaleSets returns true if the master availability profile is VMSS

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1239,6 +1239,11 @@ func (m *MasterProfile) IsVHDDistro() bool {
 	return m.Distro == AKSUbuntu1604 || m.Distro == AKSUbuntu1804
 }
 
+// IsAvailabilitySets returns true if the customer specified disks
+func (m *MasterProfile) IsAvailabilitySets() bool {
+	return m.AvailabilityProfile == AvailabilitySet
+}
+
 // IsVirtualMachineScaleSets returns true if the master availability profile is VMSS
 func (m *MasterProfile) IsVirtualMachineScaleSets() bool {
 	return m.AvailabilityProfile == VirtualMachineScaleSets

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1169,6 +1169,9 @@ func TestMasterAvailabilityProfile(t *testing.T) {
 			if c.p.MasterProfile.IsVirtualMachineScaleSets() != c.expectedISVMSS {
 				t.Fatalf("expected MasterProfile.IsVirtualMachineScaleSets() to return %t but instead returned %t", c.expectedISVMSS, c.p.MasterProfile.IsVirtualMachineScaleSets())
 			}
+			if c.p.MasterProfile.IsAvailabilitySets() == c.expectedISVMSS {
+				t.Fatalf("expected MasterProfile.IsAvailabilitySets() to return %t but instead returned %t", !c.expectedISVMSS, c.p.MasterProfile.IsAvailabilitySets())
+			}
 		})
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
Fixes the case where `aks-engine scale` ignores the `platformFaultDomainCount` for a VMAS master if the node pools are all VMSS.

**Issue Fixed**:
Fixes #1530
Fixes #1581

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
There is an AKS issue reported that has similar symptoms, but this isn't likely to be the fix for that.
