### PR TITLE
ci: Windows VHD winrm delay start

### DIFF
--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -123,6 +123,21 @@ function Install-WindowsPatches
 
 }
 
+function Set-WinRmServiceAutoStart
+{
+    Write-Log "Setting WinRM service start to auto"
+    sc.exe config winrm start=auto
+}
+
+function Set-WinRmServiceDelayedStart
+{
+    # Hyper-V messes with networking components on startup after the feature is enabled
+    # causing issues with communication over winrm and setting winrm to delayed start
+    # gives Hyper-V enough time to finish configuration before having packer continue.
+    Write-Log "Setting WinRM service start to delayed-auto"
+    sc.exe config winrm start=delayed-auto
+}
+
 function Update-WindowsFeatures
 {
     $featuresToEnable = @(
@@ -142,6 +157,7 @@ switch ($env:ProvisioningPhase)
     "1"
     {
         Write-Log "Performing actions for provisioning phase 1"
+        Set-WinRmServiceDelayedStart
         Disable-WindowsUpdates
         Install-WindowsPatches
         Install-OpenSSH
@@ -150,6 +166,7 @@ switch ($env:ProvisioningPhase)
     "2"
     {
         Write-Log "Performing actions for provisioning phase 2"
+        Set-WinRmServiceAutoStart
         Install-Docker
         Get-ContainerImages
     }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
I ran into some stability issues when trying to move the Windows VHD to start with the August images where winrm was not always reconnecting.
Hyper-V messes with networking on the reboot following it being enabled and delaying the winrm service start allows for windows to finish the reconfiguration before allowing packer to attempt connecting back to the machine.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
