### PR TITLE
feat: enable re-use of VHD

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -58,15 +58,15 @@ if [[ "${GPU_NODE}" != "true" ]]; then
 fi
 
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
-if [[ "${IS_VHD}" = true ]]; then
-    if [ ! -f $VHD_LOGS_FILEPATH ]; then
-        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
-        exit $ERR_VHD_FILE_NOT_FOUND
-    fi
+if [ -f $VHD_LOGS_FILEPATH ]; then
     echo "detected golden image pre-install"
     cleanUpContainerImages
     FULL_INSTALL_REQUIRED=false
 else
+    if [[ "${IS_VHD}" = true ]]; then
+        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
+        exit $ERR_VHD_FILE_NOT_FOUND
+    fi
     FULL_INSTALL_REQUIRED=true
 fi
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -15456,15 +15456,15 @@ if [[ "${GPU_NODE}" != "true" ]]; then
 fi
 
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
-if [[ "${IS_VHD}" = true ]]; then
-    if [ ! -f $VHD_LOGS_FILEPATH ]; then
-        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
-        exit $ERR_VHD_FILE_NOT_FOUND
-    fi
+if [ -f $VHD_LOGS_FILEPATH ]; then
     echo "detected golden image pre-install"
     cleanUpContainerImages
     FULL_INSTALL_REQUIRED=false
 else
+    if [[ "${IS_VHD}" = true ]]; then
+        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
+        exit $ERR_VHD_FILE_NOT_FOUND
+    fi
     FULL_INSTALL_REQUIRED=true
 fi
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR re-orders the "do I have the 'created by AKS VHD CI' OS signature?" and the "does my cluster configuration explicitly declare a VHD distro?" checks in order to enable AKS VHD re-use scenarios. E.g.:

- create a new managed image / shared gallery image / VHD _from_ the AKS VHD

Specifically, the boolean variable `FULL_INSTALL_REQUIRED` in our CSE implementation is functionally coupled with the VHD CI implementation that pairs with that CSE implementation at that commit of aks-engine. In practice, this means that for folks who want to re-use the AKS VHD as a base for creating their own Kubernetes node OS images can (1) take advantage of the optimized CSE code paths (e.g., don't execute unnecessary `apt` operations) and (2) implement the proper cleanup functionality so that the resultant Kubernetes node isn't unnecessarily burdened with the storage overhead of dozens of unused, pre-pulled Kubernetes hyperkube images (we use a common VHD to support a large set of Kubernetes versions).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2036 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
