### PR TITLE
fix: only include OrchestratorProfile validation during data marshalling for create

### DIFF
--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -608,8 +608,10 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 		setVlabsKubernetesDefaults(vp, api)
 
 		// TODO (hack): this validation should be done as part of the main validation, but deploy does it only after loading the container.
-		if err := vp.ValidateOrchestratorProfile(isUpdate); err != nil {
-			return err
+		if !isUpdate {
+			if err := vp.ValidateOrchestratorProfile(isUpdate); err != nil {
+				return err
+			}
 		}
 
 		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -290,7 +290,7 @@ func ParseInput(path string) (*api.VlabsARMContainerService, error) {
 }
 
 // ParseOutput takes the generated api model and will parse that into a api.ContainerService
-func ParseOutput(path string, validate bool) (*api.ContainerService, error) {
+func ParseOutput(path string, validate, isUpdate bool) (*api.ContainerService, error) {
 	locale, err := i18n.LoadTranslations()
 	if err != nil {
 		return nil, errors.Errorf(fmt.Sprintf("error loading translation files: %s", err.Error()))
@@ -300,7 +300,7 @@ func ParseOutput(path string, validate bool) (*api.ContainerService, error) {
 			Locale: locale,
 		},
 	}
-	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, validate, false, nil)
+	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, validate, isUpdate, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -290,8 +290,7 @@ func ParseInput(path string) (*api.VlabsARMContainerService, error) {
 }
 
 // ParseOutput takes the generated api model and will parse that into a api.ContainerService
-func ParseOutput(engCfg *Config, isUpdate bool) (*api.ContainerService, error) {
-	path := engCfg.GeneratedDefinitionPath + "/apimodel.json"
+func ParseOutput(path string) (*api.ContainerService, error) {
 	locale, err := i18n.LoadTranslations()
 	if err != nil {
 		return nil, errors.Errorf(fmt.Sprintf("error loading translation files: %s", err.Error()))
@@ -301,7 +300,7 @@ func ParseOutput(engCfg *Config, isUpdate bool) (*api.ContainerService, error) {
 			Locale: locale,
 		},
 	}
-	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, true, isUpdate, nil)
+	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, true, false, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -290,7 +290,8 @@ func ParseInput(path string) (*api.VlabsARMContainerService, error) {
 }
 
 // ParseOutput takes the generated api model and will parse that into a api.ContainerService
-func ParseOutput(path string) (*api.ContainerService, error) {
+func ParseOutput(engCfg *Config, isUpdate bool) (*api.ContainerService, error) {
+	path := engCfg.GeneratedDefinitionPath + "/apimodel.json"
 	locale, err := i18n.LoadTranslations()
 	if err != nil {
 		return nil, errors.Errorf(fmt.Sprintf("error loading translation files: %s", err.Error()))
@@ -300,7 +301,7 @@ func ParseOutput(path string) (*api.ContainerService, error) {
 			Locale: locale,
 		},
 	}
-	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, true, false, nil)
+	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, true, isUpdate, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -290,7 +290,7 @@ func ParseInput(path string) (*api.VlabsARMContainerService, error) {
 }
 
 // ParseOutput takes the generated api model and will parse that into a api.ContainerService
-func ParseOutput(path string) (*api.ContainerService, error) {
+func ParseOutput(path string, validate bool) (*api.ContainerService, error) {
 	locale, err := i18n.LoadTranslations()
 	if err != nil {
 		return nil, errors.Errorf(fmt.Sprintf("error loading translation files: %s", err.Error()))
@@ -300,7 +300,7 @@ func ParseOutput(path string) (*api.ContainerService, error) {
 			Locale: locale,
 		},
 	}
-	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, true, false, nil)
+	containerService, _, err := apiloader.LoadContainerServiceFromFile(path, validate, false, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -74,8 +74,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	csInput, err := engine.ParseInput(engCfg.ClusterDefinitionTemplate)
 	Expect(err).NotTo(HaveOccurred())
+	var isUpdate bool
+	if cfg.Name != "" {
+		isUpdate = true
+	}
 	validate := false
-	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath+"/apimodel.json", validate)
+	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath+"/apimodel.json", validate, isUpdate)
 	Expect(err).NotTo(HaveOccurred())
 	eng = engine.Engine{
 		Config:             engCfg,

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -5,10 +5,8 @@ package kubernetes
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -23,7 +21,6 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
-	"github.com/Azure/aks-engine/pkg/api/vlabs"
 	"github.com/Azure/aks-engine/test/e2e/config"
 	"github.com/Azure/aks-engine/test/e2e/engine"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/deployment"
@@ -77,20 +74,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	csInput, err := engine.ParseInput(engCfg.ClusterDefinitionTemplate)
 	Expect(err).NotTo(HaveOccurred())
-	var csGenerated *api.ContainerService
-	if cfg.Name != "" {
-		contents, err := ioutil.ReadFile(engCfg.GeneratedDefinitionPath + "/apimodel.json")
-		Expect(err).NotTo(HaveOccurred())
-		cs := &vlabs.ContainerService{}
-		err = json.Unmarshal(contents, &cs)
-		Expect(err).NotTo(HaveOccurred())
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = ""
-		csGenerated, err = api.ConvertVLabsContainerService(cs, false)
-		Expect(err).NotTo(HaveOccurred())
-	} else {
-		csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath + "/apimodel.json")
-		Expect(err).NotTo(HaveOccurred())
-	}
+	validate := false
+	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath+"/apimodel.json", validate)
+	Expect(err).NotTo(HaveOccurred())
 	eng = engine.Engine{
 		Config:             engCfg,
 		ClusterDefinition:  csInput,

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -74,7 +74,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	csInput, err := engine.ParseInput(engCfg.ClusterDefinitionTemplate)
 	Expect(err).NotTo(HaveOccurred())
-	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath + "/apimodel.json")
+	var isUpdate bool
+	if cfg.Name != "" {
+		isUpdate = true
+	}
+	csGenerated, err := engine.ParseOutput(engCfg, isUpdate)
 	Expect(err).NotTo(HaveOccurred())
 	eng = engine.Engine{
 		Config:             engCfg,

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -74,10 +74,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	csInput, err := engine.ParseInput(engCfg.ClusterDefinitionTemplate)
 	Expect(err).NotTo(HaveOccurred())
-	var isUpdate bool
-	if cfg.Name != "" {
-		isUpdate = true
-	}
+	isUpdate := cfg.Name != ""
 	validate := false
 	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath+"/apimodel.json", validate, isUpdate)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -5,8 +5,10 @@ package kubernetes
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -21,6 +23,7 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/aks-engine/pkg/api/vlabs"
 	"github.com/Azure/aks-engine/test/e2e/config"
 	"github.com/Azure/aks-engine/test/e2e/engine"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/deployment"
@@ -74,12 +77,20 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	csInput, err := engine.ParseInput(engCfg.ClusterDefinitionTemplate)
 	Expect(err).NotTo(HaveOccurred())
-	var isUpdate bool
+	var csGenerated *api.ContainerService
 	if cfg.Name != "" {
-		isUpdate = true
+		contents, err := ioutil.ReadFile(engCfg.GeneratedDefinitionPath + "/apimodel.json")
+		Expect(err).NotTo(HaveOccurred())
+		cs := &vlabs.ContainerService{}
+		err = json.Unmarshal(contents, &cs)
+		Expect(err).NotTo(HaveOccurred())
+		cs.Properties.OrchestratorProfile.OrchestratorVersion = ""
+		csGenerated, err = api.ConvertVLabsContainerService(cs, false)
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath + "/apimodel.json")
+		Expect(err).NotTo(HaveOccurred())
 	}
-	csGenerated, err := engine.ParseOutput(engCfg, isUpdate)
-	Expect(err).NotTo(HaveOccurred())
 	eng = engine.Engine{
 		Config:             engCfg,
 		ClusterDefinition:  csInput,

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -261,7 +261,8 @@ func (cli *CLIProvisioner) generateAndDeploy() error {
 	if err != nil {
 		return errors.Wrap(err, "unable to parse config")
 	}
-	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath + "/apimodel.json")
+	validate := true
+	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath+"/apimodel.json", validate)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse output")
 	}

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -261,8 +261,7 @@ func (cli *CLIProvisioner) generateAndDeploy() error {
 	if err != nil {
 		return errors.Wrap(err, "unable to parse config")
 	}
-	isUpdate := false
-	csGenerated, err := engine.ParseOutput(engCfg, isUpdate)
+	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath + "/apimodel.json")
 	if err != nil {
 		return errors.Wrap(err, "unable to parse output")
 	}

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -261,7 +261,8 @@ func (cli *CLIProvisioner) generateAndDeploy() error {
 	if err != nil {
 		return errors.Wrap(err, "unable to parse config")
 	}
-	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath + "/apimodel.json")
+	isUpdate := false
+	csGenerated, err := engine.ParseOutput(engCfg, isUpdate)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse output")
 	}

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -262,7 +262,8 @@ func (cli *CLIProvisioner) generateAndDeploy() error {
 		return errors.Wrap(err, "unable to parse config")
 	}
 	validate := true
-	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath+"/apimodel.json", validate)
+	isUpdate := false
+	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath+"/apimodel.json", validate, isUpdate)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse output")
 	}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Based on pre-existing architectural debt, we are validating the `OrchestratorProfile` input data during the data marshalling flow, in particular in order to validate OrchestratorVersion for aks-engine deploy operations. See: #355

This PR modifies that vlabs hack a bit so that we only do this during create operations. The specific scenario that this fixes is scaling a pre-existing cluster with a pre-existing apimodel.json that was generated using an older version of aks-engine with a different (breaking) versions support matrix.

Also fixed up the E2E implementation a bit so when we marshall this data during an E2E run, we pass in the appropriate "update" context to skip validation, so that we can do back-compat style tests more easily (e.g., create from old branch, switch to new branch, scale in/out, re-run E2E).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
