### PR TITLE
fix: check the nodes of all agentpools during upgrade

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -377,7 +377,7 @@ func (ku *Upgrader) upgradeAgentPools(ctx context.Context) error {
 
 		if toBeUpgradedCount == 0 {
 			ku.logger.Infof("No nodes to upgrade")
-			return nil
+			continue
 		}
 
 		// Upgrade nodes in agent pool


### PR DESCRIPTION
**Reason for Change**:

The upgrade operation did not properly check if the nodes of all agentpools have been upgraded.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1794

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
