### PR TITLE
feat: add support for Kubernetes v1.16.1

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -379,6 +379,7 @@ echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 # TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
 K8S_VERSIONS="
+1.16.1
 1.16.0
 1.16.0-azs
 1.15.4

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -142,13 +142,14 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.15.2":         false,
 	"1.15.3":         true,
 	"1.15.4":         true,
-	"1.16.0-alpha.1": true,
-	"1.16.0-alpha.2": true,
-	"1.16.0-alpha.3": true,
-	"1.16.0-beta.1":  true,
-	"1.16.0-beta.2":  true,
-	"1.16.0-rc.1":    true,
+	"1.16.0-alpha.1": false,
+	"1.16.0-alpha.2": false,
+	"1.16.0-alpha.3": false,
+	"1.16.0-beta.1":  false,
+	"1.16.0-beta.2":  false,
+	"1.16.0-rc.1":    false,
 	"1.16.0":         true,
+	"1.16.1":         true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#changelog-since-v1160

**Issue Fixed**:

**Requirements**:
- [x] Windows artifacts uploaded to acsmirror blob store
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Still waiting on publishing of k8s.gcr.io/hyperkube:v1.16.1. *Update*: published now.
