### PR TITLE
test: print logs after E2E tests

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -120,6 +120,20 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
+var _ = AfterSuite(func() {
+	cmd := exec.Command("k", "get", "deployments,pods,svc,daemonsets,configmaps,endpoints,jobs,clusterroles,clusterrolebindings,roles,rolebindings,storageclasses", "--all-namespaces", "-o", "wide")
+	out, err := cmd.CombinedOutput()
+	log.Printf("%s\n", out)
+	if err != nil {
+		log.Printf("Error: Unable to print all cluster resources\n")
+	}
+	pod.PrintPodsLogs("kube-addon-manager", "kube-system")
+	pod.PrintPodsLogs("kube-proxy", "kube-system")
+	pod.PrintPodsLogs("kube-scheduler", "kube-system")
+	pod.PrintPodsLogs("kube-apiserver", "kube-system")
+	pod.PrintPodsLogs("kube-controller-manager", "kube-system")
+})
+
 var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", func() {
 	Describe("regardless of agent pool type", func() {
 		It("should validate host OS DNS", func() {
@@ -597,7 +611,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			out, err := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
 			if err != nil {
-				log.Printf("Error: Unable to print all pods\n")
+				log.Printf("Error: Unable to print all cluster resources\n")
 			}
 		})
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Print out a bunch o' cluster logs after running E2E tests to help diagnose issues.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
