### PR TITLE
test: remove windows-specific tests, use windows node pools

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -76,7 +76,6 @@ jobs:
     k8sRelease: '1.13'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -84,7 +83,6 @@ jobs:
     k8sRelease: '1.14'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -92,7 +90,6 @@ jobs:
     k8sRelease: '1.15'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -100,7 +97,6 @@ jobs:
     k8sRelease: '1.16'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
-    stabilityIterations: '3'
 
 - template: e2e-job-template.yaml
   parameters:
@@ -108,34 +104,3 @@ jobs:
     k8sRelease: '1.17'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
     createVNET: true
-    stabilityIterations: '3'
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_windows_1_13_release_e2e'
-    k8sRelease: '1.13'
-    apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_windows_1_14_release_e2e'
-    k8sRelease: '1.14'
-    apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_windows_1_15_release_e2e'
-    k8sRelease: '1.15'
-    apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_windows_1_16_release_e2e'
-    k8sRelease: '1.16'
-    apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'
-
-- template: e2e-job-template.yaml
-  parameters:
-    name: 'k8s_windows_1_17_release_e2e'
-    k8sRelease: '1.17'
-    apimodel: 'examples/e2e-tests/kubernetes/windows/hybrid/definition.json'

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -67,6 +67,14 @@
         ],
         "availabilityProfile": "VirtualMachineScaleSets",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
+      },
+      {
+        "name": "agentwfast",
+        "count": 1,
+        "vmSize": "Standard_D2s_v3",
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "osType": "Windows",
+        "storageProfile": "Ephemeral"
       }
     ],
     "linuxProfile": {
@@ -78,6 +86,12 @@
           }
         ]
       }
+    },
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "sshEnabled": true,
+      "enableAutomaticUpdates": false
     },
     "servicePrincipalProfile": {
       "clientId": "",

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -73,6 +73,7 @@
         "count": 1,
         "vmSize": "Standard_D2s_v3",
         "availabilityProfile": "VirtualMachineScaleSets",
+        "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "osType": "Windows",
         "storageProfile": "Ephemeral"
       }

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1584,7 +1584,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).ToNot(BeZero())
 				for _, iisPod := range iisPods {
 					var pass bool
-					pass, err = iisPod.CheckWindowsOutboundConnection(sleepBetweenRetriesWhenWaitingForPodReady, timeoutWhenWaitingForPodOutboundAccess)
+					pass, err = iisPod.CheckWindowsOutboundConnection(sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pass).To(BeTrue())
 				}
@@ -1891,11 +1891,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				if clusterAutoscalerEngaged {
 					cpuTarget = 50
 					for _, profile := range eng.ExpandedDefinition.Properties.AgentPoolProfiles {
-						maxPods, _ := strconv.Atoi(profile.KubernetesConfig.KubeletConfig["--max-pods"])
-						var n []node.Node
-						n, err = node.GetByRegexWithRetry(fmt.Sprintf("^k8s-%s", profile.Name), 3*time.Minute, cfg.Timeout)
-						Expect(err).NotTo(HaveOccurred())
-						totalMaxPods += (len(n) * maxPods)
+						// TODO enable cluster-autoscaler tests for Windows
+						if profile.IsLinux() {
+							maxPods, _ := strconv.Atoi(profile.KubernetesConfig.KubeletConfig["--max-pods"])
+							totalMaxPods += (profile.Count * maxPods)
+						}
 					}
 					maxPods, _ := strconv.Atoi(eng.ExpandedDefinition.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--max-pods"])
 					totalMaxPods += (len(masterNodes) * maxPods)


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Rather than test Windows by creating entirely new clusters, let's just add a Windows node pool to every cluster configuration we test across Kubernetes versions.

This PR adds a Windows node pool to the "standard" cluster configuration we use for our current "Linux" Kubernetes version tests, effectively making them OS-agnostic (or more appropriately: OS-generic, as they will cover both OS flavors).

This PR also removes 1.11 and 1.12 from our PR test matrix to reflect that 1.13-->1.17 are the versions of Kubernetes that are actively under development upstream.

Fewer tests for the same amount of coverage!

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
