### PR TITLE
fix: userAssignedIdentityId in windows azure.json missing quotes

### DIFF
--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -67,7 +67,7 @@ Write-AzureConfig {
     "primaryAvailabilitySetName": "$PrimaryAvailabilitySetName",
     "primaryScaleSetName": "$PrimaryScaleSetName",
     "useManagedIdentityExtension": $UseManagedIdentityExtension,
-    "userAssignedIdentityID": $UserAssignedClientID,
+    "userAssignedIdentityID": "$UserAssignedClientID",
     "useInstanceMetadata": $UseInstanceMetadata,
     "loadBalancerSku": "$LoadBalancerSku",
     "excludeMasterFromStandardLB": $ExcludeMasterFromStandardLB

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -35057,7 +35057,7 @@ Write-AzureConfig {
     "primaryAvailabilitySetName": "$PrimaryAvailabilitySetName",
     "primaryScaleSetName": "$PrimaryScaleSetName",
     "useManagedIdentityExtension": $UseManagedIdentityExtension,
-    "userAssignedIdentityID": $UserAssignedClientID,
+    "userAssignedIdentityID": "$UserAssignedClientID",
     "useInstanceMetadata": $UseInstanceMetadata,
     "loadBalancerSku": "$LoadBalancerSku",
     "excludeMasterFromStandardLB": $ExcludeMasterFromStandardLB


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
The userAssignedIdentity property in azure.json for windows does not have quotes around the values. So when the value is empty string, you will get the following line in the json:

"userAssignedIdentityID": ,

That is a syntax error. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
