### PR TITLE
chore: Change Windows default to Windows Server 2019 LTSC, July patch

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -646,8 +646,8 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 | adminPassword                    | yes      | Password for the Windows adminstrator account created on each Windows node |
 | windowsPublisher                 | no       | Publisher used to find Windows VM to deploy from marketplace. Default: `MicrosoftWindowsServer` |
 | windowsOffer                     | no       | Offer used to find Windows VM to deploy from marketplace. Default: `WindowsServer` |
-| windowsSku                       | no       | SKU usedto find Windows VM to deploy from marketplace. Default: `Datacenter-Core-1809-with-Containers-smalldisk` |
-| imageVersion                     | no       | Specific image version to deploy from marketplace.  Default: `17763.557.20190604`. This default is incremented as new versions are tested to avoid unexpected breaks. |
+| windowsSku                       | no       | SKU usedto find Windows VM to deploy from marketplace. Default: `2019-Datacenter-Core-with-Containers-smalldisk` |
+| imageVersion                     | no       | Specific image version to deploy from marketplace.  Default: `17763.615.1907121548`. This default is incremented as new versions are tested to avoid unexpected breaks. |
 | windowsImageSourceURL            | no       | Path to an existing Azure storage blob with a sysprepped VHD. This is used to test pre-release or customized VHD files that you have uploaded to Azure. If provided, the above 4 parameters are ignored. |
 | sshEnabled                       | no       | If set to `true`, OpenSSH will be installed on windows nodes to allow for ssh remoting. **Only for Windows version 1809/2019 or later** . The same SSH authorized public key(s) will be added from [linuxProfile.ssh.publicKeys](#linuxProfile) |
 
@@ -656,22 +656,7 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 
 If you want to choose a specific Windows image, but automatically use the latest - set `windowsPublisher`, `windowsOffer`, and `windowsSku`. If you need a specific version, then add `agentWindowsVersion` too.
 
-You can find all available images with `az vm image list`, and the contents of these images are described in the knowledge base article [Windows Server release on Azure Marketplace update history](https://support.microsoft.com/en-us/help/4497947).
-
-
-```bash
-$ az vm image list --publisher MicrosoftWindowsServer --all -o table
-
-Offer                    Publisher                      Sku                                             Urn                                                                                                            Version
------------------------  -----------------------------  ----------------------------------------------  -------------------------------------------------------------------------------------------------------------  -----------------
-...
-WindowsServer              MicrosoftWindowsServer         2019-Datacenter-with-Containers                 MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers:2019.0.20190603                           2019.0.20190603
-WindowsServer              MicrosoftWindowsServer         2019-Datacenter-with-Containers-smalldisk       MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers-smalldisk:2019.0.20190603                 2019.0.20190603
-WindowsServer              MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20190603            1803.0.20190603
-WindowsServer              MicrosoftWindowsServer         Datacenter-Core-1809-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1809-with-Containers-smalldisk:1809.0.20190603            1809.0.20190603
-WindowsServer              MicrosoftWindowsServer         Datacenter-Core-1903-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:1903.0.20190603            1903.0.20190603
-...
-```
+You can find all available images with `az vm image list --all --publisher MicrosoftWindowsServer --offer WindowsServer --output table`, and the contents of these images are described in the knowledge base article [Windows Server release on Azure Marketplace update history](https://support.microsoft.com/en-us/help/4497947).
 
 If you want to use a specific image then `windowsPublisher`, `windowsOffer`, `windowsSku`, and `imageVersion` must all be set:
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -281,9 +281,9 @@ const (
 	// DefaultWindowsOffer sets the default WindowsOffer value in WindowsProfile
 	DefaultWindowsOffer = "WindowsServer"
 	// DefaultWindowsSku sets the default WindowsSku value in WindowsProfile
-	DefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
+	DefaultWindowsSku = "2019-Datacenter-Core-with-Containers-smalldisk"
 	// DefaultImageVersion sets the default ImageVersion value in WindowsProfile
-	DefaultImageVersion = "17763.557.20190604"
+	DefaultImageVersion = "17763.615.1907121548"
 )
 
 const (


### PR DESCRIPTION
- This switches from Windows Server 1809 to Windows Server 2019. They are the same thing, but 2019 is supported longer.
- Use the latest available Windows cumulative update for security fixes