### PR TITLE
chore: Update to Docker EE 18.09.7 by default

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -47,7 +47,7 @@ const (
 	// DockerCEDockerComposeVersion is the Docker Compose version
 	DockerCEDockerComposeVersion = "1.14.0"
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
-	KubernetesWindowsDockerVersion = "18.09.2"
+	KubernetesWindowsDockerVersion = "18.09.7"
 	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
 	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 )


### PR DESCRIPTION
**Reason for Change**:

Version catch-up. The Windows default images come with 18.09.7, so don't downgrade to 18.09.2.

The Docker release notes don't seem to have anything relevant but downgrading costs time & reboot. https://docs.docker.com/engine/release-notes/#18097 
