### PR TITLE
fix: Ensured identity system passed from cli is propagated to api model

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -220,6 +220,10 @@ func (dc *deployCmd) loadAPIModel() error {
 		return errors.New("--location does not match api model location")
 	}
 
+	if dc.containerService.Properties.CustomCloudProfile.IdentitySystem == "" {
+		dc.containerService.Properties.CustomCloudProfile.IdentitySystem = dc.authProvider.getAuthArgs().IdentitySystem
+	}
+
 	if dc.containerService.Properties.IsAzureStackCloud() {
 		err = dc.containerService.SetCustomCloudProfileEnvironment()
 		if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -220,16 +220,18 @@ func (dc *deployCmd) loadAPIModel() error {
 		return errors.New("--location does not match api model location")
 	}
 
-	if dc.containerService.Properties.CustomCloudProfile.IdentitySystem == "" {
-		dc.containerService.Properties.CustomCloudProfile.IdentitySystem = dc.authProvider.getAuthArgs().IdentitySystem
-	}
-
 	if dc.containerService.Properties.IsAzureStackCloud() {
 		err = dc.containerService.SetCustomCloudProfileEnvironment()
 		if err != nil {
 			return errors.Wrap(err, "error parsing the api model")
 		}
 		writeCustomCloudProfile(dc.containerService)
+
+		if dc.containerService.Properties.CustomCloudProfile.IdentitySystem == "" {
+			if dc.authProvider != nil {
+				dc.containerService.Properties.CustomCloudProfile.IdentitySystem = dc.authProvider.getAuthArgs().IdentitySystem
+			}
+		}
 	}
 
 	if err = dc.getAuthArgs().validateAuthArgs(); err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -227,7 +227,7 @@ func (dc *deployCmd) loadAPIModel() error {
 		}
 		writeCustomCloudProfile(dc.containerService)
 
-		if dc.containerService.Properties.CustomCloudProfile.IdentitySystem == "" {
+		if dc.containerService.Properties.CustomCloudProfile.IdentitySystem == "" || dc.containerService.Properties.CustomCloudProfile.IdentitySystem != dc.authProvider.getAuthArgs().IdentitySystem {
 			if dc.authProvider != nil {
 				dc.containerService.Properties.CustomCloudProfile.IdentitySystem = dc.authProvider.getAuthArgs().IdentitySystem
 			}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -624,6 +624,47 @@ func TestDeployCmdRun(t *testing.T) {
 	}
 }
 
+func TestLoadApiModelOnAzureStack(t *testing.T) {
+	d := &deployCmd{
+		client: &armhelpers.MockAKSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs:      &authArgs{},
+			getClientMock: &armhelpers.MockAKSEngineClient{},
+		},
+		apimodelPath:    "../pkg/engine/testdata/azurestack/kubernetes.json",
+		outputDirectory: "_test_output",
+		forceOverwrite:  true,
+		location:        "westus",
+	}
+
+	r := &cobra.Command{}
+	f := r.Flags()
+
+	addAuthFlags(d.getAuthArgs(), f)
+
+	d.location = "local"
+	fakeRawSubscriptionID := "6dc93fae-9a76-421f-bbe5-cc6460ea81cb"
+	fakeSubscriptionID, err := uuid.Parse(fakeRawSubscriptionID)
+	fakeClientID := "b829b379-ca1f-4f1d-91a2-0d26b244680d"
+	fakeClientSecret := "0se43bie-3zs5-303e-aav5-dcf231vb82ds"
+	if err != nil {
+		t.Fatalf("Invalid SubscriptionId in Test: %s", err)
+	}
+
+	d.getAuthArgs().SubscriptionID = fakeSubscriptionID
+	d.getAuthArgs().rawSubscriptionID = fakeRawSubscriptionID
+	d.getAuthArgs().rawClientID = fakeClientID
+	d.getAuthArgs().ClientSecret = fakeClientSecret
+	if err != nil {
+		t.Fatalf("Invalid SubscriptionId in Test: %s", err)
+	}
+
+	err = d.loadAPIModel()
+	if err != nil {
+		t.Fatalf("Failed to call LoadAPIModel: %s", err)
+	}
+}
+
 func TestOutputDirectoryWithDNSPrefix(t *testing.T) {
 	apiloader := &api.Apiloader{
 		Translator: nil,

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -651,6 +651,7 @@ func TestLoadApiModelOnAzureStack(t *testing.T) {
 		t.Fatalf("Invalid SubscriptionId in Test: %s", err)
 	}
 
+	d.getAuthArgs().IdentitySystem = "adfs"
 	d.getAuthArgs().SubscriptionID = fakeSubscriptionID
 	d.getAuthArgs().rawSubscriptionID = fakeRawSubscriptionID
 	d.getAuthArgs().rawClientID = fakeClientID
@@ -662,6 +663,10 @@ func TestLoadApiModelOnAzureStack(t *testing.T) {
 	err = d.loadAPIModel()
 	if err != nil {
 		t.Fatalf("Failed to call LoadAPIModel: %s", err)
+	}
+
+	if d.getAuthArgs().IdentitySystem != d.containerService.Properties.CustomCloudProfile.IdentitySystem {
+		t.Fatal("Failed to set cli Identity system as default ")
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Ensures that in cases where the cloud profile in the api model has not specified an identity system, the identity system passed in the cli will be used before using defaults. Issue only happens in deploy command. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2054

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
