### PR TITLE
test: ensure manifests aren't change by go template processing

### DIFF
--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -298,15 +298,15 @@ func kubernetesManifestSettingsInit(p *api.Properties) []kubernetesComponentFile
 	if k.APIServerConfig == nil {
 		k.APIServerConfig = map[string]string{}
 	}
-	kubeControllerManagerYaml := "kubernetesmaster-kube-controller-manager.yaml"
+	kubeControllerManagerYaml := kubeControllerManagerManifestFilename
 
 	if p.IsAzureStackCloud() {
-		kubeControllerManagerYaml = "kubernetesmaster-kube-controller-manager-custom.yaml"
+		kubeControllerManagerYaml = kubeControllerManagerCustomManifestFilename
 	}
 
 	return []kubernetesComponentFileSpec{
 		{
-			sourceFile:      "kubernetesmaster-kube-scheduler.yaml",
+			sourceFile:      kubeSchedulerManifestFilename,
 			base64Data:      k.SchedulerConfig["data"],
 			destinationFile: "kube-scheduler.yaml",
 			isEnabled:       true,
@@ -318,19 +318,19 @@ func kubernetesManifestSettingsInit(p *api.Properties) []kubernetesComponentFile
 			isEnabled:       true,
 		},
 		{
-			sourceFile:      "kubernetesmaster-cloud-controller-manager.yaml",
+			sourceFile:      ccmManifestFilename,
 			base64Data:      k.CloudControllerManagerConfig["data"],
 			destinationFile: "cloud-controller-manager.yaml",
 			isEnabled:       to.Bool(k.UseCloudControllerManager),
 		},
 		{
-			sourceFile:      "kubernetesmaster-kube-apiserver.yaml",
+			sourceFile:      kubeAPIServerManifestFilename,
 			base64Data:      k.APIServerConfig["data"],
 			destinationFile: "kube-apiserver.yaml",
 			isEnabled:       true,
 		},
 		{
-			sourceFile:      "kubernetesmaster-kube-addon-manager.yaml",
+			sourceFile:      kubeAddonManagerManifestFilename,
 			base64Data:      "", // arbitrary user-provided data not enabled for kube-addon-manager spec
 			destinationFile: "kube-addon-manager.yaml",
 			isEnabled:       true,

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -198,6 +198,16 @@ const (
 	dhcpv6ConfigurationScript = "k8s/cloud-init/artifacts/enable-dhcpv6.sh"
 )
 
+// Kubernetes manifests file references
+const (
+	kubeSchedulerManifestFilename               = "kubernetesmaster-kube-scheduler.yaml"
+	kubeControllerManagerManifestFilename       = "kubernetesmaster-kube-controller-manager.yaml"
+	kubeControllerManagerCustomManifestFilename = "kubernetesmaster-kube-controller-manager-custom.yaml"
+	ccmManifestFilename                         = "kubernetesmaster-cloud-controller-manager.yaml"
+	kubeAPIServerManifestFilename               = "kubernetesmaster-kube-apiserver.yaml"
+	kubeAddonManagerManifestFilename            = "kubernetesmaster-kube-addon-manager.yaml"
+)
+
 const (
 	dcosCustomData188       = "dcos/dcoscustomdata188.t"
 	dcosCustomData190       = "dcos/dcoscustomdata190.t"

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1749,6 +1749,12 @@ func TestVerifyGetBase64EncodedGzippedCustomScriptIsTransparent(t *testing.T) {
 				auditdRules,
 				kubernetesCSECustomCloud,
 				systemdBPFMount,
+				"k8s/manifests/" + kubeSchedulerManifestFilename,
+				"k8s/manifests/" + kubeControllerManagerManifestFilename,
+				"k8s/manifests/" + kubeControllerManagerCustomManifestFilename,
+				"k8s/manifests/" + ccmManifestFilename,
+				"k8s/manifests/" + kubeAPIServerManifestFilename,
+				"k8s/manifests/" + kubeAddonManagerManifestFilename,
 			} {
 				ret := getBase64EncodedGzippedCustomScript(file, c.cs)
 				b, err := Asset(file)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Follow-up of #2290 

We are also interpreting Kubernetes manifest file artifacts w/ go templating + `ContainerService` data context. Until we actually use that data context, we need to ensure that this traversal doesn't change the file contents.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
