### PR TITLE
feat: add support for Kubernetes 1.16.0 on Azure Stack

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -372,9 +372,9 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 # TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
-# TODO add 1.15.4-azs, 1.14.7-azs, 1.13.11-azs when those hyperkube images are ready
 K8S_VERSIONS="
 1.16.0
+1.16.0-azs
 1.15.4
 1.15.4-azs
 1.15.3


### PR DESCRIPTION
**Reason for Change**:
Add support for Kubernetes 1.16.0 on Azure Stack


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1989 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
We will update documentation to support 1.16.0 when new aks-vhd is generated.