### PR TITLE
fix: set streaming-connection-idle-timeout as 4h

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -94,7 +94,7 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		"--pod-max-pids":                      strconv.Itoa(DefaultKubeletPodMaxPIDs),
 		"--image-pull-progress-deadline":      "30m",
 		"--enforce-node-allocatable":          "pods",
-		"--streaming-connection-idle-timeout": "5m",
+		"--streaming-connection-idle-timeout": "4h",
 	}
 
 	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -52,7 +52,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--pod-max-pids":                      strconv.Itoa(DefaultKubeletPodMaxPIDs),
 		"--protect-kernel-defaults":           "true",
 		"--rotate-certificates":               "true",
-		"--streaming-connection-idle-timeout": "5m",
+		"--streaming-connection-idle-timeout": "4h",
 		"--feature-gates":                     "PodPriority=true,RotateKubeletServerCertificate=true",
 		"--tls-cipher-suites":                 TLSStrongCipherSuitesKubelet,
 		"--tls-cert-file":                     "/etc/kubernetes/certs/kubeletserver.crt",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
fix: set streaming-connection-idle-timeout as 4h

Per https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options, streaming-connection-idle-timeout means `Maximum time a streaming connection can be idle before the connection is automatically closed. 0 indicates no timeout. Example: '5m' (default 4h0m0s)`, we should set as `4h`, there is user complaining about the original `5m` value:
 `when user run kubectl exec , then session terminated after 5 idle minutes.`


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

/assign @jackfrancis @CecileRobertMichon
/azp run pr-e2e