### PR TITLE
fix: add retry/logging/validation around docker command for windows

### DIFF
--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -116,6 +116,7 @@ function Invoke-Executable
         & $Executable $ArgList
         if ($LASTEXITCODE -notin $AllowedExitCodes) {
             Write-Log "$Executable returned unsuccessfully with exit code $LASTEXITCODE"
+            Start-Sleep -Seconds $RetryDelaySeconds
             continue
         } else {
             Write-Log "$Executable returned successfully"
@@ -123,7 +124,7 @@ function Invoke-Executable
         }
     }
 
-    throw "Exhasted retries for $Executable $ArgList"
+    throw "Exhausted retries for $Executable $ArgList"
 }
 
 function Get-NetworkLogCollectionScripts {

--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -96,6 +96,36 @@ function Retry-Command
     }
 }
 
+function Invoke-Executable
+{
+    Param(
+        [string]
+        $Executable,
+        [string[]]
+        $ArgList,
+        [int[]]
+        $AllowedExitCodes = @(0),
+        [int]
+        $Retries = 1,
+        [int]
+        $RetryDelaySeconds = 1
+    )
+
+    for ($i = 0; $i -lt $Retries; $i++) {
+        Write-Log "Running $Executable $ArgList ..."
+        & $Executable $ArgList
+        if ($LASTEXITCODE -notin $AllowedExitCodes) {
+            Write-Log "$Executable returned unsuccessfully with exit code $LASTEXITCODE"
+            continue
+        } else {
+            Write-Log "$Executable returned successfully"
+            return
+        }
+    }
+
+    throw "Exhasted retries for $Executable $ArgList"
+}
+
 function Get-NetworkLogCollectionScripts {
     Write-Log "Getting CollectLogs.ps1 and depencencies"
     mkdir 'c:\k\debug'

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -239,6 +239,13 @@ try
         Write-Log "Create the Pause Container kubletwin/pause"
         New-InfraContainer -KubeDir $global:KubeDir
 
+        if (-not (Test-ContainerImageExists -Image "kubletwin/pause")) {
+            Write-Log "Could not find container with name kubletwin/pause"
+            $o = docker image list
+            Write-Log $o
+            throw "Kubeletwin/pause container does not exist!"
+        }
+
         Write-Log "Configuring networking with NetworkPlugin:$global:NetworkPlugin"
 
         # Configure network policy.

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -243,7 +243,7 @@ try
             Write-Log "Could not find container with name kubletwin/pause"
             $o = docker image list
             Write-Log $o
-            throw "Kubeletwin/pause container does not exist!"
+            throw "kubletwin/pause container does not exist!"
         }
 
         Write-Log "Configuring networking with NetworkPlugin:$global:NetworkPlugin"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -33419,6 +33419,7 @@ function Invoke-Executable
         & $Executable $ArgList
         if ($LASTEXITCODE -notin $AllowedExitCodes) {
             Write-Log "$Executable returned unsuccessfully with exit code $LASTEXITCODE"
+            Start-Sleep -Seconds $RetryDelaySeconds
             continue
         } else {
             Write-Log "$Executable returned successfully"
@@ -33426,7 +33427,7 @@ function Invoke-Executable
         }
     }
 
-    throw "Exhasted retries for $Executable $ArgList"
+    throw "Exhausted retries for $Executable $ArgList"
 }
 
 function Get-NetworkLogCollectionScripts {
@@ -33701,7 +33702,7 @@ try
             Write-Log "Could not find container with name kubletwin/pause"
             $o = docker image list
             Write-Log $o
-            throw "Kubeletwin/pause container does not exist!"
+            throw "kubletwin/pause container does not exist!"
         }
 
         Write-Log "Configuring networking with NetworkPlugin:$global:NetworkPlugin"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -33399,6 +33399,36 @@ function Retry-Command
     }
 }
 
+function Invoke-Executable
+{
+    Param(
+        [string]
+        $Executable,
+        [string[]]
+        $ArgList,
+        [int[]]
+        $AllowedExitCodes = @(0),
+        [int]
+        $Retries = 1,
+        [int]
+        $RetryDelaySeconds = 1
+    )
+
+    for ($i = 0; $i -lt $Retries; $i++) {
+        Write-Log "Running $Executable $ArgList ..."
+        & $Executable $ArgList
+        if ($LASTEXITCODE -notin $AllowedExitCodes) {
+            Write-Log "$Executable returned unsuccessfully with exit code $LASTEXITCODE"
+            continue
+        } else {
+            Write-Log "$Executable returned successfully"
+            return
+        }
+    }
+
+    throw "Exhasted retries for $Executable $ArgList"
+}
+
 function Get-NetworkLogCollectionScripts {
     Write-Log "Getting CollectLogs.ps1 and depencencies"
     mkdir 'c:\k\debug'
@@ -33666,6 +33696,13 @@ try
 
         Write-Log "Create the Pause Container kubletwin/pause"
         New-InfraContainer -KubeDir $global:KubeDir
+
+        if (-not (Test-ContainerImageExists -Image "kubletwin/pause")) {
+            Write-Log "Could not find container with name kubletwin/pause"
+            $o = docker image list
+            Write-Log $o
+            throw "Kubeletwin/pause container does not exist!"
+        }
 
         Write-Log "Configuring networking with NetworkPlugin:$global:NetworkPlugin"
 
@@ -34799,7 +34836,7 @@ Build-PauseContainer {
     # Future work: This needs to build wincat - see https://github.com/Azure/aks-engine/issues/1461
     "FROM $($WindowsBase)" | Out-File -encoding ascii -FilePath Dockerfile
     "CMD cmd /c ping -t localhost" | Out-File -encoding ascii -FilePath Dockerfile -Append
-    docker build -t $DestinationTag .
+    Invoke-Executable -Executable "docker" -ArgList @("build", "-t", "$DestinationTag", ".")
 }
 
 function
@@ -34821,20 +34858,39 @@ New-InfraContainer {
         "1803" { 
             $imageList = docker images $defaultPauseImage --format "{{.Repository}}:{{.Tag}}"
             if (-not $imageList) {
-                docker pull $defaultPauseImage                 
+                Invoke-Executable -Executable "docker" -ArgList @("pull", "$defaultPauseImage") -Retries 5 -RetryDelaySeconds 30
             }
-            docker tag $defaultPauseImage $DestinationTag
+            Invoke-Executable -Executable "docker" -ArgList @("tag", "$defaultPauseImage", "$DestinationTag")
         }
         "1809" { 
             $imageList = docker images $defaultPauseImage --format "{{.Repository}}:{{.Tag}}"
             if (-not $imageList) {
-                docker pull $defaultPauseImage                
+                Invoke-Executable -Executable "docker" -ArgList @("pull", "$defaultPauseImage") -Retries 5 -RetryDelaySeconds 30
             }
-            docker tag $defaultPauseImage $DestinationTag 
+            Invoke-Executable -Executable "docker" -ArgList @("tag", "$defaultPauseImage", "$DestinationTag")
         }
         "1903" { Build-PauseContainer -WindowsBase "mcr.microsoft.com/windows/nanoserver:1903" -DestinationTag $DestinationTag}
         default { Build-PauseContainer -WindowsBase "mcr.microsoft.com/nanoserver-insider" -DestinationTag $DestinationTag}
     }
+}
+
+function
+Test-ContainerImageExists {
+    Param(
+        [Parameter(Mandatory = $true)][string]
+        $Image,
+        [Parameter(Mandatory = $false)][string]
+        $Tag
+    )
+
+    $target = $Image
+    if ($Tag) {
+        $target += ":$Tag"
+    }
+
+    $images = docker image list $target --format "{{json .}}"
+
+    return $images.Count -gt 0
 }
 
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Issue #2220 documents a case where the CSE failed to pull the pause image but reported success which led to a bunch of problems. This change adds checks around key docker commands and will fail the CSE if they do not run successfully (after a specified amount of retires)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2220

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
