### PR TITLE
feat: autofill client Id and client secret for generate command

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -85,9 +85,9 @@ func getAPIModel(baseAPIModel string, useManagedIdentity bool, clientID, clientS
 		clientSecret)
 }
 
-func getAPIModelWithoutServicePrincipalProfile(baseAPIModel string, useManagedIdentity bool) string {
+func getAPIModelWithoutServicePrincipalProfile(useManagedIdentity bool) string {
 	return fmt.Sprintf(
-		baseAPIModel,
+		ExampleAPIModelWithoutServicePrincipalProfile,
 		strconv.FormatBool(useManagedIdentity))
 }
 
@@ -268,7 +268,7 @@ func TestAPIModelWithoutServicePrincipalProfileAndClientIdAndSecretInCmd(t *test
 		Translator: nil,
 	}
 
-	apimodel := getAPIModelWithoutServicePrincipalProfile(ExampleAPIModelWithoutServicePrincipalProfile, false)
+	apimodel := getAPIModelWithoutServicePrincipalProfile(false)
 	TestClientIDInCmd, err := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 	if err != nil {
 		t.Fatalf("Invalid ClientID in Test: %s", err)
@@ -373,7 +373,7 @@ func TestAPIModelWithoutServicePrincipalProfileAndWithoutClientIdAndSecretInCmd(
 		Translator: nil,
 	}
 
-	apimodel := getAPIModelWithoutServicePrincipalProfile(ExampleAPIModelWithoutServicePrincipalProfile, false)
+	apimodel := getAPIModelWithoutServicePrincipalProfile(false)
 
 	cs, ver, err := apiloader.DeserializeContainerService([]byte(apimodel), false, false, nil)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
feat: autofill client Id and client secret for generate command

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
