### PR TITLE
fix: set kubelet config for containerd in templates

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -248,12 +248,6 @@ configureCNIIPTables() {
     fi
 }
 
-setKubeletOpts () {
-    KUBELET_DEFAULT_FILE=/etc/default/kubelet
-    wait_for_file 1200 1 $KUBELET_DEFAULT_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    sed -i "s#^KUBELET_OPTS=.*#KUBELET_OPTS=${1}#" $KUBELET_DEFAULT_FILE
-}
-
 setupContainerd() {
     echo "Configuring cri-containerd..."
     mkdir -p "/etc/containerd"
@@ -274,7 +268,6 @@ setupContainerd() {
         echo "runtime_type = 'io.containerd.runtime.v1.linux'"
         echo "runtime_engine = '/usr/local/sbin/runc'"
     } > "$CRI_CONTAINERD_CONFIG"
-    setKubeletOpts " --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
 }
 
 ensureContainerd() {

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -295,8 +295,8 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
   permissions: "0644"
   owner: root
   content: |
-{{if IsKubernetesVersionLt "1.8.0"}}
-    KUBELET_OPTS=--require-kubeconfig
+{{if HasContainerd}}
+    KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=
 {{end}}

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -295,7 +295,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
   permissions: "0644"
   owner: root
   content: |
-{{if HasContainerd}}
+{{if NeedsContainerd}}
     KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -242,7 +242,7 @@ write_files:
   permissions: "0644"
   owner: root
   content: |
-{{if HasContainerd}}
+{{if NeedsContainerd}}
     KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -242,8 +242,8 @@ write_files:
   permissions: "0644"
   owner: root
   content: |
-{{if IsKubernetesVersionLt "1.8.0"}}
-    KUBELET_OPTS=--require-kubeconfig
+{{if HasContainerd}}
+    KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=
 {{end}}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1733,6 +1733,11 @@ func (k *KubernetesConfig) GetOrderedKubeletConfigStringForPowershell() string {
 	return strings.TrimSuffix(buf.String(), ", ")
 }
 
+// HasContainerd returns whether or not we need the containerd runtime
+func (k *KubernetesConfig) HasContainerd() bool {
+	return k.ContainerRuntime == KataContainers || k.ContainerRuntime == Containerd
+}
+
 // IsNSeriesSKU returns true if the agent pool contains an N-series (NVIDIA GPU) VM
 func (a *AgentPoolProfile) IsNSeriesSKU() bool {
 	return common.IsNvidiaEnabledSKU(a.VMSize)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1733,8 +1733,9 @@ func (k *KubernetesConfig) GetOrderedKubeletConfigStringForPowershell() string {
 	return strings.TrimSuffix(buf.String(), ", ")
 }
 
-// HasContainerd returns whether or not we need the containerd runtime
-func (k *KubernetesConfig) HasContainerd() bool {
+// NeedsContainerd returns whether or not we need the containerd runtime configuration
+// E.g., kata configuration requires containerd config
+func (k *KubernetesConfig) NeedsContainerd() bool {
 	return k.ContainerRuntime == KataContainers || k.ContainerRuntime == Containerd
 }
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -5837,7 +5837,7 @@ func TestHasContainerd(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			ret := test.k.HasContainerd()
+			ret := test.k.NeedsContainerd()
 			if test.expected != ret {
 				t.Errorf("expected %t, instead got : %t", test.expected, ret)
 			}

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -5789,3 +5789,58 @@ func TestAnyAgentIsLinux(t *testing.T) {
 		})
 	}
 }
+
+func TestHasContainerd(t *testing.T) {
+	tests := []struct {
+		name     string
+		k        *KubernetesConfig
+		expected bool
+	}{
+		{
+			name: "docker",
+			k: &KubernetesConfig{
+				ContainerRuntime: Docker,
+			},
+			expected: false,
+		},
+		{
+			name: "empty string",
+			k: &KubernetesConfig{
+				ContainerRuntime: "",
+			},
+			expected: false,
+		},
+		{
+			name: "unexpected string",
+			k: &KubernetesConfig{
+				ContainerRuntime: "foo",
+			},
+			expected: false,
+		},
+		{
+			name: "containerd",
+			k: &KubernetesConfig{
+				ContainerRuntime: Containerd,
+			},
+			expected: true,
+		},
+		{
+			name: "kata",
+			k: &KubernetesConfig{
+				ContainerRuntime: KataContainers,
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ret := test.k.HasContainerd()
+			if test.expected != ret {
+				t.Errorf("expected %t, instead got : %t", test.expected, ret)
+			}
+		})
+	}
+}

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -644,6 +644,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 
 			return api.AzureADIdentitySystem
 		},
+		"HasContainerd": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.HasContainerd()
+		},
 	}
 }
 

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -644,8 +644,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 
 			return api.AzureADIdentitySystem
 		},
-		"HasContainerd": func() bool {
-			return cs.Properties.OrchestratorProfile.KubernetesConfig.HasContainerd()
+		"NeedsContainerd": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.NeedsContainerd()
 		},
 	}
 }

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -100,6 +100,7 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		"HasAvailabilityZones",
 		"GetBase64EncodedEnvironmentJSON",
 		"GetIdentitySystem",
+		"HasContainerd",
 		// TODO validate that the remaining func strings in getTemplateFuncMap are thinly wrapped and unit tested
 	}
 
@@ -127,6 +128,12 @@ func TestGetTemplateFuncMap(t *testing.T) {
 			ret := v.Call(rargs)
 			if ret[0].Interface() != "" {
 				t.Fatalf("Got unexpected GetKubernetesMasterPreprovisionYaml response")
+			}
+		case "HasContainerd":
+			rargs := make([]reflect.Value, 0)
+			ret := v.Call(rargs)
+			if ret[0].Interface() != false {
+				t.Fatalf("Got unexpected HasContainerd response")
 			}
 		}
 	}

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -100,7 +100,7 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		"HasAvailabilityZones",
 		"GetBase64EncodedEnvironmentJSON",
 		"GetIdentitySystem",
-		"HasContainerd",
+		"NeedsContainerd",
 		// TODO validate that the remaining func strings in getTemplateFuncMap are thinly wrapped and unit tested
 	}
 
@@ -129,11 +129,11 @@ func TestGetTemplateFuncMap(t *testing.T) {
 			if ret[0].Interface() != "" {
 				t.Fatalf("Got unexpected GetKubernetesMasterPreprovisionYaml response")
 			}
-		case "HasContainerd":
+		case "NeedsContainerd":
 			rargs := make([]reflect.Value, 0)
 			ret := v.Call(rargs)
 			if ret[0].Interface() != false {
-				t.Fatalf("Got unexpected HasContainerd response")
+				t.Fatalf("Got unexpected NeedsContainerd response")
 			}
 		}
 	}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -2399,7 +2399,7 @@ var _dcosDcoswindowsprovisionPs1 = []byte(`<#
         Provisions VM as a DCOS agent.
 
      Invoke by:
-       
+
 #>
 
 [CmdletBinding(DefaultParameterSetName="Standard")]
@@ -2411,7 +2411,7 @@ param(
     [string]
     [ValidateNotNullOrEmpty()]
     $firstMasterIP,
-    
+
     [string]
     [ValidateNotNullOrEmpty()]
     $bootstrapUri,
@@ -2465,7 +2465,7 @@ Expand-ZIPFile($file, $destination)
 }
 
 
-function 
+function
 Remove-Directory($dirname)
 {
 
@@ -2482,25 +2482,25 @@ Remove-Directory($dirname)
 }
 
 
-function 
+function
 Check-Subnet ([string]$cidr, [string]$ip)
 {
     try {
 
         $network, [int]$subnetlen = $cidr.Split('/')
-    
+
         if ($subnetlen -eq 0)
         {
             $subnetlen = 8 # Default in case we get an IP addr, not CIDR
         }
         $a = ([IPAddress] $network)
         [uint32] $unetwork = [uint32]$a.Address
-    
+
         $mask = -bnot ((-bnot [uint32]0) -shl (32 - $subnetlen))
-    
+
         $a = [IPAddress]$ip
         [uint32] $uip = [uint32]$a.Address
-    
+
         return ($unetwork -eq ($mask -band $uip))
     }
     catch {
@@ -2526,7 +2526,7 @@ Get-BootstrapScript($download_uri, $download_dir)
 try
 {
     # Set to false for debugging.  This will output the start script to
-    # c:\AzureData\dcosProvisionScript.log, and then you can RDP 
+    # c:\AzureData\dcosProvisionScript.log, and then you can RDP
     # to the windows machine, and run the script manually to watch
     # the output.
     Write-Log "Get the install script"
@@ -2543,16 +2543,16 @@ try
     $ip = ([IPAddress]($ip -join '.')).Address
 
     $MasterIP = @([IPAddress]$null)
-    
-    for ($i = 0; $i -lt $MasterCount; $i++ ) 
+
+    for ($i = 0; $i -lt $MasterCount; $i++ )
     {
        $new_ip = ([IPAddress]$ip).getAddressBytes()
        [Array]::Reverse($new_ip)
        $new_ip = [IPAddress]($new_ip -join '.')
        $MasterIP += $new_ip
-      
+
        $ip++
-     
+
     }
     $master_str  = $MasterIP.IPAddressToString
 
@@ -2561,7 +2561,7 @@ try
         $master_str += ":2181"
     }
     else {
-        for ($i = 0; $i -lt $master_str.count; $i++) 
+        for ($i = 0; $i -lt $master_str.count; $i++)
         {
             $master_str[$i] += ":2181"
         }
@@ -2574,12 +2574,12 @@ try
 
     if ($isAgent)
     {
-        $run_cmd = $global:BootstrapInstallDir+"\DCOSWindowsAgentSetup.ps1 -MasterIP '$master_json' -AgentPrivateIP "+($private_ip.IPAddress) +" -BootstrapUrl '$bootstrapUri' " 
-        if ($isPublic) 
+        $run_cmd = $global:BootstrapInstallDir+"\DCOSWindowsAgentSetup.ps1 -MasterIP '$master_json' -AgentPrivateIP "+($private_ip.IPAddress) +" -BootstrapUrl '$bootstrapUri' "
+        if ($isPublic)
         {
             $run_cmd += " -isPublic:` + "`" + `$true "
         }
-        if ($customAttrs) 
+        if ($customAttrs)
         {
             $run_cmd += " -customAttrs '$customAttrs'"
         }
@@ -4093,13 +4093,13 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - lxc-net.service
 - - tar
-  - czf 
+  - czf
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm 
-  - -rf 
+- - rm
+  - -rf
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -4474,13 +4474,13 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - lxc-net.service
 - - tar
-  - czf 
+  - czf
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm 
-  - -rf 
+- - rm
+  - -rf
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -4869,16 +4869,16 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - unscd.service
 - sed -i "s/^Port 22$/Port 22\nPort 2222/1" /etc/ssh/sshd_config
-- service ssh restart 
+- service ssh restart
 - /opt/azure/containers/setup_ephemeral_disk.sh
 - - tar
-  - czf 
+  - czf
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm 
-  - -rf 
+- - rm
+  - -rf
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -5242,16 +5242,16 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - unscd.service
 - sed -i "s/^Port 22$/Port 22\nPort 2222/1" /etc/ssh/sshd_config
-- service ssh restart 
+- service ssh restart
 - /opt/azure/containers/setup_ephemeral_disk.sh
 - - tar
-  - czf 
+  - czf
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm 
-  - -rf 
+- - rm
+  - -rf
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -6155,21 +6155,21 @@ var _dcosDcosparamsT = []byte(`    "dcosBootstrapURL": {
       "defaultValue": "https://dcosio.azureedge.net/dcos/stable",
       "metadata": {
         "description": "The repository URL"
-      }, 
+      },
       "type": "string"
     },
     "dcosClusterPackageListID": {
       "defaultValue": "77282d8864a5bf36db345b54a0d1de3674a0e937",
       "metadata": {
         "description": "The default cluster package list IDs."
-      }, 
+      },
       "type": "string"
     },
     "dcosProviderPackageID": {
       "defaultValue": "",
       "metadata": {
         "description": "The guid for provider dcos-provider package."
-      }, 
+      },
       "type": "string"
     },
 `)
@@ -15030,7 +15030,7 @@ func k8sCloudInitArtifactsSysFsBpfMount() (*asset, error) {
 var _k8sCloudInitArtifactsSysctlD60CisConf = []byte(`# 3.1.2 Ensure packet redirect sending is disabled
 net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.send_redirects = 0
-# 3.2.1 Ensure source routed packets are not accepted 
+# 3.2.1 Ensure source routed packets are not accepted
 net.ipv4.conf.all.accept_source_route = 0
 net.ipv4.conf.default.accept_source_route = 0
 # 3.2.2 Ensure ICMP redirects are not accepted
@@ -15409,7 +15409,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
   permissions: "0644"
   owner: root
   content: |
-{{if HasContainerd}}
+{{if NeedsContainerd}}
     KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=
@@ -15940,7 +15940,7 @@ write_files:
   permissions: "0644"
   owner: root
   content: |
-{{if HasContainerd}}
+{{if NeedsContainerd}}
     KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=
@@ -18849,7 +18849,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}            
+              value: {{ContainerConfig "clusterName"}}
             - name: CONTROLLER_TYPE
               value: "DaemonSet"
             - name: ISTEST
@@ -18884,7 +18884,7 @@ spec:
               name: omsagent-secret
               readOnly: true
             - mountPath: /etc/config/settings
-              name: settings-vol-config  
+              name: settings-vol-config
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
@@ -18917,7 +18917,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true    
+            optional: true
   updateStrategy:
     type: RollingUpdate
 ---
@@ -18965,7 +18965,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}            
+              value: {{ContainerConfig "clusterName"}}
             - name: CONTROLLER_TYPE
               value: "ReplicaSet"
             - name: ISTEST
@@ -18992,7 +18992,7 @@ spec:
             - mountPath : /etc/config
               name: omsagent-rs-config
             - mountPath: /etc/config/settings
-              name: settings-vol-config              
+              name: settings-vol-config
           livenessProbe:
             exec:
               command:
@@ -19029,7 +19029,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true    
+            optional: true
 `)
 
 func k8sContaineraddons116KubernetesmasteraddonsOmsagentDaemonsetYamlBytes() ([]byte, error) {
@@ -20475,11 +20475,11 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/      
+          mountPath: /var/log/
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/              
+          path: /var/log/
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/
@@ -22561,7 +22561,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}            
+              value: {{ContainerConfig "clusterName"}}
             - name: CONTROLLER_TYPE
               value: "DaemonSet"
             - name: ISTEST
@@ -22596,7 +22596,7 @@ spec:
               name: omsagent-secret
               readOnly: true
             - mountPath: /etc/config/settings
-              name: settings-vol-config  
+              name: settings-vol-config
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
@@ -22629,7 +22629,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true    
+            optional: true
   updateStrategy:
     type: RollingUpdate
 ---
@@ -22677,7 +22677,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}            
+              value: {{ContainerConfig "clusterName"}}
             - name: CONTROLLER_TYPE
               value: "ReplicaSet"
             - name: ISTEST
@@ -22704,7 +22704,7 @@ spec:
             - mountPath : /etc/config
               name: omsagent-rs-config
             - mountPath: /etc/config/settings
-              name: settings-vol-config              
+              name: settings-vol-config
           livenessProbe:
             exec:
               command:
@@ -22741,7 +22741,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true    
+            optional: true
 `)
 
 func k8sContaineraddonsKubernetesmasteraddonsOmsagentDaemonsetYamlBytes() ([]byte, error) {
@@ -22792,11 +22792,11 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/      
+          mountPath: /var/log/
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/              
+          path: /var/log/
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/
@@ -24737,7 +24737,7 @@ func k8sWindowsconfigfuncPs1() (*asset, error) {
 var _k8sWindowsinstallopensshfuncPs1 = []byte(`function
 Install-OpenSSH {
     Param(
-        [Parameter(Mandatory = $true)][string[]] 
+        [Parameter(Mandatory = $true)][string[]]
         $SSHKeys
     )
 
@@ -24778,7 +24778,7 @@ Install-OpenSSH {
     # OPTIONAL but recommended:
     Set-Service -Name sshd -StartupType 'Automatic'
 
-    # Confirm the Firewall rule is configured. It should be created automatically by setup. 
+    # Confirm the Firewall rule is configured. It should be created automatically by setup.
     $firewall = Get-NetFirewallRule -Name *ssh*
 
     if (!$firewall) {
@@ -25788,14 +25788,14 @@ Start-Docker()
 {
     Write-Log "Starting $global:DockerServiceName..."
     $startTime = Get-Date
-        
+
     while (-not $dockerReady)
     {
         try
         {
             Start-Service -Name $global:DockerServiceName -ea Stop
 
-            $dockerReady = $true            
+            $dockerReady = $true
         }
         catch
         {
@@ -25807,7 +25807,7 @@ Start-Docker()
             }
 
             $errorStr = $_.Exception.Message
-            Write-Log "Starting Service failed: $errorStr" 
+            Write-Log "Starting Service failed: $errorStr"
             Write-Log "sleeping for 10 seconds..."
             Start-Sleep -sec 10
         }
@@ -25821,7 +25821,7 @@ Stop-Docker()
     Write-Log "Stopping $global:DockerServiceName..."
     try
     {
-        Stop-Service -Name $global:DockerServiceName -ea Stop   
+        Stop-Service -Name $global:DockerServiceName -ea Stop
     }
     catch
     {
@@ -25834,7 +25834,7 @@ Update-DockerServiceRecoveryPolicy()
 {
     $dockerReady = $false
     $startTime = Get-Date
-    
+
     # wait until the service exists
     while (-not $dockerReady)
     {
@@ -25842,7 +25842,7 @@ Update-DockerServiceRecoveryPolicy()
         {
             $dockerReady = $true
         }
-        else 
+        else
         {
             $timeElapsed = $(Get-Date) - $startTime
             if ($($timeElapsed).TotalMinutes -ge 5)
@@ -25854,7 +25854,7 @@ Update-DockerServiceRecoveryPolicy()
             Start-Sleep -sec 5
         }
     }
-    
+
     Write-Log "Updating docker restart policy, to ensure it restarts on error"
     $services = Get-WMIObject win32_service | Where-Object {$_.name -imatch $global:DockerServiceName}
     foreach ($service in $services)
@@ -25928,7 +25928,7 @@ try
 
     Write-Log "Update Docker restart policy"
     Update-DockerServiceRecoveryPolicy
-    
+
     Write-Log "Start Docker"
     Start-Docker
 
@@ -26020,14 +26020,14 @@ function Start-Docker()
 {
     Write-Log "Starting $global:DockerServiceName..."
     $startTime = Get-Date
-        
+
     while (-not $dockerReady)
     {
         try
         {
             Start-Service -Name $global:DockerServiceName -ea Stop
 
-            $dockerReady = $true            
+            $dockerReady = $true
         }
         catch
         {
@@ -26039,7 +26039,7 @@ function Start-Docker()
             }
 
             $errorStr = $_.Exception.Message
-            Write-Log "Starting Service failed: $errorStr" 
+            Write-Log "Starting Service failed: $errorStr"
             Write-Log "sleeping for 10 seconds..."
             Start-Sleep -sec 10
         }
@@ -26051,7 +26051,7 @@ function Stop-Docker()
     Write-Log "Stopping $global:DockerServiceName..."
     try
     {
-        Stop-Service -Name $global:DockerServiceName -ea Stop   
+        Stop-Service -Name $global:DockerServiceName -ea Stop
     }
     catch
     {
@@ -26104,7 +26104,7 @@ function Install-DockerBinaries()
             $currentRetry = $currentRetry + 1;
         }
     } while (!$success);
-      
+
     Write-Log "Expanding zip file at destination: $global:DockerExePath"
     Expand-ZIPFile -File $zipfile -Destination $global:DockerExePath
 
@@ -26116,7 +26116,7 @@ function Update-DockerServiceRecoveryPolicy()
 {
     $dockerReady = $false
     $startTime = Get-Date
-    
+
     # wait until the service exists
     while (-not $dockerReady)
     {
@@ -26124,7 +26124,7 @@ function Update-DockerServiceRecoveryPolicy()
         {
             $dockerReady = $true
         }
-        else 
+        else
         {
             $timeElapsed = $(Get-Date) - $startTime
             if ($($timeElapsed).TotalMinutes -ge 5)
@@ -26136,7 +26136,7 @@ function Update-DockerServiceRecoveryPolicy()
             Start-Sleep -sec 5
         }
     }
-    
+
     Write-Log "Updating docker restart policy, to ensure it restarts on error"
     $services = Get-WMIObject win32_service | Where-Object {$_.name -imatch $global:DockerServiceName}
     foreach ($service in $services)
@@ -26240,7 +26240,7 @@ function Confirm-DockerVersion()
    $dockerClientVersion = Invoke-Expression -Command:$dockerClientVersionCmd
 
    Write-Log "Docker Server version: $dockerServerVersion, Docker Client verison: $dockerClientVersion"
-   
+
    $serverVersionData = $dockerServerVersion.Split(".")
    $isNewServerVersion = $false;
    if(($serverVersionData[0] -ge 1) -and ($serverVersionData[1] -ge 13)){
@@ -26252,7 +26252,7 @@ function Confirm-DockerVersion()
    $isNewClientVersion = $false;
    if(($clientVersionData[0] -ge 1) -and ($clientVersionData[1] -ge 13)){
        $isNewClientVersion = $true;
-       Write-Log "Setting  isNewClientVersion to $isNewClientVersion"   
+       Write-Log "Setting  isNewClientVersion to $isNewClientVersion"
    }
 
    if($isNewServerVersion -and $isNewClientVersion)
@@ -26283,10 +26283,10 @@ try
 
     Write-Log "Update Docker restart policy"
     Update-DockerServiceRecoveryPolicy
-    
+
     Write-Log "Start Docker"
     Start-Docker
-    
+
     Write-Log "Join existing Swarm"
     Join-Swarm
 
@@ -26483,7 +26483,7 @@ installDocker()
 {
   for i in {1..10}; do
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 
+    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     apt-get update
     apt-get install -y docker-ce=${DOCKER_CE_VERSION}
@@ -26801,7 +26801,7 @@ installDockerUbuntu()
 {
   for i in {1..10}; do
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 
+    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     apt-get update
     apt-get install -y docker-ce=${DOCKER_CE_VERSION}
@@ -27199,10 +27199,10 @@ var _swarmSwarmagentresourcesvmasT = []byte(`    {
           "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
 {{if IsSwarmMode}}
   {{if not .IsRHEL}}
-            {{GetAgentSwarmModeCustomData .}} 
+            {{GetAgentSwarmModeCustomData .}}
   {{end}}
 {{else}}
-            {{GetAgentSwarmCustomData .}} 
+            {{GetAgentSwarmCustomData .}}
 {{end}}
           "linuxConfiguration": {
               "disablePasswordAuthentication": true,
@@ -28178,11 +28178,11 @@ func swarmSwarmparamsT() (*asset, error) {
 }
 
 var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
-      "apiVersion": "[variables('apiVersionDefault')]", 
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]", 
+        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "loop"
-      }, 
+      },
       "dependsOn": [
 {{if not .IsCustomVNET}}
       "[variables('vnetID')]"
@@ -28190,13 +28190,13 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
 {{if IsPublic .Ports}}
 	  ,"[variables('{{.Name}}LbID')]"
 {{end}}
-      ], 
-      "location": "[variables('location')]", 
+      ],
+      "location": "[variables('location')]",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
       "properties": {
         "ipConfigurations": [
           {
-            "name": "ipConfigNode", 
+            "name": "ipConfigNode",
             "properties": {
 {{if IsPublic .Ports}}
               "loadBalancerBackendAddressPools": [
@@ -28209,24 +28209,24 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
                   "id": "[concat(variables('{{.Name}}LbID'), '/inboundNatPools/', 'RDP-', variables('{{.Name}}VMNamePrefix'))]"
                 }
               ],
-{{end}}  
-              "privateIPAllocationMethod": "Dynamic", 
+{{end}}
+              "privateIPAllocationMethod": "Dynamic",
               "subnet": {
                 "id": "[variables('{{.Name}}VnetSubnetID')]"
              }
             }
           }
         ]
-      }, 
+      },
       "type": "Microsoft.Network/networkInterfaces"
     },
 {{if .IsManagedDisks}}
     {
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]", 
-      "location": "[variables('location')]", 
-      "name": "[variables('{{.Name}}AvailabilitySet')]", 
-      "properties": { 
-        "platformFaultDomainCount": 2, 
+      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
+      "location": "[variables('location')]",
+      "name": "[variables('{{.Name}}AvailabilitySet')]",
+      "properties": {
+        "platformFaultDomainCount": 2,
         "platformUpdateDomainCount": 3,
         "managed": "true"
       },
@@ -28234,76 +28234,76 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
     },
 {{else if .IsStorageAccount}}
     {
-      "apiVersion": "[variables('apiVersionStorage')]", 
+      "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
-        "count": "[variables('{{.Name}}StorageAccountsCount')]", 
+        "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "vmLoopNode"
-      }, 
+      },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-      ], 
-      "location": "[variables('location')]", 
-      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]", 
+      ],
+      "location": "[variables('location')]",
+      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
       "properties": {
         "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-      }, 
+      },
       "type": "Microsoft.Storage/storageAccounts"
     },
   {{if .HasDisks}}
       {
-        "apiVersion": "[variables('apiVersionStorage')]", 
+        "apiVersion": "[variables('apiVersionStorage')]",
         "copy": {
-          "count": "[variables('{{.Name}}StorageAccountsCount')]", 
+          "count": "[variables('{{.Name}}StorageAccountsCount')]",
           "name": "datadiskLoop"
-        }, 
+        },
         "dependsOn": [
           "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-        ], 
-        "location": "[variables('location')]", 
-        "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]", 
+        ],
+        "location": "[variables('location')]",
+        "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
         "properties": {
           "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-        }, 
+        },
         "type": "Microsoft.Storage/storageAccounts"
-      }, 
+      },
   {{end}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]", 
-      "location": "[variables('location')]", 
-      "name": "[variables('{{.Name}}AvailabilitySet')]", 
-      "properties": {}, 
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "location": "[variables('location')]",
+      "name": "[variables('{{.Name}}AvailabilitySet')]",
+      "properties": {},
       "type": "Microsoft.Compute/availabilitySets"
     },
 {{end}}
 {{if IsPublic .Ports}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]", 
-      "location": "[variables('location')]", 
-      "name": "[variables('{{.Name}}IPAddressName')]", 
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "location": "[variables('location')]",
+      "name": "[variables('{{.Name}}IPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[variables('{{.Name}}EndpointDNSNamePrefix')]"
-        }, 
+        },
         "publicIPAllocationMethod": "Dynamic"
-      }, 
+      },
       "type": "Microsoft.Network/publicIPAddresses"
-    }, 
+    },
     {
-      "apiVersion": "[variables('apiVersionDefault')]", 
+      "apiVersion": "[variables('apiVersionDefault')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('{{.Name}}IPAddressName'))]"
-      ], 
-      "location": "[variables('location')]", 
-      "name": "[variables('{{.Name}}LbName')]", 
+      ],
+      "location": "[variables('location')]",
+      "name": "[variables('{{.Name}}LbName')]",
       "properties": {
         "backendAddressPools": [
           {
             "name": "[variables('{{.Name}}LbBackendPoolName')]"
           }
-        ], 
+        ],
         "frontendIPConfigurations": [
           {
-            "name": "[variables('{{.Name}}LbIPConfigName')]", 
+            "name": "[variables('{{.Name}}LbIPConfigName')]",
             "properties": {
               "publicIPAddress": {
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('{{.Name}}IPAddressName'))]"
@@ -28324,16 +28324,16 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
               "backendPort": "[variables('agentWindowsBackendPort')]"
             }
           }
-        ], 
+        ],
         "loadBalancingRules": [
           {{(GetLBRules .Name .Ports)}}
-        ], 
+        ],
         "probes": [
           {{(GetProbes .Ports)}}
         ]
-      }, 
+      },
       "type": "Microsoft.Network/loadBalancers"
-    }, 
+    },
 {{end}}
     {
 {{if .IsManagedDisks}}
@@ -28342,9 +28342,9 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
     "apiVersion": "[variables('apiVersionDefault')]",
 {{end}}
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]", 
+        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
-      }, 
+      },
       "dependsOn": [
 {{if .IsStorageAccount}}
         "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
@@ -28352,35 +28352,35 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
           "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]", 
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
         "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
       ],
       "tags":
       {
         "creationSource" : "[concat('acsengine-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
       },
-      "location": "[variables('location')]",  
+      "location": "[variables('location')]",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
       "properties": {
         "availabilitySet": {
           "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('{{.Name}}AvailabilitySet'))]"
-        }, 
+        },
         "hardwareProfile": {
           "vmSize": "[variables('{{.Name}}VMSize')]"
-        }, 
+        },
         "networkProfile": {
           "networkInterfaces": [
             {
               "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset'))))]"
             }
           ]
-        }, 
+        },
         "osProfile": {
           "computername": "[concat(substring(variables('nameSuffix'), 0, 5), 'acs', copyIndex(variables('{{.Name}}Offset')), add(900,variables('{{.Name}}Index')))]",
           "adminUsername": "[variables('windowsAdminUsername')]",
           "adminPassword": "[variables('windowsAdminPassword')]",
           {{if IsSwarmMode}}
-            {{GetWinAgentSwarmModeCustomData}}           
+            {{GetWinAgentSwarmModeCustomData}}
           {{else}}
             {{GetWinAgentSwarmCustomData}}
           {{end}}
@@ -28388,7 +28388,7 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
               ,
               "secrets": "[variables('windowsProfileSecrets')]"
           {{end}}
-        }, 
+        },
         "storageProfile": {
           {{GetDataDisks .}}
           "imageReference": {
@@ -28411,19 +28411,19 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
 {{end}}
           }
         }
-      }, 
+      },
       "type": "Microsoft.Compute/virtualMachines"
-    }, 
+    },
     {
-      "apiVersion": "[variables('apiVersionDefault')]", 
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]", 
+        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
-      }, 
+      },
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
-      ], 
-      "location": "[variables('location')]", 
+      ],
+      "location": "[variables('location')]",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/cse')]",
       "properties": {
         "publisher": "Microsoft.Compute",
@@ -28433,7 +28433,7 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
         "settings": {
           "commandToExecute": "[variables('windowsCustomScript')]"
         }
-      }, 
+      },
       "type": "Microsoft.Compute/virtualMachines/extensions"
     }
 `)

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -2399,7 +2399,7 @@ var _dcosDcoswindowsprovisionPs1 = []byte(`<#
         Provisions VM as a DCOS agent.
 
      Invoke by:
-
+       
 #>
 
 [CmdletBinding(DefaultParameterSetName="Standard")]
@@ -2411,7 +2411,7 @@ param(
     [string]
     [ValidateNotNullOrEmpty()]
     $firstMasterIP,
-
+    
     [string]
     [ValidateNotNullOrEmpty()]
     $bootstrapUri,
@@ -2465,7 +2465,7 @@ Expand-ZIPFile($file, $destination)
 }
 
 
-function
+function 
 Remove-Directory($dirname)
 {
 
@@ -2482,25 +2482,25 @@ Remove-Directory($dirname)
 }
 
 
-function
+function 
 Check-Subnet ([string]$cidr, [string]$ip)
 {
     try {
 
         $network, [int]$subnetlen = $cidr.Split('/')
-
+    
         if ($subnetlen -eq 0)
         {
             $subnetlen = 8 # Default in case we get an IP addr, not CIDR
         }
         $a = ([IPAddress] $network)
         [uint32] $unetwork = [uint32]$a.Address
-
+    
         $mask = -bnot ((-bnot [uint32]0) -shl (32 - $subnetlen))
-
+    
         $a = [IPAddress]$ip
         [uint32] $uip = [uint32]$a.Address
-
+    
         return ($unetwork -eq ($mask -band $uip))
     }
     catch {
@@ -2526,7 +2526,7 @@ Get-BootstrapScript($download_uri, $download_dir)
 try
 {
     # Set to false for debugging.  This will output the start script to
-    # c:\AzureData\dcosProvisionScript.log, and then you can RDP
+    # c:\AzureData\dcosProvisionScript.log, and then you can RDP 
     # to the windows machine, and run the script manually to watch
     # the output.
     Write-Log "Get the install script"
@@ -2543,16 +2543,16 @@ try
     $ip = ([IPAddress]($ip -join '.')).Address
 
     $MasterIP = @([IPAddress]$null)
-
-    for ($i = 0; $i -lt $MasterCount; $i++ )
+    
+    for ($i = 0; $i -lt $MasterCount; $i++ ) 
     {
        $new_ip = ([IPAddress]$ip).getAddressBytes()
        [Array]::Reverse($new_ip)
        $new_ip = [IPAddress]($new_ip -join '.')
        $MasterIP += $new_ip
-
+      
        $ip++
-
+     
     }
     $master_str  = $MasterIP.IPAddressToString
 
@@ -2561,7 +2561,7 @@ try
         $master_str += ":2181"
     }
     else {
-        for ($i = 0; $i -lt $master_str.count; $i++)
+        for ($i = 0; $i -lt $master_str.count; $i++) 
         {
             $master_str[$i] += ":2181"
         }
@@ -2574,12 +2574,12 @@ try
 
     if ($isAgent)
     {
-        $run_cmd = $global:BootstrapInstallDir+"\DCOSWindowsAgentSetup.ps1 -MasterIP '$master_json' -AgentPrivateIP "+($private_ip.IPAddress) +" -BootstrapUrl '$bootstrapUri' "
-        if ($isPublic)
+        $run_cmd = $global:BootstrapInstallDir+"\DCOSWindowsAgentSetup.ps1 -MasterIP '$master_json' -AgentPrivateIP "+($private_ip.IPAddress) +" -BootstrapUrl '$bootstrapUri' " 
+        if ($isPublic) 
         {
             $run_cmd += " -isPublic:` + "`" + `$true "
         }
-        if ($customAttrs)
+        if ($customAttrs) 
         {
             $run_cmd += " -customAttrs '$customAttrs'"
         }
@@ -4093,13 +4093,13 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - lxc-net.service
 - - tar
-  - czf
+  - czf 
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm
-  - -rf
+- - rm 
+  - -rf 
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -4474,13 +4474,13 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - lxc-net.service
 - - tar
-  - czf
+  - czf 
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm
-  - -rf
+- - rm 
+  - -rf 
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -4869,16 +4869,16 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - unscd.service
 - sed -i "s/^Port 22$/Port 22\nPort 2222/1" /etc/ssh/sshd_config
-- service ssh restart
+- service ssh restart 
 - /opt/azure/containers/setup_ephemeral_disk.sh
 - - tar
-  - czf
+  - czf 
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm
-  - -rf
+- - rm 
+  - -rf 
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -5242,16 +5242,16 @@ runcmd: PREPROVISION_EXTENSION
   - --now
   - unscd.service
 - sed -i "s/^Port 22$/Port 22\nPort 2222/1" /etc/ssh/sshd_config
-- service ssh restart
+- service ssh restart 
 - /opt/azure/containers/setup_ephemeral_disk.sh
 - - tar
-  - czf
+  - czf 
   - /etc/docker.tar.gz
   - -C
   - /tmp/xtoph
   - .docker
-- - rm
-  - -rf
+- - rm 
+  - -rf 
   - /tmp/xtoph
 - /opt/azure/containers/provision.sh
 - - cp
@@ -6155,21 +6155,21 @@ var _dcosDcosparamsT = []byte(`    "dcosBootstrapURL": {
       "defaultValue": "https://dcosio.azureedge.net/dcos/stable",
       "metadata": {
         "description": "The repository URL"
-      },
+      }, 
       "type": "string"
     },
     "dcosClusterPackageListID": {
       "defaultValue": "77282d8864a5bf36db345b54a0d1de3674a0e937",
       "metadata": {
         "description": "The default cluster package list IDs."
-      },
+      }, 
       "type": "string"
     },
     "dcosProviderPackageID": {
       "defaultValue": "",
       "metadata": {
         "description": "The guid for provider dcos-provider package."
-      },
+      }, 
       "type": "string"
     },
 `)
@@ -15030,7 +15030,7 @@ func k8sCloudInitArtifactsSysFsBpfMount() (*asset, error) {
 var _k8sCloudInitArtifactsSysctlD60CisConf = []byte(`# 3.1.2 Ensure packet redirect sending is disabled
 net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.send_redirects = 0
-# 3.2.1 Ensure source routed packets are not accepted
+# 3.2.1 Ensure source routed packets are not accepted 
 net.ipv4.conf.all.accept_source_route = 0
 net.ipv4.conf.default.accept_source_route = 0
 # 3.2.2 Ensure ICMP redirects are not accepted
@@ -18849,7 +18849,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}
+              value: {{ContainerConfig "clusterName"}}            
             - name: CONTROLLER_TYPE
               value: "DaemonSet"
             - name: ISTEST
@@ -18884,7 +18884,7 @@ spec:
               name: omsagent-secret
               readOnly: true
             - mountPath: /etc/config/settings
-              name: settings-vol-config
+              name: settings-vol-config  
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
@@ -18917,7 +18917,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true
+            optional: true    
   updateStrategy:
     type: RollingUpdate
 ---
@@ -18965,7 +18965,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}
+              value: {{ContainerConfig "clusterName"}}            
             - name: CONTROLLER_TYPE
               value: "ReplicaSet"
             - name: ISTEST
@@ -18992,7 +18992,7 @@ spec:
             - mountPath : /etc/config
               name: omsagent-rs-config
             - mountPath: /etc/config/settings
-              name: settings-vol-config
+              name: settings-vol-config              
           livenessProbe:
             exec:
               command:
@@ -19029,7 +19029,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true
+            optional: true    
 `)
 
 func k8sContaineraddons116KubernetesmasteraddonsOmsagentDaemonsetYamlBytes() ([]byte, error) {
@@ -20475,11 +20475,11 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/
+          mountPath: /var/log/      
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/
+          path: /var/log/              
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/
@@ -22561,7 +22561,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}
+              value: {{ContainerConfig "clusterName"}}            
             - name: CONTROLLER_TYPE
               value: "DaemonSet"
             - name: ISTEST
@@ -22596,7 +22596,7 @@ spec:
               name: omsagent-secret
               readOnly: true
             - mountPath: /etc/config/settings
-              name: settings-vol-config
+              name: settings-vol-config  
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
@@ -22629,7 +22629,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true
+            optional: true    
   updateStrategy:
     type: RollingUpdate
 ---
@@ -22677,7 +22677,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: ACS_RESOURCE_NAME
-              value: {{ContainerConfig "clusterName"}}
+              value: {{ContainerConfig "clusterName"}}            
             - name: CONTROLLER_TYPE
               value: "ReplicaSet"
             - name: ISTEST
@@ -22704,7 +22704,7 @@ spec:
             - mountPath : /etc/config
               name: omsagent-rs-config
             - mountPath: /etc/config/settings
-              name: settings-vol-config
+              name: settings-vol-config              
           livenessProbe:
             exec:
               command:
@@ -22741,7 +22741,7 @@ spec:
         - name: settings-vol-config
           configMap:
             name: container-azm-ms-agentconfig
-            optional: true
+            optional: true    
 `)
 
 func k8sContaineraddonsKubernetesmasteraddonsOmsagentDaemonsetYamlBytes() ([]byte, error) {
@@ -22792,11 +22792,11 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/
+          mountPath: /var/log/      
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/
+          path: /var/log/              
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/
@@ -24737,7 +24737,7 @@ func k8sWindowsconfigfuncPs1() (*asset, error) {
 var _k8sWindowsinstallopensshfuncPs1 = []byte(`function
 Install-OpenSSH {
     Param(
-        [Parameter(Mandatory = $true)][string[]]
+        [Parameter(Mandatory = $true)][string[]] 
         $SSHKeys
     )
 
@@ -24778,7 +24778,7 @@ Install-OpenSSH {
     # OPTIONAL but recommended:
     Set-Service -Name sshd -StartupType 'Automatic'
 
-    # Confirm the Firewall rule is configured. It should be created automatically by setup.
+    # Confirm the Firewall rule is configured. It should be created automatically by setup. 
     $firewall = Get-NetFirewallRule -Name *ssh*
 
     if (!$firewall) {
@@ -25788,14 +25788,14 @@ Start-Docker()
 {
     Write-Log "Starting $global:DockerServiceName..."
     $startTime = Get-Date
-
+        
     while (-not $dockerReady)
     {
         try
         {
             Start-Service -Name $global:DockerServiceName -ea Stop
 
-            $dockerReady = $true
+            $dockerReady = $true            
         }
         catch
         {
@@ -25807,7 +25807,7 @@ Start-Docker()
             }
 
             $errorStr = $_.Exception.Message
-            Write-Log "Starting Service failed: $errorStr"
+            Write-Log "Starting Service failed: $errorStr" 
             Write-Log "sleeping for 10 seconds..."
             Start-Sleep -sec 10
         }
@@ -25821,7 +25821,7 @@ Stop-Docker()
     Write-Log "Stopping $global:DockerServiceName..."
     try
     {
-        Stop-Service -Name $global:DockerServiceName -ea Stop
+        Stop-Service -Name $global:DockerServiceName -ea Stop   
     }
     catch
     {
@@ -25834,7 +25834,7 @@ Update-DockerServiceRecoveryPolicy()
 {
     $dockerReady = $false
     $startTime = Get-Date
-
+    
     # wait until the service exists
     while (-not $dockerReady)
     {
@@ -25842,7 +25842,7 @@ Update-DockerServiceRecoveryPolicy()
         {
             $dockerReady = $true
         }
-        else
+        else 
         {
             $timeElapsed = $(Get-Date) - $startTime
             if ($($timeElapsed).TotalMinutes -ge 5)
@@ -25854,7 +25854,7 @@ Update-DockerServiceRecoveryPolicy()
             Start-Sleep -sec 5
         }
     }
-
+    
     Write-Log "Updating docker restart policy, to ensure it restarts on error"
     $services = Get-WMIObject win32_service | Where-Object {$_.name -imatch $global:DockerServiceName}
     foreach ($service in $services)
@@ -25928,7 +25928,7 @@ try
 
     Write-Log "Update Docker restart policy"
     Update-DockerServiceRecoveryPolicy
-
+    
     Write-Log "Start Docker"
     Start-Docker
 
@@ -26020,14 +26020,14 @@ function Start-Docker()
 {
     Write-Log "Starting $global:DockerServiceName..."
     $startTime = Get-Date
-
+        
     while (-not $dockerReady)
     {
         try
         {
             Start-Service -Name $global:DockerServiceName -ea Stop
 
-            $dockerReady = $true
+            $dockerReady = $true            
         }
         catch
         {
@@ -26039,7 +26039,7 @@ function Start-Docker()
             }
 
             $errorStr = $_.Exception.Message
-            Write-Log "Starting Service failed: $errorStr"
+            Write-Log "Starting Service failed: $errorStr" 
             Write-Log "sleeping for 10 seconds..."
             Start-Sleep -sec 10
         }
@@ -26051,7 +26051,7 @@ function Stop-Docker()
     Write-Log "Stopping $global:DockerServiceName..."
     try
     {
-        Stop-Service -Name $global:DockerServiceName -ea Stop
+        Stop-Service -Name $global:DockerServiceName -ea Stop   
     }
     catch
     {
@@ -26104,7 +26104,7 @@ function Install-DockerBinaries()
             $currentRetry = $currentRetry + 1;
         }
     } while (!$success);
-
+      
     Write-Log "Expanding zip file at destination: $global:DockerExePath"
     Expand-ZIPFile -File $zipfile -Destination $global:DockerExePath
 
@@ -26116,7 +26116,7 @@ function Update-DockerServiceRecoveryPolicy()
 {
     $dockerReady = $false
     $startTime = Get-Date
-
+    
     # wait until the service exists
     while (-not $dockerReady)
     {
@@ -26124,7 +26124,7 @@ function Update-DockerServiceRecoveryPolicy()
         {
             $dockerReady = $true
         }
-        else
+        else 
         {
             $timeElapsed = $(Get-Date) - $startTime
             if ($($timeElapsed).TotalMinutes -ge 5)
@@ -26136,7 +26136,7 @@ function Update-DockerServiceRecoveryPolicy()
             Start-Sleep -sec 5
         }
     }
-
+    
     Write-Log "Updating docker restart policy, to ensure it restarts on error"
     $services = Get-WMIObject win32_service | Where-Object {$_.name -imatch $global:DockerServiceName}
     foreach ($service in $services)
@@ -26240,7 +26240,7 @@ function Confirm-DockerVersion()
    $dockerClientVersion = Invoke-Expression -Command:$dockerClientVersionCmd
 
    Write-Log "Docker Server version: $dockerServerVersion, Docker Client verison: $dockerClientVersion"
-
+   
    $serverVersionData = $dockerServerVersion.Split(".")
    $isNewServerVersion = $false;
    if(($serverVersionData[0] -ge 1) -and ($serverVersionData[1] -ge 13)){
@@ -26252,7 +26252,7 @@ function Confirm-DockerVersion()
    $isNewClientVersion = $false;
    if(($clientVersionData[0] -ge 1) -and ($clientVersionData[1] -ge 13)){
        $isNewClientVersion = $true;
-       Write-Log "Setting  isNewClientVersion to $isNewClientVersion"
+       Write-Log "Setting  isNewClientVersion to $isNewClientVersion"   
    }
 
    if($isNewServerVersion -and $isNewClientVersion)
@@ -26283,10 +26283,10 @@ try
 
     Write-Log "Update Docker restart policy"
     Update-DockerServiceRecoveryPolicy
-
+    
     Write-Log "Start Docker"
     Start-Docker
-
+    
     Write-Log "Join existing Swarm"
     Join-Swarm
 
@@ -26483,7 +26483,7 @@ installDocker()
 {
   for i in {1..10}; do
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     apt-get update
     apt-get install -y docker-ce=${DOCKER_CE_VERSION}
@@ -26801,7 +26801,7 @@ installDockerUbuntu()
 {
   for i in {1..10}; do
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     apt-get update
     apt-get install -y docker-ce=${DOCKER_CE_VERSION}
@@ -27199,10 +27199,10 @@ var _swarmSwarmagentresourcesvmasT = []byte(`    {
           "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
 {{if IsSwarmMode}}
   {{if not .IsRHEL}}
-            {{GetAgentSwarmModeCustomData .}}
+            {{GetAgentSwarmModeCustomData .}} 
   {{end}}
 {{else}}
-            {{GetAgentSwarmCustomData .}}
+            {{GetAgentSwarmCustomData .}} 
 {{end}}
           "linuxConfiguration": {
               "disablePasswordAuthentication": true,
@@ -28178,11 +28178,11 @@ func swarmSwarmparamsT() (*asset, error) {
 }
 
 var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionDefault')]", 
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]", 
         "name": "loop"
-      },
+      }, 
       "dependsOn": [
 {{if not .IsCustomVNET}}
       "[variables('vnetID')]"
@@ -28190,13 +28190,13 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
 {{if IsPublic .Ports}}
 	  ,"[variables('{{.Name}}LbID')]"
 {{end}}
-      ],
-      "location": "[variables('location')]",
+      ], 
+      "location": "[variables('location')]", 
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
       "properties": {
         "ipConfigurations": [
           {
-            "name": "ipConfigNode",
+            "name": "ipConfigNode", 
             "properties": {
 {{if IsPublic .Ports}}
               "loadBalancerBackendAddressPools": [
@@ -28209,24 +28209,24 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
                   "id": "[concat(variables('{{.Name}}LbID'), '/inboundNatPools/', 'RDP-', variables('{{.Name}}VMNamePrefix'))]"
                 }
               ],
-{{end}}
-              "privateIPAllocationMethod": "Dynamic",
+{{end}}  
+              "privateIPAllocationMethod": "Dynamic", 
               "subnet": {
                 "id": "[variables('{{.Name}}VnetSubnetID')]"
              }
             }
           }
         ]
-      },
+      }, 
       "type": "Microsoft.Network/networkInterfaces"
     },
 {{if .IsManagedDisks}}
     {
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
-      "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "properties": {
-        "platformFaultDomainCount": 2,
+      "apiVersion": "[variables('apiVersionStorageManagedDisks')]", 
+      "location": "[variables('location')]", 
+      "name": "[variables('{{.Name}}AvailabilitySet')]", 
+      "properties": { 
+        "platformFaultDomainCount": 2, 
         "platformUpdateDomainCount": 3,
         "managed": "true"
       },
@@ -28234,76 +28234,76 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
     },
 {{else if .IsStorageAccount}}
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "[variables('apiVersionStorage')]", 
       "copy": {
-        "count": "[variables('{{.Name}}StorageAccountsCount')]",
+        "count": "[variables('{{.Name}}StorageAccountsCount')]", 
         "name": "vmLoopNode"
-      },
+      }, 
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-      ],
-      "location": "[variables('location')]",
-      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
+      ], 
+      "location": "[variables('location')]", 
+      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]", 
       "properties": {
         "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-      },
+      }, 
       "type": "Microsoft.Storage/storageAccounts"
     },
   {{if .HasDisks}}
       {
-        "apiVersion": "[variables('apiVersionStorage')]",
+        "apiVersion": "[variables('apiVersionStorage')]", 
         "copy": {
-          "count": "[variables('{{.Name}}StorageAccountsCount')]",
+          "count": "[variables('{{.Name}}StorageAccountsCount')]", 
           "name": "datadiskLoop"
-        },
+        }, 
         "dependsOn": [
           "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-        ],
-        "location": "[variables('location')]",
-        "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
+        ], 
+        "location": "[variables('location')]", 
+        "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]", 
         "properties": {
           "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-        },
+        }, 
         "type": "Microsoft.Storage/storageAccounts"
-      },
+      }, 
   {{end}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "properties": {},
+      "apiVersion": "[variables('apiVersionDefault')]", 
+      "location": "[variables('location')]", 
+      "name": "[variables('{{.Name}}AvailabilitySet')]", 
+      "properties": {}, 
       "type": "Microsoft.Compute/availabilitySets"
     },
 {{end}}
 {{if IsPublic .Ports}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}IPAddressName')]",
+      "apiVersion": "[variables('apiVersionDefault')]", 
+      "location": "[variables('location')]", 
+      "name": "[variables('{{.Name}}IPAddressName')]", 
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[variables('{{.Name}}EndpointDNSNamePrefix')]"
-        },
+        }, 
         "publicIPAllocationMethod": "Dynamic"
-      },
+      }, 
       "type": "Microsoft.Network/publicIPAddresses"
-    },
+    }, 
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionDefault')]", 
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('{{.Name}}IPAddressName'))]"
-      ],
-      "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}LbName')]",
+      ], 
+      "location": "[variables('location')]", 
+      "name": "[variables('{{.Name}}LbName')]", 
       "properties": {
         "backendAddressPools": [
           {
             "name": "[variables('{{.Name}}LbBackendPoolName')]"
           }
-        ],
+        ], 
         "frontendIPConfigurations": [
           {
-            "name": "[variables('{{.Name}}LbIPConfigName')]",
+            "name": "[variables('{{.Name}}LbIPConfigName')]", 
             "properties": {
               "publicIPAddress": {
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('{{.Name}}IPAddressName'))]"
@@ -28324,16 +28324,16 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
               "backendPort": "[variables('agentWindowsBackendPort')]"
             }
           }
-        ],
+        ], 
         "loadBalancingRules": [
           {{(GetLBRules .Name .Ports)}}
-        ],
+        ], 
         "probes": [
           {{(GetProbes .Ports)}}
         ]
-      },
+      }, 
       "type": "Microsoft.Network/loadBalancers"
-    },
+    }, 
 {{end}}
     {
 {{if .IsManagedDisks}}
@@ -28342,9 +28342,9 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
     "apiVersion": "[variables('apiVersionDefault')]",
 {{end}}
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]", 
         "name": "vmLoopNode"
-      },
+      }, 
       "dependsOn": [
 {{if .IsStorageAccount}}
         "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
@@ -28352,35 +28352,35 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
           "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]", 
         "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
       ],
       "tags":
       {
         "creationSource" : "[concat('acsengine-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
       },
-      "location": "[variables('location')]",
+      "location": "[variables('location')]",  
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
       "properties": {
         "availabilitySet": {
           "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('{{.Name}}AvailabilitySet'))]"
-        },
+        }, 
         "hardwareProfile": {
           "vmSize": "[variables('{{.Name}}VMSize')]"
-        },
+        }, 
         "networkProfile": {
           "networkInterfaces": [
             {
               "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset'))))]"
             }
           ]
-        },
+        }, 
         "osProfile": {
           "computername": "[concat(substring(variables('nameSuffix'), 0, 5), 'acs', copyIndex(variables('{{.Name}}Offset')), add(900,variables('{{.Name}}Index')))]",
           "adminUsername": "[variables('windowsAdminUsername')]",
           "adminPassword": "[variables('windowsAdminPassword')]",
           {{if IsSwarmMode}}
-            {{GetWinAgentSwarmModeCustomData}}
+            {{GetWinAgentSwarmModeCustomData}}           
           {{else}}
             {{GetWinAgentSwarmCustomData}}
           {{end}}
@@ -28388,7 +28388,7 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
               ,
               "secrets": "[variables('windowsProfileSecrets')]"
           {{end}}
-        },
+        }, 
         "storageProfile": {
           {{GetDataDisks .}}
           "imageReference": {
@@ -28411,19 +28411,19 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
 {{end}}
           }
         }
-      },
+      }, 
       "type": "Microsoft.Compute/virtualMachines"
-    },
+    }, 
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionDefault')]", 
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]", 
         "name": "vmLoopNode"
-      },
+      }, 
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
-      ],
-      "location": "[variables('location')]",
+      ], 
+      "location": "[variables('location')]", 
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/cse')]",
       "properties": {
         "publisher": "Microsoft.Compute",
@@ -28433,7 +28433,7 @@ var _swarmSwarmwinagentresourcesvmasT = []byte(`    {
         "settings": {
           "commandToExecute": "[variables('windowsCustomScript')]"
         }
-      },
+      }, 
       "type": "Microsoft.Compute/virtualMachines/extensions"
     }
 `)

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12541,12 +12541,6 @@ configureCNIIPTables() {
     fi
 }
 
-setKubeletOpts () {
-    KUBELET_DEFAULT_FILE=/etc/default/kubelet
-    wait_for_file 1200 1 $KUBELET_DEFAULT_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    sed -i "s#^KUBELET_OPTS=.*#KUBELET_OPTS=${1}#" $KUBELET_DEFAULT_FILE
-}
-
 setupContainerd() {
     echo "Configuring cri-containerd..."
     mkdir -p "/etc/containerd"
@@ -12567,7 +12561,6 @@ setupContainerd() {
         echo "runtime_type = 'io.containerd.runtime.v1.linux'"
         echo "runtime_engine = '/usr/local/sbin/runc'"
     } > "$CRI_CONTAINERD_CONFIG"
-    setKubeletOpts " --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
 }
 
 ensureContainerd() {
@@ -15416,8 +15409,8 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
   permissions: "0644"
   owner: root
   content: |
-{{if IsKubernetesVersionLt "1.8.0"}}
-    KUBELET_OPTS=--require-kubeconfig
+{{if HasContainerd}}
+    KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=
 {{end}}
@@ -15947,8 +15940,8 @@ write_files:
   permissions: "0644"
   owner: root
   content: |
-{{if IsKubernetesVersionLt "1.8.0"}}
-    KUBELET_OPTS=--require-kubeconfig
+{{if HasContainerd}}
+    KUBELET_OPTS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock
 {{else}}
     KUBELET_OPTS=
 {{end}}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Simplify containerd kubelet config implementation: do this during cloud-init template generation instead of via sed at the last mile.

Also remove some deprecated "if less than k8s 1.8" logic to make the above more maintainable/expressive.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1786 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
