### PR TITLE
refactor: configure kube-proxy 1.16 with a ConfigMap

### DIFF
--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -1,3 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  config.yaml: |
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    kind: KubeProxyConfiguration
+    clientConnection:
+      kubeconfig: /var/lib/kubelet/kubeconfig
+    clusterCIDR: "<CIDR>"
+    mode: "<kubeProxyMode>"
+metadata:
+  name: kube-proxy-config
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/cluster-service: "true"
+    component: kube-proxy
+    tier: node
+    k8s-app: kube-proxy
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -44,9 +65,7 @@ spec:
       - command:
         - /hyperkube
         - kube-proxy
-        - --kubeconfig=/var/lib/kubelet/kubeconfig
-        - --cluster-cidr=<CIDR>
-        - --proxy-mode=<kubeProxyMode>
+        - --config=/var/lib/kube-proxy/config.yaml
         image: <img>
         imagePullPolicy: IfNotPresent
         name: kube-proxy
@@ -70,6 +89,10 @@ spec:
         - mountPath: /lib/modules/
           name: kernelmodules
           readOnly: true
+        - mountPath: /var/lib/kube-proxy/config.yaml
+          subPath: config.yaml
+          name: kube-proxy-config-volume
+          readOnly: true
       hostNetwork: true
       volumes:
       - hostPath:
@@ -87,5 +110,8 @@ spec:
       - hostPath:
           path: /lib/modules/
         name: kernelmodules
+      - configMap:
+          name: kube-proxy-config
+        name: kube-proxy-config-volume
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
**Reason for Change**:

To silence this kube-proxy startup output in Kubernetes 1.16.0-beta.1:

> WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.


**Issue Fixed**:

Fixes #1830

See also #377. I'll see about kubelet and friends next.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

Is `/var/lib/kube-proxy/config.yaml` the best path for this?

Should we make the same fix for versions earlier than 1.16? This has been a warning for several Kubernetes versions.

The output looks warning-free and correct to me:

```shell
$ kubectl -n kube-system logs kube-proxy-n4skv
I0827 00:55:05.735413       1 node.go:135] Successfully retrieved node IP: 10.255.255.5
I0827 00:55:05.735503       1 server_others.go:145] Using iptables Proxier.
I0827 00:55:05.735972       1 server.go:525] Version: v1.16.0-beta.1
I0827 00:55:05.737312       1 conntrack.go:100] Set sysctl 'net/netfilter/nf_conntrack_max' to 131072
I0827 00:55:05.737355       1 conntrack.go:52] Setting nf_conntrack_max to 131072
I0827 00:55:05.737928       1 conntrack.go:100] Set sysctl 'net/netfilter/nf_conntrack_tcp_timeout_established' to 86400
I0827 00:55:05.738011       1 conntrack.go:100] Set sysctl 'net/netfilter/nf_conntrack_tcp_timeout_close_wait' to 3600
I0827 00:55:05.738434       1 config.go:187] Starting service config controller
I0827 00:55:05.738453       1 controller_utils.go:1029] Waiting for caches to sync for service config controller
I0827 00:55:05.738511       1 config.go:96] Starting endpoints config controller
I0827 00:55:05.738529       1 controller_utils.go:1029] Waiting for caches to sync for endpoints config controller
I0827 00:55:05.838555       1 controller_utils.go:1036] Caches are synced for service config controller
I0827 00:55:05.838665       1 controller_utils.go:1036] Caches are synced for endpoints config controller
```
