### PR TITLE
chore: fix closure capture for UPGRADE_VERSIONS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ def taskForCreateJob(jobCfg, jobName, version) {
 }
 
 def runJobWithEnvironment(jobCfg, jobName, version) {
+	def jobSpecificEnv = defaultEnv + jobCfg.env
 	return {
 		node {
 			ws("${env.JOB_NAME}-${jobName}") {
@@ -56,7 +57,6 @@ def runJobWithEnvironment(jobCfg, jobName, version) {
 						unstash(name: 'aks-engine-bin')
 					}
 
-					def jobSpecificEnv = defaultEnv + jobCfg.env
 					// set environment variables needed for the test script
 					def envVars = [
 							ORCHESTRATOR_RELEASE: "${version}",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
When upgrade / scaling, the test pipeline was passing even though the upgrade version was always the last one in the list (v1.16.rc1) due to the upgrade version var being captured in a closure enclosed in a loop. This change properly capture the upgrade version.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
