### PR TITLE
feat: add support for Kubernetes 1.13.10, 1.14.6, 1.15.3 on Azure Stack

### DIFF
--- a/docs/topics/azure-stack.md
+++ b/docs/topics/azure-stack.md
@@ -173,12 +173,12 @@ If you need to expose more than 5 services, then the recommendation is to route 
 
 These are the Kubernetes versions that you can deploy to Azure Stack using AKS Engine:
 
+- 1.15.3
 - 1.15.2
-- 1.15.1
+- 1.14.6
 - 1.14.5
-- 1.14.4
+- 1.13.10
 - 1.13.9
-- 1.13.8
 - 1.12.8
 - 1.12.7
 - 1.11.10

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -371,12 +371,15 @@ echo "  - busybox" >> ${RELEASE_NOTES_FILEPATH}
 # TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
 K8S_VERSIONS="
 1.15.3
+1.15.3-azs
 1.15.2
 1.15.2-azs
 1.14.6
+1.14.6-azs
 1.14.5
 1.14.5-azs
 1.13.10
+1.13.10-azs
 1.13.9
 1.13.9-azs
 1.12.8


### PR DESCRIPTION

**Reason for Change**:
Add support for Kubernetes 1.13.9, 1.14.5, 1.15.2 on Azure Stack

**Issue Fixed**:

Fixes #1809 
Fixes #1810 
Fixes #1811 

**Requirements**:


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
