### PR TITLE
chore: update go toolchain to 1.12.9 (#1789)

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go for aks-engine",
-	"image": "quay.io/deis/go-dev:v1.23.1",
+	"image": "quay.io/deis/go-dev:v1.23.2",
 	"extensions": [
 		"ms-vscode.go"
 	],

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -17,7 +17,7 @@ pr:
 resources:
   containers:
   - container: dev1
-    image: quay.io/deis/go-dev:v1.23.1
+    image: quay.io/deis/go-dev:v1.23.2
 
 jobs:
 - job: unit_tests

--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -7,7 +7,7 @@ trigger: none
 # - POST a new SKU to azure marketplace
 
 variables:
-  CONTAINER_IMAGE:  'quay.io/deis/go-dev:v1.23.1' 
+  CONTAINER_IMAGE:  'quay.io/deis/go-dev:v1.23.2'
 
 phases:
 - phase: build_vhd

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GITTAG := $(VERSION_SHORT)
 endif
 
 REPO_PATH := github.com/Azure/$(PROJECT)
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.23.1
+DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.23.2
 DEV_ENV_WORK_DIR := /go/src/$(REPO_PATH)
 DEV_ENV_OPTS := --rm -v $(CURDIR):$(DEV_ENV_WORK_DIR) -w $(DEV_ENV_WORK_DIR) $(DEV_ENV_VARS)
 DEV_ENV_CMD := docker run $(DEV_ENV_OPTS) $(DEV_ENV_IMAGE)

--- a/makedev.ps1
+++ b/makedev.ps1
@@ -1,5 +1,5 @@
 $REPO_PATH = "github.com/Azure/aks-engine"
-$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.23.1"
+$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.23.2"
 $DEV_ENV_WORK_DIR = "/go/src/$REPO_PATH"
 
 docker.exe run -it --rm -w $DEV_ENV_WORK_DIR -v `"$($PWD)`":$DEV_ENV_WORK_DIR $DEV_ENV_IMAGE bash


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/deis/docker-go-dev/releases/tag/v1.23.2
and https://github.com/golang/go/issues?q=milestone%3AGo1.12.9

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Restores a working (old) `azcopy` to the go-dev image:

```shell
$ docker run quay.io/deis/go-dev:v1.23.2 azcopy
------------------------------------------------------------------------------
azcopy 7.3.0-netcore Copyright (c) 2018 Microsoft Corp. All Rights Reserved.
------------------------------------------------------------------------------
...
$ docker run quay.io/deis/go-dev:v1.23.2 azcopy-preview
AzCopy 10.2.1
Project URL: github.com/Azure/azure-storage-azcopy
...
```
