### PR TITLE
fix: fix customVMTags functionality and add more unit tests

### DIFF
--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -585,7 +585,7 @@ func addCustomTagsToVM(tags map[string]string, vm *compute.VirtualMachine) {
 	for key, value := range tags {
 		_, found := vm.Tags[key]
 		if !found {
-			vm.Tags[key] = &value
+			vm.Tags[key] = to.StringPtr(value)
 		}
 	}
 }

--- a/pkg/engine/virtualmachines_test.go
+++ b/pkg/engine/virtualmachines_test.go
@@ -311,7 +311,10 @@ func TestCreateVmWithCustomTags(t *testing.T) {
 	}
 
 	testTagsToAdd := map[string]string{
-		"myTestKey": "myTestValue",
+		"myTestKey1": "myTestValue1",
+		"myTestKey2": "myTestValue2",
+		"foo":        "bar",
+		"poolName":   "myName",
 	}
 
 	addCustomTagsToVM(testTagsToAdd, &testVirtualMachine)
@@ -320,7 +323,9 @@ func TestCreateVmWithCustomTags(t *testing.T) {
 		"orchestrator":     to.StringPtr("k8s"),
 		"aksEngineVersion": to.StringPtr("1.15"),
 		"poolName":         to.StringPtr("TestPool"),
-		"myTestKey":        to.StringPtr("myTestValue"),
+		"myTestKey1":       to.StringPtr("myTestValue1"),
+		"myTestKey2":       to.StringPtr("myTestValue2"),
+		"foo":              to.StringPtr("bar"),
 	}
 
 	diff := cmp.Diff(testVirtualMachine.Tags, expectedTags)

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -813,7 +813,7 @@ func addCustomTagsToVMScaleSets(tags map[string]string, vm *compute.VirtualMachi
 	for key, value := range tags {
 		_, found := vm.Tags[key]
 		if !found {
-			vm.Tags[key] = &value
+			vm.Tags[key] = to.StringPtr(value)
 		}
 	}
 }

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -857,7 +857,9 @@ func TestCreateVmScaleSetsWithCustomTags(t *testing.T) {
 	}
 
 	testTagsToAdd := map[string]string{
-		"myTestKey": "myTestValue",
+		"myTestKey1": "myTestValue1",
+		"myTestKey2": "myTestValue2",
+		"poolName":   "myName",
 	}
 
 	addCustomTagsToVMScaleSets(testTagsToAdd, &testVirtualMachineScaleSet)
@@ -866,7 +868,8 @@ func TestCreateVmScaleSetsWithCustomTags(t *testing.T) {
 		"orchestrator":     to.StringPtr("k8s"),
 		"aksEngineVersion": to.StringPtr("1.15"),
 		"poolName":         to.StringPtr("TestPool"),
-		"myTestKey":        to.StringPtr("myTestValue"),
+		"myTestKey1":       to.StringPtr("myTestValue1"),
+		"myTestKey2":       to.StringPtr("myTestValue2"),
 	}
 
 	diff := cmp.Diff(testVirtualMachineScaleSet.Tags, expectedTags)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The function to add customVMTags was using a dereferencing the value string which caused all the keys to have the same value. Fixed by using the to.StringPtr() function instead.
Added more unit tests to cover this scenario (and validated that the tests were failing before the fix).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1866 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
