### PR TITLE
fix: cleanup cloud-init and waagent during VHD build

### DIFF
--- a/packer/cleanup-vhd.sh
+++ b/packer/cleanup-vhd.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -eux
-
-# Cleanup packer SSH key and machine ID generated for this boot
-rm -f /root/.ssh/authorized_keys
-rm -f /home/packer/.ssh/authorized_keys
-rm -f /etc/machine-id
-touch /etc/machine-id

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -436,3 +436,5 @@ sudo mv /var/log /var/log.vhd
 sudo mkdir /var/log
 
 applyCIS
+cloud-init clean --logs
+waagent -force -deprovision

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -431,4 +431,8 @@ cat ${RELEASE_NOTES_FILEPATH}
 echo "END_OF_NOTES"
 set -x
 
+# Move logs from VHD creation out of /var/log
+sudo mv /var/log /var/log.vhd
+sudo mkdir /var/log
+
 applyCIS

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -431,8 +431,4 @@ cat ${RELEASE_NOTES_FILEPATH}
 echo "END_OF_NOTES"
 set -x
 
-# Move logs from VHD creation out of /var/log
-sudo mv /var/log /var/log.vhd
-sudo mkdir /var/log
-
 applyCIS

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -436,5 +436,3 @@ sudo mv /var/log /var/log.vhd
 sudo mkdir /var/log
 
 applyCIS
-cloud-init clean --logs
-waagent -force -deprovision

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -46,11 +46,6 @@
         },
         {
             "type": "file",
-            "source": "packer/cleanup-vhd.sh",
-            "destination": "/home/packer/cleanup-vhd.sh"
-        },
-        {
-            "type": "file",
             "source": "packer/packer_source.sh",
             "destination": "/home/packer/packer_source.sh"
         },
@@ -193,10 +188,11 @@
             "type": "shell",
             "inline": [
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
-                "sudo /bin/bash -eux /home/packer/cleanup-vhd.sh",
-                "sudo rm -rf /home/packer",
-                "cloud-init clean --logs",
-                "waagent -force -deprovision"
+                "sudo rm -f /root/.ssh/authorized_keys",
+                "sudo rm -f /etc/machine-id",
+                "sudo touch /etc/machine-id",
+                "sudo cloud-init clean --logs",
+                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ]
         }
     ]

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -188,13 +188,11 @@
             "type": "shell",
             "inline": [
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
-                "sudo rm -f /root/.ssh/authorized_keys || exit 101",
-                "sudo rm -f /etc/machine-id || exit 102",
-                "sudo touch /etc/machine-id || exit 103",
-                "sudo mv /var/log /var/log.vhd || exit 104",
-                "sudo mkdir /var/log || exit 105",
-                "sudo cloud-init clean --logs || exit 106",
-                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync || exit 107"
+                "sudo rm -f /root/.ssh/authorized_keys || exit 125",
+                "sudo rm -f /etc/machine-id || exit 125",
+                "sudo touch /etc/machine-id || exit 125",
+                "sudo cloud-init clean --logs || exit 125",
+                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync || exit 125"
             ]
         }
     ]

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -188,11 +188,13 @@
             "type": "shell",
             "inline": [
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
-                "sudo rm -f /root/.ssh/authorized_keys",
-                "sudo rm -f /etc/machine-id",
-                "sudo touch /etc/machine-id",
-                "sudo cloud-init clean --logs",
-                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+                "sudo rm -f /root/.ssh/authorized_keys || exit 101",
+                "sudo rm -f /etc/machine-id || exit 102",
+                "sudo touch /etc/machine-id || exit 103",
+                "sudo mv /var/log /var/log.vhd || exit 104",
+                "sudo mkdir /var/log || exit 105",
+                "sudo cloud-init clean --logs || exit 106",
+                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync || exit 107"
             ]
         }
     ]

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -194,7 +194,9 @@
             "inline": [
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
                 "sudo /bin/bash -eux /home/packer/cleanup-vhd.sh",
-                "sudo rm -rf /home/packer"
+                "sudo rm -rf /home/packer",
+                "cloud-init clean --logs",
+                "waagent -force -deprovision"
             ]
         }
     ]

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -58,6 +58,8 @@ ERR_AZURE_STACK_GET_ARM_TOKEN=120 # Error generating a token to use with Azure R
 ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION=121 # Error fetching the network configuration for the node
 ERR_AZURE_STACK_GET_SUBNET_PREFIX=122 # Error fetching the subnet address prefix for a subnet ID
 
+ERR_VHD_BUILD_ERROR=125 # Reserved for VHD CI exit conditions
+
 OS=$(sort -r /etc/*-release | gawk 'match($0, /^(ID_LIKE=(coreos)|ID=(.*))$/, a) { print toupper(a[2] a[3]); exit }')
 UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13020,6 +13020,8 @@ ERR_AZURE_STACK_GET_ARM_TOKEN=120 # Error generating a token to use with Azure R
 ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION=121 # Error fetching the network configuration for the node
 ERR_AZURE_STACK_GET_SUBNET_PREFIX=122 # Error fetching the subnet address prefix for a subnet ID
 
+ERR_VHD_BUILD_ERROR=125 # Reserved for VHD CI exit conditions
+
 OS=$(sort -r /etc/*-release | gawk 'match($0, /^(ID_LIKE=(coreos)|ID=(.*))$/, a) { print toupper(a[2] a[3]); exit }')
 UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR adds waagent and cloud-init cleanup steps to the VHD CI build script.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1720 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
