### PR TITLE
fix: Add 1.0.28 Azure CNI zip file into windows vhd

### DIFF
--- a/packer/configure-windows-vhd.ps1
+++ b/packer/configure-windows-vhd.ps1
@@ -65,26 +65,21 @@ function Get-FilesToCacheOnVHD
             "https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1"
         );
         "c:\akse-cache\win-k8s\" = @(
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.6-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.7-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.14.8-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.3-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.4-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.15.5-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/azs-v1.16.0-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/azs-v1.16.1-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/v1.14.6-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.14.7-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.14.8-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/v1.15.3-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.15.4-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.15.5-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/v1.16.0-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.16.1-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.16.2-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
-            "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.27.zip"
+            "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.27.zip",
+            "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.28.zip"
         )
     }
 


### PR DESCRIPTION

**Reason for Change**:
Add 1.0.28 Azure CNI zip file into windows vhd to get align with linux vhd

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2267 

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
