### PR TITLE
test: retry’able node get

### DIFF
--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -311,21 +311,12 @@ func (cli *CLIProvisioner) waitForNodes() error {
 			if !ready {
 				return errors.New("Error: Not all nodes in a healthy state")
 			}
-			var version string
-			var err error
-			if cli.Config.IsKubernetes() {
-				version, err = node.Version()
-			}
-			if err != nil {
-				log.Printf("Ready nodes did not return a version: %s", err)
-			}
-			log.Printf("Testing a %s %s cluster...\n", cli.Config.Orchestrator, version)
-			nodeList, err := node.Get()
+			nodes, err := node.GetWithRetry(1*time.Second, cli.Config.Timeout)
 			if err != nil {
 				return errors.Wrap(err, "Unable to get the list of nodes")
 			}
 			if !cli.Engine.ExpandedDefinition.Properties.HasLowPriorityScaleset() {
-				for _, n := range nodeList.Nodes {
+				for _, n := range nodes {
 					exp, err := regexp.Compile("k8s-master")
 					if err != nil {
 						return err


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Our most common E2E flake at present is node get operations returning unexpected results. This PR tolerates transient node get responses within a given retry timeout period.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
