### PR TITLE
docs: Move master and agent node OS vhd size to default value i.e 30GB

### DIFF
--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -17,14 +17,12 @@
         "masterProfile": {
             "dnsPrefix": "",
             "distro": "ubuntu",
-            "osDiskSizeGB": 200,
             "count": 3,
             "vmSize": "Standard_D2_v2"
         },
         "agentPoolProfiles": [
             {
                 "name": "linuxpool",
-                "osDiskSizeGB": 200,
                 "count": 3,
                 "vmSize": "Standard_D2_v2",
                 "distro": "ubuntu",


### PR DESCRIPTION
**Reason for Change**:
Based on PM comment we need to keep the OS disk size as small as possible.

**Issue Fixed**:
Fixes #1812 


**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
