### PR TITLE
chore: rev VHD images to 2019.10.15

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -154,7 +154,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1604-201910",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2019.10.15",
+		ImageVersion:   "2019.10.24",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
@@ -162,7 +162,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1804-201910",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2019.10.15",
+		ImageVersion:   "2019.10.27",
 	}
 
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019
@@ -170,7 +170,7 @@ var (
 		ImageOffer:     "aks-windows",
 		ImageSku:       "2019-datacenter-core-smalldisk",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "17763.805.191016",
+		ImageVersion:   "17763.805.191024",
 	}
 
 	// WindowsServer2019OSImageConfig is the 'vanilla' Windows Server 2019 image

--- a/releases/vhd-notes/aks-ubuntu-1604/aks-ubuntu-1604-201910_2019.10.24.txt
+++ b/releases/vhd-notes/aks-ubuntu-1604/aks-ubuntu-1604-201910_2019.10.24.txt
@@ -1,0 +1,177 @@
+Starting build on  Thu Oct 24 18:01:06 UTC 2019
+Using kernel:
+Linux version 4.15.0-1057-azure (buildd@lgw01-amd64-035) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.10)) #62-Ubuntu SMP Thu Sep 5 18:25:30 UTC 2019
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - etcd v3.3.15
+  - moby v3.0.7
+  - nvidia-docker2 nvidia-container-runtime
+  - Azure CNI version 1.0.28
+  - Azure CNI version 1.0.27
+  - CNI plugin version 0.7.5
+  - CNI plugin version 0.7.1
+  - containerd version 1.2.4
+  - containerd version 1.1.6
+  - containerd version 1.1.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - k8s.gcr.io/exechealthz-amd64:1.2
+  - k8s.gcr.io/addon-resizer:1.8.5
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - k8s.gcr.io/addon-resizer:1.8.1
+  - k8s.gcr.io/addon-resizer:1.7
+  - k8s.gcr.io/heapster-amd64:v1.5.4
+  - k8s.gcr.io/heapster-amd64:v1.5.3
+  - k8s.gcr.io/heapster-amd64:v1.5.1
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.8
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.7
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.6
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.0
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - mcr.microsoft.com/k8s/azurestack/core/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - gcr.io/kubernetes-helm/tiller:v2.11.0
+  - gcr.io/kubernetes-helm/tiller:v2.8.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.2
+  - k8s.gcr.io/cluster-autoscaler:v1.16.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.0
+  - k8s.gcr.io/cluster-autoscaler:v1.15.3
+  - k8s.gcr.io/cluster-autoscaler:v1.15.2
+  - k8s.gcr.io/cluster-autoscaler:v1.15.1
+  - k8s.gcr.io/cluster-autoscaler:v1.15.0
+  - k8s.gcr.io/cluster-autoscaler:v1.14.6
+  - k8s.gcr.io/cluster-autoscaler:v1.14.5
+  - k8s.gcr.io/cluster-autoscaler:v1.14.4
+  - k8s.gcr.io/cluster-autoscaler:v1.14.2
+  - k8s.gcr.io/cluster-autoscaler:v1.14.0
+  - k8s.gcr.io/cluster-autoscaler:v1.13.7
+  - k8s.gcr.io/cluster-autoscaler:v1.13.6
+  - k8s.gcr.io/cluster-autoscaler:v1.13.4
+  - k8s.gcr.io/cluster-autoscaler:v1.13.2
+  - k8s.gcr.io/cluster-autoscaler:v1.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.12.8
+  - k8s.gcr.io/cluster-autoscaler:v1.12.7
+  - k8s.gcr.io/cluster-autoscaler:v1.12.5
+  - k8s.gcr.io/cluster-autoscaler:v1.12.3
+  - k8s.gcr.io/cluster-autoscaler:v1.12.2
+  - k8s.gcr.io/cluster-autoscaler:v1.3.9
+  - k8s.gcr.io/cluster-autoscaler:v1.3.8
+  - k8s.gcr.io/cluster-autoscaler:v1.3.7
+  - k8s.gcr.io/cluster-autoscaler:v1.3.4
+  - k8s.gcr.io/cluster-autoscaler:v1.3.3
+  - k8s.gcr.io/cluster-autoscaler:v1.2.5
+  - k8s.gcr.io/cluster-autoscaler:v1.2.2
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+  - k8s.gcr.io/coredns:1.6.2
+  - k8s.gcr.io/coredns:1.5.0
+  - k8s.gcr.io/coredns:1.3.1
+  - k8s.gcr.io/coredns:1.2.6
+  - k8s.gcr.io/coredns:1.2.2
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - k8s.gcr.io/rescheduler:v0.3.1
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.5
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.18
+  - nvidia/k8s-device-plugin:1.11
+  - nvidia/k8s-device-plugin:1.10
+  - docker.io/deis/hcp-tunnel-front:v1.9.2-v4.0.4
+  - docker.io/deis/kube-svc-redirect:v1.0.2
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.5.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.3.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
+  - gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.0.0
+  - nginx:1.13.12-alpine
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/hyperkube-amd64:v1.16.2
+  - k8s.gcr.io/hyperkube-amd64:v1.16.1
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.16.1-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.5
+  - k8s.gcr.io/hyperkube-amd64:v1.15.5
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.5-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.4
+  - k8s.gcr.io/hyperkube-amd64:v1.15.4
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.4-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+  - k8s.gcr.io/hyperkube-amd64:v1.14.8
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.8-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+  - k8s.gcr.io/hyperkube-amd64:v1.14.7
+  - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.7-azs
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+  - k8s.gcr.io/hyperkube-amd64:v1.13.12
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+  - k8s.gcr.io/hyperkube-amd64:v1.13.11
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.8
+  - k8s.gcr.io/hyperkube-amd64:v1.12.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.7
+  - k8s.gcr.io/hyperkube-amd64:v1.12.7
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.10
+  - k8s.gcr.io/hyperkube-amd64:v1.11.10
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.9
+  - k8s.gcr.io/hyperkube-amd64:v1.11.9
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.13
+  - k8s.gcr.io/hyperkube-amd64:v1.10.13
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.12
+  - k8s.gcr.io/hyperkube-amd64:v1.10.12
+  - registry:2.7.1
+WARNING: 75% of /dev/sda1 is used
+Install completed successfully on  Thu Oct 24 18:29:12 UTC 2019
+VSTS Build NUMBER: 20191024.5
+VSTS Build ID: 26114315
+Commit: 4dfc7d54ae4d7f31499e5f96a1f4d55510874a6a
+Feature flags:

--- a/releases/vhd-notes/aks-ubuntu-1804/aks-ubuntu-1804-201910_2019.10.24.txt
+++ b/releases/vhd-notes/aks-ubuntu-1804/aks-ubuntu-1804-201910_2019.10.24.txt
@@ -1,0 +1,190 @@
+##[section]Starting: Generate VHD release notes
+==============================================================================
+Task         : Command line
+Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
+Version      : 2.151.2
+Author       : Microsoft Corporation
+Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
+==============================================================================
+Generating script.
+========================== Starting Command Output ===========================
+[command]/bin/bash --noprofile --norc /home/vsts/work/_temp/508a96da-7380-4aa6-b687-b989b0c02dc4.sh
+awk '/START_OF_NOTES/{y=1;next}y' packer-output > release-notes-raw.txt && awk '/END_OF_NOTES/ {exit} {print}' release-notes-raw.txt | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" | sed -e s/azure-arm://g | egrep -v '^==>\s{2}\+' > release-notes.txt && cat release-notes.txt
+     Starting build on  Thu Oct 24 21:36:35 UTC 2019
+     Using kernel:
+     Linux version 5.0.0-1022-azure (buildd@lgw01-amd64-047) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #23~18.04.1-Ubuntu SMP Mon Sep 30 19:47:06 UTC 2019
+     Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+       - apache2-utils
+       - apt-transport-https
+       - auditd
+       - blobfuse
+       - ca-certificates
+       - ceph-common
+       - cgroup-lite
+       - cifs-utils
+       - conntrack
+       - cracklib-runtime
+       - ebtables
+       - ethtool
+       - fuse
+       - git
+       - glusterfs-client
+       - init-system-helpers
+       - iproute2
+       - ipset
+       - iptables
+       - jq
+       - libpam-pwquality
+       - libpwquality-tools
+       - mount
+       - nfs-common
+       - pigz socat
+       - traceroute
+       - util-linux
+       - xz-utils
+       - zip
+       - etcd v3.3.15
+       - moby v3.0.7
+       - nvidia-docker2 nvidia-container-runtime
+       - Azure CNI version 1.0.28
+       - Azure CNI version 1.0.27
+       - CNI plugin version 0.7.5
+       - CNI plugin version 0.7.1
+       - containerd version 1.2.4
+       - containerd version 1.1.6
+       - containerd version 1.1.5
+       - img
+     Docker images pre-pulled:
+       - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+       - k8s.gcr.io/exechealthz-amd64:1.2
+       - k8s.gcr.io/addon-resizer:1.8.5
+       - k8s.gcr.io/addon-resizer:1.8.4
+       - k8s.gcr.io/addon-resizer:1.8.1
+       - k8s.gcr.io/addon-resizer:1.7
+       - k8s.gcr.io/heapster-amd64:v1.5.4
+       - k8s.gcr.io/heapster-amd64:v1.5.3
+       - k8s.gcr.io/heapster-amd64:v1.5.1
+       - k8s.gcr.io/metrics-server-amd64:v0.3.5
+       - k8s.gcr.io/metrics-server-amd64:v0.3.4
+       - k8s.gcr.io/metrics-server-amd64:v0.2.1
+       - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+       - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.0
+       - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
+       - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+       - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+       - k8s.gcr.io/kube-addon-manager-amd64:v9.0.1
+       - k8s.gcr.io/kube-addon-manager-amd64:v9.0
+       - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+       - k8s.gcr.io/kube-addon-manager-amd64:v8.9
+       - k8s.gcr.io/kube-addon-manager-amd64:v8.8
+       - k8s.gcr.io/kube-addon-manager-amd64:v8.7
+       - k8s.gcr.io/kube-addon-manager-amd64:v8.6
+       - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+       - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.0
+       - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+       - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+       - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+       - mcr.microsoft.com/k8s/core/pause:1.2.0
+       - k8s.gcr.io/pause-amd64:3.1
+       - mcr.microsoft.com/k8s/azurestack/core/pause-amd64:3.1
+       - gcr.io/kubernetes-helm/tiller:v2.13.1
+       - gcr.io/kubernetes-helm/tiller:v2.11.0
+       - gcr.io/kubernetes-helm/tiller:v2.8.1
+       - k8s.gcr.io/cluster-autoscaler:v1.16.2
+       - k8s.gcr.io/cluster-autoscaler:v1.16.1
+       - k8s.gcr.io/cluster-autoscaler:v1.16.0
+       - k8s.gcr.io/cluster-autoscaler:v1.15.3
+       - k8s.gcr.io/cluster-autoscaler:v1.15.2
+       - k8s.gcr.io/cluster-autoscaler:v1.15.1
+       - k8s.gcr.io/cluster-autoscaler:v1.15.0
+       - k8s.gcr.io/cluster-autoscaler:v1.14.6
+       - k8s.gcr.io/cluster-autoscaler:v1.14.5
+       - k8s.gcr.io/cluster-autoscaler:v1.14.4
+       - k8s.gcr.io/cluster-autoscaler:v1.14.2
+       - k8s.gcr.io/cluster-autoscaler:v1.14.0
+       - k8s.gcr.io/cluster-autoscaler:v1.13.7
+       - k8s.gcr.io/cluster-autoscaler:v1.13.6
+       - k8s.gcr.io/cluster-autoscaler:v1.13.4
+       - k8s.gcr.io/cluster-autoscaler:v1.13.2
+       - k8s.gcr.io/cluster-autoscaler:v1.13.1
+       - k8s.gcr.io/cluster-autoscaler:v1.12.8
+       - k8s.gcr.io/cluster-autoscaler:v1.12.7
+       - k8s.gcr.io/cluster-autoscaler:v1.12.5
+       - k8s.gcr.io/cluster-autoscaler:v1.12.3
+       - k8s.gcr.io/cluster-autoscaler:v1.12.2
+       - k8s.gcr.io/cluster-autoscaler:v1.3.9
+       - k8s.gcr.io/cluster-autoscaler:v1.3.8
+       - k8s.gcr.io/cluster-autoscaler:v1.3.7
+       - k8s.gcr.io/cluster-autoscaler:v1.3.4
+       - k8s.gcr.io/cluster-autoscaler:v1.3.3
+       - k8s.gcr.io/cluster-autoscaler:v1.2.5
+       - k8s.gcr.io/cluster-autoscaler:v1.2.2
+       - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+       - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+       - k8s.gcr.io/coredns:1.6.2
+       - k8s.gcr.io/coredns:1.5.0
+       - k8s.gcr.io/coredns:1.3.1
+       - k8s.gcr.io/coredns:1.2.6
+       - k8s.gcr.io/coredns:1.2.2
+       - k8s.gcr.io/rescheduler:v0.4.0
+       - k8s.gcr.io/rescheduler:v0.3.1
+       - microsoft/virtual-kubelet:latest
+       - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+       - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.5
+       - mcr.microsoft.com/containernetworking/azure-npm:v1.0.18
+       - nvidia/k8s-device-plugin:1.11
+       - nvidia/k8s-device-plugin:1.10
+       - docker.io/deis/hcp-tunnel-front:v1.9.2-v4.0.4
+       - docker.io/deis/kube-svc-redirect:v1.0.2
+       - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13
+       - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+       - gcr.io/google-containers/ip-masq-agent-amd64:v2.5.0
+       - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+       - gcr.io/google-containers/ip-masq-agent-amd64:v2.3.0
+       - k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
+       - gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
+       - k8s.gcr.io/ip-masq-agent-amd64:v2.0.0
+       - nginx:1.13.12-alpine
+       - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+       - quay.io/coreos/flannel:v0.10.0-amd64
+       - quay.io/coreos/flannel:v0.8.0-amd64
+       - busybox
+       - k8s.gcr.io/hyperkube-amd64:v1.16.2
+       - k8s.gcr.io/hyperkube-amd64:v1.16.1
+       - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.16.1-azs
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.5
+       - k8s.gcr.io/hyperkube-amd64:v1.15.5
+       - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.5-azs
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.4
+       - k8s.gcr.io/hyperkube-amd64:v1.15.4
+       - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.4-azs
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+       - k8s.gcr.io/hyperkube-amd64:v1.14.8
+       - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.8-azs
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+       - k8s.gcr.io/hyperkube-amd64:v1.14.7
+       - mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.7-azs
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+       - k8s.gcr.io/hyperkube-amd64:v1.13.12
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+       - k8s.gcr.io/hyperkube-amd64:v1.13.11
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.8
+       - k8s.gcr.io/hyperkube-amd64:v1.12.8
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.12.7
+       - k8s.gcr.io/hyperkube-amd64:v1.12.7
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.10
+       - k8s.gcr.io/hyperkube-amd64:v1.11.10
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.11.9
+       - k8s.gcr.io/hyperkube-amd64:v1.11.9
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.13
+       - k8s.gcr.io/hyperkube-amd64:v1.10.13
+       - k8s.gcr.io/cloud-controller-manager-amd64:v1.10.12
+       - k8s.gcr.io/hyperkube-amd64:v1.10.12
+       - registry:2.7.1
+     WARNING: 75% of /dev/sda1 is used
+     Install completed successfully on  Thu Oct 24 22:05:37 UTC 2019
+     VSTS Build NUMBER: 20191024.10
+     VSTS Build ID: 26120877
+     Commit: 8d885abef4a4bf176d155b7d3573e7cf8d9b54de
+     Feature flags:
+##[section]Finishing: Generate VHD release notes

--- a/releases/vhd-notes/aks-windows/2019-datacenter-core-smalldisk-17763.805.191024.txt
+++ b/releases/vhd-notes/aks-windows/2019-datacenter-core-smalldisk-17763.805.191024.txt
@@ -1,0 +1,103 @@
+﻿Build Number: 20191024.1
+Build Id:     1195
+Build Repo:   https://github.com/Azure/aks-engine
+Build Branch: master
+Commit:       4dfc7d54ae4d7f31499e5f96a1f4d55510874a6a
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.805
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB4515855 : Update          : http://support.microsoft.com/?kbid=4515855
+	KB4521862 : Security Update : http://support.microsoft.com/?kbid=4521862
+	KB4519338 : Security Update : http://support.microsoft.com/?kbid=4519338
+
+Installed Updates
+	2019-10 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB4524099)
+	Security Intelligence Update for Windows Defender Antivirus - KB2267602 (Version 1.305.552.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+ 
+Docker Info
+Version: Docker version 19.03.2, build c92ab06ed9
+ 
+Images:
+
+Repository                           Tag      ID
+----------                           ---      --
+mcr.microsoft.com/windows/servercore ltsc2019 739b21bd02e7
+mcr.microsoft.com/windows/nanoserver 1809     8a09fa9e06cd
+mcr.microsoft.com/k8s/core/pause     1.2.0    a74290a8271a
+
+Cached Files:
+
+File                                                                Sha256                                                           SizeBytes
+----                                                                ------                                                           ---------
+c:\akse-cache\collectlogs.ps1                                       20EBF26879A5E90EC152782D4B31CD7EA7C612CF0136B4C247A2076B141A0F21      6447
+c:\akse-cache\dumpVfpPolicies.ps1                                   02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                           E3082C3C63F4BE928B2293CA8C83085FA90C717F70314B6B9653E72AFE8CCC18     17945
+c:\akse-cache\hns.psm1                                              A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\starthnstrace.cmd                                     3A566462ADBD27A0DCAB4049EF4A1A3EE7AECF2FCFEC6ED8A1CAE305AE7EF562       408
+c:\akse-cache\startpacketcapture.cmd                                3E31690E507C8B18AC5CC569C89B51CE1901630A501472DA1BC1FBF2737AA5BC       756
+c:\akse-cache\stoppacketcapture.cmd                                 BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\win-bridge.exe                                        CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\win-k8s\azs-v1.14.6-1int.zip                          43C9CBE75B621DB2AF802E5FB3C6C53BDF8BEF5DA59623DDD9D5483DD761A1AF  56008759
+c:\akse-cache\win-k8s\azs-v1.14.7-1int.zip                          B67C9B684FCA483DBDB9C2D1024CE39A06384B63F7E9B261DA4A4E1334C9F8B7  59750140
+c:\akse-cache\win-k8s\azs-v1.14.8-1int.zip                          7E67A468C18C4821DDA2D98E255E4F8915C93458AD48916E4DBF1A481807831C  59761800
+c:\akse-cache\win-k8s\azs-v1.15.3-1int.zip                          66F6110E23CEB4BBFA21E2B0A586FAA9FB012CBE7A05C9E5975A90F73B01DC1A  95274346
+c:\akse-cache\win-k8s\azs-v1.15.4-1int.zip                          1E7B76FA30DFBF14D201D7058FFC258DBB0FA4A96FF07168A4B8AC3D4A200838  99025654
+c:\akse-cache\win-k8s\azs-v1.15.5-1int.zip                          C3432D22404369D6DEBC32B3EC4B90A01FC9AD38BAC28FF9BA838CC2B915FD51  99058367
+c:\akse-cache\win-k8s\azs-v1.16.0-1int.zip                          2387A0A44873D1E293D58D1D74F796CBB63F46AE34B5953D4BACCB16CD83D6A0 104442496
+c:\akse-cache\win-k8s\azs-v1.16.1-1int.zip                          2B00DECA4D742345DD96B22C9BEDB1FC327CE8563AD0139E7CA5131F052706A9 104444767
+c:\akse-cache\win-k8s\v1.14.6-1int.zip                              60DCBF2DD2A1B7D9CD43AFCA4C73B1954CFCD8D3BD889FEFBA6BE1BF74A933FC  59749551
+c:\akse-cache\win-k8s\v1.14.7-1int.zip                              161FECE8E31EAF3E9B5F3AFF9D138E3D5CF8F4AC5834C00069ADD815A573AB7B  59754112
+c:\akse-cache\win-k8s\v1.14.8-1int.zip                              BF63ECE78C64F284D3A87DB23664C7FB3E9C946D7B87A2F67D54ECD59BC287B0  59763614
+c:\akse-cache\win-k8s\v1.15.3-1int.zip                              7F6B2F6D1FAB497133F5256830F52C3DB134D712D881EBA35C2A3110FDA68D7A  59719316
+c:\akse-cache\win-k8s\v1.15.4-1int.zip                              6B7ED827B29D02B161C6F57F23FD483864EBA39FE84E0A66CF366BB583CBB256  59740293
+c:\akse-cache\win-k8s\v1.15.5-1int.zip                              BEE2B8FA7A4BEE07A400285C7753176404828F7C56B1079A760AF14A03F87D8E  59748073
+c:\akse-cache\win-k8s\v1.16.0-1int.zip                              08CD45F298FFCC8324F819E2AF3958FB400E48A814AEDD51DC2DEBAD3E216D4B  62486113
+c:\akse-cache\win-k8s\v1.16.1-1int.zip                              A8211D7247DB059903541986BAC83F7C4B9C783DB7609F631D155F560FBA5807  62484467
+c:\akse-cache\win-k8s\v1.16.2-1int.zip                              6AE1FA3474AA4BDA1F89C47023F7CC299BFE547A03995D829EA08FB1B886D5DD  62496659
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-windows-amd64-v1.0.27.zip 7EFE962E00D4766C8ABDAF50ABCF7176A6CF046C43B760DB63C3D13A6A4F8DE4   6511793


### PR DESCRIPTION
**Reason for Change**:
This PR pre-downloads hyperkube images for the following Kubernetes versions:

v1.15.5 Azure Stack
v1.14.8 Azure Stack

No longer includes pre-pulled hyperkube images for these versions:

v1.13.11 Azure Stack

Pre-pulls the following container images:

k8s.gcr.io/cluster-autoscaler:v1.16.2
k8s.gcr.io/cluster-autoscaler:v1.15.3
k8s.gcr.io/cluster-autoscaler:v1.14.6

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
