### PR TITLE
fix: updating windows release notes script to set a file encoding

### DIFF
--- a/packer/write-release-notes-windows.ps1
+++ b/packer/write-release-notes-windows.ps1
@@ -8,9 +8,11 @@
 
 $ErrorActionPreference = "Stop"
 
+$releaseNotesFilePath = "c:\release-notes.txt"
+
 function Log($Message) {
     # Write-Output $Message
-    $Message | Tee-Object -FilePath "c:\release-notes.txt" -Append
+    $Message | Tee-Object -FilePath $releaseNotesFilePath -Append
 }
 
 Log "Build Number: $env:BUILD_NUMBER"
@@ -106,3 +108,6 @@ foreach ($file in [IO.Directory]::GetFiles('c:\akse-cache', '*', [IO.SearchOptio
 }
 
 Log ($displayObjects | Format-Table -Property File, Sha256, SizeBytes | Out-String -Width 4096)
+
+# Ensure proper encoding is set for release notes file
+[IO.File]::ReadAllText($releaseNotesFilePath) | Out-File -Encoding utf8 $releaseNotesFilePath


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Powershell does not add a file encoding by default which is results in github treating the text file as a binary file which checking in release notes generated for windows VHD images.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
