### PR TITLE
test: retry "get nodes that match regex" test

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func() {
 		ClusterDefinition:  csInput,
 		ExpandedDefinition: csGenerated,
 	}
-	masterNodes, err := node.GetByRegexWithRetry("^k8s-master-")
+	masterNodes, err := node.GetByRegexWithRetry("^k8s-master-", 3*time.Minute, cfg.Timeout)
 	Expect(err).NotTo(HaveOccurred())
 	masterName := masterNodes[0].Metadata.Name
 	if strings.Contains(masterName, "vmss") {
@@ -129,7 +129,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				nodeList, err = node.GetReady()
 			} else {
 				var nodes []node.Node
-				nodes, err = node.GetByRegexWithRetry(firstMasterRegexStr)
+				nodes, err = node.GetByRegexWithRetry(firstMasterRegexStr, 3*time.Minute, cfg.Timeout)
 				nodeList = &node.List{
 					Nodes: nodes,
 				}
@@ -555,7 +555,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should have node labels and annotations", func() {
 			if !eng.ExpandedDefinition.Properties.HasLowPriorityScaleset() {
 				totalNodeCount := eng.NodeCount()
-				masterNodes, err := node.GetByRegexWithRetry(firstMasterRegexStr)
+				masterNodes, err := node.GetByRegexWithRetry(firstMasterRegexStr, 3*time.Minute, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				nodes := totalNodeCount - len(masterNodes)
 				nodeList, err := node.GetByLabel("foo")
@@ -1299,7 +1299,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 					By("Ensuring that attached volume pv has the same zone as the zone of the node")
 					nodeName := testPod.Spec.NodeName
-					nodeList, err := node.GetByRegexWithRetry(nodeName)
+					nodeList, err := node.GetByRegexWithRetry(nodeName, 3*time.Minute, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					nodeZone := nodeList[0].Metadata.Labels["failure-domain.beta.kubernetes.io/zone"]
 					fmt.Printf("pvZone: %s\n", pvZone)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func() {
 		ClusterDefinition:  csInput,
 		ExpandedDefinition: csGenerated,
 	}
-	masterNodes, err := node.GetByRegex("^k8s-master-")
+	masterNodes, err := node.GetByRegexWithRetry("^k8s-master-")
 	Expect(err).NotTo(HaveOccurred())
 	masterName := masterNodes[0].Metadata.Name
 	if strings.Contains(masterName, "vmss") {
@@ -129,7 +129,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				nodeList, err = node.GetReady()
 			} else {
 				var nodes []node.Node
-				nodes, err = node.GetByRegex(firstMasterRegexStr)
+				nodes, err = node.GetByRegexWithRetry(firstMasterRegexStr)
 				nodeList = &node.List{
 					Nodes: nodes,
 				}
@@ -555,7 +555,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should have node labels and annotations", func() {
 			if !eng.ExpandedDefinition.Properties.HasLowPriorityScaleset() {
 				totalNodeCount := eng.NodeCount()
-				masterNodes, err := node.GetByRegex(firstMasterRegexStr)
+				masterNodes, err := node.GetByRegexWithRetry(firstMasterRegexStr)
 				Expect(err).NotTo(HaveOccurred())
 				nodes := totalNodeCount - len(masterNodes)
 				nodeList, err := node.GetByLabel("foo")
@@ -1299,7 +1299,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 					By("Ensuring that attached volume pv has the same zone as the zone of the node")
 					nodeName := testPod.Spec.NodeName
-					nodeList, err := node.GetByRegex(nodeName)
+					nodeList, err := node.GetByRegexWithRetry(nodeName)
 					Expect(err).NotTo(HaveOccurred())
 					nodeZone := nodeList[0].Metadata.Labels["failure-domain.beta.kubernetes.io/zone"]
 					fmt.Printf("pvZone: %s\n", pvZone)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Observed this E2E flake:

```
$ k get nodes -o json
 Failure [30.437 seconds]
 2019/10/07 21:04:48 Error trying to run 'kubectl get nodes':
  - exit status 1
 2019/10/07 21:04:48 
  - {
     "apiVersion": "v1",
     "items": [],
     "kind": "List",
     "metadata": {
         "resourceVersion": "",
         "selfLink": ""
     }
 }
 Unable to connect to the server: dial tcp 13.81.26.234:443: i/o timeout
 [BeforeSuite] BeforeSuite [0m
 /go/src/github.com/Azure/aks-engine/test/e2e/kubernetes/kubernetes_test.go:71
 
   Expected error:
       <*exec.ExitError | 0xc0003cbc40>: {
           ProcessState: {
               pid: 3198,
               status: 256,
               rusage: {
                   Utime: {Sec: 0, Usec: 150474},
                   Stime: {Sec: 0, Usec: 22361},
                   Maxrss: 37936,
                   Ixrss: 0,
                   Idrss: 0,
                   Isrss: 0,
                   Minflt: 3460,
                   Majflt: 0,
                   Nswap: 0,
                   Inblock: 0,
                   Oublock: 8,
                   Msgsnd: 0,
                   Msgrcv: 0,
                   Nsignals: 0,
                   Nvcsw: 349,
                   Nivcsw: 229,
               },
           },
           Stderr: nil,
       }
       exit status 1
   not to have occurred
 
   /go/src/github.com/Azure/aks-engine/test/e2e/kubernetes/kubernetes_test.go:93
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
