### PR TITLE
chore: use k8s test infra archive for nssm.exe

### DIFF
--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -303,7 +303,7 @@ build_kube_binaries_for_upstream_e2e() {
 
 download_nssm() {
 	NSSM_VERSION=2.24
-	NSSM_URL=https://nssm.cc/release/nssm-${NSSM_VERSION}.zip
+	NSSM_URL=https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-${NSSM_VERSION}.zip
 	echo "downloading nssm ..."
 	curl ${NSSM_URL} -o /tmp/nssm-${NSSM_VERSION}.zip
 	unzip -q -d /tmp /tmp/nssm-${NSSM_VERSION}.zip


### PR DESCRIPTION
**Reason for Change**:
`make build-windows-k8s` began failing since the website https://nssm.cc is not accessible, so let's fetch it from a stable archive instead.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I used this change to create the Windows archive for #1694, so it has been tested. ✔️ 
