### PR TITLE
test: retrying "get resource group" too long in soak test scenarios

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -77,10 +77,10 @@ installSGXDrivers() {
     VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
     case $VERSION in
     "18.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.0.1/dcap_installer/ubuntuServer1804/sgx_linux_x64_driver_dcap_4f32b98.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin"
         ;;
     "16.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.0.1/dcap_installer/ubuntuServer1604/sgx_linux_x64_driver_dcap_4f32b98.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin"
         ;;
     "*")
         echo "Version $VERSION is not supported"

--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -227,6 +227,40 @@ func GetNSeriesVMCasesForTesting() []struct {
 	return cases
 }
 
+// GetDCSeriesVMCasesForTesting returns a struct w/ VM SKUs and whether or not we expect them to be SGX-enabled
+func GetDCSeriesVMCasesForTesting() []struct {
+	VMSKU    string
+	Expected bool
+} {
+	cases := []struct {
+		VMSKU    string
+		Expected bool
+	}{
+		{
+			"Standard_DC2s",
+			true,
+		},
+		{
+			"Standard_DC4s",
+			true,
+		},
+		{
+			"Standard_NC12",
+			false,
+		},
+		{
+			"gobledygook",
+			false,
+		},
+		{
+			"",
+			false,
+		},
+	}
+
+	return cases
+}
+
 // IsSgxEnabledSKU determines if an VM SKU has SGX driver support
 func IsSgxEnabledSKU(vmSize string) bool {
 	switch vmSize {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1808,6 +1808,16 @@ func (p *Properties) HasNSeriesSKU() bool {
 	return false
 }
 
+// HasDCSeriesSKU returns whether or not there is an DC series SKU agent pool
+func (p *Properties) HasDCSeriesSKU() bool {
+	for _, profile := range p.AgentPoolProfiles {
+		if strings.Contains(profile.VMSize, "Standard_DC") {
+			return true
+		}
+	}
+	return false
+}
+
 // IsNVIDIADevicePluginEnabled checks if the NVIDIA Device Plugin addon is enabled
 // It is enabled by default if agents contain a GPU and Kubernetes version is >= 1.10.0
 func (p *Properties) IsNVIDIADevicePluginEnabled() bool {

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -6447,3 +6447,27 @@ func TestGetSecondaryNonMasqueradeCIDR(t *testing.T) {
 		})
 	}
 }
+
+func TestPropertiesHasDCSeriesSKU(t *testing.T) {
+	cases := common.GetDCSeriesVMCasesForTesting()
+
+	for _, c := range cases {
+		p := Properties{
+			AgentPoolProfiles: []*AgentPoolProfile{
+				{
+					Name:   "agentpool",
+					VMSize: c.VMSKU,
+					Count:  1,
+				},
+			},
+			OrchestratorProfile: &OrchestratorProfile{
+				OrchestratorType:    Kubernetes,
+				OrchestratorVersion: "1.16.0",
+			},
+		}
+		ret := p.HasDCSeriesSKU()
+		if ret != c.Expected {
+			t.Fatalf("expected HasDCSeriesSKU(%s) to return %t, but instead got %t", c.VMSKU, c.Expected, ret)
+		}
+	}
+}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -101,7 +101,7 @@ var _ = BeforeSuite(func() {
 	longRunningApacheDeploymentName = "php-apache-long-running"
 	kubeConfig, err = GetConfigWithRetry(3*time.Second, cfg.Timeout)
 	Expect(err).NotTo(HaveOccurred())
-	sshConn, err = remote.NewConnection(kubeConfig.GetServerName(), masterSSHPort, eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath)
+	sshConn, err = remote.NewConnectionWithRetry(kubeConfig.GetServerName(), masterSSHPort, eng.ExpandedDefinition.Properties.LinuxProfile.AdminUsername, masterSSHPrivateKeyFilepath, 3*time.Second, cfg.Timeout)
 	Expect(err).NotTo(HaveOccurred())
 	success := false
 	for i := 0; i < 3; i++ {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -831,7 +831,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should have functional container networking DNS", func() {
 			By("Ensuring that we have functional DNS resolution from a linux container")
-			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-linux.yaml"), "validate-dns-linux", "default")
+			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-linux.yaml"), "validate-dns-linux", "default", 3*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
 			ready, err := j.WaitOnSucceeded(sleepBetweenRetriesWhenWaitingForPodReady, validateDNSTimeout)
 			delErr := j.Delete(util.DefaultDeleteRetries)
@@ -846,7 +846,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring that we have functional DNS resolution from a windows container")
 				windowsImages, imgErr := eng.GetWindowsTestImages()
 				Expect(imgErr).NotTo(HaveOccurred())
-				j, err = job.CreateWindowsJobFromTemplateDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default", windowsImages)
+				j, err = job.CreateWindowsJobFromTemplateDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-windows.yaml"), "validate-dns-windows", "default", windowsImages, 3*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				ready, err = j.WaitOnSucceeded(sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				delErr = j.Delete(util.DefaultDeleteRetries)
@@ -1184,7 +1184,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					false,
 					eng.HasWindowsAgents())
 				if common.IsKubernetesVersionGe(version, "1.10.0") {
-					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "cuda-vector-add.yaml"), "cuda-vector-add", "default")
+					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "cuda-vector-add.yaml"), "cuda-vector-add", "default", 3*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					ready, err := j.WaitOnSucceeded(30*time.Second, cfg.Timeout)
 					delErr := j.Delete(util.DefaultDeleteRetries)
@@ -1195,7 +1195,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					Expect(err).NotTo(HaveOccurred())
 					Expect(ready).To(Equal(true))
 				} else {
-					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "nvidia-smi.yaml"), "nvidia-smi", "default")
+					j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "nvidia-smi.yaml"), "nvidia-smi", "default", 3*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					ready, err := j.WaitOnSucceeded(30*time.Second, cfg.Timeout)
 					delErr := j.Delete(util.DefaultDeleteRetries)
@@ -1208,6 +1208,25 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 			} else {
 				Skip("This is not a GPU-enabled cluster")
+			}
+		})
+	})
+
+	Describe("with a DC-series SKU agent pool", func() {
+		It("should be able to run an SGX job", func() {
+			if eng.ExpandedDefinition.Properties.HasDCSeriesSKU() {
+				j, err := job.CreateJobFromFile(filepath.Join(WorkloadDir, "sgx-test.yaml"), "sgx-test", "default", 3*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				ready, err := j.WaitOnSucceeded(30*time.Second, cfg.Timeout)
+				delErr := j.Delete(util.DefaultDeleteRetries)
+				if delErr != nil {
+					fmt.Printf("could not delete job %s\n", j.Metadata.Name)
+					fmt.Println(delErr)
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ready).To(Equal(true))
+			} else {
+				Skip("This cluster does not have a DC-series SKU agent pool")
 			}
 		})
 	})

--- a/test/e2e/kubernetes/workloads/sgx-test.yaml
+++ b/test/e2e/kubernetes/workloads/sgx-test.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sgxtest
+  name: sgx-test
 spec:
   template:
     spec:
@@ -20,4 +20,3 @@ spec:
           path: /dev/sgx
       restartPolicy: Never
   backoffLimit: 0
-  

--- a/test/e2e/kubernetes/workloads/sgx-test.yaml
+++ b/test/e2e/kubernetes/workloads/sgx-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sgxtest
+spec:
+  template:
+    spec:
+      containers:
+      - name: sgxtest
+        image: johnkord/sgxtest:0.1
+        command: ["./sgxtesthost", "sgxtestenc.signed"]
+        volumeMounts:
+        - mountPath: /dev/sgx
+          name: dev-sgx
+        securityContext:
+          privileged: true
+      volumes:
+      - name: dev-sgx
+        hostPath:
+          path: /dev/sgx
+      restartPolicy: Never
+  backoffLimit: 0
+  

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -94,10 +94,12 @@ func main() {
 			log.Fatalf("Error while trying to set storage account connection string: %s\n", err)
 		}
 		provision := true
+		rgExists := true
 		rg := cfg.SoakClusterName
 		err = acct.SetResourceGroupWithRetry(rg, 3*time.Second, 1*time.Minute)
 		if err != nil {
 			log.Printf("Error while trying to set RG:%s\n", err)
+			rgExists = false
 		} else {
 			// set expiration time to 7 days = 168h for now
 			var d time.Duration
@@ -109,8 +111,10 @@ func main() {
 		}
 		if provision || cfg.ForceDeploy {
 			log.Printf("Soak cluster %s does not exist or has expired\n", rg)
-			log.Printf("Deleting Resource Group:%s\n", rg)
-			acct.DeleteGroupWithRetry(rg, true, 3*time.Second, cfg.Timeout)
+			if rgExists {
+				log.Printf("Deleting Resource Group:%s\n", rg)
+				acct.DeleteGroupWithRetry(rg, true, 3*time.Second, cfg.Timeout)
+			}
 			log.Printf("Deleting Storage files:%s\n", rg)
 			sa.DeleteFiles(cfg.SoakClusterName)
 			cfg.Name = ""

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -95,7 +95,7 @@ func main() {
 		}
 		provision := true
 		rg := cfg.SoakClusterName
-		err = acct.SetResourceGroupWithRetry(rg, 3*time.Second, cfg.Timeout)
+		err = acct.SetResourceGroupWithRetry(rg, 3*time.Second, 1*time.Minute)
 		if err != nil {
 			log.Printf("Error while trying to set RG:%s\n", err)
 		} else {

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -371,7 +371,7 @@ func (cli *CLIProvisioner) FetchProvisioningMetrics(path string, cfg *config.Con
 	authSock := strings.Split(strings.Split(string(out), "=")[1], ";")
 	os.Setenv("SSH_AUTH_SOCK", authSock[0])
 	var conn *remote.Connection
-	conn, err = remote.NewConnection(hostname, "22", cli.Engine.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cli.Config.GetSSHKeyPath())
+	conn, err = remote.NewConnectionWithRetry(hostname, "22", cli.Engine.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cli.Config.GetSSHKeyPath(), 3*time.Second, cli.Config.Timeout)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/test_cluster_configs/sgx.json
+++ b/test/e2e/test_cluster_configs/sgx.json
@@ -1,0 +1,46 @@
+{
+	"env": {
+		"REGION_OPTIONS": "westus2"
+	},
+	"apiModel": {
+        "apiVersion": "vlabs",
+        "properties": {
+          "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "1.13",
+            "kubernetesConfig": {
+              "useManagedIdentity": true
+            }
+          },
+          "masterProfile": {
+            "count": 1,
+            "vmSize": "Standard_D2s_v3",
+            "dnsPrefix": ""
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "agentpool",
+              "count": 1,
+              "availabilityProfile": "VirtualMachineScaleSets",
+              "distro": "aks-ubuntu-18.04",
+              "vmSize": "Standard_DC4s",
+              "storageProfile": "ManagedDisks"
+            }
+          ],
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": ""
+                }
+              ]
+            }
+          },
+          "servicePrincipalProfile": {
+            "clientId": "",
+            "secret": ""
+          }
+        }
+      }
+}

--- a/test/e2e/test_cluster_configs/sgx.json
+++ b/test/e2e/test_cluster_configs/sgx.json
@@ -6,11 +6,7 @@
         "apiVersion": "vlabs",
         "properties": {
           "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.13",
-            "kubernetesConfig": {
-              "useManagedIdentity": true
-            }
+            "orchestratorType": "Kubernetes"
           },
           "masterProfile": {
             "count": 1,

--- a/test/e2e/test_cluster_configs/sgx.json
+++ b/test/e2e/test_cluster_configs/sgx.json
@@ -1,6 +1,6 @@
 {
 	"env": {
-		"REGION_OPTIONS": "westus2"
+		"REGION_OPTIONS": "westeurope"
 	},
 	"apiModel": {
         "apiVersion": "vlabs",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

We're retrying the "get the soak resource group" operation too long, as the resource group will not exist (by design) when running a new soak scenario for the first time.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
