### PR TITLE
test: address 4 E2E test flakes

### DIFF
--- a/test/e2e/kubernetes/hpa/hpa.go
+++ b/test/e2e/kubernetes/hpa/hpa.go
@@ -15,8 +15,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const commandTimeout = 1 * time.Minute
-
 type List struct {
 	HPAs []HPA `json:"items"`
 }
@@ -132,6 +130,7 @@ func GetAllByPrefix(prefix, namespace string) ([]HPA, error) {
 
 // Describe will describe a HPA resource
 func (h *HPA) Describe() error {
+	var commandTimeout time.Duration
 	cmd := exec.Command("k", "describe", "hpa", h.Metadata.Name, "-n", h.Metadata.Namespace)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))
@@ -140,6 +139,7 @@ func (h *HPA) Describe() error {
 
 // Delete will delete a HPA in a given namespace
 func (h *HPA) Delete(retries int) error {
+	var commandTimeout time.Duration
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -20,8 +20,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const commandTimeout = 1 * time.Minute
-
 // List is a container that holds all jobs returned from doing a kubectl get jobs
 type List struct {
 	Jobs []Job `json:"items"`
@@ -311,6 +309,7 @@ func DescribeJobs(jobPrefix, namespace string) {
 
 // Describe will describe a Job resource
 func (j *Job) Describe() error {
+	var commandTimeout time.Duration
 	cmd := exec.Command("k", "describe", "jobs/", j.Metadata.Name, "-n", j.Metadata.Namespace)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -48,7 +48,7 @@ const (
 	kubeSystemPodsReadinessChecks             = 6
 	sleepBetweenRetriesWhenWaitingForPodReady = 1 * time.Second
 	timeoutWhenWaitingForPodOutboundAccess    = 1 * time.Minute
-	stabilityCommandTimeout                   = 1 * time.Second
+	stabilityCommandTimeout                   = 3 * time.Second
 	windowsCommandTimeout                     = 1 * time.Minute
 	validateNetworkPolicyTimeout              = 3 * time.Minute
 	validateDNSTimeout                        = 2 * time.Minute
@@ -979,7 +979,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring we can create an ILB service attachment")
 				sILB, err := service.CreateServiceFromFileDeleteIfExist(filepath.Join(WorkloadDir, "ingress-nginx-ilb.yaml"), serviceName+"-ilb", "default")
 				Expect(err).NotTo(HaveOccurred())
-				svc, err := sILB.WaitForIngress(cfg.Timeout, 5*time.Second)
+				err = sILB.WaitForIngress(cfg.Timeout, 5*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Ensuring we can create a curl pod to connect to the service")
@@ -995,12 +995,12 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring we can connect to the ILB service from another pod")
 				var success bool
 				for _, curlPod := range curlPods {
-					pass, curlErr := curlPod.ValidateCurlConnection(svc.Status.LoadBalancer.Ingress[0]["ip"], 30*time.Second, 3*time.Minute)
+					pass, curlErr := curlPod.ValidateCurlConnection(sILB.Status.LoadBalancer.Ingress[0]["ip"], 30*time.Second, 3*time.Minute)
 					if curlErr == nil && pass {
 						success = true
 						break
 					} else {
-						e := svc.Describe()
+						e := sILB.Describe()
 						if e != nil {
 							log.Printf("Unable to describe service\n: %s", e)
 						}
@@ -1011,21 +1011,21 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring we can create an ELB service attachment")
 				sELB, err := service.CreateServiceFromFileDeleteIfExist(filepath.Join(WorkloadDir, "ingress-nginx-elb.yaml"), serviceName+"-elb", "default")
 				Expect(err).NotTo(HaveOccurred())
-				svc, err = sELB.WaitForIngress(cfg.Timeout, 5*time.Second)
+				err = sELB.WaitForIngress(cfg.Timeout, 5*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Ensuring we can connect to the ELB service on the service IP")
-				valid := sELB.Validate("(Welcome to nginx)", 5, 30*time.Second, cfg.Timeout)
-				Expect(valid).To(BeTrue())
+				err = sELB.ValidateWithRetry("(Welcome to nginx)", 30*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
 				By("Ensuring we can connect to the ELB service from another pod")
 				success = false
 				for _, curlPod := range curlPods {
-					pass, curlErr := curlPod.ValidateCurlConnection(svc.Status.LoadBalancer.Ingress[0]["ip"], 30*time.Second, 3*time.Minute)
+					pass, curlErr := curlPod.ValidateCurlConnection(sELB.Status.LoadBalancer.Ingress[0]["ip"], 30*time.Second, 3*time.Minute)
 					if curlErr == nil && pass {
 						success = true
 						break
 					} else {
-						e := svc.Describe()
+						e := sELB.Describe()
 						if e != nil {
 							log.Printf("Unable to describe service\n: %s", e)
 						}
@@ -1569,10 +1569,12 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				iisService, err := service.Get(deploymentName, "default")
 				Expect(err).NotTo(HaveOccurred())
+				err = iisService.WaitForIngress(cfg.Timeout, 5*time.Second)
+				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				valid := iisService.Validate("(IIS Windows Server)", 10, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
-				Expect(valid).To(BeTrue())
+				err = iisService.ValidateWithRetry("(IIS Windows Server)", sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
 				var iisPods []pod.Pod
@@ -1601,8 +1603,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).To(Equal(5))
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				valid = iisService.Validate("(IIS Windows Server)", 10, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
-				Expect(valid).To(BeTrue())
+				err = iisService.ValidateWithRetry("(IIS Windows Server)", sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
 				iisPods, err = iisDeploy.Pods()
@@ -1632,8 +1634,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).To(Equal(2))
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				valid = iisService.Validate("(IIS Windows Server)", 10, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
-				Expect(valid).To(BeTrue())
+				err = iisService.ValidateWithRetry("(IIS Windows Server)", sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
 				iisPods, err = iisDeploy.Pods()
@@ -1698,14 +1700,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Connecting to Windows from another Windows deployment")
 				name := fmt.Sprintf("windows-2-windows-%s", cfg.Name)
 				command := fmt.Sprintf("iwr -UseBasicParsing -TimeoutSec 60 %s", windowsService.Metadata.Name)
-				successes, err := pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsImages.ServerCore, name, command, cfg.StabilityIterations, 1*time.Second, retryCommandsTimeout, windowsCommandTimeout)
+				successes, err := pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsImages.ServerCore, name, command, cfg.StabilityIterations, 1*time.Second, windowsCommandTimeout, retryCommandsTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(successes).To(Equal(cfg.StabilityIterations))
 
 				By("Connecting to Linux from Windows deployment")
 				name = fmt.Sprintf("windows-2-linux-%s", cfg.Name)
 				command = fmt.Sprintf("iwr -UseBasicParsing -TimeoutSec 60 %s", linuxService.Metadata.Name)
-				successes, err = pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsImages.ServerCore, name, command, cfg.StabilityIterations, 1*time.Second, retryCommandsTimeout, windowsCommandTimeout)
+				successes, err = pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsImages.ServerCore, name, command, cfg.StabilityIterations, 1*time.Second, windowsCommandTimeout, retryCommandsTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(successes).To(Equal(cfg.StabilityIterations))
 

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -18,8 +18,7 @@ import (
 
 const (
 	//ServerVersion is used to parse out the version of the API running
-	ServerVersion  = `(Server Version:\s)+(.*)`
-	commandTimeout = 1 * time.Minute
+	ServerVersion = `(Server Version:\s)+(.*)`
 )
 
 // Node represents the kubernetes Node Resource
@@ -162,6 +161,7 @@ func DescribeNodes() {
 
 // Describe will describe a node resource
 func (n *Node) Describe() error {
+	var commandTimeout time.Duration
 	cmd := exec.Command("k", "describe", "node", n.Metadata.Name)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))

--- a/test/e2e/kubernetes/persistentvolume/persistentvolume.go
+++ b/test/e2e/kubernetes/persistentvolume/persistentvolume.go
@@ -13,8 +13,6 @@ import (
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/util"
 )
 
-const commandTimeout = 1 * time.Minute
-
 // PersistentVolume is used to parse data from kubectl get pv
 type PersistentVolume struct {
 	Metadata Metadata `json:"metadata"`
@@ -86,6 +84,7 @@ func DescribePVs() {
 
 // Describe will describe a pv resource
 func (pv *PersistentVolume) Describe() error {
+	var commandTimeout time.Duration
 	cmd := exec.Command("k", "describe", "pv", pv.Metadata.Name)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -15,8 +15,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const commandTimeout = 1 * time.Minute
-
 type List struct {
 	PersistentVolumeClaims []PersistentVolumeClaim `json:"items"`
 }
@@ -179,6 +177,7 @@ func DescribePVCs(pvcPrefix, namespace string) {
 
 // Describe will describe a pv resource
 func (pvc *PersistentVolumeClaim) Describe() error {
+	var commandTimeout time.Duration
 	cmd := exec.Command("k", "describe", "pvc", pvc.Metadata.Name, "-n", pvc.Metadata.Namespace)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))
@@ -187,6 +186,7 @@ func (pvc *PersistentVolumeClaim) Describe() error {
 
 // Delete will delete a PersistentVolumeClaim in a given namespace
 func (pvc *PersistentVolumeClaim) Delete(retries int) error {
+	var commandTimeout time.Duration
 	var kubectlOutput []byte
 	var kubectlError error
 	for i := 0; i < retries; i++ {

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	testDir                    string = "testdirectory"
-	commandTimeout                    = 1 * time.Minute
 	deleteTimeout                     = 5 * time.Minute
 	validatePodNotExistRetries        = 3
 )
@@ -1112,6 +1111,7 @@ func (p *Pod) CheckWindowsOutboundConnection(sleep, timeout time.Duration) (bool
 
 // ValidateHostPort will attempt to run curl against the POD's hostIP and hostPort
 func (p *Pod) ValidateHostPort(check string, attempts int, sleep time.Duration, master, sshKeyPath string) bool {
+	var commandTimeout time.Duration
 	hostIP := p.Status.HostIP
 	if len(p.Spec.Containers) == 0 || len(p.Spec.Containers[0].Ports) == 0 {
 		log.Printf("Unexpected POD container spec: %v. Should have hostPort.\n", p.Spec)
@@ -1138,6 +1138,7 @@ func (p *Pod) ValidateHostPort(check string, attempts int, sleep time.Duration, 
 
 // Logs will get logs from all containers in a pod
 func (p *Pod) Logs() error {
+	var commandTimeout time.Duration
 	for _, container := range p.Spec.Containers {
 		cmd := exec.Command("k", "logs", p.Metadata.Name, "-c", container.Name, "-n", p.Metadata.Namespace)
 		out, err := util.RunAndLogCommand(cmd, commandTimeout)
@@ -1151,6 +1152,7 @@ func (p *Pod) Logs() error {
 
 // Describe will describe a pod resource
 func (p *Pod) Describe() error {
+	var commandTimeout time.Duration
 	cmd := exec.Command("k", "describe", "pod", p.Metadata.Name, "-n", p.Metadata.Namespace)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))

--- a/test/e2e/kubernetes/storageclass/storageclass.go
+++ b/test/e2e/kubernetes/storageclass/storageclass.go
@@ -14,8 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const commandTimeout = 1 * time.Minute
-
 // StorageClass is used to parse data from kubectl get storageclass
 type StorageClass struct {
 	Metadata   Metadata   `json:"metadata"`
@@ -84,6 +82,7 @@ func Get(scName string) (*StorageClass, error) {
 
 // Describe will describe a storageclass resource
 func (sc *StorageClass) Describe() error {
+	var commandTimeout time.Duration
 	cmd := exec.Command("k", "describe", "storageclass", sc.Metadata.Name)
 	out, err := util.RunAndLogCommand(cmd, commandTimeout)
 	log.Printf("\n%s\n", string(out))

--- a/test/e2e/kubernetes/util/util.go
+++ b/test/e2e/kubernetes/util/util.go
@@ -23,6 +23,7 @@ func PrintCommand(cmd *exec.Cmd) {
 
 // RunAndLogCommand logs the command with a timestamp when it's run, and the duration at end
 func RunAndLogCommand(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
+	var zeroValueDuration time.Duration
 	var err error
 	var out []byte
 	cmdLine := fmt.Sprintf("$ %s", strings.Join(cmd.Args, " "))
@@ -32,8 +33,10 @@ func RunAndLogCommand(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
 	end := time.Now()
 	total := time.Since(start)
 	log.Printf("#### %s completed in %s", cmdLine, end.Sub(start).String())
-	if total.Seconds() > timeout.Seconds() {
-		err = errors.Errorf("%s took too long!", cmdLine)
+	if zeroValueDuration != timeout {
+		if total.Seconds() > timeout.Seconds() {
+			err = errors.Errorf("%s took too long!", cmdLine)
+		}
 	}
 	return out, err
 }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

1. validate service URLs w/ retries
2. don’t enforce “shell out command” timeouts everywhere
3. standardize Linux stability tests timeout to 3 secs per test
4. standardize some Windows stability tests timeout to 1 minute per test

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
