### PR TITLE
fix: fix cni conf json for single exception address

### DIFF
--- a/parts/k8s/windowsazurecnifunc.ps1
+++ b/parts/k8s/windowsazurecnifunc.ps1
@@ -90,7 +90,7 @@ Set-AzureCNIConfig
         $configJson.plugins.AdditionalArgs[0].Value.ExceptionList = $processedExceptions
     }
     else {
-        $configJson.plugins.AdditionalArgs[0].Value.ExceptionList[0] = $exceptionAddresses
+        $configJson.plugins.AdditionalArgs[0].Value.ExceptionList = $exceptionAddresses
     }
 
     $configJson.plugins.AdditionalArgs[1].Value.DestinationPrefix  = $KubeServiceCIDR
@@ -126,7 +126,8 @@ function GetBroadestRangesForEachAddress{
         $returnValues += $ip + "/" + $range
     }
 
-    return $returnValues
+    # prefix $returnValues with common to ensure single values get returned as an array otherwise invalid json may be generated
+    return ,$returnValues
 }
 
 function GetSubnetPrefix

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -30780,7 +30780,7 @@ Set-AzureCNIConfig
         $configJson.plugins.AdditionalArgs[0].Value.ExceptionList = $processedExceptions
     }
     else {
-        $configJson.plugins.AdditionalArgs[0].Value.ExceptionList[0] = $exceptionAddresses
+        $configJson.plugins.AdditionalArgs[0].Value.ExceptionList = $exceptionAddresses
     }
 
     $configJson.plugins.AdditionalArgs[1].Value.DestinationPrefix  = $KubeServiceCIDR
@@ -30816,7 +30816,8 @@ function GetBroadestRangesForEachAddress{
         $returnValues += $ip + "/" + $range
     }
 
-    return $returnValues
+    # prefix $returnValues with common to ensure single values get returned as an array otherwise invalid json may be generated
+    return ,$returnValues
 }
 
 function GetSubnetPrefix


### PR DESCRIPTION


<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Fixes an issue where invalid cni conf json is generated when route exception lists contain a single value by forcing powershell function to return an array even for single values in GetBroadestRangesForEachAddress function 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
This should fix failing windows/custom_vnet jenkins test jobs

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
