### PR TITLE
ci: Adding provenance info in Windows VHD release notes

### DIFF
--- a/.pipelines/vhd-builder-windows.yaml
+++ b/.pipelines/vhd-builder-windows.yaml
@@ -33,6 +33,8 @@ jobs:
       -e AZURE_RESOURCE_GROUP_NAME=${AZURE_RESOURCE_GROUP_NAME} \
       -e AZURE_LOCATION=${AZURE_LOCATION} \
       -e AZURE_VM_SIZE=${PACKER_VM_SIZE} \
+      -e GIT_BRANCH=$(Build.SourceBranchName) \
+      -e GIT_REPO=$(Build.Repository.Uri) \
       -e GIT_VERSION=$(Build.SourceVersion) \
       -e BUILD_ID=$(Build.BuildId) \
       -e BUILD_NUMBER=$(Build.BuildNumber) \

--- a/packer/windows-vhd-builder.json
+++ b/packer/windows-vhd-builder.json
@@ -1,5 +1,10 @@
 {
     "variables": {
+        "build_branch": "{{env `GIT_BRANCH`}}",
+        "build_commit": "{{env `GIT_VERSION`}}",
+        "build_id": "{{env `BUILD_ID`}}",
+        "build_number": "{{env `BUILD_NUMBER`}}",
+        "build_repo": "{{env `GIT_REPO`}}",
         "client_id": "{{env `AZURE_CLIENT_ID`}}",
         "client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
         "tenant_id": "{{env `AZURE_TENANT_ID`}}",
@@ -67,6 +72,13 @@
         {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
+            "environment_vars" : [
+                "BUILD_BRANCH={{user `build_branch`}}",
+                "BUILD_COMMIT={{user `build_commit`}}",
+                "BUILD_ID={{user `build_id`}}",
+                "BUILD_NUMBER={{user `build_number`}}",
+                "BUILD_REPO={{user `build_repo`}}"
+            ],
             "type": "powershell",
             "script": "packer/write-release-notes-windows.ps1"
         },

--- a/packer/write-release-notes-windows.ps1
+++ b/packer/write-release-notes-windows.ps1
@@ -13,6 +13,13 @@ function Log($Message) {
     $Message | Tee-Object -FilePath "c:\release-notes.txt" -Append
 }
 
+Log "Build Number: $env:BUILD_NUMBER"
+Log "Build Id:     $env:BUILD_ID"
+Log "Build Repo:   $env:BUILD_REPO"
+Log "Build Branch: $env:BUILD_BRANCH"
+Log "Commit:       $env:BUILD_COMMIT"
+Log ""
+
 Log "System Info"
 $systemInfo = Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion'
 Log ("`t{0,-14} : {1}" -f "OS Name", $systemInfo.ProductName)


### PR DESCRIPTION
**Reason for Change**:
Logging info about the git commit/branch/repo and azure devops build used to produce Windows VHDs

**Issue Fixed**:



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
