### PR TITLE
feat: update cloud provider rate limit for vmas.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1834,10 +1834,12 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 // SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
-		if p.AnyAgentUsesAvailabilitySets() || p.AnyAgentUsesVirtualMachineScaleSets() {
-			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = len(p.AgentPoolProfiles) * common.MaxAgentCount
-		} else {
+		var agentPoolProfilesCount int
+		agentPoolProfilesCount = len(p.AgentPoolProfiles)
+		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
+		} else {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = agentPoolProfilesCount * common.MaxAgentCount
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS == 0 {
@@ -1848,10 +1850,12 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite == 0 {
-		if p.AnyAgentUsesAvailabilitySets() || p.AnyAgentUsesVirtualMachineScaleSets() {
-			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = len(p.AgentPoolProfiles) * common.MaxAgentCount
-		} else {
+		var agentPoolProfilesCount int
+		agentPoolProfilesCount = len(p.AgentPoolProfiles)
+		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = DefaultKubernetesCloudProviderRateLimitBucketWrite
+		} else {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = agentPoolProfilesCount * common.MaxAgentCount
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPSWrite == 0 {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1834,8 +1834,7 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 // SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
-		var agentPoolProfilesCount int
-		agentPoolProfilesCount = len(p.AgentPoolProfiles)
+		var agentPoolProfilesCount = len(p.AgentPoolProfiles)
 		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
 		} else {
@@ -1850,8 +1849,7 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite == 0 {
-		var agentPoolProfilesCount int
-		agentPoolProfilesCount = len(p.AgentPoolProfiles)
+		var agentPoolProfilesCount = len(p.AgentPoolProfiles)
 		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = DefaultKubernetesCloudProviderRateLimitBucketWrite
 		} else {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1834,7 +1834,7 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 // SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
-		if !p.IsHostedMasterProfile() {
+		if p.AnyAgentUsesAvailabilitySets() || p.AnyAgentUsesVirtualMachineScaleSets() {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = len(p.AgentPoolProfiles) * common.MaxAgentCount
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
@@ -1848,7 +1848,7 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite == 0 {
-		if !p.IsHostedMasterProfile() {
+		if p.AnyAgentUsesAvailabilitySets() || p.AnyAgentUsesVirtualMachineScaleSets() {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = len(p.AgentPoolProfiles) * common.MaxAgentCount
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = DefaultKubernetesCloudProviderRateLimitBucketWrite

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1834,15 +1834,8 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 // SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
-		if p.HasVMSSAgentPool() && !p.IsHostedMasterProfile() {
-			var rateLimitBucket int
-			for _, profile := range p.AgentPoolProfiles {
-				if profile.AvailabilityProfile == VirtualMachineScaleSets {
-					rateLimitBucket += common.MaxAgentCount
-				}
-
-			}
-			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = rateLimitBucket
+		if !p.IsHostedMasterProfile() {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = len(p.AgentPoolProfiles) * common.MaxAgentCount
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
 		}
@@ -1855,15 +1848,8 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite == 0 {
-		if p.HasVMSSAgentPool() && !p.IsHostedMasterProfile() {
-			var rateLimitBucket int
-			for _, profile := range p.AgentPoolProfiles {
-				if profile.AvailabilityProfile == VirtualMachineScaleSets {
-					rateLimitBucket += common.MaxAgentCount
-				}
-
-			}
-			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = rateLimitBucket
+		if !p.IsHostedMasterProfile() {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = len(p.AgentPoolProfiles) * common.MaxAgentCount
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = DefaultKubernetesCloudProviderRateLimitBucketWrite
 		}


### PR DESCRIPTION
**Reason for Change**:
PR changes the cloudprovider-enforced rate limiter configuration for VMAS scenarios as well to allow for more "burstability". For large cluster on Azure Stack, app deployment which requires LoadBalancer reconciliation either NicGet call or NicUpdate call is failing. Updating the code to support "burstability" on VMAS as well.

**Issue Fixed**:
Fixes #1806 

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/) 
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
