### PR TITLE
fix: go template and does not short circuit causing nil ptr

### DIFF
--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -267,14 +267,14 @@ write_files:
     {{CloudInitData "generateProxyCertsScript"}}
 {{end}}
 
-{{if and HasLinuxProfile HasCustomSearchDomain}}
+{{if HasLinuxProfile }}{{if HasCustomSearchDomain}}
 - path: /opt/azure/containers/setup-custom-search-domains.sh
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "customSearchDomainsScript"}}
-{{end}}
+{{end}}{{end}}
 
 - path: /var/lib/kubelet/kubeconfig
   permissions: "0644"

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -268,14 +268,14 @@ write_files:
   content: |
     {{WrapAsParameter "clientCertificate"}}
 
-{{if and HasLinuxProfile HasCustomSearchDomain}}
+{{if HasLinuxProfile }}{{if HasCustomSearchDomain}}
 - path: /opt/azure/containers/setup-custom-search-domains.sh
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "customSearchDomainsScript"}}
-{{end}}
+{{end}}{{end}}
 
 - path: /var/lib/kubelet/kubeconfig
   permissions: "0644"

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -661,8 +661,17 @@ func TestTemplateGenerator_GetKubernetesLinuxNodeCustomDataJSONObject(t *testing
 						AvailabilityProfile: api.VirtualMachineScaleSets,
 						VnetCidrs:           []string{"10.0.0.0/8"},
 					},
+				}
+				return *cs
+			},
+		},
+		{
+			Name: "VMSSWithNoLinuxProfile",
+			CSFactory: func() api.ContainerService {
+				cs := api.CreateMockContainerService("VMSSWithNoLinuxProfile", "1.10.13", 3, 0, false)
+				cs.Properties.AgentPoolProfiles = []*api.AgentPoolProfile{
 					{
-						Name:                "pool2",
+						Name:                "pool1",
 						Count:               1,
 						OSType:              api.Linux,
 						VMSize:              "Standard_D2_v2",
@@ -670,6 +679,7 @@ func TestTemplateGenerator_GetKubernetesLinuxNodeCustomDataJSONObject(t *testing
 						VnetCidrs:           []string{"10.0.0.0/8"},
 					},
 				}
+				cs.Properties.LinuxProfile = nil
 				return *cs
 			},
 		},

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17293,14 +17293,14 @@ write_files:
     {{CloudInitData "generateProxyCertsScript"}}
 {{end}}
 
-{{if and HasLinuxProfile HasCustomSearchDomain}}
+{{if HasLinuxProfile }}{{if HasCustomSearchDomain}}
 - path: /opt/azure/containers/setup-custom-search-domains.sh
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "customSearchDomainsScript"}}
-{{end}}
+{{end}}{{end}}
 
 - path: /var/lib/kubelet/kubeconfig
   permissions: "0644"
@@ -17935,14 +17935,14 @@ write_files:
   content: |
     {{WrapAsParameter "clientCertificate"}}
 
-{{if and HasLinuxProfile HasCustomSearchDomain}}
+{{if HasLinuxProfile }}{{if HasCustomSearchDomain}}
 - path: /opt/azure/containers/setup-custom-search-domains.sh
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "customSearchDomainsScript"}}
-{{end}}
+{{end}}{{end}}
 
 - path: /var/lib/kubelet/kubeconfig
   permissions: "0644"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
In #2050 I pulled together two if statements in the custom data templates to make the code more concise. Unfortunately, I didn't test `if` the `and` statement short circuits or if it executes both side of the statement. This PR replaces the concise `and` with the less concise, but functionally correct double `if` statement.

I also added a test to ensure no one else will ever have this happen to them.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

/cc @Bhuvaneswari-Santharam 