### PR TITLE
test: Add 'latestReleasedVersion' target to Jenkins jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,9 +158,9 @@ stage ("discover tests") {
 				// (version being process equals latestReleasedVersion AND allowedOrchestratorVersions contains "latestReleasedVersion")
 				def allowedVersions = jobCfg.options?.allowedOrchestratorVersions
 				def isVersionAllowed = allowedVersions == null ? true  : version allowedVersions
-				isAllowedVersion |= version == latestReleasedVersion && allowedVersions && "latestReleasedVersion" in allowedVersions
+				isVersionAllowed |= version == latestReleasedVersion && allowedVersions && "latestReleasedVersion" in allowedVersions
 
-				if(!isAllowedVersion) {
+				if(!isVersionAllowed) {
 					// the job config has limited this job to not run for this verion of the orchestrator
 					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running for ${version}")
 					return // this is a continue and will not exit the entire iteration

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,11 +153,13 @@ stage ("discover tests") {
 				}
 
 				def isAllowedVersion = jobCfg.options?.allowedOrchestratorVersions == null ? true : version in jobCfg.options.allowedOrchestratorVersions
-				isAllowedVersion |= (version == stableVersion) && stableVersion in jobCfg.options.allowedOrchestratorVersions
+				isAllowedVersion |= (version.equals(stableVersion)) && stableVersion in jobCfg.options.allowedOrchestratorVersions
 				if(!isAllowedVersion) {
 					// the job config has limited this job to not run for this verion of the orchestrator
 					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running ${version}")
 					return // this is a continue and will not exit the entire iteration
+				} else {
+					echo("${jobName} has the following allowed versions '${jobCfg.options?.allowedOrchestratorVersions}")
 				}
 
 				if(params.UPGRADE_CLUSTER) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ defaultEnv = [
 	] + params
 
 def k8sVersions = ["1.12", "1.13", "1.14", "1.15", "1.16"]
-def stableVersion = "1.16"
+def latestReleasedVersion = "1.16"
 def tasks = [:]
 def testConfigs = []
 
@@ -153,13 +153,13 @@ stage ("discover tests") {
 				}
 
 				def isAllowedVersion = jobCfg.options?.allowedOrchestratorVersions == null ? true : version in jobCfg.options.allowedOrchestratorVersions
-				isAllowedVersion |= (version.equals(stableVersion)) && stableVersion in jobCfg.options.allowedOrchestratorVersions
+				isAllowedVersion |= (version.equals(latestReleasedVersion)) && "latestReleasedVersion" in jobCfg.options.allowedOrchestratorVersions
 				if(!isAllowedVersion) {
 					// the job config has limited this job to not run for this verion of the orchestrator
 					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running ${version}")
 					return // this is a continue and will not exit the entire iteration
 				} else {
-					echo("${jobName} has the following allowed versions '${jobCfg.options?.allowedOrchestratorVersions}")
+					echo("${jobName} is limted to '${jobCfg.options?.allowedOrchestratorVersions}'; running ${version}")
 				}
 
 				if(params.UPGRADE_CLUSTER) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,7 +153,7 @@ stage ("discover tests") {
 				}
 
 				def isAllowedVersion = jobCfg.options?.allowedOrchestratorVersions == null ? true : version in jobCfg.options.allowedOrchestratorVersions
-				isAllowedVersion |= (version.equals(latestReleasedVersion)) && "latestReleasedVersion" in jobCfg.options.allowedOrchestratorVersions
+				isAllowedVersion |= (version.equals(latestReleasedVersion)) && jobCfg.options?.allowedOrchestratorVersions != null && "latestReleasedVersion" in jobCfg.options.allowedOrchestratorVersions
 				if(!isAllowedVersion) {
 					// the job config has limited this job to not run for this verion of the orchestrator
 					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running ${version}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ def runJobWithEnvironment(jobCfg, jobName, version) {
 							try {
 								echo "EXECUTOR_NUMBER :: $EXECUTOR_NUMBER"
 								echo "NODE_NAME :: $NODE_NAME"
-								// sh "./test/e2e/cluster.sh"
+								sh "./test/e2e/cluster.sh"
 							} finally {
 								sh "./test/e2e/jenkins_reown.sh"
 							}
@@ -156,10 +156,10 @@ stage ("discover tests") {
 				isAllowedVersion |= (version.equals(latestReleasedVersion)) && jobCfg.options?.allowedOrchestratorVersions != null && "latestReleasedVersion" in jobCfg.options.allowedOrchestratorVersions
 				if(!isAllowedVersion) {
 					// the job config has limited this job to not run for this verion of the orchestrator
-					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running ${version}")
+					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running for ${version}")
 					return // this is a continue and will not exit the entire iteration
 				} else {
-					echo("${jobName} is limted to '${jobCfg.options?.allowedOrchestratorVersions}'; running ${version}")
+					echo("${jobName} is limted to '${jobCfg.options?.allowedOrchestratorVersions}'; running for ${version}")
 				}
 
 				if(params.UPGRADE_CLUSTER) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ defaultEnv = [
 	] + params
 
 def k8sVersions = ["1.12", "1.13", "1.14", "1.15", "1.16"]
+def stableVersion = "1.16"
 def tasks = [:]
 def testConfigs = []
 
@@ -79,7 +80,7 @@ def runJobWithEnvironment(jobCfg, jobName, version) {
 							try {
 								echo "EXECUTOR_NUMBER :: $EXECUTOR_NUMBER"
 								echo "NODE_NAME :: $NODE_NAME"
-								sh "./test/e2e/cluster.sh"
+								// sh "./test/e2e/cluster.sh"
 							} finally {
 								sh "./test/e2e/jenkins_reown.sh"
 							}
@@ -152,6 +153,7 @@ stage ("discover tests") {
 				}
 
 				def isAllowedVersion = jobCfg.options?.allowedOrchestratorVersions == null ? true : version in jobCfg.options.allowedOrchestratorVersions
+				isAllowedVersion |= (version == stableVersion) && stableVersion in jobCfg.options.allowedOrchestratorVersions
 				if(!isAllowedVersion) {
 					// the job config has limited this job to not run for this verion of the orchestrator
 					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running ${version}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,7 @@ stage ("discover tests") {
 				// allowedOrchestratorVersions contains version being processed OR
 				// (version being process equals latestReleasedVersion AND allowedOrchestratorVersions contains "latestReleasedVersion")
 				def allowedVersions = jobCfg.options?.allowedOrchestratorVersions
-				def isVersionAllowed = allowedVersions == null ? true  : version allowedVersions
+				def isVersionAllowed = allowedVersions == null ? true  : version in allowedVersions
 				isVersionAllowed |= version == latestReleasedVersion && allowedVersions && "latestReleasedVersion" in allowedVersions
 
 				if(!isVersionAllowed) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ def runJobWithEnvironment(jobCfg, jobName, version) {
 							try {
 								echo "EXECUTOR_NUMBER :: $EXECUTOR_NUMBER"
 								echo "NODE_NAME :: $NODE_NAME"
-								// sh "./test/e2e/cluster.sh"
+								sh "./test/e2e/cluster.sh"
 							} finally {
 								sh "./test/e2e/jenkins_reown.sh"
 							}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ def runJobWithEnvironment(jobCfg, jobName, version) {
 							try {
 								echo "EXECUTOR_NUMBER :: $EXECUTOR_NUMBER"
 								echo "NODE_NAME :: $NODE_NAME"
-								sh "./test/e2e/cluster.sh"
+								// sh "./test/e2e/cluster.sh"
 							} finally {
 								sh "./test/e2e/jenkins_reown.sh"
 							}
@@ -152,8 +152,14 @@ stage ("discover tests") {
 					return // this is a continue and will not exit the entire iteration
 				}
 
-				def isAllowedVersion = jobCfg.options?.allowedOrchestratorVersions == null ? true : version in jobCfg.options.allowedOrchestratorVersions
-				isAllowedVersion |= (version.equals(latestReleasedVersion)) && jobCfg.options?.allowedOrchestratorVersions != null && "latestReleasedVersion" in jobCfg.options.allowedOrchestratorVersions
+				// run the job if:
+				// allowedOrchestratorVersions is not set OR
+				// allowedOrchestratorVersions contains version being processed OR
+				// (version being process equals latestReleasedVersion AND allowedOrchestratorVersions contains "latestReleasedVersion")
+				def allowedVersions = jobCfg.options?.allowedOrchestratorVersions
+				def isVersionAllowed = allowedVersions == null ? true  : version allowedVersions
+				isAllowedVersion |= version == latestReleasedVersion && allowedVersions && "latestReleasedVersion" in allowedVersions
+
 				if(!isAllowedVersion) {
 					// the job config has limited this job to not run for this verion of the orchestrator
 					echo("${jobName} is limited to ${jobCfg.options?.allowedOrchestratorVersions}; not running for ${version}")

--- a/test/e2e/test_cluster_configs/windows/cse_benchmark_aks_vhds.json
+++ b/test/e2e/test_cluster_configs/windows/cse_benchmark_aks_vhds.json
@@ -1,6 +1,6 @@
 {
 	"env": {
-		"allowedOrchestratorVersions": ["1.16"],
+		"allowedOrchestratorVersions": ["stable"],
 		"SKIP_TEST": "true"
 	},
 	"options": {

--- a/test/e2e/test_cluster_configs/windows/cse_benchmark_aks_vhds.json
+++ b/test/e2e/test_cluster_configs/windows/cse_benchmark_aks_vhds.json
@@ -1,9 +1,9 @@
 {
 	"env": {
-		"allowedOrchestratorVersions": ["stable"],
 		"SKIP_TEST": "true"
 	},
 	"options": {
+		"allowedOrchestratorVersions": ["latestReleasedVersion"],
 		"clientId": "AKS_ENGINE_9251926c_CLIENT_ID",
 		"clientSecret": "AKS_ENGINE_9251926c_CLIENT_SECRET"
 	},

--- a/test/e2e/test_cluster_configs/windows/cse_benchmark_win_vhds.json
+++ b/test/e2e/test_cluster_configs/windows/cse_benchmark_win_vhds.json
@@ -1,9 +1,9 @@
 {
 	"env": {
-		"allowedOrchestratorVersions": ["1.16"],
 		"SKIP_TEST": "true"
 	},
 	"options": {
+		"allowedOrchestratorVersions": ["latestReleasedVersion"],
 		"clientId": "AKS_ENGINE_e7b1dca4_CLIENT_ID",
 		"clientSecret": "AKS_ENGINE_e7b1dca4_CLIENT_SECRET"
 	},

--- a/test/e2e/test_cluster_configs/windows/custom_image.json
+++ b/test/e2e/test_cluster_configs/windows/custom_image.json
@@ -1,5 +1,7 @@
 {
-	"env": {},
+	"env": {
+		"allowedOrchestratorVersions": ["stable"]
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {

--- a/test/e2e/test_cluster_configs/windows/custom_image.json
+++ b/test/e2e/test_cluster_configs/windows/custom_image.json
@@ -1,6 +1,6 @@
 {
-	"env": {
-		"allowedOrchestratorVersions": ["stable"]
+	"options": {
+		"allowedOrchestratorVersions": ["latestReleasedVersion"]
 	},
 	"apiModel": {
 		"apiVersion": "vlabs",

--- a/test/e2e/test_cluster_configs/windows/image_reference.json
+++ b/test/e2e/test_cluster_configs/windows/image_reference.json
@@ -1,9 +1,11 @@
 {
 	"env": {
-		"allowedOrchestratorVersions": ["stable"],
 		"REGION_OPTIONS": "westus",
 		"WINDOWS_NODE_IMAGE_NAME": "WS2019-1908",
 		"WINDOWS_NODE_IMAGE_RESOURCE_GROUP": "acse-test-infrastructure"
+	},
+	"options": {
+		"allowedOrchestratorVersions": ["latestReleasedVersion"]
 	},
 	"apiModel": {
 		"apiVersion": "vlabs",

--- a/test/e2e/test_cluster_configs/windows/image_reference.json
+++ b/test/e2e/test_cluster_configs/windows/image_reference.json
@@ -1,5 +1,6 @@
 {
 	"env": {
+		"allowedOrchestratorVersions": ["stable"],
 		"REGION_OPTIONS": "westus",
 		"WINDOWS_NODE_IMAGE_NAME": "WS2019-1908",
 		"WINDOWS_NODE_IMAGE_RESOURCE_GROUP": "acse-test-infrastructure"

--- a/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
+++ b/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
@@ -1,12 +1,14 @@
 {
 	"env": {
-		"allowedOrchestratorVersions": ["stable"],
 		"REGION_OPTIONS": "westus",
 		"WINDOWS_NODE_IMAGE_NAME": "AKS-Engine-WS2019",
 		"WINDOWS_NODE_IMAGE_RESOURCE_GROUP": "acse-test-infrastructure",
 		"WINDOWS_NODE_IMAGE_GALLERY": "akse_test_images",
 		"WINDOWS_NODE_IMAGE_SUBSCRIPTION_ID": "3014546b-7d1c-4f80-8523-f24a9976fe6a",
 		"WINDOWS_NODE_IMAGE_VERSION": "17763.678.190826"
+	},
+	"options": {
+		"allowedOrchestratorVersions": ["latestReleasedVersion"]
 	},
 	"apiModel": {
 		"apiVersion": "vlabs",

--- a/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
+++ b/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
@@ -1,5 +1,6 @@
 {
 	"env": {
+		"allowedOrchestratorVersions": ["stable"],
 		"REGION_OPTIONS": "westus",
 		"WINDOWS_NODE_IMAGE_NAME": "AKS-Engine-WS2019",
 		"WINDOWS_NODE_IMAGE_RESOURCE_GROUP": "acse-test-infrastructure",

--- a/test/e2e/test_cluster_configs/windows/vhd_url.json
+++ b/test/e2e/test_cluster_configs/windows/vhd_url.json
@@ -3,6 +3,9 @@
 		"REGION_OPTIONS": "westus",
 		"WINDOWS_NODE_VHD_URL": "https://aksenginee2etestimages.blob.core.windows.net/vhds/WS2019-1908.vhd"
 	},
+	"options": {
+		"allowedOrchestratorVersions": ["latestReleasedVersion"]
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
This change 
- Fixes some of the test configs by moving allowedOrchestratorRelease to options instead of env
- Adds the abililty to target a 'latest released' k8s version for jobs that do not benefits from running against multiple k8s versions
- Updates some additional test configs to use the 'latestReleasedVersion' allowedOrchestratorRelease

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Addresses issue #2072 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
