### PR TITLE
chore: update network plugin value to kubenet in Azure Stack example file

### DIFF
--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -5,11 +5,11 @@
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.14",
-            "orchestratorVersion": "1.14.5",
+            "orchestratorVersion": "1.14.7",
             "kubernetesConfig": {
                 "kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
                 "useInstanceMetadata": false,
-                "networkPlugin": "flannel"
+                "networkPlugin": "kubenet"
             }
         },
         "customCloudProfile": {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Update network plugin value to kubenet in Azure Stack example file as moby + flannel is not supported.

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/) 
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
