### PR TITLE
chore: update go-dev image to v1.23.0

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go for aks-engine",
-	"image": "quay.io/deis/go-dev:v1.22.4",
+	"image": "quay.io/deis/go-dev:v1.23.0",
 	"extensions": [
 		"ms-vscode.go"
 	],

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -17,7 +17,7 @@ pr:
 resources:
   containers:
   - container: dev1
-    image: quay.io/deis/go-dev:v1.22.4
+    image: quay.io/deis/go-dev:v1.23.0
 
 jobs:
 - job: unit_tests

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GITTAG := $(VERSION_SHORT)
 endif
 
 REPO_PATH := github.com/Azure/$(PROJECT)
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.22.4
+DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.23.0
 DEV_ENV_WORK_DIR := /go/src/$(REPO_PATH)
 DEV_ENV_OPTS := --rm -v $(CURDIR):$(DEV_ENV_WORK_DIR) -w $(DEV_ENV_WORK_DIR) $(DEV_ENV_VARS)
 DEV_ENV_CMD := docker run $(DEV_ENV_OPTS) $(DEV_ENV_IMAGE)

--- a/makedev.ps1
+++ b/makedev.ps1
@@ -1,5 +1,5 @@
 $REPO_PATH = "github.com/Azure/aks-engine"
-$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.22.4"
+$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.23.0"
 $DEV_ENV_WORK_DIR = "/go/src/$REPO_PATH"
 
 docker.exe run -it --rm -w $DEV_ENV_WORK_DIR -v `"$($PWD)`":$DEV_ENV_WORK_DIR $DEV_ENV_IMAGE bash


### PR DESCRIPTION
**Reason for Change**:
Updates the `go-dev` toolbox image to be based on Ubuntu 18.04.

See https://github.com/deis/docker-go-dev/releases/tag/v1.23.0

**Issue Fixed**:
Provides a fresher version of `curl`, among other things.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I updated `DEIS_GO_DEV_IMAGE` to use this on the Jenkins instance.
