### PR TITLE
fix: lock docker distribution version for Azure Stack

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -404,7 +404,7 @@ for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
 done
 
 # TODO: remove once ACR is available on Azure Stack
-pullContainerImage "docker" "registry:2"
+pullContainerImage "docker" "registry:2.7.1"
 
 df -h
 


### PR DESCRIPTION
**Reason for Change**:
Make sure the "registered" version of docker registry is delivered

**Issue Fixed**:
Fixes: #1625