### PR TITLE
fix: distinct component update messages for upgrade/scale

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -152,7 +152,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 					if isUpgrade {
 						log.Warnf("Moby will be upgraded to version %s\n", DefaultMobyVersion)
 					} else if isScale {
-						log.Warnf("Any new scaled up nodes will have Moby version %s\n", DefaultMobyVersion)
+						log.Warnf("Any new nodes will have Moby version %s\n", DefaultMobyVersion)
 					}
 				}
 				o.KubernetesConfig.MobyVersion = DefaultMobyVersion
@@ -163,7 +163,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 					if isUpgrade {
 						log.Warnf("containerd will be upgraded to version %s\n", DefaultContainerdVersion)
 					} else if isScale {
-						log.Warnf("Any new scaled up nodes will have containerd version %s\n", DefaultContainerdVersion)
+						log.Warnf("Any new nodes will have containerd version %s\n", DefaultContainerdVersion)
 					}
 				}
 				o.KubernetesConfig.ContainerdVersion = DefaultContainerdVersion

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -148,15 +148,23 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		switch o.KubernetesConfig.ContainerRuntime {
 		case Docker:
 			if o.KubernetesConfig.MobyVersion == "" || isUpdate {
-				if isUpdate && o.KubernetesConfig.MobyVersion != DefaultMobyVersion {
-					log.Warnf("Moby will be upgraded to version %s\n", DefaultMobyVersion)
+				if o.KubernetesConfig.MobyVersion != DefaultMobyVersion {
+					if isUpgrade {
+						log.Warnf("Moby will be upgraded to version %s\n", DefaultMobyVersion)
+					} else if isScale {
+						log.Warnf("Any new scaled up nodes will have Moby version %s\n", DefaultMobyVersion)
+					}
 				}
 				o.KubernetesConfig.MobyVersion = DefaultMobyVersion
 			}
 		case Containerd, KataContainers:
 			if o.KubernetesConfig.ContainerdVersion == "" || isUpdate {
-				if isUpdate && o.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
-					log.Warnf("containerd will be upgraded to version %s\n", DefaultContainerdVersion)
+				if o.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
+					if isUpgrade {
+						log.Warnf("containerd will be upgraded to version %s\n", DefaultContainerdVersion)
+					} else if isScale {
+						log.Warnf("Any new scaled up nodes will have containerd version %s\n", DefaultContainerdVersion)
+					}
 				}
 				o.KubernetesConfig.ContainerdVersion = DefaultContainerdVersion
 			}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Currently we erroneously state that we're upgrading certain components (e.g., moby) during a scale operation if we're using a newer version of the `aks-engine` binary, or if the user has manually updated the generated apimodel.json to a newer component version:

```
aks-engine scale --subscription-id <sub_id> ----api-model _output/kubernetes-uksouth-52692/apimodel.json --location uksouth --resource-group kubernetes-uksouth-52692 --master-FQDN kubernetes-uksouth-52692.uksouth.cloudapp.azure.com --node-pool agent1 --new-node-count 1 --auth-method client_secret --client-id **** --client-secret ****
INFO[0000] validating...                                
INFO[0006] Name suffix: 20965292                        
WARN[0006] Moby will be upgraded to version 3.0.6       
... 
```

This PR improves the clarity of the messaging:

```
aks-engine scale --subscription-id <sub_id> ----api-model _output/kubernetes-uksouth-52692/apimodel.json --location uksouth --resource-group kubernetes-uksouth-52692 --master-FQDN kubernetes-uksouth-52692.uksouth.cloudapp.azure.com --node-pool agent1 --new-node-count 1 --auth-method client_secret --client-id **** --client-secret ****
INFO[0000] validating...                                
INFO[0006] Name suffix: 20965292                        
WARN[0006] Any new scaled up nodes will have Moby version 3.0.6       
...
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
