### PR TITLE
feat: use aks windows vhds by default for Azure Stack

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -171,14 +171,6 @@ var (
 		ImageVersion:   "17763.737.190923",
 	}
 
-	// AzureStackWindowsServer2019OSImageConfig is the 'vanilla' Windows Server 2019 image to be used to with Azure Stack deployments
-	AzureStackWindowsServer2019OSImageConfig = AzureOSImageConfig{
-		ImageOffer:     "WindowsServer",
-		ImageSku:       "2019-Datacenter-Core-with-Containers",
-		ImagePublisher: "MicrosoftWindowsServer",
-		ImageVersion:   "latest",
-	}
-
 	// WindowsServer2019OSImageConfig is the 'vanilla' Windows Server 2019 image
 	WindowsServer2019OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "WindowsServer",

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -704,40 +704,24 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool, cloudName 
 func (p *Properties) setWindowsProfileDefaults(isUpgrade, isScale bool) {
 	windowsProfile := p.WindowsProfile
 	if !isUpgrade && !isScale {
+		if windowsProfile.WindowsPublisher == "" {
+			windowsProfile.WindowsPublisher = AKSWindowsServer2019OSImageConfig.ImagePublisher
+		}
+		if windowsProfile.WindowsOffer == "" {
+			windowsProfile.WindowsOffer = AKSWindowsServer2019OSImageConfig.ImageOffer
+		}
+		if windowsProfile.WindowsSku == "" {
+			windowsProfile.WindowsSku = AKSWindowsServer2019OSImageConfig.ImageSku
+		}
 
-		if p.IsAzureStackCloud() {
-			if windowsProfile.WindowsPublisher == "" {
-				windowsProfile.WindowsPublisher = AzureStackWindowsServer2019OSImageConfig.ImagePublisher
-			}
-			if windowsProfile.WindowsOffer == "" {
-				windowsProfile.WindowsOffer = AzureStackWindowsServer2019OSImageConfig.ImageOffer
-			}
-			if windowsProfile.WindowsSku == "" {
-				windowsProfile.WindowsSku = AzureStackWindowsServer2019OSImageConfig.ImageSku
-			}
-			if windowsProfile.ImageVersion == "" {
-				windowsProfile.ImageVersion = AzureStackWindowsServer2019OSImageConfig.ImageVersion
-			}
-		} else {
-			if windowsProfile.WindowsPublisher == "" {
-				windowsProfile.WindowsPublisher = AKSWindowsServer2019OSImageConfig.ImagePublisher
-			}
-			if windowsProfile.WindowsOffer == "" {
-				windowsProfile.WindowsOffer = AKSWindowsServer2019OSImageConfig.ImageOffer
-			}
-			if windowsProfile.WindowsSku == "" {
-				windowsProfile.WindowsSku = AKSWindowsServer2019OSImageConfig.ImageSku
-			}
-
-			if windowsProfile.ImageVersion == "" {
-				// default versions are specific to a publisher/offer/sku
-				if windowsProfile.WindowsPublisher == AKSWindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == AKSWindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == AKSWindowsServer2019OSImageConfig.ImageSku {
-					windowsProfile.ImageVersion = AKSWindowsServer2019OSImageConfig.ImageVersion
-				} else if windowsProfile.WindowsPublisher == WindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == WindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == WindowsServer2019OSImageConfig.ImageSku {
-					windowsProfile.ImageVersion = WindowsServer2019OSImageConfig.ImageVersion
-				} else {
-					windowsProfile.ImageVersion = "latest"
-				}
+		if windowsProfile.ImageVersion == "" {
+			// default versions are specific to a publisher/offer/sku
+			if windowsProfile.WindowsPublisher == AKSWindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == AKSWindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == AKSWindowsServer2019OSImageConfig.ImageSku {
+				windowsProfile.ImageVersion = AKSWindowsServer2019OSImageConfig.ImageVersion
+			} else if windowsProfile.WindowsPublisher == WindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == WindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == WindowsServer2019OSImageConfig.ImageSku {
+				windowsProfile.ImageVersion = WindowsServer2019OSImageConfig.ImageVersion
+			} else {
+				windowsProfile.ImageVersion = "latest"
 			}
 		}
 	}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1729,22 +1729,6 @@ func TestWindowsProfileDefaults(t *testing.T) {
 			},
 			false,
 		},
-		{
-			"Azure Stack defaults",
-			WindowsProfile{},
-			WindowsProfile{
-				WindowsPublisher:      AzureStackWindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:          AzureStackWindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:            AzureStackWindowsServer2019OSImageConfig.ImageSku,
-				ImageVersion:          AzureStackWindowsServer2019OSImageConfig.ImageVersion,
-				AdminUsername:         "",
-				AdminPassword:         "",
-				WindowsImageSourceURL: "",
-				WindowsDockerVersion:  "",
-				SSHEnabled:            false,
-			},
-			true,
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Use aks windows vhds by default for Azure Stack

**Issue Fixed**:
Fixes #2107 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
