### PR TITLE
ci: verify published VHD images

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -58,7 +58,10 @@ jobs:
   - script: make generate test-style
     displayName: Run linting rules
     workingDirectory: $(modulePath)
-  - script: make ensure-vhd
+  - script: |
+    export CLIENT_ID=$(SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES)
+    export CLIENT_SECRET=$(SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES)
+    make ensure-vhd
     displayName: Check if published VHD matches the expected count
     workingDirectory: $(modulePath)
   - script: make build-cross

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -59,9 +59,9 @@ jobs:
     displayName: Run linting rules
     workingDirectory: $(modulePath)
   - script: |
-    export CLIENT_ID=$(SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES)
-    export CLIENT_SECRET=$(SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES)
-    make ensure-vhd
+        export CLIENT_ID=$(SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES)
+        export CLIENT_SECRET=$(SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES)
+        make ensure-vhd
     displayName: Check if published VHD matches the expected count
     workingDirectory: $(modulePath)
   - script: make build-cross

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -58,6 +58,9 @@ jobs:
   - script: make generate test-style
     displayName: Run linting rules
     workingDirectory: $(modulePath)
+  - script: make ensure-vhd
+    displayName: Check if published VHD matches the expected count
+    workingDirectory: $(modulePath)
   - script: make build-cross
     displayName: Build cross-architectural binaries
     workingDirectory: $(modulePath)

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ ensure-generated:
 	@echo "==> Checking generated files <=="
 	@scripts/ensure-generated.sh
 
+.PHONY: ensure-vhd
+ensure-vhd:
+	@scripts/ensure-vhd-images.sh
+
 .PHONY: test-e2e
 test-e2e:
 	@test/e2e.sh

--- a/scripts/ensure-vhd-images.sh
+++ b/scripts/ensure-vhd-images.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+PUBLISHED_IMAGES=100
+
+exit_code=0
+
+echo "==> Using az CLI to validate published VHD images <=="
+
+IMAGES=$(az vm image list -p AKS -f aks --all -l eastus | jq '. | length')
+
+if [ "$IMAGES" != "$PUBLISHED_IMAGES" ]; then
+  echo "Expected to find $PUBLISHED_IMAGES published VHD images, instead found $IMAGES"
+  exit_code=1
+fi
+
+exit $exit_code

--- a/scripts/ensure-vhd-images.sh
+++ b/scripts/ensure-vhd-images.sh
@@ -9,6 +9,7 @@ exit_code=0
 
 echo "==> Using az CLI to validate published VHD images <=="
 
+az login --service-principal --username "${CLIENT_ID}" --password "${CLIENT_SECRET}" --tenant "${TENANT_ID}" &>/dev/null
 IMAGES=$(az vm image list -p AKS -f aks --all -l eastus | jq '. | length')
 
 if [ "$IMAGES" != "$PUBLISHED_IMAGES" ]; then


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This isn't ideal, but due to last week's disappearance of published VHD images, maintaining a static int to validate that the number of published VHD images never changes will alert us in the place we're most likely to notice (PR CI) when something unexpected happens.

In practice, we'd move the static int forward in the "change VHD reference" PRs that land after the publication of new images.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
