### PR TITLE
fix: Remove the blind mkdir when writing outputs (#1048)

### DIFF
--- a/pkg/helpers/filesaver.go
+++ b/pkg/helpers/filesaver.go
@@ -24,9 +24,12 @@ func (f *FileSaver) SaveFileString(dir string, file string, data string) error {
 
 // SaveFile saves binary data to file
 func (f *FileSaver) SaveFile(dir string, file string, data []byte) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if e := os.MkdirAll(dir, 0700); e != nil {
-			return f.Translator.Errorf("error creating directory '%s': %s", dir, e.Error())
+	// don't blindly create directory
+	if dir != "" {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if e := os.MkdirAll(dir, 0700); e != nil {
+				return f.Translator.Errorf("error creating directory '%s': %s", dir, e.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This fixes the blind mkdir which fails if it is empty.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1048 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
