### PR TITLE
test: enable stability tests for PR E2E

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -4,6 +4,7 @@ parameters:
   apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
   createVNET: false
   skipTests: ''
+  stabilityIterations: '0'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -29,6 +30,7 @@ jobs:
     CLEANUP_ON_EXIT: true
     CLEANUP_IF_FAIL: true
     GINKGO_SKIP: ${{ parameters.skipTests }}
+    STABILITY_ITERATIONS: ${{ parameters.stabilityIterations }}
     RETAIN_SSH: false
     ENABLE_KMS_ENCRYPTION: true
     SUBSCRIPTION_ID: '$(SUBSCRIPTION_ID_E2E_KUBERNETES)'

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -132,32 +132,27 @@ jobs:
     name: 'k8s_windows_1_12_release_e2e'
     k8sRelease: '1.12'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_13_release_e2e'
     k8sRelease: '1.13'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_14_release_e2e'
     k8sRelease: '1.14'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_15_release_e2e'
     k8sRelease: '1.15'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_16_release_e2e'
     k8sRelease: '1.16'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-    stabilityIterations: '3'

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -77,6 +77,7 @@ jobs:
     name: 'ubuntu_18_04_linux_e2e'
     apimodel: 'examples/ubuntu-1804/kubernetes.json'
     skipTests: 'should have healthy time synchronization'
+    stabilityIterations: '10'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -84,6 +85,7 @@ jobs:
     k8sRelease: '1.11'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -91,6 +93,7 @@ jobs:
     k8sRelease: '1.12'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -98,6 +101,7 @@ jobs:
     k8sRelease: '1.13'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -105,6 +109,7 @@ jobs:
     k8sRelease: '1.14'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -112,6 +117,7 @@ jobs:
     k8sRelease: '1.15'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -119,33 +125,39 @@ jobs:
     k8sRelease: '1.16'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_12_release_e2e'
     k8sRelease: '1.12'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_13_release_e2e'
     k8sRelease: '1.13'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_14_release_e2e'
     k8sRelease: '1.14'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_15_release_e2e'
     k8sRelease: '1.15'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
+    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_windows_1_16_release_e2e'
     k8sRelease: '1.16'
     apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
+    stabilityIterations: '3'


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Enable stability tests on PR E2E now that those tests have stabilized.

This PR:

- enables 10 successive tests for the 18.04-LTS job to help provide signal as we decide whether or not to cut over to 18.04-LTS as the default OS version
- enables 3 successive tests for all Linux k8s version-specific test jobs
- no stability tests for Windows nodes as those haven't yet stabilized

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
