### PR TITLE
fix: enable cloud-node-manager addon on upgrade when appropriate

### DIFF
--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -540,6 +540,13 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		}
 	}
 
+	// Ensure cloud-node-manager is enabled on appropriate upgrades
+	if isUpgrade {
+		if i := getAddonsIndexByName(o.KubernetesConfig.Addons, CloudNodeManagerAddonName); i > -1 {
+			o.KubernetesConfig.Addons[i] = defaultCloudNodeManagerAddonsConfig
+		}
+	}
+
 	// Back-compat for older addon specs of cluster-autoscaler
 	if isUpgrade {
 		i := getAddonsIndexByName(o.KubernetesConfig.Addons, ClusterAutoscalerAddonName)

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -6982,6 +6982,220 @@ func TestSetAddonsConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "azure cloud-node-manager enabled for k8s >= 1.17.0 - upgrade",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.17.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin:             NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: []KubernetesAddon{
+				{
+					Name:    HeapsterAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    TillerAddonName,
+					Enabled: to.BoolPtr(DefaultTillerAddonEnabled),
+				},
+				{
+					Name:    ACIConnectorAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    BlobfuseFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           BlobfuseFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8",
+						},
+					},
+				},
+				{
+					Name:    SMBFlexVolumeAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    KeyVaultFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           KeyVaultFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13",
+						},
+					},
+				},
+				{
+					Name:    DashboardAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           DashboardAddonName,
+							CPURequests:    "300m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "300m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.17.0"][DashboardAddonName],
+						},
+					},
+				},
+				{
+					Name:    ReschedulerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    MetricsServerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  MetricsServerAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.17.0"][MetricsServerAddonName],
+						},
+					},
+				},
+				{
+					Name:    NVIDIADevicePluginAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    ContainerMonitoringAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + "ip-masq-agent-amd64:v2.5.0",
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr": DefaultVNETCIDR,
+						"non-masq-cni-cidr":   DefaultCNICIDR,
+						"enable-ipv6":         "false",
+					},
+				},
+				{
+					Name:    AzureCNINetworkMonitoringAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  AzureCNINetworkMonitoringAddonName,
+							Image: specConfig.AzureCNIImageBase + K8sComponentsByVersionMap["1.17.0"][AzureCNINetworkMonitoringAddonName],
+						},
+					},
+				},
+				{
+					Name:    AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    CalicoAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AADPodIdentityAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  "csi-provisioner",
+							Image: "quay.io/k8scsi/csi-provisioner:v1.0.1",
+						},
+						{
+							Name:  "csi-attacher",
+							Image: "quay.io/k8scsi/csi-attacher:v1.0.1",
+						},
+						{
+							Name:  "csi-cluster-driver-registrar",
+							Image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1",
+						},
+						{
+							Name:  "livenessprobe",
+							Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+						},
+						{
+							Name:  "csi-node-driver-registrar",
+							Image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+						},
+						{
+							Name:  "azurefile-csi",
+							Image: "mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0",
+						},
+					},
+				},
+				{
+					Name:    AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  "csi-provisioner",
+							Image: "quay.io/k8scsi/csi-provisioner:v1.0.1",
+						},
+						{
+							Name:  "csi-attacher",
+							Image: "quay.io/k8scsi/csi-attacher:v1.0.1",
+						},
+						{
+							Name:  "csi-cluster-driver-registrar",
+							Image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1",
+						},
+						{
+							Name:  "livenessprobe",
+							Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+						},
+						{
+							Name:  "csi-node-driver-registrar",
+							Image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+						},
+						{
+							Name:  "azuredisk-csi",
+							Image: "mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.4.0",
+						},
+					},
+				},
+				{
+					Name:    CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(true),
+				},
+				{
+					Name:    AzurePolicyAddonName,
+					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**Reason for Change**:
Enables the cloud-node-manager addon if appropriate during `aks-engine upgrade`.

**Issue Fixed**:
Fixes #2337

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
