### PR TITLE
fix: continue upgrading after node drain error

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -550,7 +550,7 @@ func (ku *Upgrader) upgradeAgentScaleSets(ctx context.Context) error {
 			)
 			if err != nil {
 				ku.logger.Errorf("Error draining VM in VMSS: %v", err)
-				return err
+				// Continue even if there's an error in draining the node.
 			}
 
 			ku.logger.Infof(


### PR DESCRIPTION
**Reason for Change**:
Doesn't return an error that occurs while draining a node during upgrade, just log it.

The idea here is that "cordon and drain" is the polite, best-effort way to upgrade, but that if it fails, upgrade can still delete the node and things will succeed with a bit more disruption to workloads.

**Issue Fixed**:
Fixes #1919


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
