### PR TITLE
feat: add support for Kubernetes v1.17.0-beta.1

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -157,6 +157,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.16.2":         true,
 	"1.17.0-alpha.1": true,
 	"1.17.0-alpha.2": true,
+	"1.17.0-alpha.3": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -158,6 +158,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.17.0-alpha.1": true,
 	"1.17.0-alpha.2": true,
 	"1.17.0-alpha.3": true,
+	"1.17.0-beta.1":  true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -156,6 +156,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.16.1":         true,
 	"1.16.2":         true,
 	"1.17.0-alpha.1": true,
+	"1.17.0-alpha.2": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.17.md#changelog-since-v1170-alpha1

**Issue Fixed**:

**Requirements**:
- [x] Windows artifacts uploaded to acsmirror blob store
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This is blocked until #2191 merges.
- ~~k8s.gcr.io/hyperkube:v1.17.0-alpha.2 is not published (yet?).~~ See #1842.
