### PR TITLE
test: allow 20 retries for ssh-dependent tests

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -52,7 +52,6 @@ const (
 	windowsCommandTimeout                  = 1 * time.Minute
 	validateNetworkPolicyTimeout           = 3 * time.Minute
 	validateDNSTimeout                     = 2 * time.Minute
-	sshRetries                             = 3
 )
 
 var (
@@ -101,7 +100,7 @@ var _ = BeforeSuite(func() {
 	sshConn, err = remote.NewConnection(kubeConfig.GetServerName(), masterSSHPort, eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
 	Expect(err).NotTo(HaveOccurred())
 	success := false
-	for i := 0; i < sshRetries; i++ {
+	for i := 0; i < 3; i++ {
 		err := util.AddToSSHKeyChain(masterSSHPrivateKeyFilepath)
 		if err == nil {
 			success = true

--- a/test/e2e/remote/ssh.go
+++ b/test/e2e/remote/ssh.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	sshRetries = 3
+	sshRetries = 20
 	scriptsDir = "scripts"
 )
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

3 retries is not enough to absorb potential environmental flakes :(

```
$ ssh -A -i /__w/1/s/gopath/src/github.com/Azure/aks-engine/_output/kubernetes-southeastasia-78856-ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no azureuser@kubernetes-southeastasia-78856.southeastasia.cloudapp.azure.com -p 22 scp -o StrictHostKeyChecking=no /tmp/auditd-validate.sh k8s-pool1-18623296-vmss000001:/tmp/auditd-validate.sh
2019/08/23 18:47:40 Error output:
Authorized uses only. All activity may be monitored and reported.
ssh: connect to host k8s-pool1-18623296-vmss000001 port 22: Connection timed out
lost connection
$ ssh -A -i /__w/1/s/gopath/src/github.com/Azure/aks-engine/_output/kubernetes-southeastasia-78856-ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no azureuser@kubernetes-southeastasia-78856.southeastasia.cloudapp.azure.com -p 22 scp -o StrictHostKeyChecking=no /tmp/auditd-validate.sh k8s-pool1-18623296-vmss000001:/tmp/auditd-validate.sh
2019/08/23 18:47:43 Error output:
Authorized uses only. All activity may be monitored and reported.
ssh: Could not resolve hostname k8s-pool1-18623296-vmss000001: Name or service not known
lost connection
$ ssh -A -i /__w/1/s/gopath/src/github.com/Azure/aks-engine/_output/kubernetes-southeastasia-78856-ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no azureuser@kubernetes-southeastasia-78856.southeastasia.cloudapp.azure.com -p 22 scp -o StrictHostKeyChecking=no /tmp/auditd-validate.sh k8s-pool1-18623296-vmss000001:/tmp/auditd-validate.sh
2019/08/23 18:47:46 Error output:
Authorized uses only. All activity may be monitored and reported.
ssh: Could not resolve hostname k8s-pool1-18623296-vmss000001: Name or service not known
lost connection
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
