### PR TITLE
fix: auditd improvements

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -14,6 +14,7 @@ copyPackerFiles
 echo ""
 echo "Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):" >> ${VHD_LOGS_FILEPATH}
 
+AUDITD_ENABLED=true
 installDeps
 cat << EOF >> ${VHD_LOGS_FILEPATH}
   - apache2-utils

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -22,16 +22,6 @@ systemctlEnableAndStart() {
         return 1
     fi
 }
-systemctlDisableAndStop() {
-    if ! systemctl_stop 100 5 30 $1; then
-        echo "$1 could not be stopped"
-        return 1
-    fi
-    if ! retrycmd_if_failure 120 5 25 systemctl disable $1; then
-        echo "$1 could not be disabled by systemctl"
-        return 1
-    fi
-}
 
 configureEtcdUser(){
     useradd -U "etcd"
@@ -132,7 +122,7 @@ ensureAuditD() {
     systemctlEnableAndStart auditd || exit $ERR_SYSTEMCTL_START_FAIL
   else
     if apt list --installed | grep 'auditd'; then
-      systemctlDisableAndStop auditd || exit $ERR_SYSTEMCTL_START_FAIL
+      apt_get_purge 20 30 120 auditd &
     fi
   fi
 }

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -41,12 +41,18 @@ installDeps() {
     aptmarkWALinuxAgent hold
     apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
     apt_get_dist_upgrade || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
-    for apt_package in apache2-utils apt-transport-https auditd blobfuse ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool fuse git glusterfs-client htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip; do
+    for apt_package in apache2-utils apt-transport-https blobfuse ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool fuse git glusterfs-client htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip; do
       if ! apt_get_install 30 1 600 $apt_package; then
         journalctl --no-pager -u $apt_package
         exit $ERR_APT_INSTALL_TIMEOUT
       fi
     done
+    if [[ "${AUDITD_ENABLED}" == true ]]; then
+      if ! apt_get_install 30 1 600 auditd; then
+        journalctl --no-pager -u auditd
+        exit $ERR_APT_INSTALL_TIMEOUT
+      fi
+    fi
 }
 
 installGPUDrivers() {

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -38,6 +38,17 @@ write_files:
     {{CloudInitData "provisionCIS"}}
 {{end}}
 
+{{if not .MasterProfile.IsVHDDistro}}
+  {{if .MasterProfile.IsAuditDEnabled}}
+- path: /etc/audit/rules.d/CIS.rules
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "auditdRules"}}
+  {{end}}
+{{end}}
+
 {{if IsAzureStackCloud}}
 - path: /opt/azure/containers/provision_configs_custom_cloud.sh
   permissions: "0744"

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -38,6 +38,17 @@ write_files:
     {{CloudInitData "provisionCIS"}}
 {{end}}
 
+{{if not .IsVHDDistro}}
+  {{if .IsAuditDEnabled}}
+- path: /etc/audit/rules.d/CIS.rules
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "auditdRules"}}
+  {{end}}
+{{end}}
+
 {{if IsAzureStackCloud}}
 - path: /opt/azure/containers/provision_configs_custom_cloud.sh
   permissions: "0744"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1299,6 +1299,11 @@ func (m *MasterProfile) IsVHDDistro() bool {
 	return m.Distro == AKSUbuntu1604 || m.Distro == AKSUbuntu1804
 }
 
+// IsAuditDEnabled returns true if the master profile is configured for auditd
+func (m *MasterProfile) IsAuditDEnabled() bool {
+	return m.AuditDEnabled != nil && to.Bool(m.AuditDEnabled)
+}
+
 // IsVirtualMachineScaleSets returns true if the master availability profile is VMSS
 func (m *MasterProfile) IsVirtualMachineScaleSets() bool {
 	return m.AvailabilityProfile == VirtualMachineScaleSets
@@ -1426,6 +1431,11 @@ func (a *AgentPoolProfile) IsCoreOS() bool {
 // IsVHDDistro returns true if the distro uses VHD SKUs
 func (a *AgentPoolProfile) IsVHDDistro() bool {
 	return a.Distro == AKSUbuntu1604 || a.Distro == AKSUbuntu1804
+}
+
+// IsAuditDEnabled returns true if the master profile is configured for auditd
+func (a *AgentPoolProfile) IsAuditDEnabled() bool {
+	return a.AuditDEnabled != nil && to.Bool(a.AuditDEnabled)
 }
 
 // IsAvailabilitySets returns true if the customer specified disks

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1301,7 +1301,7 @@ func (m *MasterProfile) IsVHDDistro() bool {
 
 // IsAuditDEnabled returns true if the master profile is configured for auditd
 func (m *MasterProfile) IsAuditDEnabled() bool {
-	return m.AuditDEnabled != nil && to.Bool(m.AuditDEnabled)
+	return to.Bool(m.AuditDEnabled)
 }
 
 // IsVirtualMachineScaleSets returns true if the master availability profile is VMSS
@@ -1435,7 +1435,7 @@ func (a *AgentPoolProfile) IsVHDDistro() bool {
 
 // IsAuditDEnabled returns true if the master profile is configured for auditd
 func (a *AgentPoolProfile) IsAuditDEnabled() bool {
-	return a.AuditDEnabled != nil && to.Bool(a.AuditDEnabled)
+	return to.Bool(a.AuditDEnabled)
 }
 
 // IsAvailabilitySets returns true if the customer specified disks

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -265,6 +265,82 @@ func TestAgentPoolProfileIsVHDDistro(t *testing.T) {
 	}
 }
 
+func TestAgentPoolProfileIsAuditDEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		ap       AgentPoolProfile
+		expected bool
+	}{
+		{
+			name:     "default",
+			ap:       AgentPoolProfile{},
+			expected: false,
+		},
+		{
+			name: "true",
+			ap: AgentPoolProfile{
+				AuditDEnabled: to.BoolPtr(true),
+			},
+			expected: true,
+		},
+		{
+			name: "false",
+			ap: AgentPoolProfile{
+				AuditDEnabled: to.BoolPtr(false),
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if c.expected != c.ap.IsAuditDEnabled() {
+				t.Fatalf("Got unexpected AgentPoolProfile.IsAuditDEnabled() result. Expected: %t. Got: %t.", c.expected, c.ap.IsAuditDEnabled())
+			}
+		})
+	}
+}
+
+func TestMasterProfileIsAuditDEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		mp       MasterProfile
+		expected bool
+	}{
+		{
+			name:     "default",
+			mp:       MasterProfile{},
+			expected: false,
+		},
+		{
+			name: "true",
+			mp: MasterProfile{
+				AuditDEnabled: to.BoolPtr(true),
+			},
+			expected: true,
+		},
+		{
+			name: "false",
+			mp: MasterProfile{
+				AuditDEnabled: to.BoolPtr(false),
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if c.expected != c.mp.IsAuditDEnabled() {
+				t.Fatalf("Got unexpected AgentPoolProfile.IsAuditDEnabled() result. Expected: %t. Got: %t.", c.expected, c.mp.IsAuditDEnabled())
+			}
+		})
+	}
+}
+
 func TestAgentPoolProfileIsUbuntuNonVHD(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -432,10 +432,8 @@ func (a *Properties) validateMasterProfile(isUpdate bool) error {
 	}
 
 	if to.Bool(m.AuditDEnabled) {
-		if m.Distro != "" {
-			if !m.IsUbuntu() {
-				return errors.Errorf("You have enabled auditd for master vms, but you did not specify an Ubuntu-based distro.")
-			}
+		if m.Distro != "" && !m.IsUbuntu() {
+			return errors.Errorf("You have enabled auditd for master vms, but you did not specify an Ubuntu-based distro.")
 		}
 	}
 
@@ -486,7 +484,7 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 		}
 
 		if to.Bool(agentPoolProfile.AuditDEnabled) {
-			if !agentPoolProfile.IsUbuntu() {
+			if agentPoolProfile.Distro != "" && !agentPoolProfile.IsUbuntu() {
 				return errors.Errorf("You have enabled auditd in agent pool %s, but you did not specify an Ubuntu-based distro", agentPoolProfile.Name)
 			}
 		}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -432,8 +432,10 @@ func (a *Properties) validateMasterProfile(isUpdate bool) error {
 	}
 
 	if to.Bool(m.AuditDEnabled) {
-		if !m.IsUbuntu() {
-			return errors.Errorf("You have enabled auditd for master vms, but you did not specify an Ubuntu-based distro.")
+		if m.Distro != "" {
+			if !m.IsUbuntu() {
+				return errors.Errorf("You have enabled auditd for master vms, but you did not specify an Ubuntu-based distro.")
+			}
 		}
 	}
 

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -143,6 +143,7 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		cloudInitFiles["dockerMonitorSystemdTimer"] = getBase64EncodedGzippedCustomScript(kubernetesDockerMonitorSystemdTimer)
 		cloudInitFiles["kubeletSystemdService"] = getBase64EncodedGzippedCustomScript(kubeletSystemdService)
 		cloudInitFiles["dockerClearMountPropagationFlags"] = getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags)
+		cloudInitFiles["auditdRules"] = getBase64EncodedGzippedCustomScript(auditdRules)
 	}
 
 	masterVars["cloudInitFiles"] = cloudInitFiles

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -231,6 +231,7 @@ func TestK8sVars(t *testing.T) {
 		"labelNodesSystemdService":         getBase64EncodedGzippedCustomScript(labelNodesSystemdService),
 		"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences),
 		"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags),
+		"auditdRules":                      getBase64EncodedGzippedCustomScript(auditdRules),
 		"etcdSystemdService":               getBase64EncodedGzippedCustomScript(etcdSystemdService),
 		"dhcpv6ConfigurationScript":        getBase64EncodedGzippedCustomScript(dhcpv6ConfigurationScript),
 		"dhcpv6SystemdService":             getBase64EncodedGzippedCustomScript(dhcpv6SystemdService),

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -180,6 +180,7 @@ const (
 	dockerClearMountPropagationFlags         = "k8s/cloud-init/artifacts/docker_clear_mount_propagation_flags.conf"
 	systemdBPFMount                          = "k8s/cloud-init/artifacts/sys-fs-bpf.mount"
 	etcdSystemdService                       = "k8s/cloud-init/artifacts/etcd.service"
+	auditdRules                              = "k8s/cloud-init/artifacts/auditd-rules"
 	// scripts and service for enabling ipv6 dual stack
 	dhcpv6SystemdService      = "k8s/cloud-init/artifacts/dhcpv6.service"
 	dhcpv6ConfigurationScript = "k8s/cloud-init/artifacts/enable-dhcpv6.sh"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12400,16 +12400,6 @@ systemctlEnableAndStart() {
         return 1
     fi
 }
-systemctlDisableAndStop() {
-    if ! systemctl_stop 100 5 30 $1; then
-        echo "$1 could not be stopped"
-        return 1
-    fi
-    if ! retrycmd_if_failure 120 5 25 systemctl disable $1; then
-        echo "$1 could not be disabled by systemctl"
-        return 1
-    fi
-}
 
 configureEtcdUser(){
     useradd -U "etcd"
@@ -12510,7 +12500,7 @@ ensureAuditD() {
     systemctlEnableAndStart auditd || exit $ERR_SYSTEMCTL_START_FAIL
   else
     if apt list --installed | grep 'auditd'; then
-      systemctlDisableAndStop auditd || exit $ERR_SYSTEMCTL_START_FAIL
+      apt_get_purge 20 30 120 auditd &
     fi
   fi
 }
@@ -13862,7 +13852,7 @@ ps auxfww > /opt/azure/provision-ps.log &
 
 if [[ "${TARGET_ENVIRONMENT,,}" != "${AZURE_STACK_ENV}"  ]]; then
     # TODO: remove once ACR is available on Azure Stack
-    apt_get_purge 20 30 120 apache2-utils || exit $ERR_APT_PURGE_FAIL
+    apt_get_purge 20 30 120 apache2-utils &
 fi
 
 if $REBOOTREQUIRED; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13852,7 +13852,7 @@ ps auxfww > /opt/azure/provision-ps.log &
 
 if [[ "${TARGET_ENVIRONMENT,,}" != "${AZURE_STACK_ENV}"  ]]; then
     # TODO: remove once ACR is available on Azure Stack
-    apt_get_purge 20 30 120 apache2-utils &
+    apt_get_purge 20 30 120 apache2-utils || exit $ERR_APT_PURGE_FAIL
 fi
 
 if $REBOOTREQUIRED; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13380,12 +13380,18 @@ installDeps() {
     aptmarkWALinuxAgent hold
     apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
     apt_get_dist_upgrade || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
-    for apt_package in apache2-utils apt-transport-https auditd blobfuse ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool fuse git glusterfs-client htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip; do
+    for apt_package in apache2-utils apt-transport-https blobfuse ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool fuse git glusterfs-client htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip; do
       if ! apt_get_install 30 1 600 $apt_package; then
         journalctl --no-pager -u $apt_package
         exit $ERR_APT_INSTALL_TIMEOUT
       fi
     done
+    if [[ "${AUDITD_ENABLED}" == true ]]; then
+      if ! apt_get_install 30 1 600 auditd; then
+        journalctl --no-pager -u auditd
+        exit $ERR_APT_INSTALL_TIMEOUT
+      fi
+    fi
 }
 
 installGPUDrivers() {
@@ -15254,6 +15260,17 @@ write_files:
     {{CloudInitData "provisionCIS"}}
 {{end}}
 
+{{if not .MasterProfile.IsVHDDistro}}
+  {{if .MasterProfile.IsAuditDEnabled}}
+- path: /etc/audit/rules.d/CIS.rules
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "auditdRules"}}
+  {{end}}
+{{end}}
+
 {{if IsAzureStackCloud}}
 - path: /opt/azure/containers/provision_configs_custom_cloud.sh
   permissions: "0744"
@@ -15836,6 +15853,17 @@ write_files:
   owner: root
   content: !!binary |
     {{CloudInitData "provisionCIS"}}
+{{end}}
+
+{{if not .IsVHDDistro}}
+  {{if .IsAuditDEnabled}}
+- path: /etc/audit/rules.d/CIS.rules
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "auditdRules"}}
+  {{end}}
 {{end}}
 
 {{if IsAzureStackCloud}}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -413,7 +413,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			err = sshConn.CopyTo(auditdValidateScript)
 			Expect(err).NotTo(HaveOccurred())
 			for _, node := range nodeList.Nodes {
-				if !node.HasSubstring(lowPriVMSSPrefixes) {
+				if !node.HasSubstring(lowPriVMSSPrefixes) && node.IsUbuntu() {
 					var enabled bool
 					if node.HasSubstring(auditDNodePrefixes) {
 						enabled = true

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -46,7 +46,8 @@
 				"vnetCidr": "10.239.0.0/16",
 				"availabilityZones": [
 					"1"
-				]
+				],
+				"auditDEnabled": true
 			},
 			"agentPoolProfiles": [
 				{
@@ -64,7 +65,8 @@
 						"1",
 						"2"
 					],
-					"scaleSetPriority": "Low"
+					"scaleSetPriority": "Low",
+					"auditDEnabled": true
 				}
 			],
 			"linuxProfile": {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR addresses auditd cruft left on vms that are built without the auditd flag enabled:

If `auditDEnabled` is not true in the cluster configuration, we should clean up the auditd apt package so that folks don't try and use it (we only deliver a working configuration *if* `auditDEnabled` is set to true.

This PR adds best-effort (i.e., it runs in the background and failures are ignored) `apt-get purge auditd`.

This PR also enables auditd for non-VHD distros.

Finally, this PR adds `"auditDEnabled": true` configuration for the "everything" test config to validate that we protect this feature with regular tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2077 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
