### PR TITLE
fix: label scheduled-maintenance manifests for addon-manager

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-scheduled-maintenance-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-scheduled-maintenance-deployment.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10,6 +11,8 @@ kind: Role
 metadata:
   name: drainsafe-leader-election-role
   namespace: drainsafe-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
   - ""
@@ -37,6 +40,8 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: drainsafe-manager-role
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -139,6 +144,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: drainsafe-proxy-role
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -153,6 +160,8 @@ kind: RoleBinding
 metadata:
   name: drainsafe-leader-election-rolebinding
   namespace: drainsafe-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -166,6 +175,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: drainsafe-manager-rolebinding
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -179,6 +190,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: drainsafe-proxy-rolebinding
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -197,6 +210,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-controller-manager-metrics-service
   namespace: drainsafe-system
 spec:
@@ -212,6 +226,7 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-controller-manager
   namespace: drainsafe-system
 spec:
@@ -271,6 +286,7 @@ kind: DaemonSet
 metadata:
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-controller-scheduledevent-manager
   namespace: drainsafe-system
 spec:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -11571,6 +11571,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11578,6 +11579,8 @@ kind: Role
 metadata:
   name: drainsafe-leader-election-role
   namespace: drainsafe-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
   - ""
@@ -11605,6 +11608,8 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: drainsafe-manager-role
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -11707,6 +11712,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: drainsafe-proxy-role
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -11721,6 +11728,8 @@ kind: RoleBinding
 metadata:
   name: drainsafe-leader-election-rolebinding
   namespace: drainsafe-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -11734,6 +11743,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: drainsafe-manager-rolebinding
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -11747,6 +11758,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: drainsafe-proxy-rolebinding
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -11765,6 +11778,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-controller-manager-metrics-service
   namespace: drainsafe-system
 spec:
@@ -11780,6 +11794,7 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-controller-manager
   namespace: drainsafe-system
 spec:
@@ -11839,6 +11854,7 @@ kind: DaemonSet
 metadata:
   labels:
     control-plane: controller-manager
+    addonmanager.kubernetes.io/mode: Reconcile
   name: drainsafe-controller-scheduledevent-manager
   namespace: drainsafe-system
 spec:


### PR DESCRIPTION
**Reason for Change**:
The `scheduled-maintenance` addon in #1575 didn't have `addonmanager.kubernetes.io/mode` labels on its manifests, so enabling it didn't actually create the "drainsafe-system" namespace and associated objects.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
