### PR TITLE
test: don't check for kubernetes.azure.com/role label

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -555,7 +555,6 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					role = "master"
 				}
 				labels := node.Metadata.Labels
-				Expect(labels).To(HaveKeyWithValue("kubernetes.azure.com/role", role))
 				// See https://github.com/Azure/aks-engine/issues/1660
 				if node.IsWindows() && common.IsKubernetesVersionGe(
 					eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.16.0-alpha.1") {


### PR DESCRIPTION
**Reason for Change**:
Skips testing for the presence of the `kubernetes.azure.com/role` label on all nodes.

After committing #1626 the AKS Engine soak tests on Jenkins began to fail because the `kubernetes.azure.com/role` label was absent. This occurs because a cluster was created before the change that introduced that label, but is being tested with master code.

This new label can be considered an implementation detail really, since its only use is to know that the `kubernetes.io/role` and `node-role.kubernetes.io` labels need to be applied. So it should be safe to omit it from this e2e test spec.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
