### PR TITLE
fix: lowercase vm name before calling drain node

### DIFF
--- a/pkg/operations/cordondrainvm.go
+++ b/pkg/operations/cordondrainvm.go
@@ -45,6 +45,7 @@ func SafelyDrainNode(az armhelpers.AKSEngineClient, logger *log.Entry, apiserver
 
 // SafelyDrainNodeWithClient safely drains a node so that it can be deleted from the cluster
 func SafelyDrainNodeWithClient(client armhelpers.KubernetesClient, logger *log.Entry, nodeName string, timeout time.Duration) error {
+	nodeName = strings.ToLower(nodeName)
 	//Mark the node unschedulable
 	var node *v1.Node
 	var err error

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -689,7 +689,7 @@ func (ku *Upgrader) copyCustomPropertiesToNewNode(client armhelpers.KubernetesCl
 	} else {
 		cordonDrainTimeout = *ku.cordonDrainTimeout
 	}
-	err := operations.SafelyDrainNodeWithClient(client, ku.logger, newNodeName, cordonDrainTimeout)
+	err := operations.SafelyDrainNodeWithClient(client, ku.logger, strings.ToLower(newNodeName), cordonDrainTimeout)
 	if err != nil {
 		ku.logger.Warningf("Error draining agent VM %s. Proceeding with copying node properties. Error: %v", newNodeName, err)
 	}

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -545,7 +545,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 			err = operations.SafelyDrainNodeWithClient(
 				client,
 				ku.logger,
-				strings.ToLower(vmToUpgrade.Name),
+				vmToUpgrade.Name,
 				cordonDrainTimeout,
 			)
 			if err != nil {
@@ -689,7 +689,7 @@ func (ku *Upgrader) copyCustomPropertiesToNewNode(client armhelpers.KubernetesCl
 	} else {
 		cordonDrainTimeout = *ku.cordonDrainTimeout
 	}
-	err := operations.SafelyDrainNodeWithClient(client, ku.logger, strings.ToLower(newNodeName), cordonDrainTimeout)
+	err := operations.SafelyDrainNodeWithClient(client, ku.logger, newNodeName, cordonDrainTimeout)
 	if err != nil {
 		ku.logger.Warningf("Error draining agent VM %s. Proceeding with copying node properties. Error: %v", newNodeName, err)
 	}


### PR DESCRIPTION
**Reason for Change**:
Ensures that `SafelyDrainNodeWithClient` uses the lowercase version of a VM's name to avoid disagreement between node name and machine name.

**Issue Fixed**:

Fixes #1982 


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
