### PR TITLE
Revert "test: retry az commands in E2E tests (#2089)"

### DIFF
--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -6,6 +6,7 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/pkg/errors"
 )
 
 // Storage provides access to StorageAccount objects
@@ -122,34 +122,6 @@ func (a *Account) Login() error {
 	return nil
 }
 
-// LoginWithRetry invokes Login, retrying up to a timeout
-func (a *Account) LoginWithRetry(sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentLoginWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.Login():
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentLoginWithRetryError = <-ch:
-			if mostRecentLoginWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("LoginWithRetry timed out: %s\n", mostRecentLoginWithRetryError)
-		}
-	}
-}
-
 // SetSubscription will call az account set --subscription for the given Account
 func (a *Account) SetSubscription() error {
 	var cmd *exec.Cmd
@@ -166,34 +138,6 @@ func (a *Account) SetSubscription() error {
 		return err
 	}
 	return nil
-}
-
-// SetSubscriptionWithRetry invokes SetSubscription, retrying up to a timeout
-func (a *Account) SetSubscriptionWithRetry(sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentSetSubscriptionWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.SetSubscription():
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentSetSubscriptionWithRetryError = <-ch:
-			if mostRecentSetSubscriptionWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("SetSubscriptionWithRetry timed out: %s\n", mostRecentSetSubscriptionWithRetryError)
-		}
-	}
 }
 
 // CreateGroup will create a resource group in a given location
@@ -224,34 +168,6 @@ func (a *Account) CreateGroup(name, location string) error {
 	return nil
 }
 
-// CreateGroupWithRetry invokes CreateGroup, retrying up to a timeout
-func (a *Account) CreateGroupWithRetry(name, location string, sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentCreateGroupWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.CreateGroup(name, location):
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentCreateGroupWithRetryError = <-ch:
-			if mostRecentCreateGroupWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("CreateGroupWithRetry timed out: %s\n", mostRecentCreateGroupWithRetryError)
-		}
-	}
-}
-
 // DeleteGroup deletes a given resource group by name
 func (a *Account) DeleteGroup(name string, wait bool) error {
 	var cmd *exec.Cmd
@@ -271,34 +187,6 @@ func (a *Account) DeleteGroup(name string, wait bool) error {
 		return err
 	}
 	return nil
-}
-
-// DeleteGroupWithRetry invokes DeleteGroup, retrying up to a timeout
-func (a *Account) DeleteGroupWithRetry(name string, wait bool, sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentDeleteGroupWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.DeleteGroup(name, wait):
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentDeleteGroupWithRetryError = <-ch:
-			if mostRecentDeleteGroupWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("DeleteGroupWithRetry timed out: %s\n", mostRecentDeleteGroupWithRetryError)
-		}
-	}
 }
 
 // CreateDeployment will deploy a cluster to a given resource group using the template and parameters on disk
@@ -340,34 +228,6 @@ func (a *Account) CreateDeployment(name string, e *engine.Engine) error {
 	return nil
 }
 
-// CreateDeploymentWithRetry invokes CreateDeployment, retrying up to a timeout
-func (a *Account) CreateDeploymentWithRetry(name string, e *engine.Engine, sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentCreateDeploymentWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.CreateDeployment(name, e):
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentCreateDeploymentWithRetryError = <-ch:
-			if mostRecentCreateDeploymentWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("CreateDeploymentWithRetry timed out: %s\n", mostRecentCreateDeploymentWithRetryError)
-		}
-	}
-}
-
 // CreateVnet will create a vnet in a resource group
 func (a *Account) CreateVnet(vnet, addressPrefixes string) error {
 	var cmd *exec.Cmd
@@ -385,34 +245,6 @@ func (a *Account) CreateVnet(vnet, addressPrefixes string) error {
 		return err
 	}
 	return nil
-}
-
-// CreateVnetWithRetry invokes CreateVnet, retrying up to a timeout
-func (a *Account) CreateVnetWithRetry(vnet, addressPrefixes string, sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentCreateVnetWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.CreateVnet(vnet, addressPrefixes):
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentCreateVnetWithRetryError = <-ch:
-			if mostRecentCreateVnetWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("CreateVnetWithRetry timed out: %s\n", mostRecentCreateVnetWithRetryError)
-		}
-	}
 }
 
 // ListRGRouteTableResult defines a struct for making a multi-value channel result type
@@ -524,34 +356,6 @@ func (a *Account) CreateSubnet(vnet, subnetName, subnetPrefix string) error {
 	return nil
 }
 
-// CreateSubnetWithRetry invokes CreateSubnet, retrying up to a timeout
-func (a *Account) CreateSubnetWithRetry(vnet, subnetName, subnetPrefix string, sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentCreateSubnetWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.CreateSubnet(vnet, subnetName, subnetPrefix):
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentCreateSubnetWithRetryError = <-ch:
-			if mostRecentCreateSubnetWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("CreateSubnetWithRetry timed out: %s\n", mostRecentCreateSubnetWithRetryError)
-		}
-	}
-}
-
 // RouteTable holds information from running az network route-table list
 type RouteTable struct {
 	ID                string `json:"id"`
@@ -561,19 +365,36 @@ type RouteTable struct {
 	ResourceGroup     string `json:"resourceGroup"`
 }
 
-// GetHostsResult is a return struct for GetAsync
-type GetHostsResult struct {
-	Vms []VM
-	Err error
-}
-
-// GetHostsAsync wraps GetHosts with a struct response for goroutine + channel usage
-func (a *Account) GetHostsAsync(name string) GetHostsResult {
-	vms, err := a.GetHosts(name)
-	return GetHostsResult{
-		Vms: vms,
-		Err: err,
+// UpdateRouteTables is used to updated a vnet with the appropriate route tables
+func (a *Account) UpdateRouteTables(subnet, vnet string) error {
+	var cmd *exec.Cmd
+	if a.TimeoutCommands {
+		cmd = exec.Command("timeout", "60", "az", "network", "route-table", "list", "-g", a.ResourceGroup.Name)
+	} else {
+		cmd = exec.Command("az", "network", "route-table", "list", "-g", a.ResourceGroup.Name)
 	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error while trying to get route table list!\n Output:%s\n", out)
+		return err
+	}
+	rts := []RouteTable{}
+	json.Unmarshal(out, &rts)
+
+	if a.TimeoutCommands {
+		cmd = exec.Command("timeout", "60", "az", "network", "vnet", "subnet", "update",
+			"-n", subnet, "-g", a.ResourceGroup.Name, "--vnet-name", vnet, "--route-table", rts[0].Name)
+	} else {
+		cmd = exec.Command("az", "network", "vnet", "subnet", "update",
+			"-n", subnet, "-g", a.ResourceGroup.Name, "--vnet-name", vnet, "--route-table", rts[0].Name)
+	}
+	util.PrintCommand(cmd)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error while trying to update vnet route tables:%s\n", out)
+		return err
+	}
+	return nil
 }
 
 // GetHosts will get a list of vms in the resource group
@@ -606,37 +427,6 @@ func (a *Account) GetHosts(name string) ([]VM, error) {
 	return v, nil
 }
 
-// GetHostsWithRetry invokes GetHostsAsync, retrying up to a timeout
-func (a *Account) GetHostsWithRetry(name string, sleep, timeout time.Duration) ([]VM, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan GetHostsResult)
-	var mostRecentGetHostsWithRetryError error
-	var vms []VM
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.GetHostsAsync(name):
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case result := <-ch:
-			mostRecentGetHostsWithRetryError = result.Err
-			vms = result.Vms
-			if mostRecentGetHostsWithRetryError == nil {
-				return vms, nil
-			}
-		case <-ctx.Done():
-			return nil, errors.Errorf("GetHostsWithRetry timed out: %s\n", mostRecentGetHostsWithRetryError)
-		}
-	}
-}
-
 // SetResourceGroup will set the account resource group
 func (a *Account) SetResourceGroup(name string) error {
 	if a.ResourceGroup.Name != "" {
@@ -666,34 +456,6 @@ func (a *Account) SetResourceGroup(name string) error {
 		return err
 	}
 	return nil
-}
-
-// SetResourceGroupWithRetry invokes SetResourceGroup, retrying up to a timeout
-func (a *Account) SetResourceGroupWithRetry(name string, sleep, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ch := make(chan error)
-	var mostRecentSetResourceGroupWithRetryError error
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- a.SetResourceGroup(name):
-				time.Sleep(sleep)
-			}
-		}
-	}()
-	for {
-		select {
-		case mostRecentSetResourceGroupWithRetryError = <-ch:
-			if mostRecentSetResourceGroupWithRetryError == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.Errorf("SetResourceGroupWithRetry timed out: %s\n", mostRecentSetResourceGroupWithRetryError)
-		}
-	}
 }
 
 // IsClusterExpired will return true if a deployment was created more than t nanoseconds ago, or if timestamp is not found

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -59,12 +59,12 @@ func main() {
 		log.Fatalf("Error while trying to setup azure account: %s\n", err)
 	}
 
-	err := acct.LoginWithRetry(3*time.Second, cfg.Timeout)
+	err := acct.Login()
 	if err != nil {
 		log.Fatalf("Error while trying to login to azure account! %s\n", err)
 	}
 
-	err = acct.SetSubscriptionWithRetry(3*time.Second, cfg.Timeout)
+	err = acct.SetSubscription()
 	if err != nil {
 		log.Fatal("Error while trying to set azure subscription!")
 	}
@@ -96,7 +96,7 @@ func main() {
 		provision := true
 		rgExists := true
 		rg := cfg.SoakClusterName
-		err = acct.SetResourceGroupWithRetry(rg, 3*time.Second, 20*time.Second)
+		err = acct.SetResourceGroup(rg)
 		if err != nil {
 			rgExists = false
 			log.Printf("Error while trying to set RG:%s\n", err)
@@ -113,7 +113,7 @@ func main() {
 			log.Printf("Soak cluster %s does not exist or has expired\n", rg)
 			if rgExists {
 				log.Printf("Deleting Resource Group:%s\n", rg)
-				acct.DeleteGroupWithRetry(rg, true, 3*time.Second, cfg.Timeout)
+				acct.DeleteGroup(rg, true)
 			}
 			log.Printf("Deleting Storage files:%s\n", rg)
 			sa.DeleteFiles(cfg.SoakClusterName)
@@ -124,7 +124,7 @@ func main() {
 			if err != nil {
 				log.Printf("Error while trying to download _output dir: %s, will provision a new cluster.\n", err)
 				log.Printf("Deleting Resource Group:%s\n", rg)
-				acct.DeleteGroupWithRetry(rg, true, 3*time.Second, cfg.Timeout)
+				acct.DeleteGroup(rg, true)
 				log.Printf("Deleting Storage files:%s\n", rg)
 				sa.DeleteFiles(cfg.SoakClusterName)
 				cfg.Name = ""
@@ -254,7 +254,7 @@ func teardown() {
 	if cfg.CleanUpOnExit {
 		for _, rg := range rgs {
 			log.Printf("Deleting Group:%s\n", rg)
-			acct.DeleteGroupWithRetry(rg, false, 3*time.Second, cfg.Timeout)
+			acct.DeleteGroup(rg, false)
 		}
 	}
 }

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -118,7 +118,7 @@ func (cli *CLIProvisioner) provision() error {
 
 	os.Setenv("DNS_PREFIX", cli.Config.Name)
 
-	err := cli.Account.CreateGroupWithRetry(cli.Config.Name, cli.Config.Location, 3*time.Second, cli.Config.Timeout)
+	err := cli.Account.CreateGroup(cli.Config.Name, cli.Config.Location)
 	if err != nil {
 		return errors.Wrap(err, "Error while trying to create resource group")
 	}
@@ -142,16 +142,16 @@ func (cli *CLIProvisioner) provision() error {
 	if cli.CreateVNET {
 		if cli.MasterVMSS {
 			agentSubnetName := fmt.Sprintf("%sCustomSubnetAgent", cli.Config.Name)
-			err = cli.Account.CreateVnetWithRetry(vnetName, "10.239.0.0/16", 3*time.Second, cli.Config.Timeout)
+			err = cli.Account.CreateVnet(vnetName, "10.239.0.0/16")
 			if err != nil {
 				return errors.Errorf("Error trying to create vnet:%s", err.Error())
 			}
-			err = cli.Account.CreateSubnetWithRetry(vnetName, masterSubnetName, "10.239.0.0/17", 3*time.Second, cli.Config.Timeout)
+			err = cli.Account.CreateSubnet(vnetName, masterSubnetName, "10.239.0.0/17")
 			if err != nil {
 				return errors.Errorf("Error trying to create subnet:%s", err.Error())
 			}
 			subnets = append(subnets, masterSubnetName)
-			err = cli.Account.CreateSubnetWithRetry(vnetName, agentSubnetName, "10.239.128.0/17", 3*time.Second, cli.Config.Timeout)
+			err = cli.Account.CreateSubnet(vnetName, agentSubnetName, "10.239.128.0/17")
 			if err != nil {
 				return errors.Errorf("Error trying to create subnet in subnet:%s", err.Error())
 			}
@@ -159,18 +159,18 @@ func (cli *CLIProvisioner) provision() error {
 			agentSubnetID = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s", cli.Account.SubscriptionID, cli.Account.ResourceGroup.Name, vnetName, agentSubnetName)
 
 		} else {
-			err = cli.Account.CreateVnetWithRetry(vnetName, "10.239.0.0/16", 3*time.Second, cli.Config.Timeout)
+			err = cli.Account.CreateVnet(vnetName, "10.239.0.0/16")
 			if err != nil {
 				return errors.Errorf("Error trying to create vnet:%s", err.Error())
 			}
-			err = cli.Account.CreateSubnetWithRetry(vnetName, masterSubnetName, "10.239.255.0/24", 3*time.Second, cli.Config.Timeout)
+			err = cli.Account.CreateSubnet(vnetName, masterSubnetName, "10.239.255.0/24")
 			if err != nil {
 				return errors.Errorf("Error trying to create subnet:%s", err.Error())
 			}
 			subnets = append(subnets, masterSubnetName)
 			for i, pool := range cs.ContainerService.Properties.AgentPoolProfiles {
 				subnetName := fmt.Sprintf("%sCustomSubnet", pool.Name)
-				err = cli.Account.CreateSubnetWithRetry(vnetName, subnetName, fmt.Sprintf("10.239.%d.0/20", i*16), 3*time.Second, cli.Config.Timeout)
+				err = cli.Account.CreateSubnet(vnetName, subnetName, fmt.Sprintf("10.239.%d.0/20", i*16))
 				if err != nil {
 					return errors.Errorf("Error trying to create subnet:%s", err.Error())
 				}
@@ -220,7 +220,7 @@ func (cli *CLIProvisioner) provision() error {
 
 	if cli.Config.IsKubernetes() {
 		// Store the hosts for future introspection
-		hosts, err := cli.Account.GetHostsWithRetry(cli.Config.Name, 3*time.Second, cli.Config.Timeout)
+		hosts, err := cli.Account.GetHosts(cli.Config.Name)
 		if err != nil {
 			return errors.Wrap(err, "GetHosts:%s")
 		}
@@ -277,7 +277,7 @@ func (cli *CLIProvisioner) generateAndDeploy() error {
 
 	//if we use Generate, then we need to call CreateDeployment
 	if !cli.Config.UseDeployCommand {
-		err = cli.Account.CreateDeploymentWithRetry(cli.Config.Name, cli.Engine, 30*time.Second, 60*time.Minute)
+		err = cli.Account.CreateDeployment(cli.Config.Name, cli.Engine)
 		if err != nil {
 			return errors.Wrap(err, "Error while trying to create deployment")
 		}


### PR DESCRIPTION
This reverts commit 133cb46c420e6c35483c77babd594a7bbd053ee0.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
#2039 doesn't work well with the current soak test implementation. Revert until we're able to re-introduce it in a more resilient way.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
