### PR TITLE
fix: don’t statically set EnablePodSecurityPolicy=true for AKS

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -329,7 +329,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			a.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = to.BoolPtr(DefaultExcludeMasterFromStandardLB)
 		}
 
-		if common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.15.0-beta.1") {
+		if common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.15.0") && !cs.Properties.IsHostedMasterProfile() {
 			a.OrchestratorProfile.KubernetesConfig.EnablePodSecurityPolicy = to.BoolPtr(true)
 		}
 

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2927,14 +2927,14 @@ func getKubernetesConfigWithFeatureGates(featureGates string) *KubernetesConfig 
 	}
 }
 
-func TestDefaultEnablePodSecurityPolicy(t *testing.T) {
+func TestEnablePodSecurityPolicy(t *testing.T) {
 	cases := []struct {
 		name     string
 		cs       ContainerService
 		expected bool
 	}{
 		{
-			name: "default",
+			name: "default, < 1.15",
 			cs: ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{
@@ -2947,33 +2947,7 @@ func TestDefaultEnablePodSecurityPolicy(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "default",
-			cs: ContainerService{
-				Properties: &Properties{
-					OrchestratorProfile: &OrchestratorProfile{
-						OrchestratorType:    Kubernetes,
-						OrchestratorVersion: "1.15.0-alpha.1",
-					},
-					MasterProfile: &MasterProfile{},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "default",
-			cs: ContainerService{
-				Properties: &Properties{
-					OrchestratorProfile: &OrchestratorProfile{
-						OrchestratorType:    Kubernetes,
-						OrchestratorVersion: "1.15.0-beta.1",
-					},
-					MasterProfile: &MasterProfile{},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "default",
+			name: "default, >= 1.15",
 			cs: ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{
@@ -2984,6 +2958,92 @@ func TestDefaultEnablePodSecurityPolicy(t *testing.T) {
 				},
 			},
 			expected: true,
+		},
+		{
+			name: ">= 1.15, EnablePodSecurityPolicy=true",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.15.0",
+						KubernetesConfig: &KubernetesConfig{
+							EnablePodSecurityPolicy: to.BoolPtr(true),
+						},
+					},
+					MasterProfile: &MasterProfile{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: ">= 1.15, EnablePodSecurityPolicy=false is statically overwritten to EnablePodSecurityPolicy=false",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.15.0",
+						KubernetesConfig: &KubernetesConfig{
+							EnablePodSecurityPolicy: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &MasterProfile{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "AKS >= 1.15.0, default",
+			cs: ContainerService{
+				Properties: &Properties{
+					HostedMasterProfile: &HostedMasterProfile{
+						FQDN: "foo",
+					},
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.15.0",
+					},
+					MasterProfile: &MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "AKS >= 1.15.0, EnablePodSecurityPolicy=true",
+			cs: ContainerService{
+				Properties: &Properties{
+					HostedMasterProfile: &HostedMasterProfile{
+						FQDN: "foo",
+					},
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.15.0",
+						KubernetesConfig: &KubernetesConfig{
+							EnablePodSecurityPolicy: to.BoolPtr(true),
+						},
+					},
+					MasterProfile: &MasterProfile{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "AKS >= 1.15.0, EnablePodSecurityPolicy=false",
+			cs: ContainerService{
+				Properties: &Properties{
+					HostedMasterProfile: &HostedMasterProfile{
+						FQDN: "foo",
+					},
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.15.0",
+						KubernetesConfig: &KubernetesConfig{
+							EnablePodSecurityPolicy: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &MasterProfile{},
+				},
+			},
+			expected: false,
 		},
 	}
 

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2976,7 +2976,7 @@ func TestEnablePodSecurityPolicy(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: ">= 1.15, EnablePodSecurityPolicy=false is statically overwritten to EnablePodSecurityPolicy=false",
+			name: ">= 1.15, EnablePodSecurityPolicy=false is statically overwritten to EnablePodSecurityPolicy=true",
 			cs: ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

AKS uses the `KubernetesConfig.EnablePodSecurityPolicy` property according to its own k8s version default requirements, so we should not statically set EnablePodSecurityPolicy to true in AKS scenarios.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
