### PR TITLE
fix: correct scale message after scale operations

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -492,7 +492,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 	deploymentSuffix := random.Int31()
 
 	if sc.nodes != nil {
-		sc.logger.Infof("Nodes in pool %s before scaling:\n", sc.agentPoolToScale)
+		sc.logger.Infof("Nodes in pool '%s' before scaling:\n", sc.agentPoolToScale)
 		operations.PrintNodes(sc.nodes)
 	}
 	_, err = sc.client.DeployTemplate(
@@ -508,7 +508,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 		nodes, err := operations.GetNodes(sc.client, sc.logger, sc.apiserverURL, sc.kubeconfig, time.Duration(5)*time.Minute, sc.agentPoolToScale, sc.newDesiredAgentCount)
 		if err == nil && nodes != nil {
 			sc.nodes = nodes
-			sc.logger.Infof("Nodes in pool %s after scaling:\n", sc.agentPoolToScale)
+			sc.logger.Infof("Nodes in pool '%s' after scaling:\n", sc.agentPoolToScale)
 			operations.PrintNodes(sc.nodes)
 		} else {
 			sc.logger.Warningf("Unable to get nodes in pool %s after scaling:\n", sc.agentPoolToScale)

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -508,7 +508,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 		nodes, err := operations.GetNodes(sc.client, sc.logger, sc.apiserverURL, sc.kubeconfig, time.Duration(5)*time.Minute, sc.agentPoolToScale, sc.newDesiredAgentCount)
 		if err == nil && nodes != nil {
 			sc.nodes = nodes
-			sc.logger.Infof("Nodes in pool %s cluster after scaling:\n", sc.agentPoolToScale)
+			sc.logger.Infof("Nodes in pool %s after scaling:\n", sc.agentPoolToScale)
 			operations.PrintNodes(sc.nodes)
 		} else {
 			sc.logger.Warningf("Unable to get nodes in pool %s after scaling:\n", sc.agentPoolToScale)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Instead of printing:

`time="2019-09-18T18:42:36Z" level=info msg="Nodes in pool pool1 cluster after scaling:"`

We should print:

`time="2019-09-18T18:42:36Z" level=info msg="Nodes in pool 'pool1' after scaling:"`

Also updated the message we print before the scale operation to surround the name of the pool in single quotes to anticipate that the name of the pool might include the word pool, and thus "stutter" in the context of the message clause.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
