### PR TITLE
fix: pass 'cacert' option to curl pre-provision scripts on Azure Stack

### DIFF
--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -139,6 +139,8 @@ const (
 	AzureStackSuffix = "-azs"
 	// AzureStackPrefix is appended to windows binary version for Azure Stack instances
 	AzureStackPrefix = "azs-"
+	// AzureStackCaCertLocation is where Azure Stack's CRP drops the stamp CA certificate
+	AzureStackCaCertLocation = "/var/lib/waagent/Certificates.pem"
 )
 
 const (


### PR DESCRIPTION
**Reason for Change**:
Same reason as #2053 (then reverted here #2135). Downloading pre-provision extensions fails if the scripts are hosted on the local Azure Stack instance. Pass the 'cacert' option to curl fixed the problem and does not cause the unintended side-effects.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version
