### PR TITLE
feat: add support for Kubernetes 1.16.0-alpha.2

### DIFF
--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-cilium-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-cilium-daemonset.yaml
@@ -50,6 +50,7 @@ spec:
       annotations:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -54,6 +54,8 @@ spec:
       labels:
         tier: node
         app: flannel
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
       nodeSelector:

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -34,6 +34,7 @@ spec:
         - kube-proxy
         - --kubeconfig=/var/lib/kubelet/kubeconfig
         - --cluster-cidr=<CIDR>
+        - --feature-gates=ExperimentalCriticalPodAnnotation=true
         - --proxy-mode=<kubeProxyMode>
         image: <img>
         imagePullPolicy: IfNotPresent

--- a/parts/k8s/containeraddons/1.16/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/containeraddons/1.16/azure-cni-networkmonitor.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         k8s-app: azure-cnms
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-azure-npm-daemonset.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-azure-npm-daemonset.yaml
@@ -65,6 +65,8 @@ spec:
     metadata:
       labels:
         k8s-app: azure-npm
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-calico-daemonset.yaml
@@ -360,6 +360,7 @@ spec:
         # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
         # add-on, ensuring it gets priority scheduling and that its resources are reserved
         # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
@@ -445,6 +446,12 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -659,6 +666,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-typha-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       securityContext:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-heapster-deployment.yaml
@@ -101,6 +101,8 @@ spec:
     metadata:
       labels:
         k8s-app: heapster
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       containers:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         k8s-app: rescheduler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-nvidia-device-plugin-daemonset.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-nvidia-device-plugin-daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: nvidia-device-plugin
     spec:

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -134,6 +134,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.15.0":         true,
 	"1.15.1":         true,
 	"1.16.0-alpha.1": true,
+	"1.16.0-alpha.2": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -7063,6 +7063,7 @@ spec:
       annotations:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium
@@ -7938,6 +7939,8 @@ spec:
       labels:
         tier: node
         app: flannel
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
       nodeSelector:
@@ -8320,6 +8323,7 @@ spec:
         - kube-proxy
         - --kubeconfig=/var/lib/kubelet/kubeconfig
         - --cluster-cidr=<CIDR>
+        - --feature-gates=ExperimentalCriticalPodAnnotation=true
         - --proxy-mode=<kubeProxyMode>
         image: <img>
         imagePullPolicy: IfNotPresent
@@ -16019,6 +16023,8 @@ spec:
     metadata:
       labels:
         k8s-app: azure-cnms
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -16634,6 +16640,8 @@ spec:
     metadata:
       labels:
         k8s-app: azure-npm
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -17107,6 +17115,7 @@ spec:
         # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
         # add-on, ensuring it gets priority scheduling and that its resources are reserved
         # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
@@ -17192,6 +17201,12 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -17406,6 +17421,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-typha-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
@@ -17869,6 +17886,8 @@ spec:
     metadata:
       labels:
         k8s-app: heapster
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       containers:
@@ -18032,6 +18051,8 @@ spec:
     metadata:
       labels:
         k8s-app: rescheduler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -18395,6 +18416,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: nvidia-device-plugin
     spec:


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#changelog-since-v1160-alpha1

**Issue Fixed**:

**Requirements**:
- [x] Windows artifacts uploaded to acsmirror blob store
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This also implied a (manual) revert of #1621. See kubernetes/kubernetes#80277. cc: @adelina-t.
