### PR TITLE
fix: restore working calico networkPolicy vlabs conversion logic

### DIFF
--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -755,7 +755,7 @@ func setVlabsKubernetesDefaults(vp *vlabs.Properties, api *OrchestratorProfile) 
 			api.KubernetesConfig.NetworkPolicy = vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy
 		}
 	}
-	if api.KubernetesConfig.NetworkPlugin == "" && api.KubernetesConfig.NetworkPolicy == "" {
+	if api.KubernetesConfig.NetworkPlugin == "" && (api.KubernetesConfig.NetworkPolicy == "" || api.KubernetesConfig.NetworkPolicy == NetworkPolicyCalico) {
 		if vp.HasWindows() {
 			api.KubernetesConfig.NetworkPlugin = vlabs.DefaultNetworkPluginWindows
 		} else {

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -207,20 +207,6 @@ func TestConvertVLabsKubernetesConfigProfile(t *testing.T) {
 	}
 }
 
-func makeKubernetesProperties() *Properties {
-	ap := &Properties{}
-	ap.OrchestratorProfile = &OrchestratorProfile{}
-	ap.OrchestratorProfile.OrchestratorType = "Kubernetes"
-	return ap
-}
-
-func makeKubernetesPropertiesVlabs() *vlabs.Properties {
-	vp := &vlabs.Properties{}
-	vp.OrchestratorProfile = &vlabs.OrchestratorProfile{}
-	vp.OrchestratorProfile.OrchestratorType = "Kubernetes"
-	return vp
-}
-
 func TestConvertCustomFilesToAPI(t *testing.T) {
 	expectedAPICustomFiles := []CustomFile{
 		{

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -182,36 +182,6 @@ func TestKubernetesOrchestratorVersionFailWhenInvalid(t *testing.T) {
 
 }
 
-func TestKubernetesVlabsDefaults(t *testing.T) {
-	vp := makeKubernetesPropertiesVlabs()
-	ap := makeKubernetesProperties()
-	setVlabsKubernetesDefaults(vp, ap.OrchestratorProfile)
-	if ap.OrchestratorProfile.KubernetesConfig == nil {
-		t.Fatalf("KubernetesConfig cannot be nil after vlabs default conversion")
-	}
-	if ap.OrchestratorProfile.KubernetesConfig.NetworkPlugin != vlabs.DefaultNetworkPlugin {
-		t.Fatalf("vlabs defaults not applied, expected NetworkPlugin: %s, instead got: %s", vlabs.DefaultNetworkPlugin, ap.OrchestratorProfile.KubernetesConfig.NetworkPlugin)
-	}
-	if ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy != vlabs.DefaultNetworkPolicy {
-		t.Fatalf("vlabs defaults not applied, expected NetworkPolicy: %s, instead got: %s", vlabs.DefaultNetworkPolicy, ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy)
-	}
-
-	vp = makeKubernetesPropertiesVlabs()
-	vp.WindowsProfile = &vlabs.WindowsProfile{}
-	vp.AgentPoolProfiles = append(vp.AgentPoolProfiles, &vlabs.AgentPoolProfile{OSType: "Windows"})
-	ap = makeKubernetesProperties()
-	setVlabsKubernetesDefaults(vp, ap.OrchestratorProfile)
-	if ap.OrchestratorProfile.KubernetesConfig == nil {
-		t.Fatalf("KubernetesConfig cannot be nil after vlabs default conversion")
-	}
-	if ap.OrchestratorProfile.KubernetesConfig.NetworkPlugin != vlabs.DefaultNetworkPluginWindows {
-		t.Fatalf("vlabs defaults not applied, expected NetworkPlugin: %s, instead got: %s", vlabs.DefaultNetworkPluginWindows, ap.OrchestratorProfile.KubernetesConfig.NetworkPlugin)
-	}
-	if ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy != vlabs.DefaultNetworkPolicy {
-		t.Fatalf("vlabs defaults not applied, expected NetworkPolicy: %s, instead got: %s", vlabs.DefaultNetworkPolicy, ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy)
-	}
-}
-
 func TestConvertVLabsKubernetesConfigProfile(t *testing.T) {
 	tests := map[string]struct {
 		props  *vlabs.KubernetesConfig
@@ -1092,6 +1062,137 @@ func TestConvertVLabsWindowsProfile(t *testing.T) {
 			diff := cmp.Diff(actual, c.expected)
 			if diff != "" {
 				t.Errorf("unexpected diff testing convertVLabsWindowsProfile: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetVlabsKubernetesDefaults(t *testing.T) {
+	tests := []struct {
+		name                  string
+		p                     *vlabs.Properties
+		expectedNetworkPlugin string
+		expectedNetworkPolicy string
+	}{
+		{
+			name: "default",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "",
+						NetworkPolicy: "",
+					},
+				},
+			},
+			expectedNetworkPlugin: vlabs.DefaultNetworkPlugin,
+			expectedNetworkPolicy: "",
+		},
+		{
+			name: "default windows",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "",
+						NetworkPolicy: "",
+					},
+				},
+				AgentPoolProfiles: []*vlabs.AgentPoolProfile{
+					{
+						OSType: "Windows",
+					},
+				},
+			},
+			expectedNetworkPlugin: vlabs.DefaultNetworkPluginWindows,
+			expectedNetworkPolicy: "",
+		},
+		{
+			name: "azure networkPlugin",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "azure",
+						NetworkPolicy: "",
+					},
+				},
+			},
+			expectedNetworkPlugin: vlabs.DefaultNetworkPlugin,
+			expectedNetworkPolicy: "",
+		},
+		{
+			name: "azure networkPolicy back-compat",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "",
+						NetworkPolicy: "azure",
+					},
+				},
+			},
+			expectedNetworkPlugin: "azure",
+			expectedNetworkPolicy: "",
+		},
+		{
+			name: "none networkPolicy back-compat",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "",
+						NetworkPolicy: "none",
+					},
+				},
+			},
+			expectedNetworkPlugin: "kubenet",
+			expectedNetworkPolicy: "",
+		},
+		{
+			name: "test literal string conversion",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "foo",
+						NetworkPolicy: "bar",
+					},
+				},
+			},
+			expectedNetworkPlugin: "foo",
+			expectedNetworkPolicy: "bar",
+		},
+		{
+			name: "calico networkPlicy",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "",
+						NetworkPolicy: "calico",
+					},
+				},
+			},
+			expectedNetworkPlugin: "azure",
+			expectedNetworkPolicy: "calico",
+		},
+		{
+			name: "cilium networkPlicy",
+			p: &vlabs.Properties{
+				OrchestratorProfile: &vlabs.OrchestratorProfile{
+					KubernetesConfig: &vlabs.KubernetesConfig{
+						NetworkPlugin: "",
+						NetworkPolicy: "cilium",
+					},
+				},
+			},
+			expectedNetworkPlugin: "",
+			expectedNetworkPolicy: "cilium",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			converted := &OrchestratorProfile{}
+			setVlabsKubernetesDefaults(test.p, converted)
+			if converted.KubernetesConfig.NetworkPlugin != test.expectedNetworkPlugin {
+				t.Errorf("expected NetworkPlugin : %s, but got %s", test.expectedNetworkPlugin, converted.KubernetesConfig.NetworkPlugin)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR changed vlabs-unversioned api model conversion logic to only set a default "azure" networkPlugin value if both networkPolicy and networkPlugin are "":

https://github.com/Azure/aks-engine/pull/1823

However, there are pre-established assumptions that "networkPolicy": "calico" should also get a networkPlugin value of "azure" during conversion, so we restore this behavior to protect pre-existing, known-working api model workflows.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
