### PR TITLE
chore: remove k8s 1.10 from VHD

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -413,8 +413,6 @@ K8S_VERSIONS="
 1.12.7
 1.11.10
 1.11.9
-1.10.13
-1.10.12
 "
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
   if [[ $KUBERNETES_VERSION == *"azs"* ]]; then


### PR DESCRIPTION
**Reason for Change**:
Removing 1.10.x hyperkube images from the VHD should have been part of removing 1.10 support in  #2234.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
