### PR TITLE
fix: not overwrite service principal profile for hosted master

### DIFF
--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -451,6 +451,19 @@
       },
       "type": "securestring"
     },
+{{ else if and UseManagedIdentity IsHostedMaster}}
+    "servicePrincipalClientId": {
+      "metadata": {
+        "description": "Client ID (used by cloudprovider)"
+      },
+      "type": "securestring"
+    },
+    "servicePrincipalClientSecret": {
+      "metadata": {
+        "description": "The Service Principal Client Secret."
+      },
+      "type": "securestring"
+    },
 {{ end }}
     "masterOffset": {
       "defaultValue": 0,

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -260,7 +260,7 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		masterVars["etcdServerCertFilepath"] = "/etc/kubernetes/certs/etcdserver.crt"
 		masterVars["etcdServerKeyFilepath"] = "/etc/kubernetes/certs/etcdserver.key"
 	}
-	if useManagedIdentity {
+	if useManagedIdentity && !isHostedMaster {
 		masterVars["servicePrincipalClientId"] = "msi"
 		masterVars["servicePrincipalClientSecret"] = "msi"
 	} else {

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -152,7 +152,7 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 
 		if kubernetesConfig == nil ||
 			!kubernetesConfig.UseManagedIdentity ||
-			kubernetesConfig.UseManagedIdentity && properties.IsHostedMasterProfile() {
+			properties.IsHostedMasterProfile() {
 			servicePrincipalProfile := properties.ServicePrincipalProfile
 
 			if servicePrincipalProfile != nil {

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -151,7 +151,8 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		}
 
 		if kubernetesConfig == nil ||
-			!kubernetesConfig.UseManagedIdentity {
+			!kubernetesConfig.UseManagedIdentity ||
+			kubernetesConfig.UseManagedIdentity && properties.IsHostedMasterProfile() {
 			servicePrincipalProfile := properties.ServicePrincipalProfile
 
 			if servicePrincipalProfile != nil {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -23539,6 +23539,19 @@ var _k8sKubernetesparamsT = []byte(`{{if .HasAadProfile}}
       },
       "type": "securestring"
     },
+{{ else if and UseManagedIdentity IsHostedMaster}}
+    "servicePrincipalClientId": {
+      "metadata": {
+        "description": "Client ID (used by cloudprovider)"
+      },
+      "type": "securestring"
+    },
+    "servicePrincipalClientSecret": {
+      "metadata": {
+        "description": "The Service Principal Client Secret."
+      },
+      "type": "securestring"
+    },
 {{ end }}
     "masterOffset": {
       "defaultValue": 0,


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
For hosted master, we do not want to overwrite service principal with "msi" even if `useManagedIdentity` is `true`, that's because some addons running on agent nodes may not support authenticating using managed identity, so even managed identity is used, we still want to provide a service principal, which is dedicated to be used by addons.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
