### PR TITLE
refactor: install kube- components without hyperkube for k8s 1.17+

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -425,7 +425,6 @@ for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     echo "  - ${HYPERKUBE_URL}" >> ${VHD_LOGS_FILEPATH}
   else
     for component in kube-apiserver kube-controller-manager kube-proxy kube-scheduler; do
-      # TODO: change base repo URL when Azure publishing is available
       CONTAINER_IMAGE="k8s.gcr.io/${component}:v${KUBERNETES_VERSION}"
       pullContainerImage "docker" ${CONTAINER_IMAGE}
       echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -431,7 +431,7 @@ for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
       echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
     done
   fi
-  if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 16 )); then
+  if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 16 )) && [[ $KUBERNETES_VERSION != *"azs"* ]]; then
     CONTAINER_IMAGE="k8s.gcr.io/cloud-controller-manager-amd64:v${KUBERNETES_VERSION}"
     pullContainerImage "docker" ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -395,7 +395,6 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="
-1.17.0-alpha.2
 1.16.2
 1.16.1
 1.16.1-azs

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -428,6 +428,8 @@ for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
       pullContainerImage "docker" ${CONTAINER_IMAGE}
       echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
     done
+    KUBE_BINARY_URL="https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"
+    extractKubeBinaries
   fi
   if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 16 )) && [[ $KUBERNETES_VERSION != *"azs"* ]]; then
     CONTAINER_IMAGE="k8s.gcr.io/cloud-controller-manager-amd64:v${KUBERNETES_VERSION}"

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -394,8 +394,8 @@ done
 pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
-# TODO: fetch supported k8s versions from an aks-engine command instead of hardcoding them here
 K8S_VERSIONS="
+1.17.0-alpha.2
 1.16.2
 1.16.1
 1.16.1-azs
@@ -415,18 +415,27 @@ K8S_VERSIONS="
 1.11.9
 "
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
-  if [[ $KUBERNETES_VERSION == *"azs"* ]]; then
-    HYPERKUBE_URL="mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v${KUBERNETES_VERSION}"
+  if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 17 )); then
+    if [[ $KUBERNETES_VERSION == *"azs"* ]]; then
+      HYPERKUBE_URL="mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v${KUBERNETES_VERSION}"
+    else
+      HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"
+    fi
+    extractHyperkube "docker"
+    echo "  - ${HYPERKUBE_URL}" >> ${VHD_LOGS_FILEPATH}
   else
-    HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"
-    if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 16 )); then
-      CONTAINER_IMAGE="k8s.gcr.io/cloud-controller-manager-amd64:v${KUBERNETES_VERSION}"
+    for component in kube-apiserver kube-controller-manager kube-proxy kube-scheduler; do
+      # TODO: change base repo URL when Azure publishing is available
+      CONTAINER_IMAGE="k8s.gcr.io/${component}:v${KUBERNETES_VERSION}"
       pullContainerImage "docker" ${CONTAINER_IMAGE}
       echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
-    fi
+    done
   fi
-  extractHyperkube "docker"
-  echo "  - ${HYPERKUBE_URL}" >> ${VHD_LOGS_FILEPATH}
+  if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 16 )); then
+    CONTAINER_IMAGE="k8s.gcr.io/cloud-controller-manager-amd64:v${KUBERNETES_VERSION}"
+    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+  fi
 done
 
 CLOUD_MANAGER_VERSIONS="

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -64,7 +64,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - command: ["/hyperkube", "kube-proxy", "--config=/var/lib/kube-proxy/config.yaml"]
+      - command:
+        - kube-proxy
+        - --config=/var/lib/kube-proxy/config.yaml
         image: <img>
         imagePullPolicy: IfNotPresent
         name: kube-proxy

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -64,10 +64,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - command:
-        - /hyperkube
-        - kube-proxy
-        - --config=/var/lib/kube-proxy/config.yaml
+      - command: ["/hyperkube", "kube-proxy", "--config=/var/lib/kube-proxy/config.yaml"]
         image: <img>
         imagePullPolicy: IfNotPresent
         name: kube-proxy

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -252,16 +252,19 @@ extractHyperkube() {
     fi
 }
 
+extractKubeBinaries() {
+    K8S_TGZ_TMP=$(echo ${KUBE_BINARY_URL} | cut -d "/" -f 5)
+    mkdir -p "${K8S_DOWNLOADS_DIR}"
+    retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${KUBE_BINARY_URL} || exit $ERR_K8S_DOWNLOAD_TIMEOUT
+    tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
+        --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
+    rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
+}
+
 installKubeletAndKubectl() {
     if [[ ! -f "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" ]]; then
         if version_gte ${KUBERNETES_VERSION} 1.17; then  # don't use hyperkube
-            K8S_DOWNLOAD_URL="https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"
-            K8S_TGZ_TMP=$(echo ${K8S_DOWNLOAD_URL} | cut -d "/" -f 5)
-            mkdir -p "${K8S_DOWNLOADS_DIR}"
-            retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${K8S_DOWNLOAD_URL} || exit $ERR_K8S_DOWNLOAD_TIMEOUT
-            tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
-                --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
-            rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
+            extractKubeBinaries
         else
             if [[ "$CONTAINER_RUNTIME" == "docker" ]]; then
                 extractHyperkube "docker"

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -253,6 +253,7 @@ extractHyperkube() {
 }
 
 extractKubeBinaries() {
+    KUBE_BINARY_URL=${KUBE_BINARY_URL:-"https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"}
     K8S_TGZ_TMP=$(echo ${KUBE_BINARY_URL} | cut -d "/" -f 5)
     mkdir -p "${K8S_DOWNLOADS_DIR}"
     retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${KUBE_BINARY_URL} || exit $ERR_K8S_DOWNLOAD_TIMEOUT

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -255,13 +255,12 @@ extractHyperkube() {
 installKubeletAndKubectl() {
     if [[ ! -f "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" ]]; then
         if version_gte ${KUBERNETES_VERSION} 1.17; then  # don't use hyperkube
-            # TODO: move this URL var to install-dependencies.sh?
-            K8S_DOWNLOAD_URL="https://kubernetesreleases.blob.core.windows.net/k8s-staging/v${KUBERNETES_VERSION}/release-tars/kubernetes-server-linux-amd64.tar.gz"
-            K8S_TGZ_TMP=$(echo ${K8S_DOWNLOAD_URL} | cut -d "/" -f 7)
+            K8S_DOWNLOAD_URL="https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"
+            K8S_TGZ_TMP=$(echo ${K8S_DOWNLOAD_URL} | cut -d "/" -f 5)
             mkdir -p "${K8S_DOWNLOADS_DIR}"
             retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${K8S_DOWNLOAD_URL} || exit $ERR_K8S_DOWNLOAD_TIMEOUT
             tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
-                --strip-components=3 -C /usr/local/bin kubernetes/server/bin/kubelet kubernetes/server/bin/kubectl
+                --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
             rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
         else
             if [[ "$CONTAINER_RUNTIME" == "docker" ]]; then

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -395,11 +395,17 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     # Redirect ILB (4443) traffic to port 443 (ELB) in the prerouting chain
     iptables -t nat -A PREROUTING -p tcp --dport 4443 -j REDIRECT --to-port 443
 {{end}}
-
     sed -i "s|<img>|{{WrapAsParameter "kubernetesAddonManagerSpec"}}|g" /etc/kubernetes/manifests/kube-addon-manager.yaml
+{{if IsKubernetesVersionGe "1.17.0-alpha.1"}}
+    sed -i "s|<img>|{{WrapAsParameter "kubeAPIServerSpec"}}|g" /etc/kubernetes/manifests/kube-apiserver.yaml
+    sed -i "s|<img>|{{WrapAsParameter "kubeControllerManagerSpec"}}|g" /etc/kubernetes/manifests/kube-controller-manager.yaml
+    sed -i "s|<img>|{{WrapAsParameter "kubeSchedulerSpec"}}|g" /etc/kubernetes/manifests/kube-scheduler.yaml
+    sed -i "s|\"/hyperkube\", ||g" /etc/kubernetes/manifests/kube-*.yaml
+{{else}}
     for a in "/etc/kubernetes/manifests/kube-apiserver.yaml /etc/kubernetes/manifests/kube-controller-manager.yaml /etc/kubernetes/manifests/kube-scheduler.yaml"; do
       sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g" $a
     done
+{{end}}
     a=/etc/kubernetes/manifests/kube-apiserver.yaml
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.APIServerConfig}}|g" $a
 {{ if HasCosmosEtcd  }}
@@ -410,11 +416,20 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     sed -i "s|<advertiseAddr>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" $a
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}|g" /etc/kubernetes/manifests/kube-controller-manager.yaml
     sed -i "s|<args>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.SchedulerConfig}}|g" /etc/kubernetes/manifests/kube-scheduler.yaml
+{{if IsKubernetesVersionGe "1.17.0-alpha.1"}}
+    {{ if IsIPv6DualStackFeatureEnabled }}
+    sed -i "s|<img>|{{WrapAsParameter "kubeProxySpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|IPv6DualStack: true|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+    {{ else }}
+    sed -i "s|<img>|{{WrapAsParameter "kubeProxySpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|{}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+    {{ end }}
+    sed -i "s|\"/hyperkube\", ||g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+{{else}}
     {{ if IsIPv6DualStackFeatureEnabled }}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|IPv6DualStack: true|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     {{ else }}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|{}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     {{ end }}
+{{end}}
     KUBEDNS=/etc/kubernetes/addons/kube-dns-deployment.yaml
 {{if NeedsKubeDNSWithExecHealthz}}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesKubeDNSSpec"}}|g; s|<imgMasq>|{{WrapAsParameter "kubernetesDNSMasqSpec"}}|g; s|<imgHealthz>|{{WrapAsParameter "kubernetesExecHealthzSpec"}}|g; s|<imgSidecar>|{{WrapAsParameter "kubernetesDNSSidecarSpec"}}|g; s|<domain>|{{WrapAsParameter "kubernetesKubeletClusterDomain"}}|g; s|<clustIP>|{{WrapAsParameter "kubeDNSServiceIP"}}|g" $KUBEDNS

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -401,7 +401,6 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     sed -i "s|<img>|{{WrapAsParameter "kubeAPIServerSpec"}}|g" /etc/kubernetes/manifests/kube-apiserver.yaml
     sed -i "s|<img>|{{WrapAsParameter "kubeControllerManagerSpec"}}|g" /etc/kubernetes/manifests/kube-controller-manager.yaml
     sed -i "s|<img>|{{WrapAsParameter "kubeSchedulerSpec"}}|g" /etc/kubernetes/manifests/kube-scheduler.yaml
-    sed -i "s|\"/hyperkube\", ||g" /etc/kubernetes/manifests/kube-*.yaml
 {{else}}
     for a in "/etc/kubernetes/manifests/kube-apiserver.yaml /etc/kubernetes/manifests/kube-controller-manager.yaml /etc/kubernetes/manifests/kube-scheduler.yaml"; do
       sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g" $a

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -395,6 +395,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     # Redirect ILB (4443) traffic to port 443 (ELB) in the prerouting chain
     iptables -t nat -A PREROUTING -p tcp --dport 4443 -j REDIRECT --to-port 443
 {{end}}
+
     sed -i "s|<img>|{{WrapAsParameter "kubernetesAddonManagerSpec"}}|g" /etc/kubernetes/manifests/kube-addon-manager.yaml
 {{if IsKubernetesVersionGe "1.17.0-alpha.1"}}
     sed -i "s|<img>|{{WrapAsParameter "kubeAPIServerSpec"}}|g" /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -423,7 +423,6 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     {{ else }}
     sed -i "s|<img>|{{WrapAsParameter "kubeProxySpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|{}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     {{ end }}
-    sed -i "s|\"/hyperkube\", ||g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
 {{else}}
     {{ if IsIPv6DualStackFeatureEnabled }}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|IPv6DualStack: true|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -197,6 +197,30 @@
       },
       "type": "string"
     },
+    "kubeAPIServerSpec": {
+      "metadata": {
+        "description": "The container spec for kube-apiserver."
+      },
+      "type": "string"
+    },
+    "kubeControllerManagerSpec": {
+      "metadata": {
+        "description": "The container spec for kube-controller-manager."
+      },
+      "type": "string"
+    },
+    "kubeProxySpec": {
+      "metadata": {
+        "description": "The container spec for kube-proxy."
+      },
+      "type": "string"
+    },
+    "kubeSchedulerSpec": {
+      "metadata": {
+        "description": "The container spec for kube-scheduler."
+      },
+      "type": "string"
+    },
     "kubernetesHyperkubeSpec": {
       "metadata": {
         "description": "The container spec for hyperkube."

--- a/parts/k8s/manifests/1.17/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/1.17/kubernetesmaster-kube-apiserver.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-apiserver
+spec:
+  priorityClassName: system-node-critical
+  hostNetwork: true
+  containers:
+    - name: kube-apiserver
+      image: <img>
+      imagePullPolicy: IfNotPresent
+      command: ["kube-apiserver"]
+      args: [<args>]
+      volumeMounts:
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: msi
+          mountPath: /var/lib/waagent/ManagedIdentity-Settings
+          readOnly: true
+        - name: sock
+          mountPath: /opt
+        - name: auditlog
+          mountPath: /var/log/kubeaudit
+  volumes:
+    - name: etc-kubernetes
+      hostPath:
+        path: /etc/kubernetes
+    - name: var-lib-kubelet
+      hostPath:
+        path: /var/lib/kubelet
+    - name: msi
+      hostPath:
+        path: /var/lib/waagent/ManagedIdentity-Settings
+    - name: sock
+      hostPath:
+        path: /opt
+    - name: auditlog
+      hostPath:
+        path: /var/log/kubeaudit

--- a/parts/k8s/manifests/1.17/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/k8s/manifests/1.17/kubernetesmaster-kube-controller-manager.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-controller-manager
+spec:
+  priorityClassName: system-node-critical
+  hostNetwork: true
+  containers:
+    - name: kube-controller-manager
+      image: <img>
+      imagePullPolicy: IfNotPresent
+      command: ["kube-controller-manager"]
+      args: [<args>]
+      volumeMounts:
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: msi
+          mountPath: /var/lib/waagent/ManagedIdentity-Settings
+          readOnly: true
+  volumes:
+    - name: etc-kubernetes
+      hostPath:
+        path: /etc/kubernetes
+    - name: var-lib-kubelet
+      hostPath:
+        path: /var/lib/kubelet
+    - name: msi
+      hostPath:
+        path: /var/lib/waagent/ManagedIdentity-Settings

--- a/parts/k8s/manifests/1.17/kubernetesmaster-kube-scheduler.yaml
+++ b/parts/k8s/manifests/1.17/kubernetesmaster-kube-scheduler.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-scheduler
+spec:
+  priorityClassName: system-node-critical
+  hostNetwork: true
+  containers:
+    - name: kube-scheduler
+      image: <img>
+      imagePullPolicy: IfNotPresent
+      command: ["kube-scheduler"]
+      args: [<args>]
+      volumeMounts:
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: msi
+          mountPath: /var/lib/waagent/ManagedIdentity-Settings
+          readOnly: true
+  volumes:
+    - name: etc-kubernetes
+      hostPath:
+        path: /etc/kubernetes
+    - name: var-lib-kubelet
+      hostPath:
+        path: /var/lib/kubelet
+    - name: msi
+      hostPath:
+        path: /var/lib/waagent/ManagedIdentity-Settings

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -483,7 +483,10 @@ func getK8sVersionComponents(version string, overrides map[string]string) map[st
 	switch majorMinor {
 	case "1.17":
 		ret = map[string]string{
-			"hyperkube":                        "hyperkube-amd64:v" + version,
+			"kube-apiserver":                   "kube-apiserver:v" + version,
+			"kube-controller-manager":          "kube-controller-manager:v" + version,
+			"kube-proxy":                       "kube-proxy:v" + version,
+			"kube-scheduler":                   "kube-scheduler:v" + version,
 			"ccm":                              "azure-cloud-controller-manager:v0.3.0",
 			CloudNodeManagerAddonName:          "azure-cloud-node-manager:v0.3.0",
 			"windowszip":                       "v" + version + "-1int.zip",

--- a/pkg/api/k8s_versions_test.go
+++ b/pkg/api/k8s_versions_test.go
@@ -18,7 +18,10 @@ func TestGetK8sVersionComponents(t *testing.T) {
 	}
 	k8sComponent := k8sComponentVersions["1.17"]
 	expected := map[string]string{
-		"hyperkube":                        "hyperkube-amd64:v1.17.0",
+		"kube-scheduler":                   "kube-scheduler:v1.17.0",
+		"kube-controller-manager":          "kube-controller-manager:v1.17.0",
+		"kube-apiserver":                   "kube-apiserver:v1.17.0",
+		"kube-proxy":                       "kube-proxy:v1.17.0",
 		"ccm":                              "azure-cloud-controller-manager:v0.3.0",
 		CloudNodeManagerAddonName:          "azure-cloud-node-manager:v0.3.0",
 		"windowszip":                       "v1.17.0-1int.zip",

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -25,6 +25,8 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		kubernetesConfig := orchestratorProfile.KubernetesConfig
 		kubernetesImageBase := kubernetesConfig.KubernetesImageBase
 		mcrKubernetesImageBase := kubernetesConfig.MCRKubernetesImageBase
+		// TODO: switch upstream to MCR when Kubernetes core components are published there
+		upstreamKubernetesImageBase := "upstream.azurecr.io/oss/kubernetes/"
 		hyperkubeImageBase := kubernetesConfig.KubernetesImageBase
 
 		if properties.IsAzureStackCloud() {
@@ -44,6 +46,18 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 
 				addValue(parametersMap, "kubernetesCcmImageSpec", kubernetesCcmSpec)
 			}
+
+			kubeAPIServerSpec := upstreamKubernetesImageBase + k8sComponents["kube-apiserver"]
+			addValue(parametersMap, "kubeAPIServerSpec", kubeAPIServerSpec)
+
+			kubeControllerManagerSpec := upstreamKubernetesImageBase + k8sComponents["kube-controller-manager"]
+			addValue(parametersMap, "kubeControllerManagerSpec", kubeControllerManagerSpec)
+
+			kubeSchedulerSpec := upstreamKubernetesImageBase + k8sComponents["kube-scheduler"]
+			addValue(parametersMap, "kubeSchedulerSpec", kubeSchedulerSpec)
+
+			kubeProxySpec := upstreamKubernetesImageBase + k8sComponents["kube-proxy"]
+			addValue(parametersMap, "kubeProxySpec", kubeProxySpec)
 
 			kubernetesHyperkubeSpec := hyperkubeImageBase + k8sComponents["hyperkube"]
 			if properties.IsAzureStackCloud() {

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -25,10 +25,6 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		kubernetesConfig := orchestratorProfile.KubernetesConfig
 		kubernetesImageBase := kubernetesConfig.KubernetesImageBase
 		mcrKubernetesImageBase := kubernetesConfig.MCRKubernetesImageBase
-		// TODO: switch upstream to MCR when Kubernetes core components are published there
-		// upstreamKubernetesImageBase := "upstream.azurecr.io/oss/kubernetes/"
-		// HACK: use canonical repository until Azure publishing is sorted out
-		upstreamKubernetesImageBase := "k8s.gcr.io/"
 		hyperkubeImageBase := kubernetesConfig.KubernetesImageBase
 
 		if properties.IsAzureStackCloud() {
@@ -49,16 +45,16 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 				addValue(parametersMap, "kubernetesCcmImageSpec", kubernetesCcmSpec)
 			}
 
-			kubeAPIServerSpec := upstreamKubernetesImageBase + k8sComponents["kube-apiserver"]
+			kubeAPIServerSpec := kubernetesImageBase + k8sComponents["kube-apiserver"]
 			addValue(parametersMap, "kubeAPIServerSpec", kubeAPIServerSpec)
 
-			kubeControllerManagerSpec := upstreamKubernetesImageBase + k8sComponents["kube-controller-manager"]
+			kubeControllerManagerSpec := kubernetesImageBase + k8sComponents["kube-controller-manager"]
 			addValue(parametersMap, "kubeControllerManagerSpec", kubeControllerManagerSpec)
 
-			kubeSchedulerSpec := upstreamKubernetesImageBase + k8sComponents["kube-scheduler"]
+			kubeSchedulerSpec := kubernetesImageBase + k8sComponents["kube-scheduler"]
 			addValue(parametersMap, "kubeSchedulerSpec", kubeSchedulerSpec)
 
-			kubeProxySpec := upstreamKubernetesImageBase + k8sComponents["kube-proxy"]
+			kubeProxySpec := kubernetesImageBase + k8sComponents["kube-proxy"]
 			addValue(parametersMap, "kubeProxySpec", kubeProxySpec)
 
 			kubernetesHyperkubeSpec := hyperkubeImageBase + k8sComponents["hyperkube"]

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -26,7 +26,9 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		kubernetesImageBase := kubernetesConfig.KubernetesImageBase
 		mcrKubernetesImageBase := kubernetesConfig.MCRKubernetesImageBase
 		// TODO: switch upstream to MCR when Kubernetes core components are published there
-		upstreamKubernetesImageBase := "upstream.azurecr.io/oss/kubernetes/"
+		// upstreamKubernetesImageBase := "upstream.azurecr.io/oss/kubernetes/"
+		// HACK: use canonical repository until Azure publishing is sorted out
+		upstreamKubernetesImageBase := "k8s.gcr.io/"
 		hyperkubeImageBase := kubernetesConfig.KubernetesImageBase
 
 		if properties.IsAzureStackCloud() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -10115,7 +10115,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - command: ["/hyperkube", "kube-proxy", "--config=/var/lib/kube-proxy/config.yaml"]
+      - command:
+        - kube-proxy
+        - --config=/var/lib/kube-proxy/config.yaml
         image: <img>
         imagePullPolicy: IfNotPresent
         name: kube-proxy
@@ -17523,7 +17525,6 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     {{ else }}
     sed -i "s|<img>|{{WrapAsParameter "kubeProxySpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|{}|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     {{ end }}
-    sed -i "s|\"/hyperkube\", ||g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml
 {{else}}
     {{ if IsIPv6DualStackFeatureEnabled }}
     sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g; s|<CIDR>|{{WrapAsParameter "kubeClusterCidr"}}|g; s|<kubeProxyMode>|{{ .OrchestratorProfile.KubernetesConfig.ProxyMode}}|g; s|<IPv6DualStackFeature>|IPv6DualStack: true|g" /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -15424,13 +15424,12 @@ extractHyperkube() {
 installKubeletAndKubectl() {
     if [[ ! -f "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" ]]; then
         if version_gte ${KUBERNETES_VERSION} 1.17; then  # don't use hyperkube
-            # TODO: move this URL var to install-dependencies.sh?
-            K8S_DOWNLOAD_URL="https://kubernetesreleases.blob.core.windows.net/k8s-staging/v${KUBERNETES_VERSION}/release-tars/kubernetes-server-linux-amd64.tar.gz"
-            K8S_TGZ_TMP=$(echo ${K8S_DOWNLOAD_URL} | cut -d "/" -f 7)
+            K8S_DOWNLOAD_URL="https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"
+            K8S_TGZ_TMP=$(echo ${K8S_DOWNLOAD_URL} | cut -d "/" -f 5)
             mkdir -p "${K8S_DOWNLOADS_DIR}"
             retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${K8S_DOWNLOAD_URL} || exit $ERR_K8S_DOWNLOAD_TIMEOUT
             tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
-                --strip-components=3 -C /usr/local/bin kubernetes/server/bin/kubelet kubernetes/server/bin/kubectl
+                --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
             rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
         else
             if [[ "$CONTAINER_RUNTIME" == "docker" ]]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17496,6 +17496,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     # Redirect ILB (4443) traffic to port 443 (ELB) in the prerouting chain
     iptables -t nat -A PREROUTING -p tcp --dport 4443 -j REDIRECT --to-port 443
 {{end}}
+
     sed -i "s|<img>|{{WrapAsParameter "kubernetesAddonManagerSpec"}}|g" /etc/kubernetes/manifests/kube-addon-manager.yaml
 {{if IsKubernetesVersionGe "1.17.0-alpha.1"}}
     sed -i "s|<img>|{{WrapAsParameter "kubeAPIServerSpec"}}|g" /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -15427,6 +15427,7 @@ extractHyperkube() {
 }
 
 extractKubeBinaries() {
+    KUBE_BINARY_URL=${KUBE_BINARY_URL:-"https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"}
     K8S_TGZ_TMP=$(echo ${KUBE_BINARY_URL} | cut -d "/" -f 5)
     mkdir -p "${K8S_DOWNLOADS_DIR}"
     retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${KUBE_BINARY_URL} || exit $ERR_K8S_DOWNLOAD_TIMEOUT

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -188,6 +188,9 @@
 // ../../parts/k8s/kubernetesparams.t
 // ../../parts/k8s/kuberneteswindowsfunctions.ps1
 // ../../parts/k8s/kuberneteswindowssetup.ps1
+// ../../parts/k8s/manifests/1.17/kubernetesmaster-kube-apiserver.yaml
+// ../../parts/k8s/manifests/1.17/kubernetesmaster-kube-controller-manager.yaml
+// ../../parts/k8s/manifests/1.17/kubernetesmaster-kube-scheduler.yaml
 // ../../parts/k8s/manifests/kubernetesmaster-cloud-controller-manager.yaml
 // ../../parts/k8s/manifests/kubernetesmaster-kube-addon-manager.yaml
 // ../../parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -17503,7 +17506,6 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
     sed -i "s|<img>|{{WrapAsParameter "kubeAPIServerSpec"}}|g" /etc/kubernetes/manifests/kube-apiserver.yaml
     sed -i "s|<img>|{{WrapAsParameter "kubeControllerManagerSpec"}}|g" /etc/kubernetes/manifests/kube-controller-manager.yaml
     sed -i "s|<img>|{{WrapAsParameter "kubeSchedulerSpec"}}|g" /etc/kubernetes/manifests/kube-scheduler.yaml
-    sed -i "s|\"/hyperkube\", ||g" /etc/kubernetes/manifests/kube-*.yaml
 {{else}}
     for a in "/etc/kubernetes/manifests/kube-apiserver.yaml /etc/kubernetes/manifests/kube-controller-manager.yaml /etc/kubernetes/manifests/kube-scheduler.yaml"; do
       sed -i "s|<img>|{{WrapAsParameter "kubernetesHyperkubeSpec"}}|g" $a
@@ -34014,6 +34016,172 @@ func k8sKuberneteswindowssetupPs1() (*asset, error) {
 	return a, nil
 }
 
+var _k8sManifests117KubernetesmasterKubeApiserverYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-apiserver
+spec:
+  priorityClassName: system-node-critical
+  hostNetwork: true
+  containers:
+    - name: kube-apiserver
+      image: <img>
+      imagePullPolicy: IfNotPresent
+      command: ["kube-apiserver"]
+      args: [<args>]
+      volumeMounts:
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: msi
+          mountPath: /var/lib/waagent/ManagedIdentity-Settings
+          readOnly: true
+        - name: sock
+          mountPath: /opt
+        - name: auditlog
+          mountPath: /var/log/kubeaudit
+  volumes:
+    - name: etc-kubernetes
+      hostPath:
+        path: /etc/kubernetes
+    - name: var-lib-kubelet
+      hostPath:
+        path: /var/lib/kubelet
+    - name: msi
+      hostPath:
+        path: /var/lib/waagent/ManagedIdentity-Settings
+    - name: sock
+      hostPath:
+        path: /opt
+    - name: auditlog
+      hostPath:
+        path: /var/log/kubeaudit
+`)
+
+func k8sManifests117KubernetesmasterKubeApiserverYamlBytes() ([]byte, error) {
+	return _k8sManifests117KubernetesmasterKubeApiserverYaml, nil
+}
+
+func k8sManifests117KubernetesmasterKubeApiserverYaml() (*asset, error) {
+	bytes, err := k8sManifests117KubernetesmasterKubeApiserverYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "k8s/manifests/1.17/kubernetesmaster-kube-apiserver.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _k8sManifests117KubernetesmasterKubeControllerManagerYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-controller-manager
+spec:
+  priorityClassName: system-node-critical
+  hostNetwork: true
+  containers:
+    - name: kube-controller-manager
+      image: <img>
+      imagePullPolicy: IfNotPresent
+      command: ["kube-controller-manager"]
+      args: [<args>]
+      volumeMounts:
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: msi
+          mountPath: /var/lib/waagent/ManagedIdentity-Settings
+          readOnly: true
+  volumes:
+    - name: etc-kubernetes
+      hostPath:
+        path: /etc/kubernetes
+    - name: var-lib-kubelet
+      hostPath:
+        path: /var/lib/kubelet
+    - name: msi
+      hostPath:
+        path: /var/lib/waagent/ManagedIdentity-Settings
+`)
+
+func k8sManifests117KubernetesmasterKubeControllerManagerYamlBytes() ([]byte, error) {
+	return _k8sManifests117KubernetesmasterKubeControllerManagerYaml, nil
+}
+
+func k8sManifests117KubernetesmasterKubeControllerManagerYaml() (*asset, error) {
+	bytes, err := k8sManifests117KubernetesmasterKubeControllerManagerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "k8s/manifests/1.17/kubernetesmaster-kube-controller-manager.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _k8sManifests117KubernetesmasterKubeSchedulerYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-scheduler
+spec:
+  priorityClassName: system-node-critical
+  hostNetwork: true
+  containers:
+    - name: kube-scheduler
+      image: <img>
+      imagePullPolicy: IfNotPresent
+      command: ["kube-scheduler"]
+      args: [<args>]
+      volumeMounts:
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: msi
+          mountPath: /var/lib/waagent/ManagedIdentity-Settings
+          readOnly: true
+  volumes:
+    - name: etc-kubernetes
+      hostPath:
+        path: /etc/kubernetes
+    - name: var-lib-kubelet
+      hostPath:
+        path: /var/lib/kubelet
+    - name: msi
+      hostPath:
+        path: /var/lib/waagent/ManagedIdentity-Settings
+`)
+
+func k8sManifests117KubernetesmasterKubeSchedulerYamlBytes() ([]byte, error) {
+	return _k8sManifests117KubernetesmasterKubeSchedulerYaml, nil
+}
+
+func k8sManifests117KubernetesmasterKubeSchedulerYaml() (*asset, error) {
+	bytes, err := k8sManifests117KubernetesmasterKubeSchedulerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "k8s/manifests/1.17/kubernetesmaster-kube-scheduler.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _k8sManifestsKubernetesmasterCloudControllerManagerYaml = []byte(`apiVersion: v1
 kind: Pod
 metadata:
@@ -39201,6 +39369,9 @@ var _bindata = map[string]func() (*asset, error){
 	"k8s/kubernetesparams.t":                                             k8sKubernetesparamsT,
 	"k8s/kuberneteswindowsfunctions.ps1":                                 k8sKuberneteswindowsfunctionsPs1,
 	"k8s/kuberneteswindowssetup.ps1":                                     k8sKuberneteswindowssetupPs1,
+	"k8s/manifests/1.17/kubernetesmaster-kube-apiserver.yaml":            k8sManifests117KubernetesmasterKubeApiserverYaml,
+	"k8s/manifests/1.17/kubernetesmaster-kube-controller-manager.yaml":   k8sManifests117KubernetesmasterKubeControllerManagerYaml,
+	"k8s/manifests/1.17/kubernetesmaster-kube-scheduler.yaml":            k8sManifests117KubernetesmasterKubeSchedulerYaml,
 	"k8s/manifests/kubernetesmaster-cloud-controller-manager.yaml":       k8sManifestsKubernetesmasterCloudControllerManagerYaml,
 	"k8s/manifests/kubernetesmaster-kube-addon-manager.yaml":             k8sManifestsKubernetesmasterKubeAddonManagerYaml,
 	"k8s/manifests/kubernetesmaster-kube-apiserver.yaml":                 k8sManifestsKubernetesmasterKubeApiserverYaml,
@@ -39514,6 +39685,11 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"kuberneteswindowsfunctions.ps1": {k8sKuberneteswindowsfunctionsPs1, map[string]*bintree{}},
 		"kuberneteswindowssetup.ps1":     {k8sKuberneteswindowssetupPs1, map[string]*bintree{}},
 		"manifests": {nil, map[string]*bintree{
+			"1.17": {nil, map[string]*bintree{
+				"kubernetesmaster-kube-apiserver.yaml":          {k8sManifests117KubernetesmasterKubeApiserverYaml, map[string]*bintree{}},
+				"kubernetesmaster-kube-controller-manager.yaml": {k8sManifests117KubernetesmasterKubeControllerManagerYaml, map[string]*bintree{}},
+				"kubernetesmaster-kube-scheduler.yaml":          {k8sManifests117KubernetesmasterKubeSchedulerYaml, map[string]*bintree{}},
+			}},
 			"kubernetesmaster-cloud-controller-manager.yaml":       {k8sManifestsKubernetesmasterCloudControllerManagerYaml, map[string]*bintree{}},
 			"kubernetesmaster-kube-addon-manager.yaml":             {k8sManifestsKubernetesmasterKubeAddonManagerYaml, map[string]*bintree{}},
 			"kubernetesmaster-kube-apiserver.yaml":                 {k8sManifestsKubernetesmasterKubeApiserverYaml, map[string]*bintree{}},


### PR DESCRIPTION
**Reason for Change**:
Hyperkube is no more as of Kubernetes 1.17.0-alpha.2, so AKS Engine needs to provision its core `kube-` components and binaries from other official builds.

**Issue Fixed**:
Fixes #1842
Unblocks #2158 (yes, I tested)
Related to #2161 (`UseCloudControllerManager=true` is broken for k8s 1.16+)

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

Still TODO:

- [x] Update Linux VHD script
- [ ] ~~Update Windows VHD script~~
- [ ] ~~Other Windows changes still needed?~~

TODO in another PR, let's keep this one simple:
- [ ] Switch to (temporary) `upstream.azurecr.io/oss/kubernetes/` container repo when builds are working
- [ ] Switch to final MCR container repo when it's available and populated
- [ ] Remove 1.17 conditional clauses when back catalog is populated
