### PR TITLE
feat: add support for Kubernetes 1.15.1 on Azure Stack

### DIFF
--- a/docs/topics/azure-stack.md
+++ b/docs/topics/azure-stack.md
@@ -173,6 +173,7 @@ If you need to expose more than 5 services, then the recommendation is to route 
 
 These are the Kubernetes versions that you can deploy to Azure Stack using AKS Engine:
 
+- 1.15.1
 - 1.14.4
 - 1.14.3
 - 1.13.8

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -365,6 +365,7 @@ echo "  - busybox" >> ${RELEASE_NOTES_FILEPATH}
 # TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
 K8S_VERSIONS="
 1.15.1
+1.15.1-azs
 1.15.0
 1.14.4
 1.14.4-azs


### PR DESCRIPTION
**Reason for Change**:
See
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#downloads-for-v1151


**Issue Fixed**:
Fixes #1647 

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
1.15 Azure Stack version CNCF certification is approved.