### PR TITLE
chore: rev vhd to 2019.09.13

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -53,11 +53,10 @@ fi
 
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
 if [[ "${IS_VHD}" = true ]]; then
-    # TODO (09/13): uncomment when new VHD is published
-    # if [ -f $VHD_LOGS_FILEPATH ]; then
-    #     echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
-    #     exit $ERR_VHD_FILE_NOT_FOUND
-    # fi
+    if [ ! -f $VHD_LOGS_FILEPATH ]; then
+        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
+        exit $ERR_VHD_FILE_NOT_FOUND
+    fi
     echo "detected golden image pre-install"
     FULL_INSTALL_REQUIRED=false
 else

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -137,7 +137,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1604-201909",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2019.09.10",
+		ImageVersion:   "2019.09.13",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
@@ -145,7 +145,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1804-201909",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2019.09.10",
+		ImageVersion:   "2019.09.13",
 	}
 
 	// ACC1604OSImageConfig is the ACC image based on Ubuntu 16.04.

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13709,11 +13709,10 @@ fi
 
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
 if [[ "${IS_VHD}" = true ]]; then
-    # TODO (09/13): uncomment when new VHD is published
-    # if [ -f $VHD_LOGS_FILEPATH ]; then
-    #     echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
-    #     exit $ERR_VHD_FILE_NOT_FOUND
-    # fi
+    if [ ! -f $VHD_LOGS_FILEPATH ]; then
+        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
+        exit $ERR_VHD_FILE_NOT_FOUND
+    fi
     echo "detected golden image pre-install"
     FULL_INSTALL_REQUIRED=false
 else

--- a/releases/vhd-notes/aks-ubuntu-1604/aks-ubuntu-1604-201908_2019.09.13.txt
+++ b/releases/vhd-notes/aks-ubuntu-1604/aks-ubuntu-1604-201908_2019.09.13.txt
@@ -1,0 +1,165 @@
+Starting build on  Fri Sep 13 23:03:19 UTC 2019
+Using kernel:
+Linux version 4.15.0-1057-azure (buildd@lgw01-amd64-035) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.10)) #62-Ubuntu SMP Thu Sep 5 18:25:30 UTC 2019
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - util-linux
+  - xz-utils
+  - zip
+  - etcd v3.3.15
+  - moby v3.0.6
+  - nvidia-docker2 nvidia-container-runtime
+  - Azure CNI version 1.0.27
+  - Azure CNI version 1.0.25
+  - CNI plugin version 0.7.5
+  - CNI plugin version 0.7.1
+  - containerd version 1.2.4
+  - containerd version 1.1.6
+  - containerd version 1.1.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - k8s.gcr.io/exechealthz-amd64:1.2
+  - k8s.gcr.io/addon-resizer:1.8.5
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - k8s.gcr.io/addon-resizer:1.8.1
+  - k8s.gcr.io/addon-resizer:1.7
+  - k8s.gcr.io/heapster-amd64:v1.5.4
+  - k8s.gcr.io/heapster-amd64:v1.5.3
+  - k8s.gcr.io/heapster-amd64:v1.5.1
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.8
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.7
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.6
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+  - k8s.gcr.io/pause-amd64:3.1
+  - mcr.microsoft.com/k8s/azurestack/core/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.11.0
+  - gcr.io/kubernetes-helm/tiller:v2.8.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.0
+  - k8s.gcr.io/cluster-autoscaler:v1.15.1
+  - k8s.gcr.io/cluster-autoscaler:v1.15.0
+  - k8s.gcr.io/cluster-autoscaler:v1.14.4
+  - k8s.gcr.io/cluster-autoscaler:v1.14.2
+  - k8s.gcr.io/cluster-autoscaler:v1.14.0
+  - k8s.gcr.io/cluster-autoscaler:v1.13.6
+  - k8s.gcr.io/cluster-autoscaler:v1.13.4
+  - k8s.gcr.io/cluster-autoscaler:v1.13.2
+  - k8s.gcr.io/cluster-autoscaler:v1.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.12.7
+  - k8s.gcr.io/cluster-autoscaler:v1.12.5
+  - k8s.gcr.io/cluster-autoscaler:v1.12.3
+  - k8s.gcr.io/cluster-autoscaler:v1.12.2
+  - k8s.gcr.io/cluster-autoscaler:v1.3.9
+  - k8s.gcr.io/cluster-autoscaler:v1.3.8
+  - k8s.gcr.io/cluster-autoscaler:v1.3.7
+  - k8s.gcr.io/cluster-autoscaler:v1.3.4
+  - k8s.gcr.io/cluster-autoscaler:v1.3.3
+  - k8s.gcr.io/cluster-autoscaler:v1.2.5
+  - k8s.gcr.io/cluster-autoscaler:v1.2.2
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+  - k8s.gcr.io/coredns:1.6.2
+  - k8s.gcr.io/coredns:1.5.0
+  - k8s.gcr.io/coredns:1.3.1
+  - k8s.gcr.io/coredns:1.2.6
+  - k8s.gcr.io/coredns:1.2.2
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - k8s.gcr.io/rescheduler:v0.3.1
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.5
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.18
+  - nvidia/k8s-device-plugin:1.11
+  - nvidia/k8s-device-plugin:1.10
+  - docker.io/deis/hcp-tunnel-front:v1.9.2-v4.0.4
+  - docker.io/deis/kube-svc-redirect:v1.0.2
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.3.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.0.0
+  - nginx:1.13.12-alpine
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.3
+  - k8s.gcr.io/hyperkube-amd64:v1.15.3
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.3-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.2
+  - k8s.gcr.io/hyperkube-amd64:v1.15.2
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.2-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.6
+  - k8s.gcr.io/hyperkube-amd64:v1.14.6
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.6-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.5
+  - k8s.gcr.io/hyperkube-amd64:v1.14.5
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.5-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.10
+  - k8s.gcr.io/hyperkube-amd64:v1.13.10
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.13.10-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.9
+  - k8s.gcr.io/hyperkube-amd64:v1.13.9
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.13.9-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.8
+  - k8s.gcr.io/hyperkube-amd64:v1.12.8
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.12.8-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.7
+  - k8s.gcr.io/hyperkube-amd64:v1.12.7
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.12.7-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.10
+  - k8s.gcr.io/hyperkube-amd64:v1.11.10
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.11.10-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.9
+  - k8s.gcr.io/hyperkube-amd64:v1.11.9
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.11.9-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.13
+  - k8s.gcr.io/hyperkube-amd64:v1.10.13
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.12
+  - k8s.gcr.io/hyperkube-amd64:v1.10.12
+  - registry:2.7.1
+WARNING: 75% of /dev/sda1 is used
+Install completed successfully on  Fri Sep 13 23:28:56 UTC 2019
+VSTS Build NUMBER: 20190913.9
+VSTS Build ID: 25006979
+Commit: 705977174d89fb93a9e66d26bae09a9aa7016694
+Feature flags:

--- a/releases/vhd-notes/aks-ubuntu-1804/aks-ubuntu-1804-201908_2019.09.13.txt
+++ b/releases/vhd-notes/aks-ubuntu-1804/aks-ubuntu-1804-201908_2019.09.13.txt
@@ -1,0 +1,165 @@
+Starting build on  Fri Sep 13 23:03:37 UTC 2019
+Using kernel:
+Linux version 5.0.0-1018-azure (buildd@lgw01-amd64-048) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #19~18.04.1-Ubuntu SMP Wed Aug 21 05:13:05 UTC 2019
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - util-linux
+  - xz-utils
+  - zip
+  - etcd v3.3.15
+  - moby v3.0.6
+  - nvidia-docker2 nvidia-container-runtime
+  - Azure CNI version 1.0.27
+  - Azure CNI version 1.0.25
+  - CNI plugin version 0.7.5
+  - CNI plugin version 0.7.1
+  - containerd version 1.2.4
+  - containerd version 1.1.6
+  - containerd version 1.1.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - k8s.gcr.io/exechealthz-amd64:1.2
+  - k8s.gcr.io/addon-resizer:1.8.5
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - k8s.gcr.io/addon-resizer:1.8.1
+  - k8s.gcr.io/addon-resizer:1.7
+  - k8s.gcr.io/heapster-amd64:v1.5.4
+  - k8s.gcr.io/heapster-amd64:v1.5.3
+  - k8s.gcr.io/heapster-amd64:v1.5.1
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.8
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.7
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.6
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+  - k8s.gcr.io/pause-amd64:3.1
+  - mcr.microsoft.com/k8s/azurestack/core/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.11.0
+  - gcr.io/kubernetes-helm/tiller:v2.8.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.0
+  - k8s.gcr.io/cluster-autoscaler:v1.15.1
+  - k8s.gcr.io/cluster-autoscaler:v1.15.0
+  - k8s.gcr.io/cluster-autoscaler:v1.14.4
+  - k8s.gcr.io/cluster-autoscaler:v1.14.2
+  - k8s.gcr.io/cluster-autoscaler:v1.14.0
+  - k8s.gcr.io/cluster-autoscaler:v1.13.6
+  - k8s.gcr.io/cluster-autoscaler:v1.13.4
+  - k8s.gcr.io/cluster-autoscaler:v1.13.2
+  - k8s.gcr.io/cluster-autoscaler:v1.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.12.7
+  - k8s.gcr.io/cluster-autoscaler:v1.12.5
+  - k8s.gcr.io/cluster-autoscaler:v1.12.3
+  - k8s.gcr.io/cluster-autoscaler:v1.12.2
+  - k8s.gcr.io/cluster-autoscaler:v1.3.9
+  - k8s.gcr.io/cluster-autoscaler:v1.3.8
+  - k8s.gcr.io/cluster-autoscaler:v1.3.7
+  - k8s.gcr.io/cluster-autoscaler:v1.3.4
+  - k8s.gcr.io/cluster-autoscaler:v1.3.3
+  - k8s.gcr.io/cluster-autoscaler:v1.2.5
+  - k8s.gcr.io/cluster-autoscaler:v1.2.2
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+  - k8s.gcr.io/coredns:1.6.2
+  - k8s.gcr.io/coredns:1.5.0
+  - k8s.gcr.io/coredns:1.3.1
+  - k8s.gcr.io/coredns:1.2.6
+  - k8s.gcr.io/coredns:1.2.2
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - k8s.gcr.io/rescheduler:v0.3.1
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.5
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.18
+  - nvidia/k8s-device-plugin:1.11
+  - nvidia/k8s-device-plugin:1.10
+  - docker.io/deis/hcp-tunnel-front:v1.9.2-v4.0.4
+  - docker.io/deis/kube-svc-redirect:v1.0.2
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.3.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.0.0
+  - nginx:1.13.12-alpine
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.3
+  - k8s.gcr.io/hyperkube-amd64:v1.15.3
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.3-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.2
+  - k8s.gcr.io/hyperkube-amd64:v1.15.2
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.2-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.6
+  - k8s.gcr.io/hyperkube-amd64:v1.14.6
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.6-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.5
+  - k8s.gcr.io/hyperkube-amd64:v1.14.5
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.5-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.10
+  - k8s.gcr.io/hyperkube-amd64:v1.13.10
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.13.10-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.9
+  - k8s.gcr.io/hyperkube-amd64:v1.13.9
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.13.9-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.8
+  - k8s.gcr.io/hyperkube-amd64:v1.12.8
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.12.8-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.7
+  - k8s.gcr.io/hyperkube-amd64:v1.12.7
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.12.7-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.10
+  - k8s.gcr.io/hyperkube-amd64:v1.11.10
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.11.10-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.9
+  - k8s.gcr.io/hyperkube-amd64:v1.11.9
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.11.9-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.13
+  - k8s.gcr.io/hyperkube-amd64:v1.10.13
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.12
+  - k8s.gcr.io/hyperkube-amd64:v1.10.12
+  - registry:2.7.1
+WARNING: 75% of /dev/sda1 is used
+Install completed successfully on  Fri Sep 13 23:30:07 UTC 2019
+VSTS Build NUMBER: 20190913.10
+VSTS Build ID: 25006997
+Commit: 705977174d89fb93a9e66d26bae09a9aa7016694
+Feature flags:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

New VHD includes the following pre-downloaded artifacts for both 16.04-LTS and 18.04-LTS:

- etcd v3.3.15

Includes the following pre-downloaded versions:

- k8s.gcr.io/cluster-autoscaler:v1.16.0

Also this VHD includes a "file fingerprint" at the new `/opt/azure/vhd-install.complete` location, which CSE has been updated to check to validate that the underlying VM OS does not need to download system package pre-requisites.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
