### PR TITLE
fix: use azcopy-preview in VHD pipeline

### DIFF
--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -7,7 +7,7 @@ trigger: none
 # - POST a new SKU to azure marketplace
 
 variables:
-  DEIS_GO_DEV_IMAGE:  'quay.io/deis/go-dev:v1.23.2' 
+  CONTAINER_IMAGE:  'quay.io/deis/go-dev:v1.23.2' 
 
 phases:
 - phase: build_vhd
@@ -30,13 +30,13 @@ phases:
       -e BUILD_ID=$(Build.BuildId) \
       -e BUILD_NUMBER=$(Build.BuildNumber) \
       -e UBUNTU_SKU=${UBUNTU_SKU} \
-      ${DEIS_GO_DEV_IMAGE} make run-packer
+      ${CONTAINER_IMAGE} make run-packer
     displayName: Building VHD
   - script: |
       docker run --rm \
       -v ${PWD}:/go/src/github.com/Azure/aks-engine \
       -w /go/src/github.com/Azure/aks-engine \
-      ${DEIS_GO_DEV_IMAGE} make vhd-notes
+      ${CONTAINER_IMAGE} make vhd-notes
     displayName: Generate VHD release notes
   - task: PublishPipelineArtifact@0
     inputs:
@@ -56,7 +56,7 @@ phases:
       -e CLASSIC_SAS_TOKEN="$(SAS_TOKEN)" \
       -e OS_DISK_SAS=${OS_DISK_SAS} \
       -e VHD_NAME=${VHD_NAME} \
-      ${DEIS_GO_DEV_IMAGE} make az-copy
+      ${CONTAINER_IMAGE} make az-copy
     displayName: Copying resource to Classic Storage Account
     condition: eq(variables.DRY_RUN, 'False')
   - script: |
@@ -69,7 +69,7 @@ phases:
       -e TENANT_ID=${TENANT_ID} \
       -e SA_NAME=${SA_NAME} \
       -e AZURE_RESOURCE_GROUP_NAME=${AZURE_RESOURCE_GROUP_NAME} \
-      ${DEIS_GO_DEV_IMAGE} make delete-sa
+      ${CONTAINER_IMAGE} make delete-sa
     displayName: Clean-up Storage Account
   - script: |
       docker run --rm \
@@ -81,5 +81,5 @@ phases:
       -e CLASSIC_SA_CONNECTION_STRING="$(CLASSIC_SA_CONNECTION_STRING)" \
       -e START_DATE=${START_DATE} \
       -e EXPIRY_DATE=${EXPIRY_DATE} \
-      ${DEIS_GO_DEV_IMAGE} make generate-sas
+      ${CONTAINER_IMAGE} make generate-sas
     displayName: Getting Shared Access Signature URI

--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -7,7 +7,7 @@ trigger: none
 # - POST a new SKU to azure marketplace
 
 variables:
-  CONTAINER_IMAGE:  'quay.io/deis/go-dev:v1.23.2' 
+  CONTAINER_IMAGE:  'quay.io/deis/go-dev:v1.23.1' 
 
 phases:
 - phase: build_vhd

--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -6,6 +6,9 @@ trigger: none
 # - generate SAS link from azure CLI
 # - POST a new SKU to azure marketplace
 
+variables:
+  DEIS_GO_DEV_IMAGE:  'quay.io/deis/go-dev:v1.23.2' 
+
 phases:
 - phase: build_vhd
   queue:

--- a/packer.mk
+++ b/packer.mk
@@ -17,7 +17,7 @@ run-packer-windows: az-login
 	@packer version && set -o pipefail && ($(MAKE) init-packer | tee packer-output) && ($(MAKE) build-packer-windows | tee -a packer-output)
 
 az-copy: az-login
-	azcopy --source "${OS_DISK_SAS}" --destination "${CLASSIC_BLOB}/${VHD_NAME}" --dest-sas "${CLASSIC_SAS_TOKEN}"
+	azcopy-preview "${OS_DISK_SAS}" "${CLASSIC_BLOB}/${VHD_NAME}?${CLASSIC_SAS_TOKEN}"
 
 delete-sa: az-login
 	az storage account delete -n ${SA_NAME} -g ${AZURE_RESOURCE_GROUP_NAME} --yes

--- a/packer.mk
+++ b/packer.mk
@@ -17,7 +17,7 @@ run-packer-windows: az-login
 	@packer version && set -o pipefail && ($(MAKE) init-packer | tee packer-output) && ($(MAKE) build-packer-windows | tee -a packer-output)
 
 az-copy: az-login
-	azcopy-preview copy "${OS_DISK_SAS}" "${CLASSIC_BLOB}/${VHD_NAME}?${CLASSIC_SAS_TOKEN}"
+	azcopy-preview copy "${OS_DISK_SAS}" "${CLASSIC_BLOB}?${CLASSIC_SAS_TOKEN}"
 
 delete-sa: az-login
 	az storage account delete -n ${SA_NAME} -g ${AZURE_RESOURCE_GROUP_NAME} --yes

--- a/packer.mk
+++ b/packer.mk
@@ -17,7 +17,7 @@ run-packer-windows: az-login
 	@packer version && set -o pipefail && ($(MAKE) init-packer | tee packer-output) && ($(MAKE) build-packer-windows | tee -a packer-output)
 
 az-copy: az-login
-	azcopy-preview copy "${OS_DISK_SAS}" "${CLASSIC_BLOB}?${CLASSIC_SAS_TOKEN}"
+	azcopy-preview copy "${OS_DISK_SAS}" "${CLASSIC_BLOB}${CLASSIC_SAS_TOKEN}"
 
 delete-sa: az-login
 	az storage account delete -n ${SA_NAME} -g ${AZURE_RESOURCE_GROUP_NAME} --yes

--- a/packer.mk
+++ b/packer.mk
@@ -17,7 +17,7 @@ run-packer-windows: az-login
 	@packer version && set -o pipefail && ($(MAKE) init-packer | tee packer-output) && ($(MAKE) build-packer-windows | tee -a packer-output)
 
 az-copy: az-login
-	azcopy-preview "${OS_DISK_SAS}" "${CLASSIC_BLOB}/${VHD_NAME}?${CLASSIC_SAS_TOKEN}"
+	azcopy-preview copy "${OS_DISK_SAS}" "${CLASSIC_BLOB}/${VHD_NAME}?${CLASSIC_SAS_TOKEN}"
 
 delete-sa: az-login
 	az storage account delete -n ${SA_NAME} -g ${AZURE_RESOURCE_GROUP_NAME} --yes


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
azcopy was removed from the latest go dev image. Move to use azcopy-preview which is the newest version of azcopy. Once the new go dev image is published, we will replace azcopy-preview with azcopy.

Also declare an in code variable for the container image instead of using a devops variable to allow us to move the image version forward with the rest of our pipelines.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
