### PR TITLE
chore: lock the golangci-lint to 1.21.0 and use vendored modules

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -16,4 +16,4 @@ $(GOBIN)/ginkgo:
 	$(GO) get github.com/onsi/ginkgo/ginkgo/...@v1.10.1
 
 $(GOBIN)/golangci-lint:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.21.0

--- a/scripts/validate-go.sh
+++ b/scripts/validate-go.sh
@@ -25,6 +25,6 @@ fi
 # exit 1 if golangci-lint output contains error text, to work
 # around https://github.com/golangci/golangci-lint/issues/276
 exec 5>&1
-if ! OUTPUT=$(golangci-lint run 2>&1 | tee >(cat - >&5)) || grep 'skipped due to error' <<<$OUTPUT; then
+if ! OUTPUT=$(golangci-lint run --modules-download-mode=vendor 2>&1 | tee >(cat - >&5)) || grep 'skipped due to error' <<<$OUTPUT; then
   exit 1
 fi


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
- Lock the version of the golangci-lint to a specific version for more build stability
- Specify vendor modules only

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
