### PR TITLE
test: get Running pods by prefix in most cases

### DIFF
--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -412,6 +412,11 @@ func (d *Deployment) Pods() ([]pod.Pod, error) {
 	return pod.GetAllByPrefixWithRetry(d.Metadata.Name, d.Metadata.Namespace, 3*time.Second, 20*time.Minute)
 }
 
+// PodsRunning will return all pods in a Running state related to a deployment
+func (d *Deployment) PodsRunning() ([]pod.Pod, error) {
+	return pod.GetAllRunningByPrefixWithRetry(d.Metadata.Name, d.Metadata.Namespace, 3*time.Second, 20*time.Minute)
+}
+
 // GetWithRetry gets a deployment, allowing for retries
 func GetWithRetry(name, namespace string, sleep, timeout time.Duration) (*Deployment, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -409,7 +409,7 @@ func (d *Deployment) CreateDeploymentHPADeleteIfExist(cpuPercent, min, max int) 
 
 // Pods will return all pods related to a deployment
 func (d *Deployment) Pods() ([]pod.Pod, error) {
-	return pod.GetAllByPrefix(d.Metadata.Name, d.Metadata.Namespace)
+	return pod.GetAllByPrefixWithRetry(d.Metadata.Name, d.Metadata.Namespace, 3*time.Second, 20*time.Minute)
 }
 
 // GetWithRetry gets a deployment, allowing for retries
@@ -472,7 +472,7 @@ func (d *Deployment) WaitForReplicas(min, max int, sleep, timeout time.Duration)
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- pod.GetAllByPrefixAsync(d.Metadata.Name, d.Metadata.Namespace):
+			case ch <- pod.GetAllRunningByPrefixAsync(d.Metadata.Name, d.Metadata.Namespace):
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -441,7 +441,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, podWaitErr := pod.WaitOnSuccesses(deploymentName, deploymentNamespace, 3, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(podWaitErr).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
-				pods, err = deploy.Pods()
+				pods, err = deploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods)).To(Equal(1))
 				for _, p := range pods {
@@ -780,7 +780,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(running).To(Equal(true))
 
 			By("Ensuring that the php-apache pod has outbound internet access")
-			pods, err := phpApacheDeploy.Pods()
+			pods, err := phpApacheDeploy.PodsRunning()
 			Expect(err).NotTo(HaveOccurred())
 			for _, p := range pods {
 				pass, outboundErr := p.CheckLinuxOutboundConnection(5*time.Second, cfg.Timeout)
@@ -992,7 +992,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, err := pod.WaitOnSuccesses(curlDeploymentName, "default", 4, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
-				curlPods, err := curlDeploy.Pods()
+				curlPods, err := curlDeploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				By("Ensuring we can connect to the ILB service from another pod")
 				var success bool
@@ -1086,7 +1086,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(running).To(Equal(true))
 
 				By("Ensuring that the php-apache pod has outbound internet access")
-				pods, err := phpApacheDeploy.Pods()
+				pods, err := phpApacheDeploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				for _, p := range pods {
 					pass, outboundErr := p.CheckLinuxOutboundConnection(5*time.Second, cfg.Timeout)
@@ -1372,7 +1372,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(running).To(Equal(true))
 
 				By("Ensuring we have outbound internet access from the frontend-prod pods")
-				frontendProdPods, err := frontendProdDeployment.Pods()
+				frontendProdPods, err := frontendProdDeployment.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(frontendProdPods)).ToNot(BeZero())
 				pl := pod.List{Pods: frontendProdPods}
@@ -1381,7 +1381,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(pass).To(BeTrue())
 
 				By("Ensuring we have outbound internet access from the frontend-dev pods")
-				frontendDevPods, err := frontendDevDeployment.Pods()
+				frontendDevPods, err := frontendDevDeployment.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(frontendDevPods)).ToNot(BeZero())
 				pl = pod.List{Pods: frontendDevPods}
@@ -1390,7 +1390,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(pass).To(BeTrue())
 
 				By("Ensuring we have outbound internet access from the backend pods")
-				backendPods, err := backendDeployment.Pods()
+				backendPods, err := backendDeployment.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(backendPods)).ToNot(BeZero())
 				pl = pod.List{Pods: backendPods}
@@ -1399,7 +1399,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(pass).To(BeTrue())
 
 				By("Ensuring we have outbound internet access from the network-policy pods")
-				nwpolicyPods, err := nwpolicyDeployment.Pods()
+				nwpolicyPods, err := nwpolicyDeployment.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(nwpolicyPods)).ToNot(BeZero())
 				pl = pod.List{Pods: nwpolicyPods}
@@ -1579,7 +1579,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 				By("Checking that each pod can reach the internet")
 				var iisPods []pod.Pod
-				iisPods, err = iisDeploy.Pods()
+				iisPods, err = iisDeploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(iisPods)).ToNot(BeZero())
 				for _, iisPod := range iisPods {
@@ -1599,7 +1599,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, err = pod.WaitOnSuccesses(deploymentName, "default", 4, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
-				iisPods, err = iisDeploy.Pods()
+				iisPods, err = iisDeploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(iisPods)).To(Equal(5))
 
@@ -1608,7 +1608,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
-				iisPods, err = iisDeploy.Pods()
+				iisPods, err = iisDeploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(iisPods)).ToNot(BeZero())
 				for _, iisPod := range iisPods {
@@ -1623,7 +1623,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				_, err = iisDeploy.WaitForReplicas(2, 2, 2*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
-				iisPods, err = iisDeploy.Pods()
+				iisPods, err = iisDeploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(iisPods)).To(Equal(2))
 
@@ -1632,7 +1632,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
-				iisPods, err = iisDeploy.Pods()
+				iisPods, err = iisDeploy.PodsRunning()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(iisPods)).ToNot(BeZero())
 				for _, iisPod := range iisPods {
@@ -1738,7 +1738,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					running, err := pod.WaitOnSuccesses(deploymentName, "default", 4, 30*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(running).To(Equal(true))
-					iisPods, err := iisDeploy.Pods()
+					iisPods, err := iisDeploy.PodsRunning()
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(iisPods)).ToNot(BeZero())
 					kubeConfig, err := GetConfigWithRetry(3*time.Second, cfg.Timeout)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -654,7 +654,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have the correct IP address for the apiserver", func() {
-			pods, err := pod.GetAllByPrefixWithRetry("kube-apiserver", "kube-system", 3*time.Second, cfg.Timeout)
+			pods, err := pod.GetAllRunningByPrefixWithRetry("kube-apiserver", "kube-system", 3*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
 			By("Ensuring that the correct IP address has been applied to the apiserver")
 			expectedIPAddress := eng.ExpandedDefinition.Properties.MasterProfile.FirstConsecutiveStaticIP
@@ -693,7 +693,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						Expect(err).NotTo(HaveOccurred())
 						Expect(running).To(Equal(true))
 						By(fmt.Sprintf("Ensuring that the correct resources have been applied for %s", addonPod))
-						pods, err := pod.GetAllByPrefixWithRetry(addonPod, addonNamespace, 3*time.Second, cfg.Timeout)
+						pods, err := pod.GetAllRunningByPrefixWithRetry(addonPod, addonNamespace, 3*time.Second, cfg.Timeout)
 						Expect(err).NotTo(HaveOccurred())
 						for i, c := range addon.Containers {
 							pod := pods[0]
@@ -713,7 +713,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, err := pod.WaitOnSuccesses("tiller", "kube-system", kubeSystemPodsReadinessChecks, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
-				pods, err := pod.GetAllByPrefixWithRetry("tiller-deploy", "kube-system", 3*time.Second, cfg.Timeout)
+				pods, err := pod.GetAllRunningByPrefixWithRetry("tiller-deploy", "kube-system", 3*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				By("Ensuring that the correct max-history has been applied")
 				maxHistory := tillerAddon.Config["max-history"]
@@ -732,7 +732,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, err := pod.WaitOnSuccesses("omsagent-rs", "kube-system", kubeSystemPodsReadinessChecks, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
-				pods, err := pod.GetAllByPrefixWithRetry("omsagent-rs", "kube-system", 3*time.Second, cfg.Timeout)
+				pods, err := pod.GetAllRunningByPrefixWithRetry("omsagent-rs", "kube-system", 3*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				By("Ensuring that the kubepodinventory plugin is writing data successfully")
 				pass, err := pods[0].ValidateOmsAgentLogs("kubePodInventoryEmitStreamSuccess", 1*time.Second, cfg.Timeout)
@@ -746,7 +746,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, err = pod.WaitOnSuccesses("omsagent", "kube-system", kubeSystemPodsReadinessChecks, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
-				pods, err = pod.GetAllByPrefixWithRetry("omsagent", "kube-system", 3*time.Second, cfg.Timeout)
+				pods, err = pod.GetAllRunningByPrefixWithRetry("omsagent", "kube-system", 3*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				By("Ensuring that the cadvisor_perf plugin is writing data successfully")
 				pass, err = pods[0].ValidateOmsAgentLogs("cAdvisorPerfEmitStreamSuccess", 1*time.Second, cfg.Timeout)
@@ -1118,9 +1118,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				running, err = pod.WaitOnSuccesses(loadTestName, "default", 4, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
-
 				// We should have three load tester pods running
-				loadTestPods, err := loadTestDeploy.Pods()
+				loadTestPods, err := pod.GetAllRunningByPrefixWithRetry(loadTestPrefix, "default", 5*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(loadTestPods)).To(Equal(numLoadTestPods))
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

In most (but not all) instances, when we want to get all pods that match a prefix substring, we want the "Running" pods. A specific example is when we want to validate that a specific deployment replica count is met: in such validations we need to filter out only "Running" pods, so that we don't accidentally pick up an extra pod in a "Terminating" state (if, for example, a transient error caused a pod to be recycled, there will be a brief period of time where a simple `kubectl get pods` yields a set that is greater than the desired replica count).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
