### PR TITLE
chore: add back compat E2E tests for N versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,13 @@ def tasksForUpgradeJob(jobCfg, aksEngineVersions, jobName, version) {
 
 	jobName = "${jobName}/upgrade/${upgradeVersion}"
 	if(isBackCompat()) {
-		def backCompatVersions = getPreviousVersions(params.UPGRADE_FORK) + "master"
+		def previousReleases = getPreviousVersions(params.UPGRADE_FORK)
+		def backCompatVersions = []
+		if(previousReleases.size() == 1) {
+			backCompatVersions = ["master"]
+		} else {
+			backCompatVersions = ["master"] + previousReleases[0..-2]
+		}
 		def baseReleaseBranch = getBaseReleaseBranch(params.FORK)
 		backCompatVersions.each { releaseBranch ->
 			backCompatJobName = "${jobName}/back/${baseReleaseBranch}-${releaseBranch}"
@@ -112,7 +118,6 @@ def runJobWithEnvironment(environmentVars, apiModel, jobName, version) {
 }
 
 def getPreviousVersions(fork) {
-	// set environment variables needed for the test script
 	def envVars = [
 			UPGRADE_FORK: fork,
 		]
@@ -124,7 +129,7 @@ def getPreviousVersions(fork) {
 
 def getBaseReleaseBranch(fork) {
 	def releases = getPreviousVersions(params.FORK)
-	return releases[backCompatVersionCount() - 1]
+	return releases[-1]
 }
 
 stage ("build binary") {

--- a/test/e2e/build.sh
+++ b/test/e2e/build.sh
@@ -5,6 +5,18 @@ set -x
 GOPATH="/go"
 WORK_DIR="${GOPATH}/src/github.com/Azure/aks-engine"
 
+if [[ -n "${FORK}" ]]; then
+  # shellcheck disable=SC2034
+  if ! output=$(git remote show "$FORK") ; then
+    git remote add $FORK https://github.com/$FORK/aks-engine.git
+  fi
+
+  git fetch $FORK
+  git branch -D $FORK/$BRANCH
+  git checkout -b $FORK/$BRANCH --track $FORK/$BRANCH
+  git pull
+fi
+
 # Assumes we're running from the git root of aks-engine
 docker run --rm \
 -v $(pwd):${WORK_DIR} \

--- a/test/e2e/build.sh
+++ b/test/e2e/build.sh
@@ -5,7 +5,7 @@ set -x
 GOPATH="/go"
 WORK_DIR="${GOPATH}/src/github.com/Azure/aks-engine"
 
-ORIGINAL_BRANCH=$(git branch --show-current)
+ORIGINAL_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 
 if [[ -n "${FORK}" ]]; then
   # shellcheck disable=SC2034

--- a/test/e2e/build.sh
+++ b/test/e2e/build.sh
@@ -5,6 +5,8 @@ set -x
 GOPATH="/go"
 WORK_DIR="${GOPATH}/src/github.com/Azure/aks-engine"
 
+ORIGINAL_BRANCH=$(git branch --show-current)
+
 if [[ -n "${FORK}" ]]; then
   # shellcheck disable=SC2034
   if ! output=$(git remote show "$FORK") ; then
@@ -23,4 +25,4 @@ docker run --rm \
 -w ${WORK_DIR} \
 "${DEV_IMAGE}" make build-binary || exit 1
 
-git checkout master
+git checkout "${ORIGINAL_BRANCH}"

--- a/test/e2e/build.sh
+++ b/test/e2e/build.sh
@@ -22,3 +22,5 @@ docker run --rm \
 -v $(pwd):${WORK_DIR} \
 -w ${WORK_DIR} \
 "${DEV_IMAGE}" make build-binary || exit 1
+
+git checkout master

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -98,7 +98,12 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ]; then
       done
     done
   fi
-  git remote add $UPGRADE_FORK https://github.com/$UPGRADE_FORK/aks-engine.git
+
+  # shellcheck disable=SC2034
+  if ! output=$(git remote show "$UPGRADE_FORK") ; then
+    git remote add $UPGRADE_FORK https://github.com/$UPGRADE_FORK/aks-engine.git
+  fi
+
   git fetch $UPGRADE_FORK
   git branch -D $UPGRADE_FORK/$UPGRADE_BRANCH
   git checkout -b $UPGRADE_FORK/$UPGRADE_BRANCH --track $UPGRADE_FORK/$UPGRADE_BRANCH

--- a/test/e2e/releases.sh
+++ b/test/e2e/releases.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x
+
+# shellcheck disable=SC2034
+if ! output=$(git remote show "$UPGRADE_FORK") ; then
+  git remote add $UPGRADE_FORK https://github.com/$UPGRADE_FORK/aks-engine.git
+fi
+
+git fetch $UPGRADE_FORK
+git branch -a --list "${UPGRADE_FORK}/release-*" | sort -r | head -$BACK_COMPAT_VERSIONS | sed "s/remotes\/${UPGRADE_FORK}\///" | sed -e 's/^[[:space:]]*//g'


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The Jenkins Pipeline should be able to test backward compatibility for upgrade and scale in aks-engine. That is, a cluster made with the current version of aks-engine should be able to work with a previous release of aks-engine.

This PR enables a variable N number of previous releases by searching for release branches in the `$UPGRADE_FORK`. 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: