### PR TITLE
test: az storage file download-batch --destination must exist

### DIFF
--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strconv"
 	"time"
@@ -552,6 +553,9 @@ func (sa *StorageAccount) UploadFiles(source, destination string) error {
 
 // DownloadFiles will download the output directory from storage
 func (sa *StorageAccount) DownloadFiles(source, destination string) error {
+	if _, err := os.Stat(destination); os.IsNotExist(err) {
+		os.Mkdir(destination, os.ModeDir)
+	}
 	cmd := exec.Command("az", "storage", "file", "download-batch", "--destination", destination, "--source", source, "--account-name", sa.Name, "--connection-string", sa.ConnectionString)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

The current soak test implementation persists the `_output/` directory to az storage for re-use across multiple runs/environments. However, there's a bug in our E2E code in that `az storage file download-batch` requires the `--destination` option to be a pre-existing directory.

This PR creates the `_output/` directory for cases where it doesn't already exist (e.g., a jenkins job configuration that cleans up its workspace directory for every job run).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
