### PR TITLE
fix: automatically get updated apt keys via CSE

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -234,6 +234,7 @@ apt_fix_keys() {
     cat $output && break || \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $(apt-get update | grep NO_PUBKEY -m 1 | awk -F "NO_PUBKEY" '{print $2}')
     if [ $i -eq $retries ]; then
+      echo Detected NO_PUBKEY but unable to fix after $i retries
       return 1
     else sleep 1
     fi

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -225,6 +225,22 @@ apt_get_dist_upgrade() {
   echo Executed apt-get dist-upgrade $i times
   wait_for_apt_locks
 }
+apt_fix_keys() {
+  retries=10
+  output=/tmp/apt-fix-keys.out
+  for i in $(seq 1 $retries); do
+    wait_for_apt_locks
+    ! (apt-get update | tee $output | grep NO_PUBKEY) && \
+    cat $output && break || \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $(apt-get update | grep NO_PUBKEY -m 1 | awk -F "NO_PUBKEY" '{print $2}')
+    if [ $i -eq $retries ]; then
+      return 1
+    else sleep 1
+    fi
+  done
+  echo Executed apt-get update NO_PUBKEY fix $i times
+  wait_for_apt_locks
+}
 systemctl_restart() {
     retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
     for i in $(seq 1 $retries); do

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -239,7 +239,6 @@ apt_fix_keys() {
     fi
   done
   echo Executed apt-get update NO_PUBKEY fix $i times
-  wait_for_apt_locks
 }
 systemctl_restart() {
     retries=$1; wait_sleep=$2; timeout=$3 svcname=$4

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -18,7 +18,7 @@ done
 sed -i "/#HELPERSEOF/d" $script_lib
 source $script_lib
 
-apt_fix_keys
+apt_fix_keys &
 
 install_script=/opt/azure/containers/provision_installs.sh
 wait_for_file 3600 1 $install_script || exit $ERR_FILE_WATCH_TIMEOUT

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -18,8 +18,6 @@ done
 sed -i "/#HELPERSEOF/d" $script_lib
 source $script_lib
 
-apt_fix_keys &
-
 install_script=/opt/azure/containers/provision_installs.sh
 wait_for_file 3600 1 $install_script || exit $ERR_FILE_WATCH_TIMEOUT
 source $install_script
@@ -58,6 +56,8 @@ fi
 if [[ "${GPU_NODE}" != "true" ]]; then
   cleanUpGPUDrivers
 fi
+
+apt_fix_keys &
 
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
 if [[ "${IS_VHD}" = true ]]; then

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -18,6 +18,8 @@ done
 sed -i "/#HELPERSEOF/d" $script_lib
 source $script_lib
 
+apt_fix_keys
+
 install_script=/opt/azure/containers/provision_installs.sh
 wait_for_file 3600 1 $install_script || exit $ERR_FILE_WATCH_TIMEOUT
 source $install_script

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13303,7 +13303,6 @@ apt_fix_keys() {
     fi
   done
   echo Executed apt-get update NO_PUBKEY fix $i times
-  wait_for_apt_locks
 }
 systemctl_restart() {
     retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
@@ -13697,7 +13696,7 @@ done
 sed -i "/#HELPERSEOF/d" $script_lib
 source $script_lib
 
-apt_fix_keys
+apt_fix_keys &
 
 install_script=/opt/azure/containers/provision_installs.sh
 wait_for_file 3600 1 $install_script || exit $ERR_FILE_WATCH_TIMEOUT

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13298,6 +13298,7 @@ apt_fix_keys() {
     cat $output && break || \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $(apt-get update | grep NO_PUBKEY -m 1 | awk -F "NO_PUBKEY" '{print $2}')
     if [ $i -eq $retries ]; then
+      echo Detected NO_PUBKEY but unable to fix after $i retries
       return 1
     else sleep 1
     fi
@@ -13696,8 +13697,6 @@ done
 sed -i "/#HELPERSEOF/d" $script_lib
 source $script_lib
 
-apt_fix_keys &
-
 install_script=/opt/azure/containers/provision_installs.sh
 wait_for_file 3600 1 $install_script || exit $ERR_FILE_WATCH_TIMEOUT
 source $install_script
@@ -13736,6 +13735,8 @@ fi
 if [[ "${GPU_NODE}" != "true" ]]; then
   cleanUpGPUDrivers
 fi
+
+apt_fix_keys &
 
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
 if [[ "${IS_VHD}" = true ]]; then


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

`apt-key adv --keyserver keyserver.ubuntu.com --recv-keys` can fix many `NO_PUBKEY` errors preventing apt operations from running.

This PR delivers such a programmatic fix via CSE during cluster bootstrapping.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
