### PR TITLE
chore: update default IPv6 subnet for dual stack, update docs

### DIFF
--- a/examples/dualstack/README.md
+++ b/examples/dualstack/README.md
@@ -4,9 +4,11 @@
 
 AKS Engine enables you to create dual stack (IPv4 *and* IPv6) Kubernetes clusters on Microsoft Azure.
 
-- Dual stack support is available for Kubernetes version 1.16.0-alpha.1 and later
+- Dual stack support is available for Kubernetes version 1.16.0 and later
 
-In order to create IPv6 enabled Azure virtual networks you must first configure your subscription [as follows](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ipv4-ipv6-dual-stack-cli#prerequisites).
+> Official docs are available here - https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+
+In order to create IPv6 enabled Azure virtual networks and use standard loadbalancer with IPv6 you must first configure your subscription [as follows](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ipv4-ipv6-dual-stack-cli#prerequisites).
 
 This example shows you how to configure a dual stack cluster:
 
@@ -14,14 +16,14 @@ This example shows you how to configure a dual stack cluster:
 
 Things to try out after the cluster is deployed -
 
-- Nodes are Kubernetes version 1.16.0-alpha.1 or later
+- Nodes are Kubernetes version 1.16.0 or later
 
 ```bash
 $ kubectl get nodes
-NAME                        STATUS   ROLES    AGE    VERSION
-k8s-linuxpool1-20403072-0   Ready    agent    116s   v1.16.0-alpha.1
-k8s-linuxpool1-20403072-1   Ready    agent    50s    v1.16.0-alpha.1
-k8s-master-20403072-0       Ready    master   2m7s   v1.16.0-alpha.1
+NAME                        STATUS   ROLES    AGE   VERSION
+k8s-linuxpool1-20403072-0   Ready    agent    22m   v1.16.0
+k8s-linuxpool1-20403072-1   Ready    agent    36m   v1.16.0
+k8s-master-20403072-0       Ready    master   37m   v1.16.0
 ```
 
 - Nodes have 2 internal IPs, one from each ip family
@@ -38,7 +40,7 @@ InternalIP: 2001:1234:5678:9abc::6
 ```bash
 $ kubectl get nodes k8s-linuxpool1-20403072-0 -o go-template --template='{{range .spec.podCIDRs}}{{printf "%s\n" .}}{{end}}'
 10.244.2.0/24
-fd00:200::/24
+fc00::/24
 ```
 
 - Pods have 2 PodIPs, one from each ip family
@@ -46,7 +48,7 @@ fd00:200::/24
 ```bash
 kubectl get pods nginx-pod -o go-template --template='{{range .status.podIPs}}{{printf "%s \n" .ip}}{{end}}'
 10.244.2.6
-fd00:200::6
+fc00:200::7
 ```
 
 - Able to reach other pods in cluster using IPv6
@@ -56,7 +58,7 @@ fd00:200::6
 # ifconfig eth0
 eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
         inet 10.244.2.6  netmask 255.255.255.0  broadcast 0.0.0.0
-        inet6 fd00:200::6  prefixlen 24  scopeid 0x0<global>
+        inet6 fc00:200::7  prefixlen 24  scopeid 0x0<global>
         inet6 fe80::8846:8cff:fe35:eaf0  prefixlen 64  scopeid 0x20<link>
         ether 8a:46:8c:35:ea:f0  txqueuelen 0  (Ethernet)
         RX packets 611  bytes 8685170 (8.2 MiB)
@@ -64,13 +66,24 @@ eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
         TX packets 415  bytes 35685 (34.8 KiB)
         TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
 # ping fd00:100::8
-PING fd00:100::8(fd00:100::8) 56 data bytes
-64 bytes from fd00:100::8: icmp_seq=1 ttl=62 time=0.798 ms
-64 bytes from fd00:100::8: icmp_seq=2 ttl=62 time=0.762 ms
+PING fc00:200::7(fc00:200::7) 56 data bytes
+64 bytes from fc00:200::7: icmp_seq=1 ttl=62 time=0.798 ms
+64 bytes from fc00:200::7: icmp_seq=2 ttl=62 time=0.762 ms
+```
+
+- Able to create services with IPv6 using `spec.IPFamily=IPv6` in the service manifest -
+
+```
+azureuser@k8s-master-13083844-0:~$ kubectl get svc
+NAME          TYPE           CLUSTER-IP       EXTERNAL-IP          PORT(S)        AGE
+kubernetes    ClusterIP      10.0.0.1         <none>               443/TCP        58m
+nginx-ipv6    LoadBalancer   fd00::6283       2603:1030:805:3::3   80:31140/TCP   32s
 ```
 
 ## Limitations
 
 - Dual stack clusters are supported only with kubenet.
 - Dual stack clusters are supported only with Linux.
-- Egress pod internet routing will be available after this pending PR (https://github.com/kubernetes-incubator/ip-masq-agent/pull/45) will be merged.
+- Dual stack clusters are currently only supported with ipvs kube-proxy mode.
+- Dual stack clusters are currently only supported with Availability sets.
+- API model enables Azure Standard LB for dual stack clusters. Azure Basic LBs have a limitation of only 1 IPv6 frontend configurations while Standard LB supports up to 600 IPv6 frontend configurations.

--- a/examples/dualstack/kubernetes.json
+++ b/examples/dualstack/kubernetes.json
@@ -8,8 +8,10 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.16",
             "kubernetesConfig": {
-                "clusterSubnet": "10.244.0.0/16,fd00:101::/8",
-                "serviceCidr": "10.0.0.0/16,fe80:20d::/112",
+                "loadBalancerSku": "Standard",
+                "excludeMasterFromStandardLB": true,
+                "clusterSubnet": "10.244.0.0/16,fc00::/8",
+                "serviceCidr": "10.0.0.0/16,fd00::/108",
                 "dnsServiceIP": "10.0.0.10",
                 "kubeProxyMode": "ipvs",
                 "networkPlugin": "kubenet",

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -439,7 +439,7 @@ const (
 	// DefaultKubernetesClusterSubnet specifies the default subnet for pods.
 	DefaultKubernetesClusterSubnet = "10.244.0.0/16"
 	// DefaultKubernetesClusterSubnetIPv6 specifies the IPv6 default subnet for pods.
-	DefaultKubernetesClusterSubnetIPv6 = "fd00:101::/8"
+	DefaultKubernetesClusterSubnetIPv6 = "fc00::/8"
 	// DefaultKubernetesServiceCIDR specifies the IP subnet that kubernetes will create Service IPs within.
 	DefaultKubernetesServiceCIDR = "10.0.0.0/16"
 	// DefaultKubernetesDNSServiceIP specifies the IP address that kube-dns listens on by default. must by in the default Service CIDR range.


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
- Updates docs with changes in dual-stack phase2
- Update default ipv6 cluster cidr to `fc00::/8`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

/cc @lachie83 