### PR TITLE
chore: rev VHD images to 2019.10.15

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -154,7 +154,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1604-201910",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2019.10.09",
+		ImageVersion:   "2019.10.15",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
@@ -162,7 +162,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1804-201910",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2019.10.09",
+		ImageVersion:   "2019.10.15",
 	}
 
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019

--- a/releases/vhd-notes/aks-ubuntu-1604/aks-ubuntu-1604-201910_2019.10.15.txt
+++ b/releases/vhd-notes/aks-ubuntu-1604/aks-ubuntu-1604-201910_2019.10.15.txt
@@ -1,0 +1,173 @@
+Starting build on  Wed Oct 16 00:08:28 UTC 2019
+Using kernel:
+Linux version 4.15.0-1057-azure (buildd@lgw01-amd64-035) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.10)) #62-Ubuntu SMP Thu Sep 5 18:25:30 UTC 2019
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - etcd v3.3.15
+  - moby v3.0.7
+  - nvidia-docker2 nvidia-container-runtime
+  - Azure CNI version 1.0.28
+  - Azure CNI version 1.0.27
+  - CNI plugin version 0.7.5
+  - CNI plugin version 0.7.1
+  - containerd version 1.2.4
+  - containerd version 1.1.6
+  - containerd version 1.1.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - k8s.gcr.io/exechealthz-amd64:1.2
+  - k8s.gcr.io/addon-resizer:1.8.5
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - k8s.gcr.io/addon-resizer:1.8.1
+  - k8s.gcr.io/addon-resizer:1.7
+  - k8s.gcr.io/heapster-amd64:v1.5.4
+  - k8s.gcr.io/heapster-amd64:v1.5.3
+  - k8s.gcr.io/heapster-amd64:v1.5.1
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.8
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.7
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.6
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - mcr.microsoft.com/k8s/azurestack/core/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - gcr.io/kubernetes-helm/tiller:v2.11.0
+  - gcr.io/kubernetes-helm/tiller:v2.8.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.0
+  - k8s.gcr.io/cluster-autoscaler:v1.15.2
+  - k8s.gcr.io/cluster-autoscaler:v1.15.1
+  - k8s.gcr.io/cluster-autoscaler:v1.15.0
+  - k8s.gcr.io/cluster-autoscaler:v1.14.5
+  - k8s.gcr.io/cluster-autoscaler:v1.14.4
+  - k8s.gcr.io/cluster-autoscaler:v1.14.2
+  - k8s.gcr.io/cluster-autoscaler:v1.14.0
+  - k8s.gcr.io/cluster-autoscaler:v1.13.7
+  - k8s.gcr.io/cluster-autoscaler:v1.13.6
+  - k8s.gcr.io/cluster-autoscaler:v1.13.4
+  - k8s.gcr.io/cluster-autoscaler:v1.13.2
+  - k8s.gcr.io/cluster-autoscaler:v1.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.12.8
+  - k8s.gcr.io/cluster-autoscaler:v1.12.7
+  - k8s.gcr.io/cluster-autoscaler:v1.12.5
+  - k8s.gcr.io/cluster-autoscaler:v1.12.3
+  - k8s.gcr.io/cluster-autoscaler:v1.12.2
+  - k8s.gcr.io/cluster-autoscaler:v1.3.9
+  - k8s.gcr.io/cluster-autoscaler:v1.3.8
+  - k8s.gcr.io/cluster-autoscaler:v1.3.7
+  - k8s.gcr.io/cluster-autoscaler:v1.3.4
+  - k8s.gcr.io/cluster-autoscaler:v1.3.3
+  - k8s.gcr.io/cluster-autoscaler:v1.2.5
+  - k8s.gcr.io/cluster-autoscaler:v1.2.2
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+  - k8s.gcr.io/coredns:1.6.2
+  - k8s.gcr.io/coredns:1.5.0
+  - k8s.gcr.io/coredns:1.3.1
+  - k8s.gcr.io/coredns:1.2.6
+  - k8s.gcr.io/coredns:1.2.2
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - k8s.gcr.io/rescheduler:v0.3.1
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.5
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.18
+  - nvidia/k8s-device-plugin:1.11
+  - nvidia/k8s-device-plugin:1.10
+  - docker.io/deis/hcp-tunnel-front:v1.9.2-v4.0.4
+  - docker.io/deis/kube-svc-redirect:v1.0.2
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.5.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.3.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.0.0
+  - nginx:1.13.12-alpine
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/hyperkube-amd64:v1.16.2
+  - k8s.gcr.io/hyperkube-amd64:v1.16.1
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.16.1-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.5
+  - k8s.gcr.io/hyperkube-amd64:v1.15.5
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.4
+  - k8s.gcr.io/hyperkube-amd64:v1.15.4
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.4-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+  - k8s.gcr.io/hyperkube-amd64:v1.14.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+  - k8s.gcr.io/hyperkube-amd64:v1.14.7
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.7-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+  - k8s.gcr.io/hyperkube-amd64:v1.13.12
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+  - k8s.gcr.io/hyperkube-amd64:v1.13.11
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.13.11-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.8
+  - k8s.gcr.io/hyperkube-amd64:v1.12.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.7
+  - k8s.gcr.io/hyperkube-amd64:v1.12.7
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.10
+  - k8s.gcr.io/hyperkube-amd64:v1.11.10
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.9
+  - k8s.gcr.io/hyperkube-amd64:v1.11.9
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.13
+  - k8s.gcr.io/hyperkube-amd64:v1.10.13
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.12
+  - k8s.gcr.io/hyperkube-amd64:v1.10.12
+  - registry:2.7.1
+WARNING: 75% of /dev/sda1 is used
+Install completed successfully on  Wed Oct 16 00:33:42 UTC 2019
+VSTS Build NUMBER: 20191015.10
+VSTS Build ID: 25863413
+Commit: 895fc9018c76ff5548dd6a0747a21a6816547a24
+Feature flags:

--- a/releases/vhd-notes/aks-ubuntu-1804/aks-ubuntu-1804-201910_2019.10.15.txt
+++ b/releases/vhd-notes/aks-ubuntu-1804/aks-ubuntu-1804-201910_2019.10.15.txt
@@ -1,0 +1,173 @@
+Starting build on  Wed Oct 16 00:09:32 UTC 2019
+Using kernel:
+Linux version 5.0.0-1018-azure (buildd@lgw01-amd64-048) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #19~18.04.1-Ubuntu SMP Wed Aug 21 05:13:05 UTC 2019
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - etcd v3.3.15
+  - moby v3.0.7
+  - nvidia-docker2 nvidia-container-runtime
+  - Azure CNI version 1.0.28
+  - Azure CNI version 1.0.27
+  - CNI plugin version 0.7.5
+  - CNI plugin version 0.7.1
+  - containerd version 1.2.4
+  - containerd version 1.1.6
+  - containerd version 1.1.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - k8s.gcr.io/exechealthz-amd64:1.2
+  - k8s.gcr.io/addon-resizer:1.8.5
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - k8s.gcr.io/addon-resizer:1.8.1
+  - k8s.gcr.io/addon-resizer:1.7
+  - k8s.gcr.io/heapster-amd64:v1.5.4
+  - k8s.gcr.io/heapster-amd64:v1.5.3
+  - k8s.gcr.io/heapster-amd64:v1.5.1
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.8
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.7
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.6
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - mcr.microsoft.com/k8s/azurestack/core/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - gcr.io/kubernetes-helm/tiller:v2.11.0
+  - gcr.io/kubernetes-helm/tiller:v2.8.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.0
+  - k8s.gcr.io/cluster-autoscaler:v1.15.2
+  - k8s.gcr.io/cluster-autoscaler:v1.15.1
+  - k8s.gcr.io/cluster-autoscaler:v1.15.0
+  - k8s.gcr.io/cluster-autoscaler:v1.14.5
+  - k8s.gcr.io/cluster-autoscaler:v1.14.4
+  - k8s.gcr.io/cluster-autoscaler:v1.14.2
+  - k8s.gcr.io/cluster-autoscaler:v1.14.0
+  - k8s.gcr.io/cluster-autoscaler:v1.13.7
+  - k8s.gcr.io/cluster-autoscaler:v1.13.6
+  - k8s.gcr.io/cluster-autoscaler:v1.13.4
+  - k8s.gcr.io/cluster-autoscaler:v1.13.2
+  - k8s.gcr.io/cluster-autoscaler:v1.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.12.8
+  - k8s.gcr.io/cluster-autoscaler:v1.12.7
+  - k8s.gcr.io/cluster-autoscaler:v1.12.5
+  - k8s.gcr.io/cluster-autoscaler:v1.12.3
+  - k8s.gcr.io/cluster-autoscaler:v1.12.2
+  - k8s.gcr.io/cluster-autoscaler:v1.3.9
+  - k8s.gcr.io/cluster-autoscaler:v1.3.8
+  - k8s.gcr.io/cluster-autoscaler:v1.3.7
+  - k8s.gcr.io/cluster-autoscaler:v1.3.4
+  - k8s.gcr.io/cluster-autoscaler:v1.3.3
+  - k8s.gcr.io/cluster-autoscaler:v1.2.5
+  - k8s.gcr.io/cluster-autoscaler:v1.2.2
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+  - k8s.gcr.io/coredns:1.6.2
+  - k8s.gcr.io/coredns:1.5.0
+  - k8s.gcr.io/coredns:1.3.1
+  - k8s.gcr.io/coredns:1.2.6
+  - k8s.gcr.io/coredns:1.2.2
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - k8s.gcr.io/rescheduler:v0.3.1
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.5
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.18
+  - nvidia/k8s-device-plugin:1.11
+  - nvidia/k8s-device-plugin:1.10
+  - docker.io/deis/hcp-tunnel-front:v1.9.2-v4.0.4
+  - docker.io/deis/kube-svc-redirect:v1.0.2
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.5.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.3.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.0.0
+  - nginx:1.13.12-alpine
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/hyperkube-amd64:v1.16.2
+  - k8s.gcr.io/hyperkube-amd64:v1.16.1
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.16.1-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.5
+  - k8s.gcr.io/hyperkube-amd64:v1.15.5
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.4
+  - k8s.gcr.io/hyperkube-amd64:v1.15.4
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.4-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+  - k8s.gcr.io/hyperkube-amd64:v1.14.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+  - k8s.gcr.io/hyperkube-amd64:v1.14.7
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.7-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+  - k8s.gcr.io/hyperkube-amd64:v1.13.12
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+  - k8s.gcr.io/hyperkube-amd64:v1.13.11
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.13.11-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.8
+  - k8s.gcr.io/hyperkube-amd64:v1.12.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.7
+  - k8s.gcr.io/hyperkube-amd64:v1.12.7
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.10
+  - k8s.gcr.io/hyperkube-amd64:v1.11.10
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.9
+  - k8s.gcr.io/hyperkube-amd64:v1.11.9
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.13
+  - k8s.gcr.io/hyperkube-amd64:v1.10.13
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.12
+  - k8s.gcr.io/hyperkube-amd64:v1.10.12
+  - registry:2.7.1
+WARNING: 75% of /dev/sda1 is used
+Install completed successfully on  Wed Oct 16 00:36:19 UTC 2019
+VSTS Build NUMBER: 20191015.11
+VSTS Build ID: 25863434
+Commit: 895fc9018c76ff5548dd6a0747a21a6816547a24
+Feature flags:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR delivers a PR w/ pre-downloaded hyperkube images for the following Kubernetes versions:

- v1.16.2
- v1.16.1 Azure Stack
- v1.15.5
- v1.14.8
- v1.13.12

No longer includes pre-pulled hyperkube images for these versions:

- v1.16.0
- v1.16.0 Azure Stack
- v1.15.3
- v1.15.3 Azure Stack
- v1.14.6
- v1.14.6 Azure Stack
- v1.13.10
- v1.13.10 Azure Stack

Pre-pulls the following container images:

- k8s.gcr.io/cloud-controller-manager-amd64:v1.15.5
- mcr.microsoft.com/k8s/core/pause:1.2.0

These images no longer pre-pulled:

- k8s.gcr.io/cloud-controller-manager-amd64:v1.15.3
- k8s.gcr.io/cloud-controller-manager-amd64:v1.14.6
- k8s.gcr.io/cloud-controller-manager-amd64:v1.13.10

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
