### PR TITLE
fix: VM and VMSS do not have user assigned identity in its dependsOn

### DIFF
--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -518,6 +518,12 @@ func TestGenerateARMResourcesWithVMSSAgentPool(t *testing.T) {
 			"[variables('userAssignedIDReference')]": {},
 		},
 	}
+	masterVM.DependsOn = []string{
+		"[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+		"[concat('Microsoft.Compute/availabilitySets/',variables('masterAvailabilitySet'))]",
+		"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]",
+	}
+
 	masterVMExtension.VirtualMachineExtension.ProtectedSettings = &map[string]interface{}{
 		"commandToExecute": `[concat('echo $(date),$(hostname);  for i in $(seq 1 1200); do grep -Fq "EOF" /opt/azure/containers/provision.sh && break; if [ $i -eq 1200 ]; then exit 100; else sleep 1; fi; done; ', variables('provisionScriptParametersCommon'),` + generateUserAssignedIdentityClientIDParameter(userAssignedIDEnabled) + `,variables('provisionScriptParametersMaster'), ' IS_VHD=true /usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1"')]`,
 	}
@@ -546,6 +552,11 @@ func TestGenerateARMResourcesWithVMSSAgentPool(t *testing.T) {
 			"[variables('userAssignedIDReference')]": {},
 		},
 	}
+	agentVM.DependsOn = []string{
+		"[variables('vnetID')]",
+		"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]",
+	}
+
 	agentVM.VirtualMachineScaleSet.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile.Extensions = &[]compute.VirtualMachineScaleSetExtension{
 		{
 			Name: to.StringPtr("vmssCSE"),

--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -35,6 +35,9 @@ func CreateMasterVM(cs *api.ContainerService) VirtualMachineARM {
 	if isStorageAccount {
 		dependencies = append(dependencies, "[variables('masterStorageAccountName')]")
 	}
+	if userAssignedIDEnabled {
+		dependencies = append(dependencies, "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]")
+	}
 
 	armResource := ARMResource{
 		APIVersion: "[variables('apiVersionCompute')]",
@@ -344,6 +347,10 @@ func createAgentAvailabilitySetVM(cs *api.ContainerService, profile *api.AgentPo
 	dependencies = append(dependencies, fmt.Sprintf("[concat('Microsoft.Network/networkInterfaces/', variables('%[1]sVMNamePrefix'), 'nic-', copyIndex(variables('%[1]sOffset')))]", profile.Name))
 
 	dependencies = append(dependencies, fmt.Sprintf("[concat('Microsoft.Compute/availabilitySets/', variables('%[1]sAvailabilitySet'))]", profile.Name))
+
+	if userAssignedIDEnabled {
+		dependencies = append(dependencies, "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]")
+	}
 
 	if profile.IsWindows() {
 		windowsProfile := cs.Properties.WindowsProfile

--- a/pkg/engine/virtualmachines_test.go
+++ b/pkg/engine/virtualmachines_test.go
@@ -137,6 +137,7 @@ func TestCreateVirtualMachines(t *testing.T) {
 	expectedVM.DependsOn = []string{
 		"[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
 		"[variables('masterStorageAccountName')]",
+		"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]",
 	}
 
 	expectedVM.StorageProfile.OsDisk = &compute.OSDisk{

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -53,6 +53,10 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 		dependencies = append(dependencies, "[variables('masterLbID')]")
 	}
 
+	if userAssignedIDEnabled {
+		dependencies = append(dependencies, "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]")
+	}
+
 	armResource := ARMResource{
 		APIVersion: "[variables('apiVersionCompute')]",
 		DependsOn:  dependencies,
@@ -369,6 +373,10 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 	orchProfile := cs.Properties.OrchestratorProfile
 	k8sConfig := orchProfile.KubernetesConfig
 	linuxProfile := cs.Properties.LinuxProfile
+
+	if k8sConfig != nil && k8sConfig.UseManagedIdentity && k8sConfig.UserAssignedID != "" {
+		dependencies = append(dependencies, "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]")
+	}
 
 	armResource.DependsOn = dependencies
 

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -374,7 +374,7 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 	k8sConfig := orchProfile.KubernetesConfig
 	linuxProfile := cs.Properties.LinuxProfile
 
-	if k8sConfig != nil && k8sConfig.UseManagedIdentity && k8sConfig.UserAssignedID != "" {
+	if k8sConfig != nil && k8sConfig.UserAssignedIDEnabled() {
 		dependencies = append(dependencies, "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]")
 	}
 

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -215,6 +215,13 @@ func TestCreateMasterVMSS(t *testing.T) {
 		},
 	}
 
+	expected.DependsOn = []string{
+		"[variables('nsgID')]",
+		"[variables('masterInternalLbName')]",
+		"[variables('masterLbID')]",
+		"[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]",
+	}
+
 	expected.VirtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{
 		Extensions: &[]compute.VirtualMachineScaleSetExtension{
 			{


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Background is described in #2082 .

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2082 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
