### PR TITLE
test: replace “vanilla” E2E cluster test with non-VHD cluster test

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -69,8 +69,8 @@ jobs:
 
 - template: e2e-job-template.yaml
   parameters:
-    name: 'default_linux_e2e'
-    apimodel: 'examples/kubernetes.json'
+    name: 'k8s_non_vhd_deployment'
+    apimodel: 'examples/kubernetes-ubuntu-distro.json'
 
 - template: e2e-job-template.yaml
   parameters:

--- a/examples/kubernetes-ubuntu-distro.json
+++ b/examples/kubernetes-ubuntu-distro.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3",
+      "distro": "ubuntu"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 2,
+        "vmSize": "Standard_D2_v3",
+        "distro": "ubuntu"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Expand the functional test area of the "default" k8s cluster E2E job to include a non-VHD implementation. This will give advance notice of environmental flakiness that VHD-backed cluster configurations can protect against, in order to more effectively maintain our CustomScriptExtension (and other cluster bootstrapping areas) implementations.

The downside to this change are the following:

- slightly longer test runs for this job (depends upon network I/O to retrieve cluster components needed during bootstrapping)
- slightly higher false positives (environmental network I/O flakiness)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
