### PR TITLE
test: ensure we don’t dereference nil node List

### DIFF
--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -94,6 +94,11 @@ type GetNodesResult struct {
 // GetNodesAsync wraps Get with a struct response for goroutine + channel usage
 func GetNodesAsync() GetNodesResult {
 	list, err := Get()
+	if list == nil {
+		list = &List{
+			Nodes: []Node{},
+		}
+	}
 	return GetNodesResult{
 		Nodes: list.Nodes,
 		Err:   err,


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Observed this E2E flake which this PR will address:

```
04:55:44  Unable to connect to the server: dial tcp 51.144.98.96:443: i/o timeout
04:56:05  2019/09/24 11:56:04 Error trying to run 'kubectl get nodes':
04:56:05   - exit status 1
04:56:05  2019/09/24 11:56:04 
04:56:05   - {
04:56:05      "apiVersion": "v1",
04:56:05      "items": [],
04:56:05      "kind": "List",
04:56:05      "metadata": {
04:56:05          "resourceVersion": "",
04:56:05          "selfLink": ""
04:56:05      }
04:56:05  }
04:56:05  Unable to connect to the server: dial tcp 51.144.98.96:443: i/o timeout
04:56:05  panic: runtime error: invalid memory address or nil pointer dereference
04:56:05  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8b3d90]
04:56:05  
04:56:05  goroutine 70 [running]:
04:56:05  github.com/Azure/aks-engine/test/e2e/kubernetes/node.GetNodesAsync(...)
04:56:05  	/go/src/github.com/Azure/aks-engine/test/e2e/kubernetes/node/node.go:98
04:56:05  github.com/Azure/aks-engine/test/e2e/kubernetes/node.GetWithRetry.func1(0xa9c020, 0xc00008b680, 0xc00039a120, 0x3b9aca00)
04:56:05  	/go/src/github.com/Azure/aks-engine/test/e2e/kubernetes/node/node.go:266 +0x90
04:56:05  created by github.com/Azure/aks-engine/test/e2e/kubernetes/node.GetWithRetry
04:56:05  	/go/src/github.com/Azure/aks-engine/test/e2e/kubernetes/node/node.go:261 +0x10e
04:56:05  exit status 2
04:56:05  test.mk:31: recipe for target 'test-kubernetes' failed
04:56:05  make: *** [test-kubernetes] Error 1
04:56:05  + exit 1
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
