### PR TITLE
feat: enable smart cloudprovider rate limiting

### DIFF
--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -114,3 +114,6 @@ func GetAllSupportedSwarmVersions() []string {
 func GetAllSupportedDockerCEVersions() []string {
 	return []string{DockerCEVersion}
 }
+
+// MinCloudProviderQPSToBucketFactor defines the minimum ratio between QPS and Bucket size for cloudprovider rate limiting
+const MinCloudProviderQPSToBucketFactor float64 = 0.1

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -228,7 +228,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			o.KubernetesConfig.CloudProviderRateLimit = to.BoolPtr(DefaultKubernetesCloudProviderRateLimit)
 		}
 		// Enforce sane cloudprovider rate limit defaults.
-		o.KubernetesConfig.SetCloudProviderRateLimitDefaults()
+		a.SetCloudProviderRateLimitDefaults()
 
 		if o.KubernetesConfig.PrivateCluster == nil {
 			o.KubernetesConfig.PrivateCluster = &PrivateCluster{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1827,6 +1827,26 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 	return p.HasNSeriesSKU() && common.IsKubernetesVersionGe(p.OrchestratorProfile.OrchestratorVersion, "1.10.0")
 }
 
+// SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
+func (p *Properties) SetCloudProviderRateLimitDefaults() {
+	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS == 0 {
+		var rateLimitQPS float64
+		for _, profile := range p.AgentPoolProfiles {
+			if profile.AvailabilityProfile == VirtualMachineScaleSets {
+				rateLimitQPS += (3.0 * float64(profile.Count))
+			}
+		}
+		if rateLimitQPS > DefaultKubernetesCloudProviderRateLimitQPS {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = rateLimitQPS
+		} else {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = DefaultKubernetesCloudProviderRateLimitQPS
+		}
+	}
+	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
+		p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
+	}
+}
+
 // IsReschedulerEnabled checks if the rescheduler addon is enabled
 func (k *KubernetesConfig) IsReschedulerEnabled() bool {
 	return k.IsAddonEnabled(ReschedulerAddonName)
@@ -1859,16 +1879,6 @@ func (k *KubernetesConfig) SetCloudProviderBackoffDefaults() {
 	}
 	if k.CloudProviderBackoffRetries == 0 {
 		k.CloudProviderBackoffRetries = DefaultKubernetesCloudProviderBackoffRetries
-	}
-}
-
-// SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
-func (k *KubernetesConfig) SetCloudProviderRateLimitDefaults() {
-	if k.CloudProviderRateLimitQPS == 0 {
-		k.CloudProviderRateLimitQPS = DefaultKubernetesCloudProviderRateLimitQPS
-	}
-	if k.CloudProviderRateLimitBucket == 0 {
-		k.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1831,11 +1831,11 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
 		if p.HasVMSSAgentPool() && !p.IsHostedMasterProfile() {
-			maxVMSSNodesSupported := 250
+			maxVMSSInstancesPerPool := 100
 			var rateLimitBucket int
 			for _, profile := range p.AgentPoolProfiles {
 				if profile.AvailabilityProfile == VirtualMachineScaleSets {
-					rateLimitBucket += maxVMSSNodesSupported
+					rateLimitBucket += maxVMSSInstancesPerPool
 				}
 
 			}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1831,11 +1831,10 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
 		if p.HasVMSSAgentPool() && !p.IsHostedMasterProfile() {
-			maxVMSSInstancesPerPool := 100
 			var rateLimitBucket int
 			for _, profile := range p.AgentPoolProfiles {
 				if profile.AvailabilityProfile == VirtualMachineScaleSets {
-					rateLimitBucket += maxVMSSInstancesPerPool
+					rateLimitBucket += common.MaxAgentCount
 				}
 
 			}
@@ -1845,9 +1844,8 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS == 0 {
-		const minQPSToBucketFactor float64 = 0.1
-		if (DefaultKubernetesCloudProviderRateLimitQPS / float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket)) < minQPSToBucketFactor {
-			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket) * minQPSToBucketFactor
+		if (DefaultKubernetesCloudProviderRateLimitQPS / float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket)) < common.MinCloudProviderQPSToBucketFactor {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket) * common.MinCloudProviderQPSToBucketFactor
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = DefaultKubernetesCloudProviderRateLimitQPS
 		}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1830,13 +1830,8 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 // SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
-		if p.HasVMSSAgentPool() {
-			var maxVMSSNodesSupported int
-			if p.HostedMasterProfile != nil {
-				maxVMSSNodesSupported = 100
-			} else {
-				maxVMSSNodesSupported = 250
-			}
+		if p.HasVMSSAgentPool() && !p.IsHostedMasterProfile() {
+			maxVMSSNodesSupported := 250
 			var rateLimitBucket int
 			for _, profile := range p.AgentPoolProfiles {
 				if profile.AvailabilityProfile == VirtualMachineScaleSets {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1833,7 +1833,7 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		var rateLimitQPS float64
 		for _, profile := range p.AgentPoolProfiles {
 			if profile.AvailabilityProfile == VirtualMachineScaleSets {
-				rateLimitQPS += (3.0 * float64(profile.Count))
+				rateLimitQPS += (4.0 * float64(profile.Count))
 			}
 		}
 		if rateLimitQPS > DefaultKubernetesCloudProviderRateLimitQPS {

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3474,13 +3474,16 @@ func TestGetAzureCNIURLFuncs(t *testing.T) {
 func TestCloudProviderDefaults(t *testing.T) {
 	// Test cloudprovider defaults when no user-provided values
 	v := "1.8.0"
-	o := OrchestratorProfile{
-		OrchestratorType:    "Kubernetes",
-		OrchestratorVersion: v,
-		KubernetesConfig:    &KubernetesConfig{},
+	p := Properties{
+		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    "Kubernetes",
+			OrchestratorVersion: v,
+			KubernetesConfig:    &KubernetesConfig{},
+		},
 	}
+	o := p.OrchestratorProfile
 	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
-	o.KubernetesConfig.SetCloudProviderRateLimitDefaults()
+	p.SetCloudProviderRateLimitDefaults()
 
 	intCases := []struct {
 		defaultVal  int
@@ -3539,20 +3542,23 @@ func TestCloudProviderDefaults(t *testing.T) {
 
 	// Test cloudprovider defaults when user provides configuration
 	v = "1.8.0"
-	o = OrchestratorProfile{
-		OrchestratorType:    "Kubernetes",
-		OrchestratorVersion: v,
-		KubernetesConfig: &KubernetesConfig{
-			CloudProviderBackoffDuration: customCloudProviderBackoffDuration,
-			CloudProviderBackoffExponent: customCloudProviderBackoffExponent,
-			CloudProviderBackoffJitter:   customCloudProviderBackoffJitter,
-			CloudProviderBackoffRetries:  customCloudProviderBackoffRetries,
-			CloudProviderRateLimitBucket: customCloudProviderRateLimitBucket,
-			CloudProviderRateLimitQPS:    customCloudProviderRateLimitQPS,
+	p = Properties{
+		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    "Kubernetes",
+			OrchestratorVersion: v,
+			KubernetesConfig: &KubernetesConfig{
+				CloudProviderBackoffDuration: customCloudProviderBackoffDuration,
+				CloudProviderBackoffExponent: customCloudProviderBackoffExponent,
+				CloudProviderBackoffJitter:   customCloudProviderBackoffJitter,
+				CloudProviderBackoffRetries:  customCloudProviderBackoffRetries,
+				CloudProviderRateLimitBucket: customCloudProviderRateLimitBucket,
+				CloudProviderRateLimitQPS:    customCloudProviderRateLimitQPS,
+			},
 		},
 	}
+	o = p.OrchestratorProfile
 	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
-	o.KubernetesConfig.SetCloudProviderRateLimitDefaults()
+	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesCustom := []struct {
 		customVal   int
@@ -3604,17 +3610,20 @@ func TestCloudProviderDefaults(t *testing.T) {
 
 	// Test cloudprovider defaults when user provides *some* config values
 	v = "1.8.0"
-	o = OrchestratorProfile{
-		OrchestratorType:    "Kubernetes",
-		OrchestratorVersion: v,
-		KubernetesConfig: &KubernetesConfig{
-			CloudProviderBackoffDuration: customCloudProviderBackoffDuration,
-			CloudProviderRateLimitBucket: customCloudProviderRateLimitBucket,
-			CloudProviderRateLimitQPS:    customCloudProviderRateLimitQPS,
+	p = Properties{
+		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    "Kubernetes",
+			OrchestratorVersion: v,
+			KubernetesConfig: &KubernetesConfig{
+				CloudProviderBackoffDuration: customCloudProviderBackoffDuration,
+				CloudProviderRateLimitBucket: customCloudProviderRateLimitBucket,
+				CloudProviderRateLimitQPS:    customCloudProviderRateLimitQPS,
+			},
 		},
 	}
+	o = p.OrchestratorProfile
 	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
-	o.KubernetesConfig.SetCloudProviderRateLimitDefaults()
+	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesMixed := []struct {
 		expectedVal int

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3654,6 +3654,64 @@ func TestCloudProviderDefaults(t *testing.T) {
 		computedVal float64
 	}{
 		{
+			expectedVal: customCloudProviderRateLimitQPS,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitQPS,
+		},
+	}
+
+	for _, c := range floatCasesMixed {
+		if c.computedVal != c.expectedVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect default values after SetCloudProviderBackoffDefaults(), expected %f, got %f", c.expectedVal, c.computedVal)
+		}
+	}
+
+	// Test cloudprovider defaults for VMSS scenario
+	v = "1.14.0"
+	p = Properties{
+		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    "Kubernetes",
+			OrchestratorVersion: v,
+			KubernetesConfig:    &KubernetesConfig{},
+		},
+		AgentPoolProfiles: []*AgentPoolProfile{
+			&AgentPoolProfile{
+				AvailabilityProfile: VirtualMachineScaleSets,
+			},
+		},
+	}
+	o = p.OrchestratorProfile
+	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderRateLimitDefaults()
+
+	intCasesMixed = []struct {
+		expectedVal int
+		computedVal int
+	}{
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffRetries,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffRetries,
+		},
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffDuration,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffDuration,
+		},
+		{
+			expectedVal: common.MaxAgentCount,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitBucket,
+		},
+	}
+
+	for _, c := range intCasesMixed {
+		if c.computedVal != c.expectedVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect default values after SetCloudProviderBackoffDefaults(), expected %d, got %d", c.expectedVal, c.computedVal)
+		}
+	}
+
+	floatCasesMixed = []struct {
+		expectedVal float64
+		computedVal float64
+	}{
+		{
 			expectedVal: DefaultKubernetesCloudProviderBackoffJitter,
 			computedVal: o.KubernetesConfig.CloudProviderBackoffJitter,
 		},
@@ -3662,7 +3720,148 @@ func TestCloudProviderDefaults(t *testing.T) {
 			computedVal: o.KubernetesConfig.CloudProviderBackoffExponent,
 		},
 		{
-			expectedVal: customCloudProviderRateLimitQPS,
+			expectedVal: float64(common.MaxAgentCount) * common.MinCloudProviderQPSToBucketFactor,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitQPS,
+		},
+	}
+
+	for _, c := range floatCasesMixed {
+		if c.computedVal != c.expectedVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect default values after SetCloudProviderBackoffDefaults(), expected %f, got %f", c.expectedVal, c.computedVal)
+		}
+	}
+
+	// Test cloudprovider defaults for VMSS scenario with 3 pools
+	v = "1.14.0"
+	p = Properties{
+		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    "Kubernetes",
+			OrchestratorVersion: v,
+			KubernetesConfig:    &KubernetesConfig{},
+		},
+		AgentPoolProfiles: []*AgentPoolProfile{
+			&AgentPoolProfile{
+				AvailabilityProfile: VirtualMachineScaleSets,
+			},
+			&AgentPoolProfile{
+				AvailabilityProfile: VirtualMachineScaleSets,
+			},
+			&AgentPoolProfile{
+				AvailabilityProfile: VirtualMachineScaleSets,
+			},
+		},
+	}
+	o = p.OrchestratorProfile
+	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderRateLimitDefaults()
+
+	intCasesMixed = []struct {
+		expectedVal int
+		computedVal int
+	}{
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffRetries,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffRetries,
+		},
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffDuration,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffDuration,
+		},
+		{
+			expectedVal: common.MaxAgentCount * 3,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitBucket,
+		},
+	}
+
+	for _, c := range intCasesMixed {
+		if c.computedVal != c.expectedVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect default values after SetCloudProviderBackoffDefaults(), expected %d, got %d", c.expectedVal, c.computedVal)
+		}
+	}
+
+	floatCasesMixed = []struct {
+		expectedVal float64
+		computedVal float64
+	}{
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffJitter,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffJitter,
+		},
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffExponent,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffExponent,
+		},
+		{
+			expectedVal: float64(common.MaxAgentCount*3) * common.MinCloudProviderQPSToBucketFactor,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitQPS,
+		},
+	}
+
+	for _, c := range floatCasesMixed {
+		if c.computedVal != c.expectedVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect default values after SetCloudProviderBackoffDefaults(), expected %f, got %f", c.expectedVal, c.computedVal)
+		}
+	}
+
+	// Test cloudprovider defaults for VMSS scenario + AKS
+	v = "1.14.0"
+	p = Properties{
+		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    "Kubernetes",
+			OrchestratorVersion: v,
+			KubernetesConfig:    &KubernetesConfig{},
+		},
+		AgentPoolProfiles: []*AgentPoolProfile{
+			&AgentPoolProfile{
+				AvailabilityProfile: VirtualMachineScaleSets,
+			},
+		},
+		HostedMasterProfile: &HostedMasterProfile{
+			FQDN: "my-cluster",
+		},
+	}
+	o = p.OrchestratorProfile
+	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderRateLimitDefaults()
+
+	intCasesMixed = []struct {
+		expectedVal int
+		computedVal int
+	}{
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffRetries,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffRetries,
+		},
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffDuration,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffDuration,
+		},
+		{
+			expectedVal: DefaultKubernetesCloudProviderRateLimitBucket,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitBucket,
+		},
+	}
+
+	for _, c := range intCasesMixed {
+		if c.computedVal != c.expectedVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect default values after SetCloudProviderBackoffDefaults(), expected %d, got %d", c.expectedVal, c.computedVal)
+		}
+	}
+
+	floatCasesMixed = []struct {
+		expectedVal float64
+		computedVal float64
+	}{
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffJitter,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffJitter,
+		},
+		{
+			expectedVal: DefaultKubernetesCloudProviderBackoffExponent,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffExponent,
+		},
+		{
+			expectedVal: DefaultKubernetesCloudProviderRateLimitQPS,
 			computedVal: o.KubernetesConfig.CloudProviderRateLimitQPS,
 		},
 	}

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3674,7 +3674,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 			KubernetesConfig:    &KubernetesConfig{},
 		},
 		AgentPoolProfiles: []*AgentPoolProfile{
-			&AgentPoolProfile{
+			{
 				AvailabilityProfile: VirtualMachineScaleSets,
 			},
 		},
@@ -3740,13 +3740,13 @@ func TestCloudProviderDefaults(t *testing.T) {
 			KubernetesConfig:    &KubernetesConfig{},
 		},
 		AgentPoolProfiles: []*AgentPoolProfile{
-			&AgentPoolProfile{
+			{
 				AvailabilityProfile: VirtualMachineScaleSets,
 			},
-			&AgentPoolProfile{
+			{
 				AvailabilityProfile: VirtualMachineScaleSets,
 			},
-			&AgentPoolProfile{
+			{
 				AvailabilityProfile: VirtualMachineScaleSets,
 			},
 		},
@@ -3812,7 +3812,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 			KubernetesConfig:    &KubernetesConfig{},
 		},
 		AgentPoolProfiles: []*AgentPoolProfile{
-			&AgentPoolProfile{
+			{
 				AvailabilityProfile: VirtualMachineScaleSets,
 			},
 		},


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR changes the cloudprovider-enforced rate limiter configuration for VMSS scenarios to allow for more "burstability". Specifically, for Kubernetes LoadBalancer reconciliation, VMSS instance Get() calls are made during backend pool creation; one Get() call per VMSS instance. Because we can't anticipate in advance exactly how many VMSS instances will be served by an AKS Engine control plane (and because we don't currently have any functionality to update control plane cloudprovider configuration in response to scale up/down events), we need to configure the control plane so that it can handle the maximum number of supported VMSS instances. At present, we support up to 100 nodes per pool, and so we configure the "burstability" of the rate limit to be a factor of 100 per pool in VMSS cluster configurations.

In addition, this PR sets the actual QPS configuration to be at least 10% of the burstability tolerance, to prevent situations where the real world QPS (which is the allowed velocity of the rate limiter to release requests from the "burst queue") is never able to empty the "burst queue".

This PR does not change the node cloudprovider configuration for AKS (which would have no effect, but this skip is there for sanity).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #420

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
