### PR TITLE
fix: add ipv6 nic config for vmss [IPv6DualStack]

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -160,6 +160,8 @@ if [ "$IS_IPV6_DUALSTACK_FEATURE_ENABLED" = "true" ]; then
     wait_for_file 3600 1 $dhcpv6_systemd_service || exit $ERR_FILE_WATCH_TIMEOUT
     wait_for_file 3600 1 $dhcpv6_configuration_script || exit $ERR_FILE_WATCH_TIMEOUT
     ensureDHCPv6
+
+    retrycmd_if_failure 120 5 25 modprobe ip6_tables || exit $ERR_MODPROBE_FAIL
 fi
 
 ensureKubelet

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -104,7 +104,7 @@ func TestGenerateARMResourcesWithVMSSAgentPool(t *testing.T) {
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									Primary:                     to.BoolPtr(true),
 									EnableAcceleratedNetworking: to.BoolPtr(true),
-									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false),
+									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false, false),
 								},
 							},
 						},
@@ -1342,7 +1342,7 @@ func TestGenerateARMResourcesWithVMSSAgentPoolAndSLB(t *testing.T) {
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									Primary:                     to.BoolPtr(true),
 									EnableAcceleratedNetworking: to.BoolPtr(true),
-									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true),
+									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true, false),
 								},
 							},
 						},
@@ -1833,7 +1833,7 @@ func TestGenerateARMResourcesWithVMSSAgentPoolAndSLB(t *testing.T) {
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									Primary:                     to.BoolPtr(true),
 									EnableAcceleratedNetworking: to.BoolPtr(true),
-									IPConfigurations:            getIPConfigs(nil, true),
+									IPConfigurations:            getIPConfigs(nil, true, false),
 								},
 							},
 						},

--- a/pkg/engine/loadbalancers.go
+++ b/pkg/engine/loadbalancers.go
@@ -33,7 +33,7 @@ func CreateClusterLoadBalancerForIPv6() LoadBalancerARM {
 				BackendAddressPools: &[]network.BackendAddressPool{
 					{
 						// cluster name used as backend addr pool name for ipv4 to ensure backward compat
-						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'))]"),
+						Name: to.StringPtr("[parameters('masterEndpointDNSNamePrefix')]"),
 					},
 					{
 						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'), '-ipv6')]"),
@@ -79,7 +79,7 @@ func CreateClusterLoadBalancerForIPv6() LoadBalancerARM {
 								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIpConfigurations', parameters('masterEndpointDNSNamePrefix'), 'LBFE-v4')]"),
 							},
 							BackendAddressPool: &network.SubResource{
-								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), concat(parameters('masterEndpointDNSNamePrefix')))]"),
+								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), parameters('masterEndpointDNSNamePrefix'))]"),
 							},
 							Protocol:     network.TransportProtocolTCP,
 							FrontendPort: to.Int32Ptr(9090),

--- a/pkg/engine/loadbalancers.go
+++ b/pkg/engine/loadbalancers.go
@@ -32,7 +32,8 @@ func CreateClusterLoadBalancerForIPv6() LoadBalancerARM {
 			LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 				BackendAddressPools: &[]network.BackendAddressPool{
 					{
-						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'), '-ipv4')]"),
+						// cluster name used as backend addr pool name for ipv4 to ensure backward compat
+						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'))]"),
 					},
 					{
 						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'), '-ipv6')]"),
@@ -78,7 +79,7 @@ func CreateClusterLoadBalancerForIPv6() LoadBalancerARM {
 								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIpConfigurations', parameters('masterEndpointDNSNamePrefix'), 'LBFE-v4')]"),
 							},
 							BackendAddressPool: &network.SubResource{
-								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), concat(parameters('masterEndpointDNSNamePrefix'), '-ipv4'))]"),
+								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), concat(parameters('masterEndpointDNSNamePrefix')))]"),
 							},
 							Protocol:     network.TransportProtocolTCP,
 							FrontendPort: to.Int32Ptr(9090),

--- a/pkg/engine/loadbalancers_test.go
+++ b/pkg/engine/loadbalancers_test.go
@@ -580,7 +580,7 @@ func TestCreateClusterLoadBalancerForIPv6(t *testing.T) {
 			LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 				BackendAddressPools: &[]network.BackendAddressPool{
 					{
-						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'), '-ipv4')]"),
+						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'))]"),
 					},
 					{
 						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'), '-ipv6')]"),
@@ -626,7 +626,7 @@ func TestCreateClusterLoadBalancerForIPv6(t *testing.T) {
 								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIpConfigurations', parameters('masterEndpointDNSNamePrefix'), 'LBFE-v4')]"),
 							},
 							BackendAddressPool: &network.SubResource{
-								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), concat(parameters('masterEndpointDNSNamePrefix'), '-ipv4'))]"),
+								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), concat(parameters('masterEndpointDNSNamePrefix')))]"),
 							},
 							Protocol:     network.TransportProtocolTCP,
 							FrontendPort: to.Int32Ptr(9090),

--- a/pkg/engine/loadbalancers_test.go
+++ b/pkg/engine/loadbalancers_test.go
@@ -580,7 +580,7 @@ func TestCreateClusterLoadBalancerForIPv6(t *testing.T) {
 			LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 				BackendAddressPools: &[]network.BackendAddressPool{
 					{
-						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'))]"),
+						Name: to.StringPtr("[parameters('masterEndpointDNSNamePrefix')]"),
 					},
 					{
 						Name: to.StringPtr("[concat(parameters('masterEndpointDNSNamePrefix'), '-ipv6')]"),
@@ -626,7 +626,7 @@ func TestCreateClusterLoadBalancerForIPv6(t *testing.T) {
 								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIpConfigurations', parameters('masterEndpointDNSNamePrefix'), 'LBFE-v4')]"),
 							},
 							BackendAddressPool: &network.SubResource{
-								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), concat(parameters('masterEndpointDNSNamePrefix')))]"),
+								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('masterEndpointDNSNamePrefix'), parameters('masterEndpointDNSNamePrefix'))]"),
 							},
 							Protocol:     network.TransportProtocolTCP,
 							FrontendPort: to.Int32Ptr(9090),

--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -380,7 +380,7 @@ func createAgentVMASNetworkInterface(cs *api.ContainerService, profile *api.Agen
 				backendPools = *ipConfig.LoadBalancerBackendAddressPools
 			}
 			backendPools = append(backendPools, network.BackendAddressPool{
-				ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'), '-ipv4')]"),
+				ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
 			})
 			ipConfig.LoadBalancerBackendAddressPools = &backendPools
 		}

--- a/pkg/engine/networkinterfaces_test.go
+++ b/pkg/engine/networkinterfaces_test.go
@@ -1042,7 +1042,7 @@ func TestCreateAgentVMASNICWithIPv6DualStackFeature(t *testing.T) {
 						ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers', variables('routerLBName')), '/backendAddressPools/backend')]"),
 					},
 					{
-						ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'), '-ipv4')]"),
+						ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
 					},
 				},
 				PrivateIPAllocationMethod: network.Dynamic,

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13776,6 +13776,8 @@ if [ "$IS_IPV6_DUALSTACK_FEATURE_ENABLED" = "true" ]; then
     wait_for_file 3600 1 $dhcpv6_systemd_service || exit $ERR_FILE_WATCH_TIMEOUT
     wait_for_file 3600 1 $dhcpv6_configuration_script || exit $ERR_FILE_WATCH_TIMEOUT
     ensureDHCPv6
+
+    retrycmd_if_failure 120 5 25 modprobe ip6_tables || exit $ERR_MODPROBE_FAIL
 fi
 
 ensureKubelet

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -494,11 +494,11 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 					ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
 				}
 				backendPools := make([]compute.SubResource, 0)
-				if ipconfig.LoadBalancerBackendAddressPools != nil {
-					backendPools = *ipconfig.LoadBalancerBackendAddressPools
+				if ipConfigProps.LoadBalancerBackendAddressPools != nil {
+					backendPools = *ipConfigProps.LoadBalancerBackendAddressPools
 				}
 				backendPools = append(backendPools, defaultIPv4BackendPool)
-				ipconfig.LoadBalancerBackendAddressPools = &backendPools
+				ipConfigProps.LoadBalancerBackendAddressPools = &backendPools
 			}
 
 			// Set VMSS node public IP if requested

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -491,7 +491,7 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 			ipConfigProps.LoadBalancerBackendAddressPools = &backendAddressPools
 			if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
 				defaultIPv4BackendPool := compute.SubResource{
-					to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
+					ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
 				}
 				backendPools := make([]compute.SubResource, 0)
 				if ipconfig.LoadBalancerBackendAddressPools != nil {

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -522,6 +522,30 @@ func TestCreateAgentVMSS(t *testing.T) {
 	if diff != "" {
 		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
 	}
+
+	// Test with ipv6 dual stack enabled
+	cs.Properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	cs.Properties.AgentPoolProfiles[0].OSType = "Linux"
+	actual = CreateAgentVMSS(cs, cs.Properties.AgentPoolProfiles[0])
+
+	expected.VirtualMachineProfile.NetworkProfile = &compute.VirtualMachineScaleSetNetworkProfile{
+		NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
+			{
+				Name: to.StringPtr("[variables('agentpool1VMNamePrefix')]"),
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					Primary:                     to.BoolPtr(true),
+					EnableAcceleratedNetworking: to.BoolPtr(true),
+					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true),
+				},
+			},
+		},
+	}
+
+	diff = cmp.Diff(actual.VirtualMachineProfile.NetworkProfile, expected.VirtualMachineProfile.NetworkProfile)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
 }
 
 func TestCreateAgentVMSSHostedMasterProfile(t *testing.T) {
@@ -745,7 +769,7 @@ func getIPConfigsMaster() *[]compute.VirtualMachineScaleSetIPConfiguration {
 
 // getIPConfigs returns a list of VirtualMachineScaleSetIPConfiguration resources
 // first ipconfig is primary with a list of references to LoadBalancerBackendAddressPools
-func getIPConfigs(lbBackendAddresPoolID *string, isStandardLB bool) *[]compute.VirtualMachineScaleSetIPConfiguration {
+func getIPConfigs(lbBackendAddresPoolID *string, isStandardLB, ipv6DualStackEnabled bool) *[]compute.VirtualMachineScaleSetIPConfiguration {
 	var ipConfigs []compute.VirtualMachineScaleSetIPConfiguration
 	for i := 1; i <= 31; i++ {
 		ipconfig := compute.VirtualMachineScaleSetIPConfiguration{
@@ -781,8 +805,42 @@ func getIPConfigs(lbBackendAddresPoolID *string, isStandardLB bool) *[]compute.V
 				}
 			}
 			ipconfig.LoadBalancerBackendAddressPools = &backendAddressPools
+			if ipv6DualStackEnabled {
+				defaultIPv4BackendPool := compute.SubResource{
+					to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
+				}
+				if ipconfig.LoadBalancerBackendAddressPools != nil {
+					backendPools := *ipconfig.LoadBalancerBackendAddressPools
+					backendPools = append(backendPools, defaultIPv4BackendPool)
+					ipconfig.LoadBalancerBackendAddressPools = &backendPools
+				} else {
+					ipconfig.LoadBalancerBackendAddressPools = &[]compute.SubResource{defaultIPv4BackendPool}
+				}
+			}
 		}
 		ipConfigs = append(ipConfigs, ipconfig)
+
+		if ipv6DualStackEnabled {
+			ipconfigv6 := compute.VirtualMachineScaleSetIPConfiguration{
+				Name: to.StringPtr(fmt.Sprintf("ipconfig%dv6", i)),
+				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+					Subnet: &compute.APIEntityReference{
+						ID: to.StringPtr(fmt.Sprintf("[variables('agentpool1VnetSubnetID')]")),
+					},
+					Primary:                 to.BoolPtr(false),
+					PrivateIPAddressVersion: "IPv6",
+				},
+			}
+			if i == 1 {
+				backendPools := make([]compute.SubResource, 0)
+				defaultIPv6BackendPool := compute.SubResource{
+					ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'), '-ipv6')]"),
+				}
+				backendPools = append(backendPools, defaultIPv6BackendPool)
+				ipconfigv6.LoadBalancerBackendAddressPools = &backendPools
+			}
+			ipConfigs = append(ipConfigs, ipconfigv6)
+		}
 	}
 	return &ipConfigs
 }

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -346,7 +346,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									Primary:                     to.BoolPtr(true),
 									EnableAcceleratedNetworking: to.BoolPtr(true),
-									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false),
+									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false, false),
 								},
 							},
 						},
@@ -396,7 +396,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					Primary:                     to.BoolPtr(true),
 					EnableAcceleratedNetworking: to.BoolPtr(true),
-					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true),
+					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true, false),
 				},
 			},
 		},
@@ -426,7 +426,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					Primary:                     to.BoolPtr(true),
 					EnableAcceleratedNetworking: to.BoolPtr(true),
-					IPConfigurations:            getIPConfigs(nil, true),
+					IPConfigurations:            getIPConfigs(nil, true, false),
 				},
 			},
 		},
@@ -464,7 +464,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					Primary:                     to.BoolPtr(true),
 					EnableAcceleratedNetworking: to.BoolPtr(true),
-					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false),
+					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false, false),
 				},
 			},
 		},
@@ -535,7 +535,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					Primary:                     to.BoolPtr(true),
 					EnableAcceleratedNetworking: to.BoolPtr(true),
-					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true),
+					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true, true),
 				},
 			},
 		},
@@ -632,7 +632,7 @@ func TestCreateAgentVMSSHostedMasterProfile(t *testing.T) {
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									Primary:                     to.BoolPtr(true),
 									EnableAcceleratedNetworking: to.BoolPtr(true),
-									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false),
+									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false, false),
 								},
 							},
 						},
@@ -1069,7 +1069,7 @@ func TestCreateCustomOSVMSS(t *testing.T) {
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									Primary:                     to.BoolPtr(true),
 									EnableAcceleratedNetworking: to.BoolPtr(true),
-									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false),
+									IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false, false),
 								},
 							},
 						},

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -807,7 +807,7 @@ func getIPConfigs(lbBackendAddresPoolID *string, isStandardLB, ipv6DualStackEnab
 			ipconfig.LoadBalancerBackendAddressPools = &backendAddressPools
 			if ipv6DualStackEnabled {
 				defaultIPv4BackendPool := compute.SubResource{
-					to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
+					ID: to.StringPtr("[concat(resourceId('Microsoft.Network/loadBalancers',parameters('masterEndpointDNSNamePrefix')), '/backendAddressPools/', parameters('masterEndpointDNSNamePrefix'))]"),
 				}
 				if ipconfig.LoadBalancerBackendAddressPools != nil {
 					backendPools := *ipconfig.LoadBalancerBackendAddressPools


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
- Add ipv6 nic config to vmss for dualstack support
- Rename default ipv4 default backend pool name to match cluster name to support backward compat
- Add `ip6_tables` module

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
