### PR TITLE
feat: add support for Kubernetes 1.16.0-beta.1

### DIFF
--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-cilium-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-cilium-daemonset.yaml
@@ -50,7 +50,6 @@ spec:
       annotations:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
-        scheduler.alpha.kubernetes.io/critical-pod: ""
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -54,8 +54,6 @@ spec:
       labels:
         tier: node
         app: flannel
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
       nodeSelector:

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -79,8 +79,6 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -46,7 +46,6 @@ spec:
         - kube-proxy
         - --kubeconfig=/var/lib/kubelet/kubeconfig
         - --cluster-cidr=<CIDR>
-        - --feature-gates=ExperimentalCriticalPodAnnotation=true
         - --proxy-mode=<kubeProxyMode>
         image: <img>
         imagePullPolicy: IfNotPresent

--- a/parts/k8s/containeraddons/1.16/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/containeraddons/1.16/azure-cni-networkmonitor.yaml
@@ -14,8 +14,6 @@ spec:
     metadata:
       labels:
         k8s-app: azure-cnms
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-azure-npm-daemonset.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-azure-npm-daemonset.yaml
@@ -65,8 +65,6 @@ spec:
     metadata:
       labels:
         k8s-app: azure-npm
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-calico-daemonset.yaml
@@ -357,12 +357,9 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
-        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
-        # add-on, ensuring it gets priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -446,13 +443,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -666,8 +658,6 @@ spec:
     metadata:
       labels:
         k8s-app: calico-typha-autoscaler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       securityContext:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-heapster-deployment.yaml
@@ -101,8 +101,6 @@ spec:
     metadata:
       labels:
         k8s-app: heapster
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       containers:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
@@ -16,9 +16,8 @@ spec:
     metadata:
       labels:
         k8s-app: rescheduler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:

--- a/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-nvidia-device-plugin-daemonset.yaml
+++ b/parts/k8s/containeraddons/1.16/kubernetesmasteraddons-nvidia-device-plugin-daemonset.yaml
@@ -15,8 +15,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: nvidia-device-plugin
     spec:

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -142,6 +142,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.16.0-alpha.1": true,
 	"1.16.0-alpha.2": true,
 	"1.16.0-alpha.3": true,
+	"1.16.0-beta.1":  true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -7063,7 +7063,6 @@ spec:
       annotations:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
-        scheduler.alpha.kubernetes.io/critical-pod: ""
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium
@@ -7866,7 +7865,8 @@ metadata:
   name: cilium
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"`)
+    addonmanager.kubernetes.io/mode: "Reconcile"
+`)
 
 func k8sAddons116KubernetesmasteraddonsCiliumDaemonsetYamlBytes() ([]byte, error) {
 	return _k8sAddons116KubernetesmasteraddonsCiliumDaemonsetYaml, nil
@@ -7939,8 +7939,6 @@ spec:
       labels:
         tier: node
         app: flannel
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
       nodeSelector:
@@ -8139,8 +8137,6 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -16094,8 +16090,6 @@ spec:
     metadata:
       labels:
         k8s-app: azure-cnms
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -16712,8 +16706,6 @@ spec:
     metadata:
       labels:
         k8s-app: azure-npm
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -17184,12 +17176,9 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
-        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
-        # add-on, ensuring it gets priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -17273,13 +17262,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -17493,8 +17477,6 @@ spec:
     metadata:
       labels:
         k8s-app: calico-typha-autoscaler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
@@ -17959,8 +17941,6 @@ spec:
     metadata:
       labels:
         k8s-app: heapster
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       containers:
@@ -18124,9 +18104,8 @@ spec:
     metadata:
       labels:
         k8s-app: rescheduler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:
@@ -18490,8 +18469,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: nvidia-device-plugin
     spec:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -8331,7 +8331,6 @@ spec:
         - kube-proxy
         - --kubeconfig=/var/lib/kubelet/kubeconfig
         - --cluster-cidr=<CIDR>
-        - --feature-gates=ExperimentalCriticalPodAnnotation=true
         - --proxy-mode=<kubeProxyMode>
         image: <img>
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#changelog-since-v1160-alpha3

**Issue Fixed**:

**Requirements**:
- [x] Windows artifacts uploaded to acsmirror blob store
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
We may still need to follow up on this:

> scheduler.alpha.kubernetes.io/critical-pod annotation is removed. Pod priority (spec.priorityClassName) should be used instead to mark pods as critical.
