### PR TITLE
fix: remove Azure agent specific artifacts from windows vhd

### DIFF
--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -189,37 +189,6 @@ function Set-WinRmServiceDelayedStart
     sc.exe config winrm start=delayed-auto
 }
 
-function Remove-AgentArtifacts
-{
-    $agentArtifacts = "$env:SystemDrive\WindowsAzure"
-
-    # Removing Azure agent services which gets installed as part of VM boot up.
-    # Removal is needed so that vhd can then be used on any platform.
-    Write-Log "Stopping Azure agent services if running"
-    Stop-Service WindowsAzureGuestAgent
-    Stop-Service WindowsAzureNetAgentSvc
-    Stop-Service RdAgent
-    Stop-Service WindowsAzureTelemetryService
-
-    Write-Log "Removing Azure agent services."
-    sc.exe delete WindowsAzureGuestAgent
-    sc.exe delete WindowsAzureNetAgentSvc
-    sc.exe delete RdAgent
-    sc.exe delete WindowsAzureTelemetryService
-
-    if (Test-Path -Path $agentArtifacts)
-    {
-        Get-ChildItem "$agentArtifacts" -Force `
-        | Sort-Object -Property FullName -Descending `
-        | ForEach-Object {
-            try {
-                Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue;
-            }
-            catch { }
-        }
-    }
-}
-
 function Update-DefenderSignatures
 {
     Write-Log "Updating windows defender signatures."
@@ -263,11 +232,6 @@ switch ($env:ProvisioningPhase)
         Install-Docker
         Get-ContainerImages
         Get-FilesToCacheOnVHD
-    }
-    "3"
-    {
-        Write-Log "Performing actions for provisioning phase 3"
-        Remove-AgentArtifacts
     }
     default
     {

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -209,7 +209,14 @@ function Remove-AgentArtifacts
 
     if (Test-Path -Path $agentArtifacts)
     {
-        Remove-Item -Path $agentArtifacts -Recurse
+        Get-ChildItem "$agentArtifacts" -Force `
+        | Sort-Object -Property FullName -Descending `
+        | ForEach-Object {
+            try {
+                Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue;
+            }
+            catch { }
+        }
     }
 }
 

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -189,6 +189,30 @@ function Set-WinRmServiceDelayedStart
     sc.exe config winrm start=delayed-auto
 }
 
+function Remove-AgentArtifacts
+{
+    $agentArtifacts = "$env:SystemDrive\windowsAzure"
+
+    # Removing Azure agent services which gets installed as part of VM boot up.
+    # Removal is needed so that vhd can then be used on any platform.
+    Write-Log "Stopping Azure agent services if running"
+    Stop-Service WindowsAzureGuestAgent
+    Stop-Service WindowsAzureNetAgentSvc
+    Stop-Service RdAgent
+    Stop-Service WindowsAzureTelemetryService
+
+    Write-Log "Removing Azure agent services."
+    sc.exe delete WindowsAzureGuestAgent
+    sc.exe delete WindowsAzureNetAgentSvc
+    sc.exe delete RdAgent
+    sc.exe delete WindowsAzureTelemetryService
+
+    if (Test-Path -Path $agentArtifacts)
+    {
+        Remove-Item -Path $agentArtifacts -Recurse
+    }
+}
+
 function Update-DefenderSignatures
 {
     Write-Log "Updating windows defender signatures."
@@ -232,6 +256,11 @@ switch ($env:ProvisioningPhase)
         Install-Docker
         Get-ContainerImages
         Get-FilesToCacheOnVHD
+    }
+    "3"
+    {
+        Write-Log "Performing actions for provisioning phase 3"
+        Remove-AgentArtifacts
     }
     default
     {

--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -191,7 +191,7 @@ function Set-WinRmServiceDelayedStart
 
 function Remove-AgentArtifacts
 {
-    $agentArtifacts = "$env:SystemDrive\windowsAzure"
+    $agentArtifacts = "$env:SystemDrive\WindowsAzure"
 
     # Removing Azure agent services which gets installed as part of VM boot up.
     # Removal is needed so that vhd can then be used on any platform.

--- a/packer/windows-vhd-builder.json
+++ b/packer/windows-vhd-builder.json
@@ -92,19 +92,15 @@
             "type": "powershell",
             "inline": [
                 "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
-                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
-            ]
-        },
-        {
-            "elevated_user": "packer",
-            "elevated_password": "{{.WinRMPassword}}",
-            "environment_vars": "ProvisioningPhase=3",
-            "type": "powershell",
-            "script": "packer/configure-windows-vhd.ps1"
-        },
-        {
-            "type": "powershell",
-            "inline": [
+                "Stop-Service WindowsAzureGuestAgent",
+                "Stop-Service WindowsAzureNetAgentSvc",
+                "Stop-Service RdAgent",
+                "Stop-Service WindowsAzureTelemetryService",
+                "& sc.exe delete WindowsAzureGuestAgent",
+                "& sc.exe delete WindowsAzureNetAgentSvc",
+                "& sc.exe delete RdAgent",
+                "& sc.exe delete WindowsAzureTelemetryService",
+                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }",
                 "Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse"
             ]
         }

--- a/packer/windows-vhd-builder.json
+++ b/packer/windows-vhd-builder.json
@@ -92,7 +92,7 @@
             "type": "powershell",
             "inline": [
                 "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
-                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }",
+                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
             ]
         },
         {

--- a/packer/windows-vhd-builder.json
+++ b/packer/windows-vhd-builder.json
@@ -89,6 +89,13 @@
             "destination": "release-notes.txt"
         },
         {
+            "elevated_user": "packer",
+            "elevated_password": "{{.WinRMPassword}}",
+            "environment_vars": "ProvisioningPhase=3",
+            "type": "powershell",
+            "script": "packer/configure-windows-vhd.ps1"
+        },
+        {
             "type": "powershell",
             "inline": [
                 "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",

--- a/packer/windows-vhd-builder.json
+++ b/packer/windows-vhd-builder.json
@@ -89,6 +89,13 @@
             "destination": "release-notes.txt"
         },
         {
+            "type": "powershell",
+            "inline": [
+                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
+                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }",
+            ]
+        },
+        {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
             "environment_vars": "ProvisioningPhase=3",
@@ -98,8 +105,6 @@
         {
             "type": "powershell",
             "inline": [
-                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
-                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }",
                 "Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse"
             ]
         }

--- a/packer/windows-vhd-builder.json
+++ b/packer/windows-vhd-builder.json
@@ -100,6 +100,7 @@
                 "& sc.exe delete WindowsAzureNetAgentSvc",
                 "& sc.exe delete RdAgent",
                 "& sc.exe delete WindowsAzureTelemetryService",
+                "Get-ChildItem c:\\WindowsAzure -Force | Sort-Object -Property FullName -Descending | ForEach-Object { try { Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue; } catch { } }",
                 "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }",
                 "Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse"
             ]


### PR DESCRIPTION
**Reason for Change**:
As part of windows VHD preparation certain Azure agents gets install which should be removed from VHD so that VHD can be consumed across platform (Azure, Azure Stack)

**Issue Fixed**:
Fixes #2086 


**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
