### PR TITLE
fix: CSE file wait is idempotent

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -137,6 +137,8 @@ retrycmd_get_executable() {
 }
 wait_for_file() {
     retries=$1; wait_sleep=$2; filepath=$3
+    paved=/opt/azure/cloud-init-files.paved
+    grep -Fq '${filepath}' $paved && return 0
     for i in $(seq 1 $retries); do
         grep -Fq '#EOF' $filepath && break
         if [ $i -eq $retries ]; then
@@ -146,6 +148,7 @@ wait_for_file() {
         fi
     done
     sed -i "/#EOF/d" $filepath
+    echo $filepath >> $paved
 }
 wait_for_apt_locks() {
     while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -138,7 +138,7 @@ retrycmd_get_executable() {
 wait_for_file() {
     retries=$1; wait_sleep=$2; filepath=$3
     paved=/opt/azure/cloud-init-files.paved
-    grep -Fq '${filepath}' $paved && return 0
+    grep -Fq "${filepath}" $paved && return 0
     for i in $(seq 1 $retries); do
         grep -Fq '#EOF' $filepath && break
         if [ $i -eq $retries ]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -14916,7 +14916,7 @@ retrycmd_get_executable() {
 wait_for_file() {
     retries=$1; wait_sleep=$2; filepath=$3
     paved=/opt/azure/cloud-init-files.paved
-    grep -Fq '${filepath}' $paved && return 0
+    grep -Fq "${filepath}" $paved && return 0
     for i in $(seq 1 $retries); do
         grep -Fq '#EOF' $filepath && break
         if [ $i -eq $retries ]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -14915,6 +14915,8 @@ retrycmd_get_executable() {
 }
 wait_for_file() {
     retries=$1; wait_sleep=$2; filepath=$3
+    paved=/opt/azure/cloud-init-files.paved
+    grep -Fq '${filepath}' $paved && return 0
     for i in $(seq 1 $retries); do
         grep -Fq '#EOF' $filepath && break
         if [ $i -eq $retries ]; then
@@ -14923,6 +14925,7 @@ wait_for_file() {
             sleep $wait_sleep
         fi
     done
+    echo $filepath >> $paved
     sed -i "/#EOF/d" $filepath
 }
 wait_for_apt_locks() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -14925,8 +14925,8 @@ wait_for_file() {
             sleep $wait_sleep
         fi
     done
-    echo $filepath >> $paved
     sed -i "/#EOF/d" $filepath
+    echo $filepath >> $paved
 }
 wait_for_apt_locks() {
     while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

PR #1719 prevented CSE from running twice, which some folks rely upon via `az vmss update|update-instances`.

This PR keeps the improvements in file wait from #1719, but keeps track of files once they have been validated as delivered by cloud-init.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
