### PR TITLE
chore: use HAS_GOLANGCI value if defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ test-e2e:
 HAS_DEP := $(shell $(CHECK) dep)
 HAS_GOX := $(shell $(CHECK) gox)
 HAS_GIT := $(shell $(CHECK) git)
-HAS_GOLANGCI := $(shell $(CHECK) golangci-lint)
+HAS_GOLANGCI ?= $(shell $(CHECK) golangci-lint)
 HAS_GINKGO := $(shell $(CHECK) ginkgo)
 
 .PHONY: bootstrap


### PR DESCRIPTION
Needed to build on windows.
