### PR TITLE
chore: enable rg substring match in azure cleanup script

### DIFF
--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -40,7 +40,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
 # find resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
-for resourceGroup in $(az group list | jq --arg dl $deadline '.[] | select(.name | contains("acse-test") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+for resourceGroup in $(az group list | jq --arg dl $deadline --arg rg $RESOURCE_GROUP_SUBSTRING '.[] | select(.name | contains("acse-test") | not) | select(.name | contains($rg)) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
     for deployment in $(az group deployment list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
         echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
         az group deployment delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -40,12 +40,24 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
 # find resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
-for resourceGroup in $(az group list | jq --arg dl $deadline --arg rg $RESOURCE_GROUP_SUBSTRING '.[] | select(.name | contains("acse-test") | not) | select(.name | contains($rg)) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+if [ -z "$RESOURCE_GROUP_SUBSTRING" ]; then
+  for resourceGroup in $(az group list | jq --arg dl $deadline '.[] | select(.name | contains("acse-test") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
     for deployment in $(az group deployment list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
-        echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
-        az group deployment delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."
+      echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
+      az group deployment delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."
     done
     echo "Will delete resource group ${resourceGroup}..."
     # delete old resource groups
     az group delete -y -n $resourceGroup --no-wait >> delete.log || echo "unable to delete resource group ${resourceGroup}, will continue..."
-done
+  done
+else
+  for resourceGroup in $(az group list | jq --arg dl $deadline --arg rg $RESOURCE_GROUP_SUBSTRING '.[] | select(.name | contains("acse-test") | not) | select(.name | contains($rg)) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+    for deployment in $(az group deployment list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
+      echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
+      az group deployment delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."
+    done
+    echo "Will delete resource group ${resourceGroup}..."
+    # delete old resource groups
+    az group delete -y -n $resourceGroup --no-wait >> delete.log || echo "unable to delete resource group ${resourceGroup}, will continue..."
+  done
+fi


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Evolves the cleanup script so that it can delete only certain rgs that match a substring.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
