### PR TITLE
fix: add #EOF for dhcpv6 service

### DIFF
--- a/parts/k8s/cloud-init/artifacts/dhcpv6.service
+++ b/parts/k8s/cloud-init/artifacts/dhcpv6.service
@@ -8,3 +8,4 @@ ExecStart=/opt/azure/containers/enable-dhcpv6.sh
 
 [Install]
 WantedBy=multi-user.target
+#EOF

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13922,7 +13922,9 @@ Type=oneshot
 ExecStart=/opt/azure/containers/enable-dhcpv6.sh
 
 [Install]
-WantedBy=multi-user.target`)
+WantedBy=multi-user.target
+#EOF
+`)
 
 func k8sCloudInitArtifactsDhcpv6ServiceBytes() ([]byte, error) {
 	return _k8sCloudInitArtifactsDhcpv6Service, nil


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
https://github.com/Azure/aks-engine/pull/1719 introduced `#EOF` in the files for `wait_for_file`. However this file has been missed because of which creating dualstack cluster fails after that change. This PR fixes that issue.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
