### PR TITLE
fix: fix restart command in setup-custom-search-domains.sh

### DIFF
--- a/parts/k8s/cloud-init/artifacts/setup-custom-search-domains.sh
+++ b/parts/k8s/cloud-init/artifacts/setup-custom-search-domains.sh
@@ -17,7 +17,7 @@ function updatevariables() {
 }
 
 function createrealmjoinscript() {
-  cat /opt/azure/containers/setup-custom-search-domains.sh | grep 'realm join' > /opt/azure/containers/realmjoin.sh
+  grep 'realm join' /opt/azure/containers/setup-custom-search-domains.sh > /opt/azure/containers/realmjoin.sh
   chmod +x /opt/azure/containers/realmjoin.sh
   bash -x /opt/azure/containers/realmjoin.sh
 }

--- a/parts/k8s/cloud-init/artifacts/setup-custom-search-domains.sh
+++ b/parts/k8s/cloud-init/artifacts/setup-custom-search-domains.sh
@@ -3,8 +3,24 @@ set -x
 source /opt/azure/containers/provision_source.sh
 
 echo "  dns-search <searchDomainName>" | tee -a /etc/network/interfaces.d/50-cloud-init.cfg
-systemctl_restart 20 5 10 restart networking
+systemctl_restart 20 5 10 networking
 wait_for_apt_locks
 retrycmd_if_failure 10 5 120 apt-get -y install realmd sssd sssd-tools samba-common samba samba-common python2.7 samba-libs packagekit
 wait_for_apt_locks
-echo "<searchDomainRealmPassword>" | realm join -U <searchDomainRealmUser>@$(echo "<searchDomainName>" | tr /a-z/ /A-Z/) $(echo "<searchDomainName>" | tr /a-z/ /A-Z/)
+
+function sourcekubeletscript() {
+  source /opt/azure/containers/kubelet.sh
+}
+
+function updatevariables() {
+  echo "<searchDomainRealmPassword>" | realm join -U <searchDomainRealmUser>@$(echo "<searchDomainName>" | tr /a-z/ /A-Z/) $(echo "<searchDomainName>" | tr /a-z/ /A-Z/)
+}
+
+function createrealmjoinscript() {
+  cat /opt/azure/containers/setup-custom-search-domains.sh | grep 'realm join' > /opt/azure/containers/realmjoin.sh
+  chmod +x /opt/azure/containers/realmjoin.sh
+  bash -x /opt/azure/containers/realmjoin.sh
+}
+
+sourcekubeletscript
+createrealmjoinscript

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -14698,7 +14698,7 @@ function updatevariables() {
 }
 
 function createrealmjoinscript() {
-  cat /opt/azure/containers/setup-custom-search-domains.sh | grep 'realm join' > /opt/azure/containers/realmjoin.sh
+  grep 'realm join' /opt/azure/containers/setup-custom-search-domains.sh > /opt/azure/containers/realmjoin.sh
   chmod +x /opt/azure/containers/realmjoin.sh
   bash -x /opt/azure/containers/realmjoin.sh
 }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -14689,22 +14689,22 @@ wait_for_apt_locks
 retrycmd_if_failure 10 5 120 apt-get -y install realmd sssd sssd-tools samba-common samba samba-common python2.7 samba-libs packagekit
 wait_for_apt_locks
 
-function updatevars1() {
+function sourcekubeletscript() {
   source /opt/azure/containers/kubelet.sh
 }
 
-function updatevars2() {
+function updatevariables() {
   echo "<searchDomainRealmPassword>" | realm join -U <searchDomainRealmUser>@$(echo "<searchDomainName>" | tr /a-z/ /A-Z/) $(echo "<searchDomainName>" | tr /a-z/ /A-Z/)
 }
 
-function updatevars3() {
+function createrealmjoinscript() {
   cat /opt/azure/containers/setup-custom-search-domains.sh | grep 'realm join' > /opt/azure/containers/realmjoin.sh
   chmod +x /opt/azure/containers/realmjoin.sh
   bash -x /opt/azure/containers/realmjoin.sh
 }
 
-updatevars1
-updatevars3
+sourcekubeletscript
+createrealmjoinscript
 `)
 
 func k8sCloudInitArtifactsSetupCustomSearchDomainsShBytes() ([]byte, error) {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -14684,11 +14684,27 @@ set -x
 source /opt/azure/containers/provision_source.sh
 
 echo "  dns-search <searchDomainName>" | tee -a /etc/network/interfaces.d/50-cloud-init.cfg
-systemctl_restart 20 5 10 restart networking
+systemctl_restart 20 5 10 networking
 wait_for_apt_locks
 retrycmd_if_failure 10 5 120 apt-get -y install realmd sssd sssd-tools samba-common samba samba-common python2.7 samba-libs packagekit
 wait_for_apt_locks
-echo "<searchDomainRealmPassword>" | realm join -U <searchDomainRealmUser>@$(echo "<searchDomainName>" | tr /a-z/ /A-Z/) $(echo "<searchDomainName>" | tr /a-z/ /A-Z/)
+
+function updatevars1() {
+  source /opt/azure/containers/kubelet.sh
+}
+
+function updatevars2() {
+  echo "<searchDomainRealmPassword>" | realm join -U <searchDomainRealmUser>@$(echo "<searchDomainName>" | tr /a-z/ /A-Z/) $(echo "<searchDomainName>" | tr /a-z/ /A-Z/)
+}
+
+function updatevars3() {
+  cat /opt/azure/containers/setup-custom-search-domains.sh | grep 'realm join' > /opt/azure/containers/realmjoin.sh
+  chmod +x /opt/azure/containers/realmjoin.sh
+  bash -x /opt/azure/containers/realmjoin.sh
+}
+
+updatevars1
+updatevars3
 `)
 
 func k8sCloudInitArtifactsSetupCustomSearchDomainsShBytes() ([]byte, error) {


### PR DESCRIPTION
fix: fix restart command in setup-custom-search-domains.sh
fix: fix sourcing kubelet.sh which is required to update the variables searchDomainRealmPassword, searchDomainRealmUser, and searchDomainName


**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

1- fix restart command in setup-custom-search-domains.sh as referenced in PR https://github.com/Azure/aks-engine/pull/1562

2- realm join command in setup-custom-search-domains.sh requires some variables to be updated searchDomainRealmPassword searchDomainRealmUser searchDomainName, those variables are updated by kubelet.sh script. but kubelet.sh runs after the setup-custom-search-domains.sh, so I sourced kubelet.sh in a function and took out the command to another script realmjoin.sh as we can not update the vaiables during the script execution. this is also discussed in more details in https://github.com/Azure/aks-engine/pull/1562.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes setup-custom-search-domains.sh


