### PR TITLE
fix: don't hide DCOS funcs from e2e-runner

### DIFF
--- a/pkg/engine/engine_dcos.go
+++ b/pkg/engine/engine_dcos.go
@@ -1,5 +1,3 @@
-//+build !test
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 


### PR DESCRIPTION
**Reason for Change**:
In trying to replicate some e2e failures where `e2e-runner` couldn't be built, I was blocked locally by this:

```shell
% go build -tags=test -o ./bin/e2e-runner .
# github.com/Azure/aks-engine/pkg/engine
pkg/engine/template_generator.go:375:11: undefined: getDCOSBootstrapCustomData
pkg/engine/template_generator.go:378:11: undefined: getDCOSMasterCustomData
pkg/engine/template_generator.go:381:11: undefined: getDCOSAgentCustomData
pkg/engine/template_generator.go:384:11: undefined: getDCOSWindowsAgentCustomData
pkg/engine/template_generator.go:420:11: undefined: getLinkedTemplatesForExtensions
```

Removing the build tag fixes it.

<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
