### PR TITLE
fix: nil pointer check for data disks in transform

### DIFF
--- a/pkg/engine/transform/transform.go
+++ b/pkg/engine/transform/transform.go
@@ -382,8 +382,18 @@ func (t *Transformer) NormalizeResourcesForK8sMasterUpgrade(logger *logrus.Entry
 				continue
 			}
 
-			dataDisks := storageProfile[dataDisksFieldName].([]interface{})
-			dataDisk, _ := dataDisks[0].(map[string]interface{})
+			dataDisks, ok := storageProfile[dataDisksFieldName].([]interface{})
+			if !ok {
+				logger.Warnf("Template improperly formatted for field name: %s, property name: %s", storageProfileFieldName, dataDisksFieldName)
+				continue
+			}
+
+			dataDisk, ok := dataDisks[0].(map[string]interface{})
+			if !ok {
+				logger.Warnf("Template improperly formatted for field name: %s, there is no data disks defined", dataDisksFieldName)
+				continue
+			}
+
 			dataDisk[createOptionFieldName] = "attach"
 
 			if isMasterManagedDisk {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Fix the possible nil pointer panic in transform logic.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Someone named an agentpool "master", and triggered nil pointer panic in transform.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
