### PR TITLE
fix: more aks guarding against agentLbID template var

### DIFF
--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -353,7 +353,8 @@ func createAgentVMASNetworkInterface(cs *api.ContainerService, profile *api.Agen
 				}
 			} else {
 				if !cs.Properties.OrchestratorProfile.IsPrivateCluster() &&
-					cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
+					cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku &&
+					!isHostedMaster {
 					agentLbBackendAddressPools := network.BackendAddressPool{
 						ID: to.StringPtr("[concat(variables('agentLbID'), '/backendAddressPools/', variables('agentLbBackendPoolName'))]"),
 					}

--- a/pkg/engine/networkinterfaces_test.go
+++ b/pkg/engine/networkinterfaces_test.go
@@ -693,6 +693,85 @@ func TestCreateAgentVMASNICWithSLB(t *testing.T) {
 	}
 }
 
+func TestCreateAgentVMASNICWithSLBHostedMaster(t *testing.T) {
+	cs := &api.ContainerService{
+		Properties: &api.Properties{
+			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+				ClientID: "barClientID",
+				Secret:   "bazSecret",
+			},
+			HostedMasterProfile: &api.HostedMasterProfile{
+				FQDN: "foo",
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				OrchestratorType:    api.Kubernetes,
+				OrchestratorVersion: "1.10.2",
+				KubernetesConfig: &api.KubernetesConfig{
+					NetworkPlugin:   "azure",
+					LoadBalancerSku: StandardLoadBalancerSku,
+				},
+			},
+			LinuxProfile: &api.LinuxProfile{},
+			AgentPoolProfiles: []*api.AgentPoolProfile{
+				{
+					Name:                "agentpool",
+					VMSize:              "Standard_D2_v2",
+					Count:               1,
+					AvailabilityProfile: api.AvailabilitySet,
+				},
+			},
+		},
+	}
+
+	profile := &api.AgentPoolProfile{
+		Name:           "fooAgent",
+		OSType:         "Linux",
+		IPAddressCount: 1,
+	}
+
+	// Test AgentVMAS NIC with Standard LB
+	actual := createAgentVMASNetworkInterface(cs, profile)
+
+	expected := NetworkInterfaceARM{
+		ARMResource: ARMResource{
+			APIVersion: "[variables('apiVersionNetwork')]",
+			Copy: map[string]string{
+				"count": "[sub(variables('fooAgentCount'), variables('fooAgentOffset'))]",
+				"name":  "loop",
+			},
+			DependsOn: []string{
+				"[variables('vnetID')]",
+			},
+		},
+		Interface: network.Interface{
+			Type:     to.StringPtr("Microsoft.Network/networkInterfaces"),
+			Name:     to.StringPtr("[concat(variables('fooAgentVMNamePrefix'), 'nic-', copyIndex(variables('fooAgentOffset')))]"),
+			Location: to.StringPtr("[variables('location')]"),
+			InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+				IPConfigurations: &[]network.InterfaceIPConfiguration{
+					{
+						Name: to.StringPtr("ipconfig1"),
+						InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+							LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+							Primary:                         to.BoolPtr(true),
+							PrivateIPAllocationMethod:       network.Dynamic,
+							Subnet: &network.Subnet{
+								ID: to.StringPtr(fmt.Sprintf("[variables('%sVnetSubnetID')]", profile.Name)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	diff := cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while comparing: %s", diff)
+	}
+}
+
 func TestCreateAgentVMASNIC(t *testing.T) {
 	cs := &api.ContainerService{
 		Properties: &api.Properties{

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -341,6 +341,7 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 }
 
 func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) VirtualMachineScaleSetARM {
+	isHostedMaster := cs.Properties.IsHostedMasterProfile()
 	armResource := ARMResource{
 		APIVersion: "[variables('apiVersionCompute')]",
 	}
@@ -354,7 +355,8 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 
 	if !cs.Properties.OrchestratorProfile.IsPrivateCluster() &&
 		profile.LoadBalancerBackendAddressPoolIDs == nil &&
-		cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
+		cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku &&
+		!isHostedMaster {
 		dependencies = append(dependencies, "[variables('agentLbID')]")
 	}
 
@@ -488,7 +490,8 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 				}
 			} else {
 				if !cs.Properties.OrchestratorProfile.IsPrivateCluster() &&
-					cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
+					cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku &&
+					!isHostedMaster {
 					agentLbBackendAddressPools := compute.SubResource{
 						ID: to.StringPtr("[concat(variables('agentLbID'), '/backendAddressPools/', variables('agentLbBackendPoolName'))]"),
 					}

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -671,6 +671,17 @@ func TestCreateAgentVMSSHostedMasterProfile(t *testing.T) {
 		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
 	}
 
+	// Now validate that hosted master Standard LB doesn't effect anything
+	cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.StandardLoadBalancerSku
+
+	actual = CreateAgentVMSS(cs, cs.Properties.AgentPoolProfiles[0])
+
+	diff = cmp.Diff(actual, expected)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
+
 	// Now Test AgentVMSS with windows
 	cs.Properties.AgentPoolProfiles[0].OSType = "Windows"
 	cs.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = to.BoolPtr(true)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow up from #1872, more guards against referring to the `agentLbID` template var in hosted master cluster configurations.

Now with Unit Tests!

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
