### PR TITLE
test: improve E2E node readiness tests

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -541,6 +541,15 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			out, _ := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
 			if !ready {
+				nodeList, err := node.GetReady()
+				Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodeList.Nodes {
+					if !node.IsReady() {
+						cmd := exec.Command("k", "describe", "node", node.Metadata.Name)
+						out, _ := cmd.CombinedOutput()
+						log.Printf("\n%s\n", out)
+					}
+				}
 				log.Printf("Error: Not all nodes in a healthy state\n")
 			}
 			Expect(ready).To(Equal(true))

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -324,25 +324,27 @@ func (cli *CLIProvisioner) waitForNodes() error {
 			if err != nil {
 				return errors.Wrap(err, "Unable to get the list of nodes")
 			}
-			for _, n := range nodeList.Nodes {
-				exp, err := regexp.Compile("k8s-master")
-				if err != nil {
-					return err
-				}
-				if !exp.MatchString(n.Metadata.Name) {
-					cmd := exec.Command("k", "label", "node", n.Metadata.Name, "foo=bar")
-					util.PrintCommand(cmd)
-					out, err := cmd.CombinedOutput()
-					log.Printf("%s\n", out)
+			if !cli.Engine.ExpandedDefinition.Properties.HasLowPriorityScaleset() {
+				for _, n := range nodeList.Nodes {
+					exp, err := regexp.Compile("k8s-master")
 					if err != nil {
-						return errors.Wrapf(err, "Unable to assign label to node %s", n.Metadata.Name)
+						return err
 					}
-					cmd = exec.Command("k", "annotate", "node", n.Metadata.Name, "foo=bar")
-					util.PrintCommand(cmd)
-					out, err = cmd.CombinedOutput()
-					log.Printf("%s\n", out)
-					if err != nil {
-						return errors.Wrapf(err, "Unable to add node annotation to node %s", n.Metadata.Name)
+					if !exp.MatchString(n.Metadata.Name) {
+						cmd := exec.Command("k", "label", "node", n.Metadata.Name, "foo=bar")
+						util.PrintCommand(cmd)
+						out, err := cmd.CombinedOutput()
+						log.Printf("%s\n", out)
+						if err != nil {
+							return errors.Wrapf(err, "Unable to assign label to node %s", n.Metadata.Name)
+						}
+						cmd = exec.Command("k", "annotate", "node", n.Metadata.Name, "foo=bar")
+						util.PrintCommand(cmd)
+						out, err = cmd.CombinedOutput()
+						log.Printf("%s\n", out)
+						if err != nil {
+							return errors.Wrapf(err, "Unable to add node annotation to node %s", n.Metadata.Name)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

1) Don't add labels/annotations during provisioning for low-pri VMSS cluster configurations and
2) describe any non-Ready nodes when the node readiness check fails

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
