### PR TITLE
test: s/southcentralus/uksouth

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -296,7 +296,7 @@ func (c *Config) IsKubernetes() bool {
 func (c *Config) SetRandomRegion() {
 	var regions []string
 	if c.Regions == nil || len(c.Regions) == 0 {
-		regions = []string{"eastus", "southcentralus", "southeastasia", "westus2", "westeurope"}
+		regions = []string{"eastus", "uksouth", "southeastasia", "westus2", "westeurope"}
 	} else {
 		regions = c.Regions
 	}

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -28,13 +28,13 @@ func TestSetRandomRegion(t *testing.T) {
 			config: Config{
 				Regions: []string{},
 			},
-			expected: []string{"eastus", "southcentralus", "southeastasia", "westus2", "westeurope"},
+			expected: []string{"eastus", "uksouth", "southeastasia", "westus2", "westeurope"},
 		},
 		{
 			config: Config{
 				Regions: nil,
 			},
-			expected: []string{"eastus", "southcentralus", "southeastasia", "westus2", "westeurope"},
+			expected: []string{"eastus", "uksouth", "southeastasia", "westus2", "westeurope"},
 		},
 		{
 			config: Config{


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR replaces the default `southcentralus` region with `uksouth`.

Seeing lots of this in recent tests:

```
Error from deployment for kubernetes-southcentralus-99368 in resource group kubernetes-southcentralus-99368:exit status 1
2019/09/13 16:51:48 Command Output: ERROR: Deployment failed. Correlation ID: 555bd6ee-8688-4088-bcc6-37caa0157810. {
  "status": "Failed",
  "error": {
    "code": "ResourceDeploymentFailure",
    "message": "The resource operation completed with terminal provisioning state 'Failed'.",
    "details": [
      {
        "code": "AllocationFailed",
        "message": "Allocation failed. We do not have sufficient capacity for the requested VM size in this region. Read more about improving likelihood of allocation success at http://aka.ms/allocation-guidance"
      }
    ]
  }
}
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
