### PR TITLE
feat: Windows vhd artifact caching

### DIFF
--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -59,6 +59,12 @@ function Get-FilesToCacheOnVHD
             "https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1"
         );
         "c:\akse-cache\win-k8s\" = @(
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.5-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.6-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.2-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.3-1int.zip"
+            "https://acs-mirror.azureedge.net/wink8s/v1.14.5-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/v1.14.6-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.15.2-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.15.3-1int.zip"
         );

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -59,14 +59,15 @@ function Get-FilesToCacheOnVHD
             "https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1"
         );
         "c:\akse-cache\win-k8s\" = @(
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.5-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.6-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.2-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.3-1int.zip"
-            "https://acs-mirror.azureedge.net/wink8s/v1.14.5-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.7-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.3-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.4-1int.zip"
             "https://acs-mirror.azureedge.net/wink8s/v1.14.6-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/v1.15.2-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/v1.15.3-1int.zip"
+            "https://acs-mirror.azureedge.net/wink8s/v1.14.7-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/v1.15.3-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/v1.15.4-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/v1.16.0-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
             "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.27.zip"
@@ -206,6 +207,9 @@ function Update-WindowsFeatures
         Install-WindowsFeature $feature
     }
 }
+
+# Disable progress writers for this session to greatly speed up operations such as Invoke-WebRequest
+$ProgressPreference = 'SilentlyContinue'
 
 switch ($env:ProvisioningPhase)
 {

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -169,7 +169,7 @@ function Set-AllowedSecurityProtocols
     }
 
     Write-Log "Settings allowed security protocols to: $allowedProtocols"
-    [System.Net.SevicePointManager]::SecurityProtocol = $allowedProtocols
+    [System.Net.ServicePointManager]::SecurityProtocol = $allowedProtocols
 }
 
 function Set-WinRmServiceAutoStart

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -60,7 +60,9 @@ function Get-FilesToCacheOnVHD
         );
         "c:\akse-cache\win-k8s\" = @(
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.6-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.7-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.3-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.4-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.14.6-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.14.7-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.15.3-1int.zip",

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -60,9 +60,7 @@ function Get-FilesToCacheOnVHD
         );
         "c:\akse-cache\win-k8s\" = @(
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.6-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.7-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.3-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.4-1int.zip"
             "https://acs-mirror.azureedge.net/wink8s/v1.14.6-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.14.7-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.15.3-1int.zip",

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -160,7 +160,7 @@ function Set-AllowedSecurityProtocols
     $allowedProtocols = @()
     $insecureProtocols = @([System.Net.SecurityProtocolType]::SystemDefault, [System.Net.SecurityProtocolType]::Ssl3)
 
-    foreach $(protocol in [System.Enum]::GetValues([System.Net.SecurityProtocolType]))
+    foreach ($protocol in [System.Enum]::GetValues([System.Net.SecurityProtocolType]))
     {
         if ($insecureProtocols -notcontains $protocol)
         {

--- a/packer/write-release-notes-windows.ps1
+++ b/packer/write-release-notes-windows.ps1
@@ -92,4 +92,4 @@ foreach ($file in [IO.Directory]::GetFiles('c:\akse-cache', '*', [IO.SearchOptio
     }
 }
 
-Log ($displayObjects | Format-Table -Property File, Sha256, SizeBytes)
+Log ($displayObjects | Format-Table -Property File, Sha256, SizeBytes | Out-String -Width 4096)

--- a/packer/write-release-notes-windows.ps1
+++ b/packer/write-release-notes-windows.ps1
@@ -77,3 +77,19 @@ if (Test-Path 'C:\Program Files\Docker\') {
     Log "Images:"
     LOG (docker images --format='{{json .}}' | ConvertFrom-Json | Format-Table Repository, Tag, ID)
 }
+Log ""
+
+Log "Cached Files:"
+$displayObjects = @()
+foreach ($file in [IO.Directory]::GetFiles('c:\akse-cache', '*', [IO.SearchOption]::AllDirectories))
+{
+    $attributes = Get-Item $file
+    $hash = Get-FileHash $file -Algorithm SHA256
+    $displayObjects += New-Object psobject -property @{
+        File = $file;
+        SizeBytes = $attributes.Length;
+        Sha256 = $hash.Hash
+    }
+}
+
+Log ($displayObjects | Format-Table -Property File, Sha256, SizeBytes)

--- a/packer/write-release-notes-windows.ps1
+++ b/packer/write-release-notes-windows.ps1
@@ -19,6 +19,11 @@ Log ("`t{0,-14} : {1}" -f "OS Name", $systemInfo.ProductName)
 LOG ("`t{0,-14} : {1}" -f "OS Version", "$($systemInfo.CurrentBuildNumber).$($systemInfo.UBR)")
 LOG ("`t{0,-14} : {1}" -f "OS InstallType", $systemInfo.InstallationType)
 Log ""
+
+$allowedSecurityProtocols = [System.Net.ServicePointManager]::SecurityProtocol
+Log "Allowed security protocols: $allowedSecurityProtocols"
+Log ""
+
 Log "Installed Features"
 if ($systemInfo.InstallationType -ne 'client') {
     Log (Get-WindowsFeature | Where-Object Installed)
@@ -27,6 +32,7 @@ else {
     LOG "`t<Cannot enumerate installed features on client skus>"
 }
 Log ""
+
 
 Log "Installed Packages"
 $packages = Get-WindowsCapability -Online | Where-Object { $_.State -eq 'Installed' }

--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -17,23 +17,36 @@ function DownloadFileOverHttp
         [Parameter(Mandatory=$true)][string]
         $DestinationPath
     )
-    $secureProtocols = @()
-    $insecureProtocols = @([System.Net.SecurityProtocolType]::SystemDefault, [System.Net.SecurityProtocolType]::Ssl3)
 
-    foreach ($protocol in [System.Enum]::GetValues([System.Net.SecurityProtocolType]))
+    # First check to see if a file with the same name is already cached on the VHD
+    $fileName = [IO.Path]::GetFileName($Url)
+    $search = [IO.Directory]::GetFiles($global:CacheDir, $fileName, [IO.SearchOption]::AllDirectories)
+
+    if ($search.Count -ne 0)
     {
-        if ($insecureProtocols -notcontains $protocol)
-        {
-            $secureProtocols += $protocol
-        }
+        Write-Log "Using chaced version of $fileName - Copying file from $($search[0]) to $DestinationPath"
+        Move-Item -Path $search[0] -Destination $DestinationPath -Force
     }
-    [System.Net.ServicePointManager]::SecurityProtocol = $secureProtocols
-
-    $oldProgressPreference = $ProgressPreference
-    $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest $Url -UseBasicParsing -OutFile $DestinationPath -Verbose
-    $ProgressPreference = $oldProgressPreference
-    Write-Log "Downloaded file to $DestinationPath"
+    else 
+    {
+        $secureProtocols = @()
+        $insecureProtocols = @([System.Net.SecurityProtocolType]::SystemDefault, [System.Net.SecurityProtocolType]::Ssl3)
+    
+        foreach ($protocol in [System.Enum]::GetValues([System.Net.SecurityProtocolType]))
+        {
+            if ($insecureProtocols -notcontains $protocol)
+            {
+                $secureProtocols += $protocol
+            }
+        }
+        [System.Net.ServicePointManager]::SecurityProtocol = $secureProtocols
+    
+        $oldProgressPreference = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest $Url -UseBasicParsing -OutFile $DestinationPath -Verbose
+        $ProgressPreference = $oldProgressPreference
+        Write-Log "Downloaded file to $DestinationPath"
+    }
 }
 
 # https://stackoverflow.com/a/34559554/697126

--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -20,7 +20,12 @@ function DownloadFileOverHttp
 
     # First check to see if a file with the same name is already cached on the VHD
     $fileName = [IO.Path]::GetFileName($Url)
-    $search = [IO.Directory]::GetFiles($global:CacheDir, $fileName, [IO.SearchOption]::AllDirectories)
+    
+    $search = @()
+    if (Test-Path $global:CacheDir)
+    {
+        $search = [IO.Directory]::GetFiles($global:CacheDir, $fileName, [IO.SearchOption]::AllDirectories)
+    }
 
     if ($search.Count -ne 0)
     {

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -161,6 +161,13 @@ try
     if ($true) {
         Write-Log "Provisioning $global:DockerServiceName... with IP $MasterIP"
 
+        # Install OpenSSH if SSH enabled
+        $sshEnabled = [System.Convert]::ToBoolean("{{ WindowsSSHEnabled }}")
+
+        if ( $sshEnabled ) {
+            Install-OpenSSH -SSHKeys $SSHKeys
+        }
+
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
@@ -187,7 +194,6 @@ try
             Write-Log "Overwriting kube node binaries from $global:WindowsKubeBinariesURL"
             Get-KubeBinaries -KubeBinariesURL $global:WindowsKubeBinariesURL
         }
-
 
         Write-Log "Write Azure cloud provider config"
         Write-AzureConfig `
@@ -229,7 +235,6 @@ try
                          -MasterIP $MasterIP `
                          -AgentKey $AgentKey `
                          -AgentCertificate $global:AgentCertificate
-
 
         Write-Log "Create the Pause Container kubletwin/pause"
         New-InfraContainer -KubeDir $global:KubeDir
@@ -287,13 +292,6 @@ try
             -KubeServiceCIDR $global:KubeServiceCIDR `
             -HNSModule $global:HNSModule `
             -KubeletNodeLabels $global:KubeletNodeLabels
-
-        # Install OpenSSH if SSH enabled
-        $sshEnabled = [System.Convert]::ToBoolean("{{ WindowsSSHEnabled }}")
-
-        if ( $sshEnabled ) {
-            Install-OpenSSH -SSHKeys $SSHKeys
-        }
 
         Write-Log "Disable Internet Explorer compat mode and set homepage"
         Set-Explorer

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -108,6 +108,7 @@ $global:ExcludeMasterFromStandardLB = "{{WrapAsVariable "excludeMasterFromStanda
 
 
 # Windows defaults, not changed by aks-engine
+$global:CacheDir = "c:\akse-cache"
 $global:KubeDir = "c:\k"
 $global:HNSModule = [Io.path]::Combine("$global:KubeDir", "hns.psm1")
 
@@ -237,6 +238,7 @@ try
 
         # Configure network policy.
         if ($global:NetworkPlugin -eq "azure") {
+            Write-Log "Installing Azure VNet plugins"
             Install-VnetPlugins -AzureCNIConfDir $global:AzureCNIConfDir `
                                 -AzureCNIBinDir $global:AzureCNIBinDir `
                                 -VNetCNIPluginsURL $global:VNetCNIPluginsURL
@@ -261,6 +263,7 @@ try
             }
 
         } elseif ($global:NetworkPlugin -eq "kubenet") {
+            Write-Log "Fetching additional files needed for kubenet"
             Update-WinCNI -CNIPath $global:CNIPath
             Get-HnsPsm1 -HNSModule $global:HNSModule
         }
@@ -303,6 +306,9 @@ try
 
         Write-Log "Update service failure actions"
         Update-ServiceFailureActions
+
+        Write-Log "Removing aks-engine bits cache directory"
+        Remove-Item $CacheDir -Recurse -Force
 
         Write-Log "Setup Complete, reboot computer"
         Restart-Computer

--- a/parts/k8s/windowsinstallopensshfunc.ps1
+++ b/parts/k8s/windowsinstallopensshfunc.ps1
@@ -15,7 +15,7 @@ Install-OpenSSH {
         $isAvailable = Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'
 
         if (!$isAvailable) {
-            Write-Error "OpenSSH is not avaliable on this machine"
+            Write-Error "OpenSSH is not available on this machine"
             exit 1
         }
 

--- a/parts/k8s/windowsinstallopensshfunc.ps1
+++ b/parts/k8s/windowsinstallopensshfunc.ps1
@@ -8,15 +8,23 @@ Install-OpenSSH {
     $adminpath = "c:\ProgramData\ssh"
     $adminfile = "administrators_authorized_keys"
 
-    Write-Host "Installing OpenSSH"
-    $isAvailable = Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'
+    $sshdService = Get-Service | ? Name -like 'sshd'
+    if ($sshdService.Count -eq 0)
+    {
+        Write-Host "Installing OpenSSH"
+        $isAvailable = Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'
 
-    if (!$isAvailable) {
-        Write-Error "OpenSSH is not avaliable on this machine"
-        exit 1
+        if (!$isAvailable) {
+            Write-Error "OpenSSH is not avaliable on this machine"
+            exit 1
+        }
+
+        Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
     }
-
-    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+    else
+    {
+        Write-Host "OpenSSH Server service detected - skipping online install..."
+    }
 
     Start-Service sshd
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -24875,15 +24875,23 @@ Install-OpenSSH {
     $adminpath = "c:\ProgramData\ssh"
     $adminfile = "administrators_authorized_keys"
 
-    Write-Host "Installing OpenSSH"
-    $isAvailable = Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'
+    $sshdService = Get-Service | ? Name -like 'sshd'
+    if ($sshdService.Count -eq 0)
+    {
+        Write-Host "Installing OpenSSH"
+        $isAvailable = Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'
 
-    if (!$isAvailable) {
-        Write-Error "OpenSSH is not avaliable on this machine"
-        exit 1
+        if (!$isAvailable) {
+            Write-Error "OpenSSH is not avaliable on this machine"
+            exit 1
+        }
+
+        Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
     }
-
-    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+    else
+    {
+        Write-Host "OpenSSH Server service detected - skipping online install..."
+    }
 
     Start-Service sshd
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -23739,7 +23739,12 @@ function DownloadFileOverHttp
 
     # First check to see if a file with the same name is already cached on the VHD
     $fileName = [IO.Path]::GetFileName($Url)
-    $search = [IO.Directory]::GetFiles($global:CacheDir, $fileName, [IO.SearchOption]::AllDirectories)
+    
+    $search = @()
+    if (Test-Path $global:CacheDir)
+    {
+        $search = [IO.Directory]::GetFiles($global:CacheDir, $fileName, [IO.SearchOption]::AllDirectories)
+    }
 
     if ($search.Count -ne 0)
     {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -24887,7 +24887,7 @@ Install-OpenSSH {
         $isAvailable = Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'
 
         if (!$isAvailable) {
-            Write-Error "OpenSSH is not avaliable on this machine"
+            Write-Error "OpenSSH is not available on this machine"
             exit 1
         }
 


### PR DESCRIPTION
**Reason for Change**:
Caching content on the Windows VHDs can help improve reliability and shorten the duration of CSEs used to configure the Windows nodes by reducing the amount of files downloaded during their execution.

**Issue Fixed**:
Addresses some of the work required for https://github.com/Azure/aks-engine/issues/1927

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
