### PR TITLE
test: disable 1.16 tests for various cluster configs

### DIFF
--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -402,6 +402,7 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 		o.KubernetesConfig.Addons[i] = assignDefaultAddonVals(o.KubernetesConfig.Addons[i], defaultAddons[j], isUpdate)
 	}
 
+	// Support back-compat configuration for Azure NetworkPolicy, which no longer ships with a "telemetry" container starting w/ 1.16.0
 	if isUpdate && o.KubernetesConfig.NetworkPolicy == NetworkPolicyAzure && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
 		i = getAddonsIndexByName(o.KubernetesConfig.Addons, AzureNetworkPolicyAddonName)
 		var hasTelemetryContainerConfig bool

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -265,11 +265,11 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 				Name:  AzureNetworkPolicyAddonName,
 				Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.28",
 			},
-			{
-				Name:  AzureVnetTelemetryAddonName,
-				Image: "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.28",
-			},
 		},
+	}
+
+	if !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
+		defaultAzureNetworkPolicyAddonsConfig.Containers = append(defaultAzureNetworkPolicyAddonsConfig.Containers, KubernetesContainerSpec{Name: AzureVnetTelemetryAddonName, Image: "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.28"})
 	}
 
 	defaultDNSAutoScalerAddonsConfig := KubernetesAddon{
@@ -400,6 +400,24 @@ func (cs *ContainerService) setAddonsConfig(isUpdate bool) {
 		o.KubernetesConfig.Addons[i].Enabled = to.BoolPtr(true)
 		// Assume addon configuration was pruned due to an inherited enabled=false, so re-apply default values
 		o.KubernetesConfig.Addons[i] = assignDefaultAddonVals(o.KubernetesConfig.Addons[i], defaultAddons[j], isUpdate)
+	}
+
+	if isUpdate && o.KubernetesConfig.NetworkPolicy == NetworkPolicyAzure && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
+		i = getAddonsIndexByName(o.KubernetesConfig.Addons, AzureNetworkPolicyAddonName)
+		var hasTelemetryContainerConfig bool
+		var prunedContainersConfig []KubernetesContainerSpec
+		if i > -1 {
+			for _, c := range o.KubernetesConfig.Addons[i].Containers {
+				if c.Name == AzureVnetTelemetryAddonName {
+					hasTelemetryContainerConfig = true
+				} else {
+					prunedContainersConfig = append(prunedContainersConfig, c)
+				}
+			}
+			if hasTelemetryContainerConfig {
+				o.KubernetesConfig.Addons[i].Containers = prunedContainersConfig
+			}
+		}
 	}
 }
 

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -1938,7 +1938,7 @@ func TestSetAddonsConfig(t *testing.T) {
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  AzureNetworkPolicyAddonName,
-							Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.27",
+							Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.28",
 						},
 					},
 				},
@@ -1972,11 +1972,11 @@ func TestSetAddonsConfig(t *testing.T) {
 									Containers: []KubernetesContainerSpec{
 										{
 											Name:  AzureNetworkPolicyAddonName,
-											Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.27",
+											Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.28",
 										},
 										{
 											Name:  AzureVnetTelemetryAddonName,
-											Image: "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.27",
+											Image: "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.28",
 										},
 									},
 								},
@@ -2105,7 +2105,7 @@ func TestSetAddonsConfig(t *testing.T) {
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  AzureNetworkPolicyAddonName,
-							Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.27",
+							Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.28",
 						},
 					},
 				},

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -1806,6 +1806,324 @@ func TestSetAddonsConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "Azure Network Policy addon enabled - 1.16",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.16.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginAzure,
+							NetworkPolicy: NetworkPolicyAzure,
+						},
+					},
+				},
+			},
+			isUpdate: false,
+			expectedAddons: []KubernetesAddon{
+				{
+					Name:    HeapsterAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    TillerAddonName,
+					Enabled: to.BoolPtr(DefaultTillerAddonEnabled),
+				},
+				{
+					Name:    ACIConnectorAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    BlobfuseFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           BlobfuseFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8",
+						},
+					},
+				},
+				{
+					Name:    SMBFlexVolumeAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    KeyVaultFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           KeyVaultFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13",
+						},
+					},
+				},
+				{
+					Name:    DashboardAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           DashboardAddonName,
+							CPURequests:    "300m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "300m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.16.0"][DashboardAddonName],
+						},
+					},
+				},
+				{
+					Name:    ReschedulerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    MetricsServerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  MetricsServerAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.16.0"][MetricsServerAddonName],
+						},
+					},
+				},
+				{
+					Name:    NVIDIADevicePluginAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ContainerMonitoringAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + "ip-masq-agent-amd64:v2.5.0",
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr": DefaultVNETCIDR,
+						"non-masq-cni-cidr":   DefaultCNICIDR,
+					},
+				},
+				{
+					Name:    AzureCNINetworkMonitoringAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  AzureCNINetworkMonitoringAddonName,
+							Image: specConfig.AzureCNIImageBase + K8sComponentsByVersionMap["1.16.0"][AzureCNINetworkMonitoringAddonName],
+						},
+					},
+				},
+				{
+					Name:    AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  AzureNetworkPolicyAddonName,
+							Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.27",
+						},
+					},
+				},
+				{
+					Name:    DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CalicoAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AADPodIdentityAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+			},
+		},
+		{
+			name: "Azure Network Policy addon enabled - 1.16 upgrade",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.16.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginAzure,
+							NetworkPolicy: NetworkPolicyAzure,
+							Addons: []KubernetesAddon{
+								{
+									Name:    AzureNetworkPolicyAddonName,
+									Enabled: to.BoolPtr(true),
+									Containers: []KubernetesContainerSpec{
+										{
+											Name:  AzureNetworkPolicyAddonName,
+											Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.27",
+										},
+										{
+											Name:  AzureVnetTelemetryAddonName,
+											Image: "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.27",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpdate: true,
+			expectedAddons: []KubernetesAddon{
+				{
+					Name:    HeapsterAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    TillerAddonName,
+					Enabled: to.BoolPtr(DefaultTillerAddonEnabled),
+				},
+				{
+					Name:    ACIConnectorAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    BlobfuseFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           BlobfuseFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8",
+						},
+					},
+				},
+				{
+					Name:    SMBFlexVolumeAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    KeyVaultFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           KeyVaultFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13",
+						},
+					},
+				},
+				{
+					Name:    DashboardAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           DashboardAddonName,
+							CPURequests:    "300m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "300m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.16.0"][DashboardAddonName],
+						},
+					},
+				},
+				{
+					Name:    ReschedulerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    MetricsServerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  MetricsServerAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.16.0"][MetricsServerAddonName],
+						},
+					},
+				},
+				{
+					Name:    NVIDIADevicePluginAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ContainerMonitoringAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + "ip-masq-agent-amd64:v2.5.0",
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr": DefaultVNETCIDR,
+						"non-masq-cni-cidr":   DefaultCNICIDR,
+					},
+				},
+				{
+					Name:    AzureCNINetworkMonitoringAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  AzureCNINetworkMonitoringAddonName,
+							Image: specConfig.AzureCNIImageBase + K8sComponentsByVersionMap["1.16.0"][AzureCNINetworkMonitoringAddonName],
+						},
+					},
+				},
+				{
+					Name:    AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  AzureNetworkPolicyAddonName,
+							Image: "mcr.microsoft.com/containernetworking/azure-npm:v1.0.27",
+						},
+					},
+				},
+				{
+					Name:    DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CalicoAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AADPodIdentityAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+			},
+		},
+		{
 			name: "dns-autoscaler addon enabled",
 			cs: &ContainerService{
 				Properties: &Properties{

--- a/test/e2e/test_cluster_configs/container_monitoring.json
+++ b/test/e2e/test_cluster_configs/container_monitoring.json
@@ -1,5 +1,8 @@
 {
 	"env": {},
+	"options": {
+		"allowedOrchestratorVersions": ["1.12", "1.13", "1.14", "1.15"]
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {

--- a/test/e2e/test_cluster_configs/flannel/docker.json
+++ b/test/e2e/test_cluster_configs/flannel/docker.json
@@ -1,6 +1,9 @@
 {
 	"env": {
 	},
+	"options": {
+		"allowedOrchestratorVersions": ["1.12", "1.13", "1.14", "1.15"]
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {

--- a/test/e2e/test_cluster_configs/network/cilium.json
+++ b/test/e2e/test_cluster_configs/network/cilium.json
@@ -1,5 +1,8 @@
 {
 	"env": {},
+	"options": {
+		"allowedOrchestratorVersions": ["1.12", "1.13", "1.14", "1.15"]
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {

--- a/test/e2e/test_cluster_configs/network_policy/azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/azure.json
@@ -1,5 +1,8 @@
 {
 	"env": {},
+	"options": {
+		"allowedOrchestratorVersions": ["1.12", "1.13", "1.14", "1.15"]
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {

--- a/test/e2e/test_cluster_configs/network_policy/azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/azure.json
@@ -1,8 +1,5 @@
 {
 	"env": {},
-	"options": {
-		"allowedOrchestratorVersions": ["1.12", "1.13", "1.14", "1.15"]
-	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {

--- a/test/e2e/test_cluster_configs/network_policy/cilium.json
+++ b/test/e2e/test_cluster_configs/network_policy/cilium.json
@@ -1,6 +1,9 @@
 {
 	"env": {
 	},
+	"options": {
+		"allowedOrchestratorVersions": ["1.12", "1.13", "1.14", "1.15"]
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Several cluster configs are consistently failing in 1.16 tests. While we triage, let's disable them so that we can get more readable test signal for configurations that do work more consistently.

While triaging 1.16 breakage for Azure NetworkPolicy addon, I determined that the issue was not practical (i.e., the addon was installed correctly on the cluster) but rather that we were adding superfluous api model configuration for >= 1.16 for this addon, which was causing the E2E test runner to panic. Because the changes are in order to fix our test signal, I've included those changes in this PR.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2069

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
