### PR TITLE
fix: don’t assign distro if image ref is provided

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -407,7 +407,7 @@ func (p *Properties) setExtensionDefaults() {
 }
 
 func (p *Properties) setMasterProfileDefaults(isUpgrade, isScale bool, cloudName string) {
-	if p.MasterProfile.Distro == "" {
+	if p.MasterProfile.Distro == "" && p.MasterProfile.ImageRef == nil {
 		if p.OrchestratorProfile.IsKubernetes() {
 			p.MasterProfile.Distro = AKSUbuntu1604
 		} else {
@@ -629,7 +629,7 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool, cloudName 
 		}
 
 		if profile.OSType != Windows {
-			if profile.Distro == "" {
+			if profile.Distro == "" && profile.ImageRef == nil {
 				if p.OrchestratorProfile.IsKubernetes() {
 					if profile.OSDiskSizeGB != 0 && profile.OSDiskSizeGB < VHDDiskSizeAKS {
 						profile.Distro = Ubuntu

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -3383,7 +3383,7 @@ func TestImageReference(t *testing.T) {
 					},
 					MasterProfile: &MasterProfile{},
 					AgentPoolProfiles: []*AgentPoolProfile{
-						&AgentPoolProfile{},
+						{},
 					},
 				},
 			},
@@ -3392,7 +3392,7 @@ func TestImageReference(t *testing.T) {
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
-				AgentPoolProfile{
+				{
 					Distro:   AKSUbuntu1604,
 					ImageRef: nil,
 				},
@@ -3415,7 +3415,7 @@ func TestImageReference(t *testing.T) {
 						},
 					},
 					AgentPoolProfiles: []*AgentPoolProfile{
-						&AgentPoolProfile{
+						{
 							ImageRef: &ImageReference{
 								Name:           "name",
 								ResourceGroup:  "resource-group",
@@ -3438,7 +3438,7 @@ func TestImageReference(t *testing.T) {
 				},
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
-				AgentPoolProfile{
+				{
 					Distro: "",
 					ImageRef: &ImageReference{
 						Name:           "name",
@@ -3459,7 +3459,7 @@ func TestImageReference(t *testing.T) {
 					},
 					MasterProfile: &MasterProfile{},
 					AgentPoolProfiles: []*AgentPoolProfile{
-						&AgentPoolProfile{
+						{
 							ImageRef: &ImageReference{
 								Name:           "name",
 								ResourceGroup:  "resource-group",
@@ -3468,7 +3468,7 @@ func TestImageReference(t *testing.T) {
 								Version:        "version",
 							},
 						},
-						&AgentPoolProfile{},
+						{},
 					},
 				},
 			},
@@ -3477,7 +3477,7 @@ func TestImageReference(t *testing.T) {
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
-				AgentPoolProfile{
+				{
 					Distro: "",
 					ImageRef: &ImageReference{
 						Name:           "name",
@@ -3487,7 +3487,7 @@ func TestImageReference(t *testing.T) {
 						Version:        "version",
 					},
 				},
-				AgentPoolProfile{
+				{
 					Distro:   AKSUbuntu1604,
 					ImageRef: nil,
 				},

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -394,7 +394,7 @@ func (a *Properties) validateMasterProfile(isUpdate bool) error {
 
 	if m.ImageRef != nil {
 		if m.Distro != "" {
-			return errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.")
+			return errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously")
 		}
 		if err := m.ImageRef.validateImageNameAndGroup(); err != nil {
 			return err
@@ -504,7 +504,7 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 
 		if agentPoolProfile.ImageRef != nil {
 			if agentPoolProfile.Distro != "" {
-				return errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.", agentPoolProfile.Name)
+				return errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously", agentPoolProfile.Name)
 			}
 			return agentPoolProfile.ImageRef.validateImageNameAndGroup()
 		}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -393,6 +393,9 @@ func (a *Properties) validateMasterProfile(isUpdate bool) error {
 	}
 
 	if m.ImageRef != nil {
+		if m.Distro != "" {
+			return errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.")
+		}
 		if err := m.ImageRef.validateImageNameAndGroup(); err != nil {
 			return err
 		}
@@ -500,6 +503,9 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 		}
 
 		if agentPoolProfile.ImageRef != nil {
+			if agentPoolProfile.Distro != "" {
+				return errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.", agentPoolProfile.Name)
+			}
 			return agentPoolProfile.ImageRef.validateImageNameAndGroup()
 		}
 

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -3382,7 +3382,7 @@ func TestValidateMasterProfileImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      false,
-			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously."),
+			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously"),
 		},
 		"should error when masterProfile includes both an ImageRef and a Distro configuration in update context": {
 			properties: &Properties{
@@ -3402,7 +3402,7 @@ func TestValidateMasterProfileImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      true,
-			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously."),
+			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously"),
 		},
 		"should not error when masterProfile includes an ImageRef configuration only": {
 			properties: &Properties{
@@ -3518,7 +3518,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name:   "foo",
 						Distro: AKSUbuntu1604,
 						ImageRef: &ImageReference{
@@ -3532,7 +3532,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      false,
-			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.", "foo"),
+			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously", "foo"),
 		},
 		"should error when AgentPoolProfile includes both an ImageRef and a Distro configuration in update context": {
 			properties: &Properties{
@@ -3540,7 +3540,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name:   "foo",
 						Distro: AKSUbuntu1604,
 						ImageRef: &ImageReference{
@@ -3554,7 +3554,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      true,
-			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.", "foo"),
+			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously", "foo"),
 		},
 		"should not error when AgentPoolProfile includes an ImageRef configuration only": {
 			properties: &Properties{
@@ -3562,7 +3562,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name: "foo",
 						ImageRef: &ImageReference{
 							Name:           "name",
@@ -3583,7 +3583,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name: "foo",
 						ImageRef: &ImageReference{
 							Name:           "name",
@@ -3604,7 +3604,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name:   "foo",
 						Distro: AKSUbuntu1604,
 					},
@@ -3619,7 +3619,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name:   "foo",
 						Distro: AKSUbuntu1604,
 					},
@@ -3634,7 +3634,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name: "foo",
 					},
 				},
@@ -3648,7 +3648,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 					OrchestratorType: Kubernetes,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
-					&AgentPoolProfile{
+					{
 						Name: "foo",
 					},
 				},

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -3357,3 +3357,315 @@ func TestValidateFeatureFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMasterProfileImageRef(t *testing.T) {
+	tests := map[string]struct {
+		properties    *Properties
+		isUpdate      bool
+		expectedError error
+	}{
+		"should error when masterProfile includes both an ImageRef and a Distro configuration": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Distro: AKSUbuntu1604,
+					ImageRef: &ImageReference{
+						Name:           "name",
+						ResourceGroup:  "rg",
+						SubscriptionID: "sub-id",
+						Gallery:        "gallery",
+						Version:        "version",
+					},
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      false,
+			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously."),
+		},
+		"should error when masterProfile includes both an ImageRef and a Distro configuration in update context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Distro: AKSUbuntu1604,
+					ImageRef: &ImageReference{
+						Name:           "name",
+						ResourceGroup:  "rg",
+						SubscriptionID: "sub-id",
+						Gallery:        "gallery",
+						Version:        "version",
+					},
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      true,
+			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously."),
+		},
+		"should not error when masterProfile includes an ImageRef configuration only": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					ImageRef: &ImageReference{
+						Name:           "name",
+						ResourceGroup:  "rg",
+						SubscriptionID: "sub-id",
+						Gallery:        "gallery",
+						Version:        "version",
+					},
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      false,
+			expectedError: nil,
+		},
+		"should not error when masterProfile includes an ImageRef configuration only in an upgrade context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					ImageRef: &ImageReference{
+						Name:           "name",
+						ResourceGroup:  "rg",
+						SubscriptionID: "sub-id",
+						Gallery:        "gallery",
+						Version:        "version",
+					},
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      true,
+			expectedError: nil,
+		},
+		"should not error when masterProfile includes a Distro configuration only": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Distro:    AKSUbuntu1604,
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      false,
+			expectedError: nil,
+		},
+		"should not error when masterProfile includes a Distro configuration only in an upgrade context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Distro:    AKSUbuntu1604,
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      true,
+			expectedError: nil,
+		},
+		"should not error when masterProfile includes neither an explicit Distro nor ImageRef configuration": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      false,
+			expectedError: nil,
+		},
+		"should not error when masterProfile includes neither an explicit Distro nor ImageRef configuration in an upgrade context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					DNSPrefix: "foo",
+				},
+			},
+			isUpdate:      true,
+			expectedError: nil,
+		},
+	}
+
+	for testName, test := range tests {
+		test := test
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			err := test.properties.validateMasterProfile(test.isUpdate)
+			if !helpers.EqualError(err, test.expectedError) {
+				t.Errorf("expected error: %v, got: %v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
+	tests := map[string]struct {
+		properties    *Properties
+		isUpdate      bool
+		expectedError error
+	}{
+		"should error when AgentPoolProfile includes both an ImageRef and a Distro configuration": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name:   "foo",
+						Distro: AKSUbuntu1604,
+						ImageRef: &ImageReference{
+							Name:           "name",
+							ResourceGroup:  "rg",
+							SubscriptionID: "sub-id",
+							Gallery:        "gallery",
+							Version:        "version",
+						},
+					},
+				},
+			},
+			isUpdate:      false,
+			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.", "foo"),
+		},
+		"should error when AgentPoolProfile includes both an ImageRef and a Distro configuration in update context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name:   "foo",
+						Distro: AKSUbuntu1604,
+						ImageRef: &ImageReference{
+							Name:           "name",
+							ResourceGroup:  "rg",
+							SubscriptionID: "sub-id",
+							Gallery:        "gallery",
+							Version:        "version",
+						},
+					},
+				},
+			},
+			isUpdate:      true,
+			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously.", "foo"),
+		},
+		"should not error when AgentPoolProfile includes an ImageRef configuration only": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name: "foo",
+						ImageRef: &ImageReference{
+							Name:           "name",
+							ResourceGroup:  "rg",
+							SubscriptionID: "sub-id",
+							Gallery:        "gallery",
+							Version:        "version",
+						},
+					},
+				},
+			},
+			isUpdate:      false,
+			expectedError: nil,
+		},
+		"should not error when AgentPoolProfile includes an ImageRef configuration only in an upgrade context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name: "foo",
+						ImageRef: &ImageReference{
+							Name:           "name",
+							ResourceGroup:  "rg",
+							SubscriptionID: "sub-id",
+							Gallery:        "gallery",
+							Version:        "version",
+						},
+					},
+				},
+			},
+			isUpdate:      true,
+			expectedError: nil,
+		},
+		"should not error when AgentPoolProfile includes a Distro configuration only": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name:   "foo",
+						Distro: AKSUbuntu1604,
+					},
+				},
+			},
+			isUpdate:      false,
+			expectedError: nil,
+		},
+		"should not error when AgentPoolProfile includes a Distro configuration only in an upgrade context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name:   "foo",
+						Distro: AKSUbuntu1604,
+					},
+				},
+			},
+			isUpdate:      true,
+			expectedError: nil,
+		},
+		"should not error when AgentPoolProfile includes neither an explicit Distro nor ImageRef configuration": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name: "foo",
+					},
+				},
+			},
+			isUpdate:      false,
+			expectedError: nil,
+		},
+		"should not error when AgentPoolProfile includes neither an explicit Distro nor ImageRef configuration in an upgrade context": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					&AgentPoolProfile{
+						Name: "foo",
+					},
+				},
+			},
+			isUpdate:      true,
+			expectedError: nil,
+		},
+	}
+
+	for testName, test := range tests {
+		test := test
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			err := test.properties.validateAgentPoolProfiles(test.isUpdate)
+			if !helpers.EqualError(err, test.expectedError) {
+				t.Errorf("expected error: %v, got: %v", test.expectedError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR addresses an unresolved collision between `imageReference` configuration and our curated OS images (which are delivered via the `distro` configuration property). Specifically, unknown outcomes will occur if we associate any specific `distro` value with a cluster spec that includes a custom `imageReference` configuration.

Includes additional validation to fail fast when `imageReference` + `distro` configurations are used.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
