### PR TITLE
fix: Wait for management IP after creating ext network.

### DIFF
--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -405,8 +405,37 @@ if (!`$hnsNetwork)
 {
     Write-Host "Creating a new hns Network"
     ipmo `$global:HNSModule
+
+    `$na = @(Get-NetAdapter -Physical)
+    if (`$na.Count -eq 0)
+    {
+        throw "Failed to find any physical network adapters"
+    }
+
+    # If there is more than one adapter, use the first adapter.
+    `$managementIP = (Get-NetIPAddress -ifIndex `$na[0].ifIndex -AddressFamily IPv4).IPAddress
+    `$adapterName = `$na[0].Name
+    write-host "Using adapter `$adapterName with IP address `$managementIP"
+    `$mgmtIPAfterNetworkCreate
+
     # Fixme : use a smallest range possible, that will not collide with any pod space
-    New-HNSNetwork -Type `$global:NetworkMode -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name `$global:ExternalNetwork -Verbose
+    New-HNSNetwork -Type `$global:NetworkMode -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -AdapterName `$adapterName -Name `$global:ExternalNetwork -Verbose
+
+    # Wait for the switch to be created and the ip address to be assigned.
+    for (`$i=0;`$i -lt 60;`$i++)
+    {
+        `$mgmtIPAfterNetworkCreate = Get-NetIPAddress `$managementIP -ErrorAction SilentlyContinue
+        if (`$mgmtIPAfterNetworkCreate)
+        {
+            break
+        }
+        sleep -Milliseconds 1000
+    }
+
+    if (-not `$mgmtIPAfterNetworkCreate)
+    {
+        throw "Failed to find `$managementIP after creating `$global:ExternalNetwork network"
+    }
 }
 
 # Find if network created by CNI exists, if yes, remove it

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -418,6 +418,8 @@ if (!`$hnsNetwork)
     write-host "Using adapter `$adapterName with IP address `$managementIP"
     `$mgmtIPAfterNetworkCreate
 
+    `$stopWatch = New-Object System.Diagnostics.Stopwatch
+    `$stopWatch.Start()
     # Fixme : use a smallest range possible, that will not collide with any pod space
     New-HNSNetwork -Type `$global:NetworkMode -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -AdapterName `$adapterName -Name `$global:ExternalNetwork -Verbose
 
@@ -432,10 +434,12 @@ if (!`$hnsNetwork)
         sleep -Milliseconds 1000
     }
 
+    `$stopWatch.Stop()
     if (-not `$mgmtIPAfterNetworkCreate)
     {
         throw "Failed to find `$managementIP after creating `$global:ExternalNetwork network"
     }
+    write-host "It took `$(`$StopWatch.Elapsed.Seconds) seconds to create the `$global:ExternalNetwork network."
 }
 
 # Find if network created by CNI exists, if yes, remove it

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -26547,6 +26547,8 @@ if (!` + "`" + `$hnsNetwork)
     write-host "Using adapter ` + "`" + `$adapterName with IP address ` + "`" + `$managementIP"
     ` + "`" + `$mgmtIPAfterNetworkCreate
 
+    ` + "`" + `$stopWatch = New-Object System.Diagnostics.Stopwatch
+    ` + "`" + `$stopWatch.Start()
     # Fixme : use a smallest range possible, that will not collide with any pod space
     New-HNSNetwork -Type ` + "`" + `$global:NetworkMode -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -AdapterName ` + "`" + `$adapterName -Name ` + "`" + `$global:ExternalNetwork -Verbose
 
@@ -26561,10 +26563,12 @@ if (!` + "`" + `$hnsNetwork)
         sleep -Milliseconds 1000
     }
 
+    ` + "`" + `$stopWatch.Stop()
     if (-not ` + "`" + `$mgmtIPAfterNetworkCreate)
     {
         throw "Failed to find ` + "`" + `$managementIP after creating ` + "`" + `$global:ExternalNetwork network"
     }
+    write-host "It took ` + "`" + `$(` + "`" + `$StopWatch.Elapsed.Seconds) seconds to create the ` + "`" + `$global:ExternalNetwork network."
 }
 
 # Find if network created by CNI exists, if yes, remove it


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Fixes a connectivity issue we see intermittently in AKS.  After the external network is created, it may take "some time" for the network adapter to get an IP address.  It will have a 169.254.0.0 address.  It is best to wait for the network adapter to get a proper IP address before continuing.
In the repro we looked at, HNS used the 169.254 address for many VFP rules.  This means we created containers before the network adapter got its proper ip address.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes ICM 147788786.  I do not think we have a public GitHub issue on this.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
