### PR TITLE
fix: add deprovision step to packer script

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -2,7 +2,6 @@
 source /home/packer/provision_installs.sh
 source /home/packer/provision_source.sh
 source /home/packer/packer_source.sh
-source /home/packer/cis.sh
 
 RELEASE_NOTES_FILEPATH=/var/log/azure/golden-image-install.complete
 
@@ -432,9 +431,3 @@ echo "START_OF_NOTES"
 cat ${RELEASE_NOTES_FILEPATH}
 echo "END_OF_NOTES"
 set -x
-
-# Move logs from VHD creation out of /var/log
-sudo mv /var/log /var/log.vhd
-sudo mkdir /var/log
-
-applyCIS

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -197,7 +197,7 @@
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
                 "sudo /bin/bash -eux /home/packer/cis.sh",
                 "sudo /bin/bash -eux /home/packer/cleanup-vhd.sh",
-                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync || exit 125"
+                "sudo /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync || exit 125"
             ]
         }
     ]

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -194,7 +194,6 @@
         {
             "type": "shell",
             "inline": [
-                "exit 111",
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
                 "sudo /bin/bash -eux /home/packer/cis.sh",
                 "sudo /bin/bash -eux /home/packer/cleanup-vhd.sh",

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -197,7 +197,7 @@
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
                 "sudo /bin/bash -eux /home/packer/cis.sh",
                 "sudo /bin/bash -eux /home/packer/cleanup-vhd.sh",
-                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync || exit 125"
             ]
         }
     ]

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -195,8 +195,9 @@
             "type": "shell",
             "inline": [
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
+                "sudo /bin/bash -eux /home/packer/cis.sh",
                 "sudo /bin/bash -eux /home/packer/cleanup-vhd.sh",
-                "sudo rm -rf /home/packer"
+                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync && cat test-deleteme"
             ]
         }
     ]

--- a/packer/vhd-image-builder.json
+++ b/packer/vhd-image-builder.json
@@ -194,10 +194,11 @@
         {
             "type": "shell",
             "inline": [
+                "exit 111",
                 "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh",
                 "sudo /bin/bash -eux /home/packer/cis.sh",
                 "sudo /bin/bash -eux /home/packer/cleanup-vhd.sh",
-                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync && cat test-deleteme"
+                "sudo -u packer /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ]
         }
     ]

--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -71,4 +71,7 @@ applyCIS() {
   assignRootPW
   assignFilePermissions
 }
+
+applyCIS
+
 #EOF

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -53,6 +53,8 @@ ERR_CIS_ASSIGN_FILE_PERMISSION=112 # Error assigning permission to a file in CIS
 ERR_PACKER_COPY_FILE=113 # Error writing a file to disk during VHD CI
 ERR_CIS_APPLY_PASSWORD_CONFIG=115 # Error applying CIS-recommended passwd configuration
 
+ERR_VHD_BUILD_ERROR=125 # Reserved for VHD CI exit conditions
+
 # Azure Stack specific errors
 ERR_AZURE_STACK_GET_ARM_TOKEN=120 # Error generating a token to use with Azure Resource Manager
 ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION=121 # Error fetching the network configuration for the node

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -26,10 +26,6 @@ config_script=/opt/azure/containers/provision_configs.sh
 wait_for_file 3600 1 $config_script || exit $ERR_FILE_WATCH_TIMEOUT
 source $config_script
 
-cis_script=/opt/azure/containers/provision_cis.sh
-wait_for_file 3600 1 $cis_script || exit $ERR_FILE_WATCH_TIMEOUT
-source $cis_script
-
 if [[ "${TARGET_ENVIRONMENT,,}" == "${AZURE_STACK_ENV}"  ]]; then
     config_script_custom_cloud=/opt/azure/containers/provision_configs_custom_cloud.sh
     wait_for_file 3600 1 $config_script_custom_cloud || exit $ERR_FILE_WATCH_TIMEOUT

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12306,6 +12306,9 @@ applyCIS() {
   assignRootPW
   assignFilePermissions
 }
+
+applyCIS
+
 #EOF
 `)
 
@@ -13067,6 +13070,8 @@ ERR_CIS_ASSIGN_FILE_PERMISSION=112 # Error assigning permission to a file in CIS
 ERR_PACKER_COPY_FILE=113 # Error writing a file to disk during VHD CI
 ERR_CIS_APPLY_PASSWORD_CONFIG=115 # Error applying CIS-recommended passwd configuration
 
+ERR_VHD_BUILD_ERROR=125 # Reserved for VHD CI exit conditions
+
 # Azure Stack specific errors
 ERR_AZURE_STACK_GET_ARM_TOKEN=120 # Error generating a token to use with Azure Resource Manager
 ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION=121 # Error fetching the network configuration for the node
@@ -13618,10 +13623,6 @@ source $install_script
 config_script=/opt/azure/containers/provision_configs.sh
 wait_for_file 3600 1 $config_script || exit $ERR_FILE_WATCH_TIMEOUT
 source $config_script
-
-cis_script=/opt/azure/containers/provision_cis.sh
-wait_for_file 3600 1 $cis_script || exit $ERR_FILE_WATCH_TIMEOUT
-source $cis_script
 
 if [[ "${TARGET_ENVIRONMENT,,}" == "${AZURE_STACK_ENV}"  ]]; then
     config_script_custom_cloud=/opt/azure/containers/provision_configs_custom_cloud.sh


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Running waagent –deprovision cleans up the contents of /var/lib/waagent, removes user authentication credentials, (usually) removes user home directories, etc. When preparing a cloud-init based VM for clean reuse, you also need to tell cloud-init to reset itself. The command cloud-init clean -logs will remove cloud-init artifacts from /var/lib/cloud so cloud-init will re-run all stages as it did on first boot, and it cleans up the cloud-init log files so the next boot of the VM gets a clean log.
https://www.packer.io/docs/builders/azure.html#deprovision

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1720
#1717 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
