### PR TITLE
test: retry all ssh-dependent E2E tests

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -43,7 +43,6 @@ import (
 
 const (
 	WorkloadDir                            = "workloads"
-	ScriptsDir                             = "scripts"
 	PolicyDir                              = "workloads/policies"
 	retryCommandsTimeout                   = 5 * time.Minute
 	kubeSystemPodsReadinessChecks          = 6
@@ -157,6 +156,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				var conn *remote.Connection
 				conn, err = remote.NewConnection(kubeConfig.GetServerName(), masterSSHPort, eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
+				Expect(err).NotTo(HaveOccurred())
 				master := fmt.Sprintf("%s@%s", eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, kubeConfig.GetServerName())
 				lsbReleaseCmd := fmt.Sprintf("lsb_release -a && uname -r")
 				err = conn.ExecuteFromMaster(master, lsbReleaseCmd, true)
@@ -175,6 +175,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				var conn *remote.Connection
 				conn, err = remote.NewConnection(kubeConfig.GetServerName(), masterSSHPort, eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
+				Expect(err).NotTo(HaveOccurred())
 				nodeList, err := node.GetReady()
 				Expect(err).NotTo(HaveOccurred())
 				dockerVersionCmd := fmt.Sprintf("\"docker version\"")
@@ -193,6 +194,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				var conn *remote.Connection
 				conn, err = remote.NewConnection(kubeConfig.GetServerName(), masterSSHPort, eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
+				Expect(err).NotTo(HaveOccurred())
 				nodeList, err := node.GetReady()
 				Expect(err).NotTo(HaveOccurred())
 				rootPasswdCmd := fmt.Sprintf("\"sudo grep '^root:[!*]:' /etc/shadow\" && exit 1 || exit 0")
@@ -909,7 +911,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				for _, node := range nodeList.Nodes {
 					if node.IsWindows() {
 						By(fmt.Sprintf("simulating docker and subsequent kubelet service crash on node: %s", node.Metadata.Name))
-						err := conn.CopyToRemote(node.Metadata.Name, "/tmp/"+simulateDockerdCrashScript)
+						err = conn.CopyToRemote(node.Metadata.Name, "/tmp/"+simulateDockerdCrashScript)
 						Expect(err).NotTo(HaveOccurred())
 						simulateDockerCrashCommand := fmt.Sprintf("\"/tmp/%s\"", simulateDockerdCrashScript)
 						err = conn.ExecuteFromMaster(node.Metadata.Name, simulateDockerCrashCommand, true)

--- a/test/e2e/remote/ssh.go
+++ b/test/e2e/remote/ssh.go
@@ -185,7 +185,7 @@ func (c *Connection) CopyToRemote(hostname, path string) error {
 		cmd = exec.Command("ssh", "-A", "-i", c.PrivateKeyPath, "-o", "ConnectTimeout=30", "-o", "StrictHostKeyChecking=no", connectString, "-p", c.Port, remoteCommand)
 		util.PrintCommand(cmd)
 		sshOut, sshError = cmd.CombinedOutput()
-		if err != nil {
+		if sshError != nil {
 			log.Printf("Error output:%s\n", sshOut)
 			continue
 		} else {

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -377,7 +377,7 @@ func (cli *CLIProvisioner) FetchProvisioningMetrics(path string, cfg *config.Con
 	}
 	for _, master := range cli.Masters {
 		for _, fp := range masterFiles {
-			err = conn.CopyFromRemote(master.Name, fp)
+			err = conn.CopyFrom(master.Name, fp)
 			if err != nil {
 				log.Printf("Error reading file from path (%s):%s", path, err)
 			}
@@ -386,7 +386,7 @@ func (cli *CLIProvisioner) FetchProvisioningMetrics(path string, cfg *config.Con
 
 	for _, agent := range cli.Agents {
 		for _, fp := range agentFiles {
-			err = conn.CopyFromRemote(agent.Name, fp)
+			err = conn.CopyFrom(agent.Name, fp)
 			if err != nil {
 				log.Printf("Error reading file from path (%s):%s", path, err)
 			}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR generalizes the "ssh to master and run commands on all nodes" pattern, and enables 3 retries. Ditto for "scp files to master and to nodes".

Specifically: we were establishing ssh connections for every test, and running `ssh-add` inline for every ssh operation. And little of that was being retried. So now we're establishing a re-usable ssh connection (to the first master node), and then every remote ssh execution on that connection is allowed 3 retries.

The idea is that the above will remove undesired flakiness due to network I/O flakiness that we're not in control over.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
