### PR TITLE
test: add k8s 1.16 and 1.17 to TestExampleAPIModel unit test

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -571,6 +571,16 @@ func TestExampleAPIModels(t *testing.T) {
 			setArgs:      defaultSet,
 		},
 		{
+			name:         "1.16 example",
+			apiModelPath: "../examples/kubernetes-releases/kubernetes1.16.json",
+			setArgs:      defaultSet,
+		},
+		{
+			name:         "1.17 example",
+			apiModelPath: "../examples/kubernetes-releases/kubernetes1.17.json",
+			setArgs:      defaultSet,
+		},
+		{
 			name:         "vmss",
 			apiModelPath: "../examples/kubernetes-vmss/kubernetes.json",
 			setArgs:      defaultSet,


### PR DESCRIPTION
**Reason for Change**:
The unit test `TestExampleAPIModel` wasn't updated after Kubernetes 1.15.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
