### PR TITLE
fix: race condition which causes concurrent map writes during tests

### DIFF
--- a/pkg/api/defaults-scheduler.go
+++ b/pkg/api/defaults-scheduler.go
@@ -18,16 +18,16 @@ var defaultSchedulerConfig = map[string]string{
 func (cs *ContainerService) setSchedulerConfig() {
 	o := cs.Properties.OrchestratorProfile
 
-	// If no user-configurable scheduler config values exists, use the defaults
+	// If no user-configurable scheduler config values exists, make an empty map, and fill in with defaults
 	if o.KubernetesConfig.SchedulerConfig == nil {
-		o.KubernetesConfig.SchedulerConfig = defaultSchedulerConfig
-	} else {
-		for key, val := range defaultSchedulerConfig {
-			// If we don't have a user-configurable scheduler config for each option
-			if _, ok := o.KubernetesConfig.SchedulerConfig[key]; !ok {
-				// then assign the default value
-				o.KubernetesConfig.SchedulerConfig[key] = val
-			}
+		o.KubernetesConfig.SchedulerConfig = make(map[string]string)
+	}
+
+	for key, val := range defaultSchedulerConfig {
+		// If we don't have a user-configurable scheduler config for each option
+		if _, ok := o.KubernetesConfig.SchedulerConfig[key]; !ok {
+			// then assign the default value
+			o.KubernetesConfig.SchedulerConfig[key] = val
 		}
 	}
 


### PR DESCRIPTION
fix: race condition which causes concurrent map writes during tests

**Reason for Change**:
Occasionally when running tests, I will run into the following which is caused by a shared reference to a map of default values. This change will cause an empty map to be created and populated with the entries from the default values map.
```
fatal error: concurrent map writes

goroutine 612 [running]:
runtime.throw(0x1822cd0, 0x15)
	/usr/local/Cellar/go/1.12.7/libexec/src/runtime/panic.go:617 +0x72 fp=0xc0000c57e8 sp=0xc0000c57b8 pc=0x102f482
runtime.mapassign_faststr(0x1752a80, 0xc00023db60, 0x181ab9b, 0xc, 0x0)
	/usr/local/Cellar/go/1.12.7/libexec/src/runtime/map_faststr.go:291 +0x40f fp=0xc0000c5850 sp=0xc0000c57e8 pc=0x1014f3f
github.com/Azure/aks-engine/pkg/api.(*ContainerService).setSchedulerConfig(0xc00027c0f0)
	/Users/davidjustice/go/src/github.com/Azure/aks-engine/pkg/api/defaults-scheduler.go:37 +0x11c fp=0xc0000c5928 sp=0xc0000c5850 pc=0x15b58fc
github.com/Azure/aks-engine/pkg/api.(*ContainerService).setOrchestratorDefaults(0xc00027c0f0, 0x1040000)
	/Users/davidjustice/go/src/github.com/Azure/aks-engine/pkg/api/defaults.go:354 +0xd0d fp=0xc0000c5f40 sp=0xc0000c5928 pc=0x15b6cdd
github.com/Azure/aks-engine/pkg/api.TestDefaultEnablePodSecurityPolicy.func1(0xc00010e300)
	/Users/davidjustice/go/src/github.com/Azure/aks-engine/pkg/api/defaults_test.go:2777 +0x51 fp=0xc0000c5fa8 sp=0xc0000c5f40 pc=0x169e701
testing.tRunner(0xc00010e300, 0xc0004a5610)
	/usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0xc0 fp=0xc0000c5fd0 sp=0xc0000c5fa8 pc=0x10ef090
runtime.goexit()
	/usr/local/Cellar/go/1.12.7/libexec/src/runtime/asm_amd64.s:1337 +0x1 fp=0xc0000c5fd8 sp=0xc0000c5fd0 pc=0x105e6f1
created by testing.(*T).Run
	/usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:916 +0x35a
```

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
