### PR TITLE
feat: support using existing identity for addons

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -109,6 +109,16 @@ type ClusterMetadata struct {
 type AddonProfile struct {
 	Enabled bool              `json:"enabled"`
 	Config  map[string]string `json:"config"`
+	// Identity contains information of the identity associated with this addon.
+	// This property will only appear in an MSI-enabled cluster.
+	Identity *UserAssignedIdentity `json:"identity,omitempty"`
+}
+
+// UserAssignedIdentity contains information that uniquely identifies an identity
+type UserAssignedIdentity struct {
+	ResourceID string `json:"resourceId,omitempty"`
+	ClientID   string `json:"clientId,omitempty"`
+	ObjectID   string `json:"objectId,omitempty"`
 }
 
 // FeatureFlags defines feature-flag restricted functionality

--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -607,6 +607,9 @@ func addCustomTagsToVM(tags map[string]string, vm *compute.VirtualMachine) {
 }
 
 func associateAddonIdentitiesToVM(addonProfiles map[string]api.AddonProfile, virtualMachine *compute.VirtualMachine) {
+	if virtualMachine == nil {
+		return
+	}
 	for _, addonProfile := range addonProfiles {
 		if addonProfile.Enabled && addonProfile.Identity != nil && addonProfile.Identity.ResourceID != "" {
 			// We need to associate addon's identity to VM, there're 3 cases:

--- a/pkg/engine/virtualmachines_test.go
+++ b/pkg/engine/virtualmachines_test.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/aks-engine/pkg/api"
@@ -681,5 +682,68 @@ func TestCreateVMsWithCustomOS(t *testing.T) {
 
 	if cs.Properties.AgentPoolProfiles[0].HasImageRef() != true || cs.Properties.AgentPoolProfiles[0].HasImageGallery() != false {
 		t.Error("expected custom OS to have image ref")
+	}
+}
+
+func TestAssociateAddonIdentitiesToVM(t *testing.T) {
+	mockKubeletIdentityResourceID := "/subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/resourcegroups/fooRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kubeletIdentity"
+	mockOMSAgentIdentityResourceID := "/subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/resourcegroups/fooRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/omsagentIdentity"
+	mockAzurePolicyIdentityResourceID := "/subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/resourcegroups/fooRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurePolicyIdentity"
+	mockAddonProfiles := map[string]api.AddonProfile{
+		"omsagent": {
+			Enabled: true,
+			Config: map[string]string{
+				"foo": "bar",
+			},
+			Identity: &api.UserAssignedIdentity{
+				ResourceID: mockOMSAgentIdentityResourceID,
+			},
+		},
+		"azurepolicy": {
+			Enabled: true,
+			Config: map[string]string{
+				"foo": "bar",
+			},
+			Identity: &api.UserAssignedIdentity{
+				ResourceID: mockAzurePolicyIdentityResourceID,
+			},
+		},
+	}
+
+	mockVM := compute.VirtualMachine{
+		Identity: &compute.VirtualMachineIdentity{
+			Type: compute.ResourceIdentityTypeUserAssigned,
+			UserAssignedIdentities: map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{
+				mockKubeletIdentityResourceID: {},
+			},
+		},
+	}
+
+	// Test with nil VM, there should be no panic
+	associateAddonIdentitiesToVM(mockAddonProfiles, nil)
+	// Test with nil addonProfiles, vmss.Identity should keep unchanged.
+	associateAddonIdentitiesToVM(nil, &mockVM)
+	expectedVMIdentity := compute.VirtualMachineIdentity{
+		Type: compute.ResourceIdentityTypeUserAssigned,
+		UserAssignedIdentities: map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{
+			mockKubeletIdentityResourceID: {},
+		},
+	}
+	if !reflect.DeepEqual(*mockVM.Identity, expectedVMIdentity) {
+		t.Errorf("unexpected error while associate nil addonProfiles to VM. Expected vm.Identity: %+v, found: %+v", expectedVMIdentity, *mockVM.Identity)
+	}
+
+	// Test with normal case
+	associateAddonIdentitiesToVM(mockAddonProfiles, &mockVM)
+	expectedVMIdentity = compute.VirtualMachineIdentity{
+		Type: compute.ResourceIdentityTypeUserAssigned,
+		UserAssignedIdentities: map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{
+			mockKubeletIdentityResourceID:     {},
+			mockOMSAgentIdentityResourceID:    {},
+			mockAzurePolicyIdentityResourceID: {},
+		},
+	}
+	if !reflect.DeepEqual(*mockVM.Identity, expectedVMIdentity) {
+		t.Errorf("unexpected error while associate addonProfiles to VMSS. Expected vmss.Identity: %+v, found: %+v", expectedVMIdentity, *mockVM.Identity)
 	}
 }

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -817,6 +817,9 @@ func addCustomTagsToVMScaleSets(tags map[string]string, vm *compute.VirtualMachi
 }
 
 func associateAddonIdentitiesToVMSS(addonProfiles map[string]api.AddonProfile, virtualMachineScaleSet *compute.VirtualMachineScaleSet) {
+	if virtualMachineScaleSet == nil {
+		return
+	}
 	for _, addonProfile := range addonProfiles {
 		if addonProfile.Enabled && addonProfile.Identity != nil && addonProfile.Identity.ResourceID != "" {
 			// We need to associate addon's identity to VMSS, there're 3 cases:

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -273,23 +273,6 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 
 	var extensions []compute.VirtualMachineScaleSetExtension
 
-	if useManagedIdentity {
-		managedIdentityExtension := compute.VirtualMachineScaleSetExtension{
-			Name: to.StringPtr("[concat(variables('masterVMNamePrefix'), 'vmss-ManagedIdentityExtension')]"),
-			VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
-				Publisher:               to.StringPtr("Microsoft.ManagedIdentity"),
-				Type:                    to.StringPtr("ManagedIdentityExtensionForLinux"),
-				TypeHandlerVersion:      to.StringPtr("1.0"),
-				AutoUpgradeMinorVersion: to.BoolPtr(true),
-				Settings: map[string]interface{}{
-					"port": 50343,
-				},
-				ProtectedSettings: map[string]interface{}{},
-			},
-		}
-		extensions = append(extensions, managedIdentityExtension)
-	}
-
 	outBoundCmd := ""
 	registry := ""
 	ncBinary := "nc"

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -217,19 +217,6 @@ func TestCreateMasterVMSS(t *testing.T) {
 	expected.VirtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{
 		Extensions: &[]compute.VirtualMachineScaleSetExtension{
 			{
-				Name: to.StringPtr("[concat(variables('masterVMNamePrefix'), 'vmss-ManagedIdentityExtension')]"),
-				VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
-					Publisher:               to.StringPtr("Microsoft.ManagedIdentity"),
-					Type:                    to.StringPtr("ManagedIdentityExtensionForLinux"),
-					TypeHandlerVersion:      to.StringPtr("1.0"),
-					AutoUpgradeMinorVersion: to.BoolPtr(true),
-					Settings: map[string]interface{}{
-						"port": 50343,
-					},
-					ProtectedSettings: map[string]interface{}{},
-				},
-			},
-			{
 				Name: to.StringPtr("[concat(variables('masterVMNamePrefix'), 'vmssCSE')]"),
 				VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
 					Publisher:               to.StringPtr("Microsoft.Azure.Extensions"),

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -1154,5 +1155,68 @@ func TestCreateCustomOSVMSS(t *testing.T) {
 
 	if diff != "" {
 		t.Errorf("unexpected diff while expecting equal agent VMSS structs: %s", diff)
+	}
+}
+
+func TestAssociateAddonIdentitiesToVMSS(t *testing.T) {
+	mockKubeletIdentityResourceID := "/subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/resourcegroups/fooRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kubeletIdentity"
+	mockOMSAgentIdentityResourceID := "/subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/resourcegroups/fooRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/omsagentIdentity"
+	mockAzurePolicyIdentityResourceID := "/subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/resourcegroups/fooRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurePolicyIdentity"
+	mockAddonProfiles := map[string]api.AddonProfile{
+		"omsagent": {
+			Enabled: true,
+			Config: map[string]string{
+				"foo": "bar",
+			},
+			Identity: &api.UserAssignedIdentity{
+				ResourceID: mockOMSAgentIdentityResourceID,
+			},
+		},
+		"azurepolicy": {
+			Enabled: true,
+			Config: map[string]string{
+				"foo": "bar",
+			},
+			Identity: &api.UserAssignedIdentity{
+				ResourceID: mockAzurePolicyIdentityResourceID,
+			},
+		},
+	}
+
+	mockVMSS := compute.VirtualMachineScaleSet{
+		Identity: &compute.VirtualMachineScaleSetIdentity{
+			Type: compute.ResourceIdentityTypeUserAssigned,
+			UserAssignedIdentities: map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{
+				mockKubeletIdentityResourceID: {},
+			},
+		},
+	}
+
+	// Test with nil VMSS, there should be no panic
+	associateAddonIdentitiesToVMSS(mockAddonProfiles, nil)
+	// Test with nil addonProfiles, vmss.Identity should keep unchanged.
+	associateAddonIdentitiesToVMSS(nil, &mockVMSS)
+	expectedVMSSIdentity := compute.VirtualMachineScaleSetIdentity{
+		Type: compute.ResourceIdentityTypeUserAssigned,
+		UserAssignedIdentities: map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{
+			mockKubeletIdentityResourceID: {},
+		},
+	}
+	if !reflect.DeepEqual(*mockVMSS.Identity, expectedVMSSIdentity) {
+		t.Errorf("unexpected error while associate nil addonProfiles to VMSS. Expected vmss.Identity: %+v, found: %+v", expectedVMSSIdentity, *mockVMSS.Identity)
+	}
+
+	// Test with normal case
+	associateAddonIdentitiesToVMSS(mockAddonProfiles, &mockVMSS)
+	expectedVMSSIdentity = compute.VirtualMachineScaleSetIdentity{
+		Type: compute.ResourceIdentityTypeUserAssigned,
+		UserAssignedIdentities: map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{
+			mockKubeletIdentityResourceID:     {},
+			mockOMSAgentIdentityResourceID:    {},
+			mockAzurePolicyIdentityResourceID: {},
+		},
+	}
+	if !reflect.DeepEqual(*mockVMSS.Identity, expectedVMSSIdentity) {
+		t.Errorf("unexpected error while associate addonProfiles to VMSS. Expected vmss.Identity: %+v, found: %+v", expectedVMSSIdentity, *mockVMSS.Identity)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Detailed background can be found in #2233 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2233 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
 - Though AKS will only generate agent nodes' ARM template, I associate addons' identity to master VM(SS) to keep consistent with agent nodes' behaviror.