### PR TITLE
ci: stop testing k8s 1.11 and 1.12 on PRs

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -72,22 +72,6 @@ jobs:
 
 - template: e2e-job-template.yaml
   parameters:
-    name: 'k8s_1_11_release_e2e'
-    k8sRelease: '1.11'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
-    stabilityIterations: '3'
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_1_12_release_e2e'
-    k8sRelease: '1.12'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
-    stabilityIterations: '3'
-
-- template: e2e-job-template.yaml
-  parameters:
     name: 'k8s_1_13_release_e2e'
     k8sRelease: '1.13'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
@@ -125,12 +109,6 @@ jobs:
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
     stabilityIterations: '3'
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_windows_1_12_release_e2e'
-    k8sRelease: '1.12'
-    apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
 
 - template: e2e-job-template.yaml
   parameters:


### PR DESCRIPTION
**Reason for Change**:
These two versions have been out of Kubernetes' support matrix (and AKS Engine's) for a while now, so let's reduce the load each PR requires in Azure DevOps. (We still have a Jenkins 1.12 job for now.)

**Issue Fixed**:
See also #2276

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
