### PR TITLE
feat: Allow customization of coredns (#1541)

### DIFF
--- a/docs/topics/coredns.md
+++ b/docs/topics/coredns.md
@@ -1,0 +1,45 @@
+# CoreDNS customization
+
+The configuration provided by aks-engine handles most setups by forwarding to
+the dns server configured on the nodes.
+
+To customize CoreDNS ([kubernetes docs][Customizing DNS Service]) you can create
+a `configmap` that is appended to the builtin configuration. See the example below.
+
+The kubernetes docs on  also has some guidance.
+
+NB:
+
+* The custom configmap must be named `coredns-custom`
+* The configmap must contain the item `Corefile`. This is imported by the main
+  Corefile.
+  * See [CoreDNS configuration docs][] for more info
+* The server block cannot be for `.` (the root domain); this is in the main
+  `Corefile` and there can not be duplicates.
+
+## Example `coredns-custom` configmap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom   # Name must be `coredns-custom`
+  namespace: kube-system
+data:
+  Corefile: |
+    example.com {
+        errors
+        cache
+        forward . 1.1.1.1 8.8.8.8
+    }
+```
+
+After applying it you can force coredns to pick up the new config with
+
+```sh
+    $ kubectl -n kube-system rollout restart deployment coredns
+    deployment.extensions/coredns restarted
+```
+
+[Customizing DNS Service]: https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configuration-of-stub-domain-and-upstream-nameserver-using-coredns
+[CoreDNS configuration docs]: https://coredns.io/manual/toc/#configuration

--- a/parts/k8s/addons/coredns.yaml
+++ b/parts/k8s/addons/coredns.yaml
@@ -59,6 +59,7 @@ metadata:
       addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
+    import conf.d/Corefile*
     .:53 {
         errors
         health
@@ -153,6 +154,9 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+        - mountPath: /etc/coredns/conf.d
+          name: config-custom
+          readOnly: true
         ports:
         - containerPort: 53
           name: dns
@@ -193,6 +197,14 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+        - name: config-custom
+          configMap:
+            name: coredns-custom
+            items:
+            - key: Corefile
+              path: Corefile
+            optional: true
+
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -9543,6 +9543,7 @@ metadata:
       addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
+    import conf.d/Corefile*
     .:53 {
         errors
         health
@@ -9637,6 +9638,9 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+        - mountPath: /etc/coredns/conf.d
+          name: config-custom
+          readOnly: true
         ports:
         - containerPort: 53
           name: dns
@@ -9677,6 +9681,14 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+        - name: config-custom
+          configMap:
+            name: coredns-custom
+            items:
+            - key: Corefile
+              path: Corefile
+            optional: true
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This resolves one piece of #1541. The change to setting
`ConfigMap/coredns` to addon mode `reconcile` in #1493 made it so that
operators can't customize CoreDNS with stub domains anymore.

This patch adds a second volume mount from the configmap
`coredns-custom` (optional) that appends configuration to what is
shipped with aks-engine.

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
