### PR TITLE
chore: use Azure CCM for k8s 1.16 and later

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -429,6 +429,17 @@ for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
   echo "  - ${HYPERKUBE_URL}" >> ${VHD_LOGS_FILEPATH}
 done
 
+CLOUD_MANAGER_VERSIONS="
+0.3.0
+"
+for CLOUD_MANAGER_VERSION in ${CLOUD_MANAGER_VERSIONS}; do
+  for COMPONENT in azure-cloud-controller-manager azure-cloud-node-manager; do
+    CONTAINER_IMAGE="mcr.microsoft.com/k8s/core/${COMPONENT}:v${CLOUD_MANAGER_VERSION}"
+    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+  done
+done
+
 # TODO: remove once ACR is available on Azure Stack
 CONTAINER_IMAGE="registry:2.7.1"
 pullContainerImage "docker" ${CONTAINER_IMAGE}

--- a/parts/k8s/containeraddons/1.17/kubernetesmasteraddons-cloud-node-manager.yaml
+++ b/parts/k8s/containeraddons/1.17/kubernetesmasteraddons-cloud-node-manager.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: cloud-node-manager
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-node-manager
+  labels:
+    k8s-app: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch","list","get","update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-node-manager
+  labels:
+    k8s-app: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-node-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-node-manager
+  namespace: kube-system
+  labels:
+    component: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cloud-node-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: cloud-node-manager
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: cloud-node-manager
+      hostNetwork: true   # required to fetch correct hostname
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - operator: "Exists"
+        effect: NoExecute
+      - operator: "Exists"
+        effect: NoSchedule
+      containers:
+      - name: cloud-node-manager
+        image: {{ContainerImage "cloud-node-manager"}}
+        imagePullPolicy: IfNotPresent
+        command: ["cloud-node-manager"]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 2000m
+            memory: 512Mi

--- a/parts/k8s/manifests/kubernetesmaster-cloud-controller-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-cloud-controller-manager.yaml
@@ -15,17 +15,24 @@ spec:
       imagePullPolicy: IfNotPresent
       command: ["cloud-controller-manager"]
       args: [<config>]
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 4
+          memory: 2Gi
       volumeMounts:
-        - name: etc-kubernetes
-          mountPath: /etc/kubernetes
-        - name: etc-ssl
-          mountPath: /etc/ssl
-          readOnly: true
-        - name: var-lib-kubelet
-          mountPath: /var/lib/kubelet
-        - name: msi
-          mountPath: /var/lib/waagent/ManagedIdentity-Settings
-          readOnly: true
+      - name: etc-kubernetes
+        mountPath: /etc/kubernetes
+      - name: etc-ssl
+        mountPath: /etc/ssl
+        readOnly: true
+      - name: var-lib-kubelet
+        mountPath: /var/lib/kubelet
+      - name: msi
+        mountPath: /var/lib/waagent/ManagedIdentity-Settings
+        readOnly: true
   volumes:
     - name: etc-kubernetes
       hostPath:

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -331,6 +331,19 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		defaultAzureNetworkPolicyAddonsConfig.Containers = append(defaultAzureNetworkPolicyAddonsConfig.Containers, KubernetesContainerSpec{Name: AzureVnetTelemetryAddonName, Image: "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.28"})
 	}
 
+	defaultCloudNodeManagerAddonsConfig := KubernetesAddon{
+		Name: CloudNodeManagerAddonName,
+		Enabled: to.BoolPtr(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") &&
+			o.KubernetesConfig.UseCloudControllerManager != nil &&
+			*o.KubernetesConfig.UseCloudControllerManager),
+		Containers: []KubernetesContainerSpec{
+			{
+				Name:  CloudNodeManagerAddonName,
+				Image: specConfig.MCRKubernetesImageBase + k8sComponents[CloudNodeManagerAddonName],
+			},
+		},
+	}
+
 	defaultDNSAutoScalerAddonsConfig := KubernetesAddon{
 		Name: DNSAutoscalerAddonName,
 		// TODO enable this when it has been smoke tested
@@ -510,6 +523,7 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		defaultContainerMonitoringAddonsConfig,
 		defaultAzureCNINetworkMonitorAddonsConfig,
 		defaultAzureNetworkPolicyAddonsConfig,
+		defaultCloudNodeManagerAddonsConfig,
 		defaultIPMasqAgentAddonsConfig,
 		defaultDNSAutoScalerAddonsConfig,
 		defaultsCalicoDaemonSetAddonsConfig,

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -332,10 +332,8 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 	}
 
 	defaultCloudNodeManagerAddonsConfig := KubernetesAddon{
-		Name: CloudNodeManagerAddonName,
-		Enabled: to.BoolPtr(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") &&
-			o.KubernetesConfig.UseCloudControllerManager != nil &&
-			*o.KubernetesConfig.UseCloudControllerManager),
+		Name:    CloudNodeManagerAddonName,
+		Enabled: to.BoolPtr(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") && to.Bool(o.KubernetesConfig.UseCloudControllerManager)),
 		Containers: []KubernetesContainerSpec{
 			{
 				Name:  CloudNodeManagerAddonName,

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -378,6 +378,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -570,6 +574,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -767,6 +775,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -987,6 +999,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 				{
@@ -1229,6 +1245,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(false),
 				},
 				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
 					Name:    AzurePolicyAddonName,
 					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
 				},
@@ -1467,6 +1487,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(false),
 				},
 				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
 					Name:    AzurePolicyAddonName,
 					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
 				},
@@ -1692,6 +1716,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 				{
@@ -1938,6 +1966,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 				{
@@ -2188,6 +2220,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 				{
@@ -2496,6 +2532,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(false),
 				},
 				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
 					Name:    AzurePolicyAddonName,
 					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
 				},
@@ -2801,6 +2841,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(false),
 				},
 				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
 					Name:    AzurePolicyAddonName,
 					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
 				},
@@ -3064,6 +3108,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(false),
 				},
 				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
 					Name:    AzurePolicyAddonName,
 					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
 				},
@@ -3323,11 +3371,7 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(false),
 				},
 				{
-					Name:    AzureFileCSIDriverAddonName,
-					Enabled: to.BoolPtr(false),
-				},
-				{
-					Name:    AzureDiskCSIDriverAddonName,
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 				{
@@ -3525,6 +3569,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -3716,6 +3764,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -3904,6 +3956,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -4104,6 +4160,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -4290,6 +4350,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -4452,6 +4516,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -4632,6 +4700,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -4821,6 +4893,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -5015,6 +5091,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -5191,6 +5271,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 				{
@@ -5434,6 +5518,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -5637,6 +5725,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -5789,6 +5881,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -5948,6 +6044,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -6095,6 +6195,10 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    AzureDiskCSIDriverAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
 			},
 		},
 		{
@@ -6236,6 +6340,10 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 				{
 					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},
 			},
@@ -6445,6 +6553,438 @@ func TestSetAddonsConfig(t *testing.T) {
 					},
 				},
 				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AzurePolicyAddonName,
+					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
+				},
+			},
+		},
+		{
+			name: "azure cloud-node-manager enabled for k8s == 1.16 and useCloudControllerManager is true",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.16.2",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin:             NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: []KubernetesAddon{
+				{
+					Name:    HeapsterAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    TillerAddonName,
+					Enabled: to.BoolPtr(DefaultTillerAddonEnabled),
+				},
+				{
+					Name:    ACIConnectorAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    BlobfuseFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           BlobfuseFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8",
+						},
+					},
+				},
+				{
+					Name:    SMBFlexVolumeAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    KeyVaultFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           KeyVaultFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13",
+						},
+					},
+				},
+				{
+					Name:    DashboardAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           DashboardAddonName,
+							CPURequests:    "300m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "300m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.16.2"][DashboardAddonName],
+						},
+					},
+				},
+				{
+					Name:    ReschedulerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    MetricsServerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  MetricsServerAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.16.2"][MetricsServerAddonName],
+						},
+					},
+				},
+				{
+					Name:    NVIDIADevicePluginAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ContainerMonitoringAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + "ip-masq-agent-amd64:v2.5.0",
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr": DefaultVNETCIDR,
+						"non-masq-cni-cidr":   DefaultCNICIDR,
+						"enable-ipv6":         "false",
+					},
+				},
+				{
+					Name:    AzureCNINetworkMonitoringAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  AzureCNINetworkMonitoringAddonName,
+							Image: specConfig.AzureCNIImageBase + K8sComponentsByVersionMap["1.16.2"][AzureCNINetworkMonitoringAddonName],
+						},
+					},
+				},
+				{
+					Name:    AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CalicoAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AADPodIdentityAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  "csi-provisioner",
+							Image: "quay.io/k8scsi/csi-provisioner:v1.0.1",
+						},
+						{
+							Name:  "csi-attacher",
+							Image: "quay.io/k8scsi/csi-attacher:v1.0.1",
+						},
+						{
+							Name:  "csi-cluster-driver-registrar",
+							Image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1",
+						},
+						{
+							Name:  "livenessprobe",
+							Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+						},
+						{
+							Name:  "csi-node-driver-registrar",
+							Image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+						},
+						{
+							Name:  "azurefile-csi",
+							Image: "mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0",
+						},
+					},
+				},
+				{
+					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  "csi-provisioner",
+							Image: "quay.io/k8scsi/csi-provisioner:v1.0.1",
+						},
+						{
+							Name:  "csi-attacher",
+							Image: "quay.io/k8scsi/csi-attacher:v1.0.1",
+						},
+						{
+							Name:  "csi-cluster-driver-registrar",
+							Image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1",
+						},
+						{
+							Name:  "livenessprobe",
+							Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+						},
+						{
+							Name:  "csi-node-driver-registrar",
+							Image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+						},
+						{
+							Name:  "azuredisk-csi",
+							Image: "mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.4.0",
+						},
+					},
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(true),
+				},
+				{
+					Name:    AzurePolicyAddonName,
+					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
+				},
+			},
+		},
+		{
+			name: "azure cloud-node-manager enabled for k8s >= 1.17.0",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.17.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin:             NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: []KubernetesAddon{
+				{
+					Name:    HeapsterAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    TillerAddonName,
+					Enabled: to.BoolPtr(DefaultTillerAddonEnabled),
+				},
+				{
+					Name:    ACIConnectorAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    BlobfuseFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           BlobfuseFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8",
+						},
+					},
+				},
+				{
+					Name:    SMBFlexVolumeAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    KeyVaultFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           KeyVaultFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13",
+						},
+					},
+				},
+				{
+					Name:    DashboardAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           DashboardAddonName,
+							CPURequests:    "300m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "300m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.17.0"][DashboardAddonName],
+						},
+					},
+				},
+				{
+					Name:    ReschedulerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    MetricsServerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  MetricsServerAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.17.0"][MetricsServerAddonName],
+						},
+					},
+				},
+				{
+					Name:    NVIDIADevicePluginAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ContainerMonitoringAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + "ip-masq-agent-amd64:v2.5.0",
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr": DefaultVNETCIDR,
+						"non-masq-cni-cidr":   DefaultCNICIDR,
+						"enable-ipv6":         "false",
+					},
+				},
+				{
+					Name:    AzureCNINetworkMonitoringAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  AzureCNINetworkMonitoringAddonName,
+							Image: specConfig.AzureCNIImageBase + K8sComponentsByVersionMap["1.17.0"][AzureCNINetworkMonitoringAddonName],
+						},
+					},
+				},
+				{
+					Name:    AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CalicoAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AADPodIdentityAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  "csi-provisioner",
+							Image: "quay.io/k8scsi/csi-provisioner:v1.0.1",
+						},
+						{
+							Name:  "csi-attacher",
+							Image: "quay.io/k8scsi/csi-attacher:v1.0.1",
+						},
+						{
+							Name:  "csi-cluster-driver-registrar",
+							Image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1",
+						},
+						{
+							Name:  "livenessprobe",
+							Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+						},
+						{
+							Name:  "csi-node-driver-registrar",
+							Image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+						},
+						{
+							Name:  "azurefile-csi",
+							Image: "mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0",
+						},
+					},
+				},
+				{
+					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  "csi-provisioner",
+							Image: "quay.io/k8scsi/csi-provisioner:v1.0.1",
+						},
+						{
+							Name:  "csi-attacher",
+							Image: "quay.io/k8scsi/csi-attacher:v1.0.1",
+						},
+						{
+							Name:  "csi-cluster-driver-registrar",
+							Image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1",
+						},
+						{
+							Name:  "livenessprobe",
+							Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+						},
+						{
+							Name:  "csi-node-driver-registrar",
+							Image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+						},
+						{
+							Name:  "azuredisk-csi",
+							Image: "mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.4.0",
+						},
+					},
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(true),
+				},
+				{
 					Name:    AzurePolicyAddonName,
 					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
 				},
@@ -6479,6 +7019,7 @@ func TestSetAddonsConfig(t *testing.T) {
 				AzurePolicyAddonName,
 				AzureFileCSIDriverAddonName,
 				AzureDiskCSIDriverAddonName,
+				CloudNodeManagerAddonName,
 			} {
 				addon := test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons[getAddonsIndexByName(test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons, addonName)]
 				expectedAddon := test.expectedAddons[getAddonsIndexByName(test.expectedAddons, addonName)]

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -3100,14 +3100,6 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(false),
 				},
 				{
-					Name:    AzureFileCSIDriverAddonName,
-					Enabled: to.BoolPtr(false),
-				},
-				{
-					Name:    AzureDiskCSIDriverAddonName,
-					Enabled: to.BoolPtr(false),
-				},
-				{
 					Name:    CloudNodeManagerAddonName,
 					Enabled: to.BoolPtr(false),
 				},

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -435,6 +435,8 @@ const (
 	AzureCNINetworkMonitoringAddonName = "azure-cni-networkmonitor"
 	// AzureNetworkPolicyAddonName is the name of the Azure network policy manager addon
 	AzureNetworkPolicyAddonName = "azure-npm-daemonset"
+	// CloudNodeManagerAddonName is the name of the cloud node manager addon
+	CloudNodeManagerAddonName = "cloud-node-manager"
 	// AzureVnetTelemetryAddonName is the name of the Azure vnet telemetry addon
 	AzureVnetTelemetryAddonName = "azure-vnet-telemetry-daemonset"
 	// DefaultMasterEtcdClientPort is the default etcd client port for Kubernetes master nodes

--- a/pkg/api/defaults-cloud-controller-manager.go
+++ b/pkg/api/defaults-cloud-controller-manager.go
@@ -5,6 +5,8 @@ package api
 
 import (
 	"strconv"
+
+	"github.com/Azure/aks-engine/pkg/api/common"
 )
 
 func (cs *ContainerService) setCloudControllerManagerConfig() {
@@ -12,7 +14,6 @@ func (cs *ContainerService) setCloudControllerManagerConfig() {
 	staticCloudControllerManagerConfig := map[string]string{
 		"--allocate-node-cidrs":         strconv.FormatBool(!o.IsAzureCNI()),
 		"--configure-cloud-routes":      strconv.FormatBool(o.RequireRouteTable()),
-		"--controllers":                 "*,-cloud-node",
 		"--cloud-provider":              "azure",
 		"--cloud-config":                "/etc/kubernetes/azure.json",
 		"--cluster-cidr":                o.KubernetesConfig.ClusterSubnet,
@@ -20,6 +21,11 @@ func (cs *ContainerService) setCloudControllerManagerConfig() {
 		"--leader-elect":                "true",
 		"--route-reconciliation-period": "10s",
 		"--v":                           "2",
+	}
+
+	// Add new arguments for Azure cloud-controller-manager component.
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
+		staticCloudControllerManagerConfig["--controllers"] = "*,-cloud-node"
 	}
 
 	// Set --cluster-name based on appropriate DNS prefix

--- a/pkg/api/defaults-cloud-controller-manager.go
+++ b/pkg/api/defaults-cloud-controller-manager.go
@@ -25,7 +25,7 @@ func (cs *ContainerService) setCloudControllerManagerConfig() {
 
 	// Add new arguments for Azure cloud-controller-manager component.
 	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
-		staticCloudControllerManagerConfig["--controllers"] = "*,-cloud-node"
+		staticCloudControllerManagerConfig["--controllers"] = "*"
 	}
 
 	// Set --cluster-name based on appropriate DNS prefix

--- a/pkg/api/defaults-cloud-controller-manager.go
+++ b/pkg/api/defaults-cloud-controller-manager.go
@@ -10,14 +10,16 @@ import (
 func (cs *ContainerService) setCloudControllerManagerConfig() {
 	o := cs.Properties.OrchestratorProfile
 	staticCloudControllerManagerConfig := map[string]string{
-		"--allocate-node-cidrs":    strconv.FormatBool(!o.IsAzureCNI()),
-		"--configure-cloud-routes": strconv.FormatBool(o.RequireRouteTable()),
-		"--cloud-provider":         "azure",
-		"--cloud-config":           "/etc/kubernetes/azure.json",
-		"--cluster-cidr":           o.KubernetesConfig.ClusterSubnet,
-		"--kubeconfig":             "/var/lib/kubelet/kubeconfig",
-		"--leader-elect":           "true",
-		"--v":                      "2",
+		"--allocate-node-cidrs":         strconv.FormatBool(!o.IsAzureCNI()),
+		"--configure-cloud-routes":      strconv.FormatBool(o.RequireRouteTable()),
+		"--controllers":                 "*,-cloud-node",
+		"--cloud-provider":              "azure",
+		"--cloud-config":                "/etc/kubernetes/azure.json",
+		"--cluster-cidr":                o.KubernetesConfig.ClusterSubnet,
+		"--kubeconfig":                  "/var/lib/kubelet/kubeconfig",
+		"--leader-elect":                "true",
+		"--route-reconciliation-period": "10s",
+		"--v":                           "2",
 	}
 
 	// Set --cluster-name based on appropriate DNS prefix

--- a/pkg/api/defaults-cloud-controller-manager_test.go
+++ b/pkg/api/defaults-cloud-controller-manager_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package api
+
+import (
+	"testing"
+)
+
+func TestCloudControllerManagerConfig(t *testing.T) {
+	k8sVersion := "1.16.2"
+	cs := CreateMockContainerService("testcluster", k8sVersion, 3, 2, false)
+	cs.setCloudControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig
+	if cm["--controllers"] != "*,-cloud-node" {
+		t.Fatalf("got unexpected '--controllers' Cloud Controller Manager config value for Kubernetes %s: %s",
+			k8sVersion, cm["--controllers"])
+	}
+
+	k8sVersion = "1.15.5"
+	cs = CreateMockContainerService("testcluster", k8sVersion, 3, 2, false)
+	cs.setCloudControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig
+	if val, ok := cm["--controllers"]; ok {
+		t.Fatalf("got unexpected '--controllers' Cloud Controller Manager config value for Kubernetes %s: %s",
+			k8sVersion, val)
+	}
+}

--- a/pkg/api/defaults-cloud-controller-manager_test.go
+++ b/pkg/api/defaults-cloud-controller-manager_test.go
@@ -12,7 +12,7 @@ func TestCloudControllerManagerConfig(t *testing.T) {
 	cs := CreateMockContainerService("testcluster", k8sVersion, 3, 2, false)
 	cs.setCloudControllerManagerConfig()
 	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig
-	if cm["--controllers"] != "*,-cloud-node" {
+	if cm["--controllers"] != "*" {
 		t.Fatalf("got unexpected '--controllers' Cloud Controller Manager config value for Kubernetes %s: %s",
 			k8sVersion, cm["--controllers"])
 	}

--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -36,6 +36,8 @@ func (cs *ContainerService) setControllerManagerConfig() {
 	if !to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
 		staticControllerManagerConfig["--cloud-provider"] = "azure"
 		staticControllerManagerConfig["--cloud-config"] = "/etc/kubernetes/azure.json"
+	} else {
+		staticControllerManagerConfig["--cloud-provider"] = "external"
 	}
 
 	// Default controller-manager config

--- a/pkg/api/defaults-controller-manager_test.go
+++ b/pkg/api/defaults-controller-manager_test.go
@@ -29,8 +29,30 @@ func TestControllerManagerConfigEnableRbac(t *testing.T) {
 		t.Fatalf("got unexpected '--use-service-account-credentials' Controller Manager config value for EnableRbac=false: %s",
 			cm["--use-service-account-credentials"])
 	}
-
 }
+
+func TestControllerManagerConfigCloudProvider(t *testing.T) {
+	// Test UseCloudControllerManager = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--cloud-provider"] != "external" {
+		t.Fatalf("got unexpected '--cloud-provider' Controller Manager config value for UseCloudControllerManager=true: %s",
+			cm["--cloud-provider"])
+	}
+
+	// Test UseCloudControllerManager = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--cloud-provider"] != "azure" {
+		t.Fatalf("got unexpected '--cloud-provider' Controller Manager config value for UseCloudControllerManager=false: %s",
+			cm["--cloud-provider"])
+	}
+}
+
 func TestControllerManagerConfigEnableProfiling(t *testing.T) {
 	// Test
 	// "controllerManagerConfig": {

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -235,6 +235,11 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			o.KubernetesConfig.ServiceCIDR = DefaultKubernetesServiceCIDR
 		}
 
+		// K8s 1.17 and later require Azure cloud-controller-manager components
+		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.17.0-alpha.1") {
+			o.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
+		}
+
 		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
 			o.KubernetesConfig.CloudProviderBackoffMode = CloudProviderBackoffModeV2
 			if o.KubernetesConfig.CloudProviderBackoff == nil {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1983,6 +1983,22 @@ func TestEnableAggregatedAPIs(t *testing.T) {
 	}
 }
 
+func TestCloudControllerManagerEnabled(t *testing.T) {
+	// test that 1.16 defaults to false
+	cs := CreateMockContainerService("testcluster", "1.16.2", 3, 2, false)
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager == to.BoolPtr(true) {
+		t.Fatal("expected UseCloudControllerManager to default to false")
+	}
+
+	// test that 1.17 defaults to true
+	cs = CreateMockContainerService("testcluster", "1.17.0", 3, 2, false)
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager == to.BoolPtr(false) {
+		t.Fatal("expected UseCloudControllerManager to default to true")
+	}
+}
+
 func TestDefaultCloudProvider(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -484,7 +484,8 @@ func getK8sVersionComponents(version string, overrides map[string]string) map[st
 	case "1.17":
 		ret = map[string]string{
 			"hyperkube":                        "hyperkube-amd64:v" + version,
-			"ccm":                              "cloud-controller-manager-amd64:v" + version,
+			"ccm":                              "azure-cloud-controller-manager:v0.3.0",
+			CloudNodeManagerAddonName:          "azure-cloud-node-manager:v0.3.0",
 			"windowszip":                       "v" + version + "-1int.zip",
 			DashboardAddonName:                 k8sComponent["dashboard"],
 			"exechealthz":                      k8sComponent["exechealthz"],
@@ -522,7 +523,8 @@ func getK8sVersionComponents(version string, overrides map[string]string) map[st
 	case "1.16":
 		ret = map[string]string{
 			"hyperkube":                        "hyperkube-amd64:v" + version,
-			"ccm":                              "cloud-controller-manager-amd64:v" + version,
+			"ccm":                              "azure-cloud-controller-manager:v0.3.0",
+			CloudNodeManagerAddonName:          "azure-cloud-node-manager:v0.3.0",
 			"windowszip":                       "v" + version + "-1int.zip",
 			DashboardAddonName:                 k8sComponent["dashboard"],
 			"exechealthz":                      k8sComponent["exechealthz"],

--- a/pkg/api/k8s_versions_test.go
+++ b/pkg/api/k8s_versions_test.go
@@ -19,7 +19,8 @@ func TestGetK8sVersionComponents(t *testing.T) {
 	k8sComponent := k8sComponentVersions["1.17"]
 	expected := map[string]string{
 		"hyperkube":                        "hyperkube-amd64:v1.17.0",
-		"ccm":                              "cloud-controller-manager-amd64:v1.17.0",
+		"ccm":                              "azure-cloud-controller-manager:v0.3.0",
+		CloudNodeManagerAddonName:          "azure-cloud-node-manager:v0.3.0",
 		"windowszip":                       "v1.17.0-1int.zip",
 		DashboardAddonName:                 k8sComponent["dashboard"],
 		"exechealthz":                      k8sComponent["exechealthz"],
@@ -63,7 +64,8 @@ func TestGetK8sVersionComponents(t *testing.T) {
 	k8sComponent = k8sComponentVersions["1.16"]
 	expected = map[string]string{
 		"hyperkube":                        "hyperkube-amd64:v1.16.0",
-		"ccm":                              "cloud-controller-manager-amd64:v1.16.0",
+		"ccm":                              "azure-cloud-controller-manager:v0.3.0",
+		CloudNodeManagerAddonName:          "azure-cloud-node-manager:v0.3.0",
 		"windowszip":                       "v1.16.0-1int.zip",
 		DashboardAddonName:                 k8sComponent["dashboard"],
 		"exechealthz":                      k8sComponent["exechealthz"],

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -716,6 +716,15 @@ func (a *Properties) validateAddons() error {
 						return errors.New(fmt.Sprintf("%s add-on requires useCloudControllerManager to be true.", addon.Name))
 					}
 				}
+			case "cloud-node-manager":
+				if to.Bool(addon.Enabled) {
+					if !common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.16.0") {
+						return errors.New(fmt.Sprintf("%s add-on can only be used Kubernetes 1.16 or above", addon.Name))
+					}
+					if !to.Bool(a.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) {
+						return errors.New(fmt.Sprintf("%s add-on requires useCloudControllerManager to be true.", addon.Name))
+					}
+				}
 			case "azure-policy":
 				if to.Bool(addon.Enabled) {
 					isValidVersion, err := common.IsValidMinVersion(a.OrchestratorProfile.OrchestratorType, a.OrchestratorProfile.OrchestratorRelease, a.OrchestratorProfile.OrchestratorVersion, "1.10.0")

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -713,7 +713,7 @@ func (a *Properties) validateAddons() error {
 						return errors.New(fmt.Sprintf("%s add-on can only be used Kubernetes 1.13 or above", addon.Name))
 					}
 					if !to.Bool(a.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) {
-						return errors.New(fmt.Sprintf("%s add-on requires useCloudControllerManager to be true.", addon.Name))
+						return errors.New(fmt.Sprintf("%s add-on requires useCloudControllerManager to be true", addon.Name))
 					}
 				}
 			case "cloud-node-manager":
@@ -722,7 +722,12 @@ func (a *Properties) validateAddons() error {
 						return errors.New(fmt.Sprintf("%s add-on can only be used Kubernetes 1.16 or above", addon.Name))
 					}
 					if !to.Bool(a.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) {
-						return errors.New(fmt.Sprintf("%s add-on requires useCloudControllerManager to be true.", addon.Name))
+						return errors.New(fmt.Sprintf("%s add-on requires useCloudControllerManager to be true", addon.Name))
+					}
+				} else {
+					if to.Bool(a.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) &&
+						common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.16.0") {
+						return errors.New(fmt.Sprintf("%s add-on is required when useCloudControllerManager is true in Kubernetes 1.16 or above", addon.Name))
 					}
 				}
 			case "azure-policy":

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1952,6 +1952,75 @@ func Test_Properties_ValidateAddons(t *testing.T) {
 			"should not error when useCloudControllerManager is enabled and k8s version is >= 1.13 for azurefile-csi-driver",
 		)
 	}
+
+	// Basic tests for cloud-node-manager
+	p.OrchestratorProfile.OrchestratorVersion = "1.15.5"
+	p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		UseCloudControllerManager: to.BoolPtr(true),
+		Addons: []KubernetesAddon{
+			{
+				Name:    "cloud-node-manager",
+				Enabled: to.BoolPtr(true),
+			},
+		},
+	}
+
+	if err := p.validateAddons(); err == nil {
+		t.Errorf(
+			"should error when the orchestrator version is less than 1.16.0 for cloud-node-manager",
+		)
+	}
+
+	p.OrchestratorProfile.OrchestratorVersion = "1.16.2"
+	p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		UseCloudControllerManager: to.BoolPtr(false),
+		Addons: []KubernetesAddon{
+			{
+				Name:    "cloud-node-manager",
+				Enabled: to.BoolPtr(true),
+			},
+		},
+	}
+
+	if err := p.validateAddons(); err == nil {
+		t.Errorf(
+			"should error when useCloudControllerManager is disabled for cloud-node-manager",
+		)
+	}
+
+	p.OrchestratorProfile.OrchestratorVersion = "1.17.0"
+	p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		UseCloudControllerManager: to.BoolPtr(true),
+		Addons: []KubernetesAddon{
+			{
+				Name:    "cloud-node-manager",
+				Enabled: to.BoolPtr(false),
+			},
+		},
+	}
+
+	if err := p.validateAddons(); err == nil {
+		t.Errorf(
+			"should error when useCloudControllerManager is enabled and cloud-node-manager isn't",
+		)
+	}
+
+	p.OrchestratorProfile.OrchestratorVersion = "1.17.0"
+	p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{
+		UseCloudControllerManager: to.BoolPtr(true),
+		Addons: []KubernetesAddon{
+			{
+				Name:    "cloud-node-manager",
+				Enabled: to.BoolPtr(true),
+			},
+		},
+	}
+
+	if err := p.validateAddons(); err != nil {
+		t.Errorf(
+			"should not error when useCloudControllerManager is enabled and k8s version is >= 1.16 for cloud-node-manager",
+		)
+	}
 }
 
 func TestWindowsVersions(t *testing.T) {

--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -158,6 +158,12 @@ func kubernetesContainerAddonSettingsInit(p *api.Properties) map[string]kubernet
 			destinationFile: "azure-policy-deployment.yaml",
 			isEnabled:       k.IsAddonEnabled(AzurePolicyAddonName),
 		},
+		CloudNodeManagerAddonName: {
+			sourceFile:      "kubernetesmasteraddons-cloud-node-manager.yaml",
+			base64Data:      "",
+			destinationFile: "cloud-node-manager.yaml",
+			isEnabled:       k.IsAddonEnabled(CloudNodeManagerAddonName),
+		},
 	}
 }
 

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -52,6 +52,8 @@ const (
 	AzureStorageClassesAddonName = "azure-storage-classes"
 	// AzureNetworkPolicyAddonName is the name of the azure npm daemon set addon
 	AzureNetworkPolicyAddonName = "azure-npm-daemonset"
+	// CloudNodeManagerAddonName is the name of the cloud node manager addon
+	CloudNodeManagerAddonName = "cloud-node-manager"
 	// AzureVnetTelemetryAddonName is the name of the Azure vnet telemetry addon
 	AzureVnetTelemetryAddonName = "azure-vnet-telemetry-daemonset"
 	// CalicoAddonName is the name of calico daemonset addon

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -33,7 +33,11 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 
 		if kubernetesConfig != nil {
 			if to.Bool(kubernetesConfig.UseCloudControllerManager) {
-				kubernetesCcmSpec := kubernetesImageBase + k8sComponents["ccm"]
+				controllerManagerBase := kubernetesImageBase
+				if common.IsKubernetesVersionGe(k8sVersion, "1.16.0") {
+					controllerManagerBase = mcrKubernetesImageBase
+				}
+				kubernetesCcmSpec := controllerManagerBase + k8sComponents["ccm"]
 				if kubernetesConfig.CustomCcmImage != "" {
 					kubernetesCcmSpec = kubernetesConfig.CustomCcmImage
 				}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -148,6 +148,7 @@
 // ../../parts/k8s/containeraddons/1.17/kubernetesmasteraddons-azure-npm-daemonset.yaml
 // ../../parts/k8s/containeraddons/1.17/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
 // ../../parts/k8s/containeraddons/1.17/kubernetesmasteraddons-calico-daemonset.yaml
+// ../../parts/k8s/containeraddons/1.17/kubernetesmasteraddons-cloud-node-manager.yaml
 // ../../parts/k8s/containeraddons/1.17/kubernetesmasteraddons-cluster-autoscaler-deployment.yaml
 // ../../parts/k8s/containeraddons/1.17/kubernetesmasteraddons-heapster-deployment.yaml
 // ../../parts/k8s/containeraddons/1.17/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -25343,6 +25344,109 @@ func k8sContaineraddons117KubernetesmasteraddonsCalicoDaemonsetYaml() (*asset, e
 	return a, nil
 }
 
+var _k8sContaineraddons117KubernetesmasteraddonsCloudNodeManagerYaml = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: cloud-node-manager
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-node-manager
+  labels:
+    k8s-app: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch","list","get","update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-node-manager
+  labels:
+    k8s-app: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-node-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-node-manager
+  namespace: kube-system
+  labels:
+    component: cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cloud-node-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: cloud-node-manager
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: cloud-node-manager
+      hostNetwork: true   # required to fetch correct hostname
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - operator: "Exists"
+        effect: NoExecute
+      - operator: "Exists"
+        effect: NoSchedule
+      containers:
+      - name: cloud-node-manager
+        image: {{ContainerImage "cloud-node-manager"}}
+        imagePullPolicy: IfNotPresent
+        command: ["cloud-node-manager"]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+`)
+
+func k8sContaineraddons117KubernetesmasteraddonsCloudNodeManagerYamlBytes() ([]byte, error) {
+	return _k8sContaineraddons117KubernetesmasteraddonsCloudNodeManagerYaml, nil
+}
+
+func k8sContaineraddons117KubernetesmasteraddonsCloudNodeManagerYaml() (*asset, error) {
+	bytes, err := k8sContaineraddons117KubernetesmasteraddonsCloudNodeManagerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "k8s/containeraddons/1.17/kubernetesmasteraddons-cloud-node-manager.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _k8sContaineraddons117KubernetesmasteraddonsClusterAutoscalerDeploymentYaml = []byte(`---
 apiVersion: v1
 kind: ServiceAccount
@@ -33876,17 +33980,24 @@ spec:
       imagePullPolicy: IfNotPresent
       command: ["cloud-controller-manager"]
       args: [<config>]
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 4
+          memory: 2Gi
       volumeMounts:
-        - name: etc-kubernetes
-          mountPath: /etc/kubernetes
-        - name: etc-ssl
-          mountPath: /etc/ssl
-          readOnly: true
-        - name: var-lib-kubelet
-          mountPath: /var/lib/kubelet
-        - name: msi
-          mountPath: /var/lib/waagent/ManagedIdentity-Settings
-          readOnly: true
+      - name: etc-kubernetes
+        mountPath: /etc/kubernetes
+      - name: etc-ssl
+        mountPath: /etc/ssl
+        readOnly: true
+      - name: var-lib-kubelet
+        mountPath: /var/lib/kubelet
+      - name: msi
+        mountPath: /var/lib/waagent/ManagedIdentity-Settings
+        readOnly: true
   volumes:
     - name: etc-kubernetes
       hostPath:
@@ -38999,6 +39110,7 @@ var _bindata = map[string]func() (*asset, error){
 	"k8s/containeraddons/1.17/kubernetesmasteraddons-azure-npm-daemonset.yaml":             k8sContaineraddons117KubernetesmasteraddonsAzureNpmDaemonsetYaml,
 	"k8s/containeraddons/1.17/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml":   k8sContaineraddons117KubernetesmasteraddonsBlobfuseFlexvolumeInstallerYaml,
 	"k8s/containeraddons/1.17/kubernetesmasteraddons-calico-daemonset.yaml":                k8sContaineraddons117KubernetesmasteraddonsCalicoDaemonsetYaml,
+	"k8s/containeraddons/1.17/kubernetesmasteraddons-cloud-node-manager.yaml":              k8sContaineraddons117KubernetesmasteraddonsCloudNodeManagerYaml,
 	"k8s/containeraddons/1.17/kubernetesmasteraddons-cluster-autoscaler-deployment.yaml":   k8sContaineraddons117KubernetesmasteraddonsClusterAutoscalerDeploymentYaml,
 	"k8s/containeraddons/1.17/kubernetesmasteraddons-heapster-deployment.yaml":             k8sContaineraddons117KubernetesmasteraddonsHeapsterDeploymentYaml,
 	"k8s/containeraddons/1.17/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml":   k8sContaineraddons117KubernetesmasteraddonsKeyvaultFlexvolumeInstallerYaml,
@@ -39300,6 +39412,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"kubernetesmasteraddons-azure-npm-daemonset.yaml":             {k8sContaineraddons117KubernetesmasteraddonsAzureNpmDaemonsetYaml, map[string]*bintree{}},
 				"kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml":   {k8sContaineraddons117KubernetesmasteraddonsBlobfuseFlexvolumeInstallerYaml, map[string]*bintree{}},
 				"kubernetesmasteraddons-calico-daemonset.yaml":                {k8sContaineraddons117KubernetesmasteraddonsCalicoDaemonsetYaml, map[string]*bintree{}},
+				"kubernetesmasteraddons-cloud-node-manager.yaml":              {k8sContaineraddons117KubernetesmasteraddonsCloudNodeManagerYaml, map[string]*bintree{}},
 				"kubernetesmasteraddons-cluster-autoscaler-deployment.yaml":   {k8sContaineraddons117KubernetesmasteraddonsClusterAutoscalerDeploymentYaml, map[string]*bintree{}},
 				"kubernetesmasteraddons-heapster-deployment.yaml":             {k8sContaineraddons117KubernetesmasteraddonsHeapsterDeploymentYaml, map[string]*bintree{}},
 				"kubernetesmasteraddons-keyvault-flexvolume-installer.yaml":   {k8sContaineraddons117KubernetesmasteraddonsKeyvaultFlexvolumeInstallerYaml, map[string]*bintree{}},

--- a/pkg/engine/testdata/key-vault-certs/kubernetes.json
+++ b/pkg/engine/testdata/key-vault-certs/kubernetes.json
@@ -318,6 +318,7 @@
           "--cluster-cidr": "10.240.0.0/12",
           "--cluster-name": "kubernetes-southcentralus-7764",
           "--configure-cloud-routes": "false",
+          "--controllers": "*,-cloud-node",
           "--kubeconfig": "/var/lib/kubelet/kubeconfig",
           "--leader-elect": "true",
           "--route-reconciliation-period": "10s",

--- a/pkg/engine/testdata/key-vault-certs/kubernetes.json
+++ b/pkg/engine/testdata/key-vault-certs/kubernetes.json
@@ -318,7 +318,6 @@
           "--cluster-cidr": "10.240.0.0/12",
           "--cluster-name": "kubernetes-southcentralus-7764",
           "--configure-cloud-routes": "false",
-          "--controllers": "*,-cloud-node",
           "--kubeconfig": "/var/lib/kubelet/kubeconfig",
           "--leader-elect": "true",
           "--route-reconciliation-period": "10s",

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -710,6 +710,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if !common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.13.0") {
 				coreComponents = append(coreComponents, "heapster")
 			}
+			if common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.0-alpha.1") {
+				coreComponents = append(coreComponents, "cloud-controller-manager", "cloud-node-manager", "csi-azuredisk-controller", "csi-azurefile-controller")
+			}
 			for _, componentName := range coreComponents {
 				By(fmt.Sprintf("Ensuring that %s is Running", componentName))
 				running, err := pod.WaitOnSuccesses(componentName, "kube-system", kubeSystemPodsReadinessChecks, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1787,6 +1787,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should be able to attach azure file", func() {
 			if eng.HasWindowsAgents() {
 				orchestratorVersion := eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion
+				if common.IsKubernetesVersionGe(orchestratorVersion, "1.17.0-alpha.1") {
+					Skip("Azure disk and file CSI drivers are not yet supported on Windows")
+				}
 				if orchestratorVersion == "1.11.0" {
 					// Failure in 1.11.0 - https://github.com/kubernetes/kubernetes/issues/65845, fixed in 1.11.1
 					Skip("Kubernetes 1.11.0 has a known issue creating Azure PersistentVolumeClaim")

--- a/test/e2e/kubernetes/workloads/storageclass-azurefile-external.yaml
+++ b/test/e2e/kubernetes/workloads/storageclass-azurefile-external.yaml
@@ -1,0 +1,8 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: azurefile
+provisioner: file.csi.azure.com
+parameters:
+  skuName: Standard_LRS


### PR DESCRIPTION
**Reason for Change**:
Switches to the [out-of-tree cloud provider components](https://github.com/kubernetes/cloud-provider-azure/releases) if `useCloudControllerManager` is enabled and the Kubernetes version is 1.16.x or later. These components are considered alpha status currently but intended to become the default by 1.17 final release (early December!).

**Issue Fixed**:
Fixes #1915


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
The cloud-controller-manager is deployed as a [static pod manifest](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/) as it already was, and the cloud-node-manager is deployed as an addon. This is odd but I would argue the best we can do, but I'm open to feedback.
