### PR TITLE
test: Use Standard_D2_v3 and low pri VMSS in E2E test configs

### DIFF
--- a/test/e2e/test_cluster_configs/base.json
+++ b/test/e2e/test_cluster_configs/base.json
@@ -15,7 +15,9 @@
 				{
 					"name": "agentpool1",
 					"count": 2,
-					"vmSize": "Standard_D2_v3"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/container_monitoring.json
+++ b/test/e2e/test_cluster_configs/container_monitoring.json
@@ -27,7 +27,8 @@
 					"name": "agentpool",
 					"count": 3,
 					"vmSize": "Standard_DS2_v2",
-					"availabilityProfile": "VirtualMachineScaleSets"
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/flannel/containerd.json
+++ b/test/e2e/test_cluster_configs/flannel/containerd.json
@@ -24,14 +24,15 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agent1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"availabilityProfile": "AvailabilitySet"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/flannel/docker.json
+++ b/test/e2e/test_cluster_configs/flannel/docker.json
@@ -14,14 +14,16 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Linux"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Linux",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/gpu.json
+++ b/test/e2e/test_cluster_configs/gpu.json
@@ -25,7 +25,8 @@
 				{
 					"name": "agent1",
 					"count": 1,
-					"vmSize": "Standard_NC6"
+					"vmSize": "Standard_NC6",
+					"availabilityProfile": "VirtualMachineScaleSets"
 				},
 				{
 					"name": "agent2",

--- a/test/e2e/test_cluster_configs/gpu.json
+++ b/test/e2e/test_cluster_configs/gpu.json
@@ -19,7 +19,7 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
@@ -30,7 +30,9 @@
 				{
 					"name": "agent2",
 					"count": 3,
-					"vmSize": "Standard_D2_v2"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/kubenet.json
+++ b/test/e2e/test_cluster_configs/kubenet.json
@@ -13,14 +13,16 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Linux"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Linux",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/network/cilium.json
+++ b/test/e2e/test_cluster_configs/network/cilium.json
@@ -26,13 +26,15 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agent1",
-					"count": 2,
-					"vmSize": "Standard_D2_v2"
+					"count": 3,
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/network_policy/azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/azure.json
@@ -13,14 +13,16 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agent1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Linux"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Linux",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/network_policy/calico.json
+++ b/test/e2e/test_cluster_configs/network_policy/calico.json
@@ -37,7 +37,7 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_DS2_v2",
+				"vmSize": "Standard_D2_v3",
 				"OSDiskSizeGB": 200,
 				"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
 				"firstConsecutiveStaticIP": "10.239.255.239",
@@ -47,7 +47,7 @@
 				{
 					"name": "agent1",
 					"count": 3,
-					"vmSize": "Standard_DS2_v2",
+					"vmSize": "Standard_D2_v3",
 					"OSDiskSizeGB": 200,
 					"storageProfile": "ManagedDisks",
 					"diskSizesGB": [

--- a/test/e2e/test_cluster_configs/network_policy/calico_azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/calico_azure.json
@@ -16,14 +16,15 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_DS2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
 					"count": 3,
-					"vmSize": "Standard_DS2_v2",
-					"availabilityProfile": "AvailabilitySet"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/network_policy/cilium.json
+++ b/test/e2e/test_cluster_configs/network_policy/cilium.json
@@ -14,14 +14,15 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_DS2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agent1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"availabilityProfile": "AvailabilitySet"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/no_outbound.json
+++ b/test/e2e/test_cluster_configs/no_outbound.json
@@ -9,13 +9,15 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/not_in_vhd.json
+++ b/test/e2e/test_cluster_configs/not_in_vhd.json
@@ -12,13 +12,15 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/rbac_disabled.json
+++ b/test/e2e/test_cluster_configs/rbac_disabled.json
@@ -16,14 +16,16 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Linux"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Linux",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/storage_profile.json
+++ b/test/e2e/test_cluster_configs/storage_profile.json
@@ -32,7 +32,7 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2",
+				"vmSize": "Standard_D2_v3",
 				"OSDiskSizeGB": 200,
 				"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
 				"firstConsecutiveStaticIP": "10.239.255.239",
@@ -42,7 +42,7 @@
 				{
 					"name": "agent1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
+					"vmSize": "Standard_D2_v3",
 					"OSDiskSizeGB": 200,
 					"storageProfile": "StorageAccount",
 					"diskSizesGB": [

--- a/test/e2e/test_cluster_configs/vmss_master.json
+++ b/test/e2e/test_cluster_configs/vmss_master.json
@@ -4,20 +4,21 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
+				"orchestratorType": "Kubernetes"
 			},
 			"masterProfile": {
 				"count": 3,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2",
+				"vmSize": "Standard_D2_v3",
 				"availabilityProfile": "VirtualMachineScaleSets"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"availabilityProfile": "VirtualMachineScaleSets"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"linuxProfile": {

--- a/test/e2e/test_cluster_configs/windows/accelerated_networking.json
+++ b/test/e2e/test_cluster_configs/windows/accelerated_networking.json
@@ -15,7 +15,7 @@
 				{
 					"name": "agentwin",
 					"count": 3,
-					"vmSize": "Standard_D2_v3",
+					"vmSize": "Standard_D2_v2",
 					"osType": "Windows",
 					"acceleratedNetworkingEnabledWindows": true,
 					"availabilityProfile": "VirtualMachineScaleSets",

--- a/test/e2e/test_cluster_configs/windows/accelerated_networking.json
+++ b/test/e2e/test_cluster_configs/windows/accelerated_networking.json
@@ -4,21 +4,22 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
+				"orchestratorType": "Kubernetes"
 			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentwin",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
+					"vmSize": "Standard_D2_v3",
 					"osType": "Windows",
 					"acceleratedNetworkingEnabledWindows": true,
-					"availabilityProfile": "AvailabilitySet"
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"windowsProfile": {

--- a/test/e2e/test_cluster_configs/windows/custom_image.json
+++ b/test/e2e/test_cluster_configs/windows/custom_image.json
@@ -15,7 +15,8 @@
 				{
 					"name": "linuxpool1",
 					"count": 1,
-					"vmSize": "Standard_D2_v3"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets"
 				},
 				{
 					"name": "agentwin",

--- a/test/e2e/test_cluster_configs/windows/custom_image.json
+++ b/test/e2e/test_cluster_configs/windows/custom_image.json
@@ -4,24 +4,26 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
+				"orchestratorType": "Kubernetes"
 			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "linuxpool1",
-					"count": 3,
-					"vmSize": "Standard_D2_v2"
+					"count": 1,
+					"vmSize": "Standard_D2_v3"
 				},
 				{
 					"name": "agentwin",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Windows"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Windows",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"windowsProfile": {

--- a/test/e2e/test_cluster_configs/windows/custom_vnet.json
+++ b/test/e2e/test_cluster_configs/windows/custom_vnet.json
@@ -36,7 +36,7 @@
 			"masterProfile": {
 				"count": 3,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2",
+				"vmSize": "Standard_D2_v3",
 				"OSDiskSizeGB": 200,
 				"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
 				"firstConsecutiveStaticIP": "10.239.255.239",
@@ -46,7 +46,7 @@
 				{
 					"name": "agent1",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
+					"vmSize": "Standard_D2_v3",
 					"osType": "Windows",
 					"OSDiskSizeGB": 200,
 					"storageProfile": "ManagedDisks",
@@ -57,6 +57,7 @@
 						128
 					],
 					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low",
 					"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
 				}
 			],

--- a/test/e2e/test_cluster_configs/windows/image_reference.json
+++ b/test/e2e/test_cluster_configs/windows/image_reference.json
@@ -19,7 +19,8 @@
 				{
 					"name": "linuxpool1",
 					"count": 1,
-					"vmSize": "Standard_D2_v3"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets"
 				},
 				{
 					"name": "agentwin",

--- a/test/e2e/test_cluster_configs/windows/image_reference.json
+++ b/test/e2e/test_cluster_configs/windows/image_reference.json
@@ -8,24 +8,26 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
+				"orchestratorType": "Kubernetes"
 			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "linuxpool1",
 					"count": 1,
-					"vmSize": "Standard_D2_v2"
+					"vmSize": "Standard_D2_v3"
 				},
 				{
 					"name": "agentwin",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Windows"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Windows",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"windowsProfile": {

--- a/test/e2e/test_cluster_configs/windows/network_plugin/kubenet.json
+++ b/test/e2e/test_cluster_configs/windows/network_plugin/kubenet.json
@@ -12,13 +12,13 @@
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "agentwin",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
+					"vmSize": "Standard_D2_v3",
 					"osType": "Windows"
 				}
 			],

--- a/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
+++ b/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
@@ -22,7 +22,8 @@
 				{
 					"name": "linuxpool1",
 					"count": 1,
-					"vmSize": "Standard_D2_v3"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets"
 				},
 				{
 					"name": "agentwin",

--- a/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
+++ b/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
@@ -11,24 +11,26 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
+				"orchestratorType": "Kubernetes"
 			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "linuxpool1",
 					"count": 1,
-					"vmSize": "Standard_D2_v2"
+					"vmSize": "Standard_D2_v3"
 				},
 				{
 					"name": "agentwin",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Windows"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Windows",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"windowsProfile": {

--- a/test/e2e/test_cluster_configs/windows/vhd_url.json
+++ b/test/e2e/test_cluster_configs/windows/vhd_url.json
@@ -7,24 +7,26 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
+				"orchestratorType": "Kubernetes"
 			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",
-				"vmSize": "Standard_D2_v2"
+				"vmSize": "Standard_D2_v3"
 			},
 			"agentPoolProfiles": [
 				{
 					"name": "linuxpool1",
-					"count": 3,
-					"vmSize": "Standard_D2_v2"
+					"count": 1,
+					"vmSize": "Standard_D2_v3"
 				},
 				{
 					"name": "agentwin",
 					"count": 3,
-					"vmSize": "Standard_D2_v2",
-					"osType": "Windows"
+					"vmSize": "Standard_D2_v3",
+					"osType": "Windows",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
 				}
 			],
 			"windowsProfile": {

--- a/test/e2e/test_cluster_configs/windows/vhd_url.json
+++ b/test/e2e/test_cluster_configs/windows/vhd_url.json
@@ -18,7 +18,8 @@
 				{
 					"name": "linuxpool1",
 					"count": 1,
-					"vmSize": "Standard_D2_v3"
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets"
 				},
 				{
 					"name": "agentwin",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Standardize E2E test config for Standard_D2_v3 VM SKUs, and low-pri VMSS where appropriate

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
