### PR TITLE
test: skip time sync test for 18.04

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -3,6 +3,7 @@ parameters:
   k8sRelease: ''
   apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
   createVNET: false
+  skipTests: ''
 
 jobs:
 - job: ${{ parameters.name }}
@@ -13,9 +14,9 @@ jobs:
     maxParallel: 0
   pool:
     vmImage: ubuntu-16.04
-  
+
   container: dev1
-  
+
   variables:
     GOBIN:  '$(GOPATH)/bin' # Go binaries path
     GOROOT: '/usr/local/go' # Go installation path
@@ -27,6 +28,7 @@ jobs:
     CREATE_VNET: ${{ parameters.createVNET }}
     CLEANUP_ON_EXIT: true
     CLEANUP_IF_FAIL: true
+    GINKGO_SKIP: ${{ parameters.skipTests }}
     RETAIN_SSH: false
     ENABLE_KMS_ENCRYPTION: true
     SUBSCRIPTION_ID: '$(SUBSCRIPTION_ID_E2E_KUBERNETES)'

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -76,6 +76,7 @@ jobs:
   parameters:
     name: 'ubuntu_18_04_linux_e2e'
     apimodel: 'examples/ubuntu-1804/kubernetes.json'
+    skipTests: '"should have healthy time synchronization"'
 
 - template: e2e-job-template.yaml
   parameters:

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -76,7 +76,7 @@ jobs:
   parameters:
     name: 'ubuntu_18_04_linux_e2e'
     apimodel: 'examples/ubuntu-1804/kubernetes.json'
-    skipTests: '"should have healthy time synchronization"'
+    skipTests: 'should have healthy time synchronization'
 
 - template: e2e-job-template.yaml
   parameters:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Ubuntu 18.04-LTS has a known symptom of regularly taking a long time (> 30 mins) to achieve time synchronization. Until we root cause and fix that, let's skip the time sync test on 18.04-LTS as a way of continuing to gather additional functional signal from Kubernetes + Azure + 18.04-LTS, without the annoying flaky test runs.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
