### PR TITLE
test: more resilient kubectl run interfaces

### DIFF
--- a/test/e2e/kubernetes/config.go
+++ b/test/e2e/kubernetes/config.go
@@ -79,7 +79,8 @@ func GetConfigWithRetry(sleep, timeout time.Duration) (*Config, error) {
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetConfigAsync():
+			default:
+				ch <- GetConfigAsync()
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -71,7 +71,7 @@ type Container struct {
 }
 
 // CreateLinuxDeployAsync wraps CreateLinuxDeploy with a struct response for goroutine + channel usage
-func CreateLinuxDeployAsync(image, name, namespace, miscOpts string) GetResult {
+func CreateLinuxDeployAsync(ctx context.Context, image, name, namespace, miscOpts string) GetResult {
 	d, err := CreateLinuxDeploy(image, name, namespace, miscOpts)
 	return GetResult{
 		deployment: d,
@@ -91,7 +91,8 @@ func CreateLinuxDeployWithRetry(image, name, namespace, miscOpts string, sleep, 
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- CreateLinuxDeployAsync(image, name, namespace, miscOpts):
+			default:
+				ch <- CreateLinuxDeployAsync(ctx, image, name, namespace, miscOpts)
 				time.Sleep(sleep)
 			}
 		}
@@ -209,7 +210,8 @@ func CreateWindowsDeployWithRetry(pattern, image, name, namespace, miscOpts stri
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- CreateWindowsDeployAsync(pattern, image, name, namespace, miscOpts):
+			default:
+				ch <- CreateWindowsDeployAsync(pattern, image, name, namespace, miscOpts)
 				time.Sleep(sleep)
 			}
 		}
@@ -376,7 +378,8 @@ func GetAllByPrefixWithRetry(prefix, namespace string, sleep, timeout time.Durat
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAllByPrefixAsync(prefix, namespace):
+			default:
+				ch <- GetAllByPrefixAsync(prefix, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -556,7 +559,8 @@ func GetWithRetry(name, namespace string, sleep, timeout time.Duration) (*Deploy
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAsync(name, namespace):
+			default:
+				ch <- GetAsync(name, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -604,7 +608,8 @@ func (d *Deployment) WaitForReplicas(min, max int, sleep, timeout time.Duration)
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- pod.GetAllRunningByPrefixAsync(d.Metadata.Name, d.Metadata.Namespace):
+			default:
+				ch <- pod.GetAllRunningByPrefixAsync(d.Metadata.Name, d.Metadata.Namespace)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/hpa/hpa.go
+++ b/test/e2e/kubernetes/hpa/hpa.go
@@ -168,7 +168,8 @@ func WaitOnDeleted(hpaPrefix, namespace string, sleep, timeout time.Duration) (b
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAllByPrefixAsync(hpaPrefix, namespace):
+			default:
+				ch <- GetAllByPrefixAsync(hpaPrefix, namespace)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -213,7 +213,8 @@ func GetWithRetry(jobName, namespace string, sleep, timeout time.Duration) (*Job
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAsync(jobName, namespace):
+			default:
+				ch <- GetAsync(jobName, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -297,7 +298,8 @@ func WaitOnSucceeded(jobPrefix, namespace string, sleep, timeout time.Duration) 
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- AreAllJobsSucceededAsync(jobPrefix, namespace):
+			default:
+				ch <- AreAllJobsSucceededAsync(jobPrefix, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -377,7 +379,8 @@ func WaitOnDeleted(jobPrefix, namespace string, sleep, timeout time.Duration) (b
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAllByPrefixAsync(jobPrefix, namespace):
+			default:
+				ch <- GetAllByPrefixAsync(jobPrefix, namespace)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -272,7 +272,8 @@ func WaitOnReady(nodeCount int, sleep, timeout time.Duration) bool {
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- AreNNodesReady(nodeCount):
+			default:
+				ch <- AreNNodesReady(nodeCount)
 				time.Sleep(sleep)
 			}
 		}
@@ -300,7 +301,8 @@ func WaitOnReadyMin(nodeCount int, sleep, timeout time.Duration) bool {
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- AreMinNodesReady(nodeCount):
+			default:
+				ch <- AreMinNodesReady(nodeCount)
 				time.Sleep(sleep)
 			}
 		}
@@ -328,7 +330,8 @@ func WaitOnReadyMax(nodeCount int, sleep, timeout time.Duration) bool {
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- AreMaxNodesReady(nodeCount):
+			default:
+				ch <- AreMaxNodesReady(nodeCount)
 				time.Sleep(sleep)
 			}
 		}
@@ -378,7 +381,8 @@ func GetWithRetry(sleep, timeout time.Duration) ([]Node, error) {
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetNodesAsync():
+			default:
+				ch <- GetNodesAsync()
 				time.Sleep(sleep)
 			}
 		}
@@ -411,7 +415,8 @@ func GetByRegexWithRetry(regex string, sleep, timeout time.Duration) ([]Node, er
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetByRegexAsync(regex):
+			default:
+				ch <- GetByRegexAsync(regex)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/persistentvolume/persistentvolume.go
+++ b/test/e2e/kubernetes/persistentvolume/persistentvolume.go
@@ -119,7 +119,8 @@ func WaitOnReady(pvCount int, sleep, timeout time.Duration) bool {
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- AreAllReady(pvCount):
+			default:
+				ch <- AreAllReady(pvCount)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -214,7 +214,8 @@ func (pvc *PersistentVolumeClaim) WaitOnReady(namespace string, sleep, timeout t
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAsync(pvc.Metadata.Name, namespace):
+			default:
+				ch <- GetAsync(pvc.Metadata.Name, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -255,7 +256,8 @@ func WaitOnDeleted(pvcPrefix, namespace string, sleep, timeout time.Duration) (b
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAllByPrefixAsync(pvcPrefix, namespace):
+			default:
+				ch <- GetAllByPrefixAsync(pvcPrefix, namespace)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -305,7 +305,8 @@ func GetWithRetry(podPrefix, namespace string, sleep, timeout time.Duration) (*P
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAsync(podPrefix, namespace):
+			default:
+				ch <- GetAsync(podPrefix, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -338,7 +339,8 @@ func RunLinuxWithRetry(image, name, namespace, command string, printOutput bool,
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- RunLinuxAsync(image, name, namespace, command, printOutput, sleep, timeout, timeout):
+			default:
+				ch <- RunLinuxAsync(image, name, namespace, command, printOutput, sleep, timeout, timeout)
 				time.Sleep(sleep)
 			}
 		}
@@ -382,7 +384,8 @@ func RunWindowsWithRetry(image, name, namespace, command string, printOutput boo
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- RunWindowsAsync(image, name, namespace, command, printOutput, sleep, timeout, timeout):
+			default:
+				ch <- RunWindowsAsync(image, name, namespace, command, printOutput, sleep, timeout, timeout)
 				time.Sleep(sleep)
 			}
 		}
@@ -512,7 +515,8 @@ func GetAllByPrefixWithRetry(prefix, namespace string, sleep, timeout time.Durat
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAllByPrefixAsync(prefix, namespace):
+			default:
+				ch <- GetAllByPrefixAsync(prefix, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -594,7 +598,8 @@ func GetAllRunningByPrefixWithRetry(prefix, namespace string, sleep, timeout tim
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAllRunningByPrefixAsync(prefix, namespace):
+			default:
+				ch <- GetAllRunningByPrefixAsync(prefix, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -751,7 +756,8 @@ func WaitOnSuccesses(podPrefix, namespace string, successesNeeded int, sleep, ti
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- AreAllPodsRunningAsync(podPrefix, namespace):
+			default:
+				ch <- AreAllPodsRunningAsync(podPrefix, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -797,7 +803,8 @@ func WaitOnSucceeded(name, namespace string, sleep, timeout time.Duration) (bool
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetPodAsync(name, namespace, timeout):
+			default:
+				ch <- GetPodAsync(name, namespace, timeout)
 				time.Sleep(sleep)
 			}
 		}
@@ -841,7 +848,8 @@ func WaitOnTerminated(name, namespace, containerName string, sleep, containerExe
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetPodAsync(name, namespace, timeout):
+			default:
+				ch <- GetPodAsync(name, namespace, timeout)
 				time.Sleep(sleep)
 			}
 		}
@@ -1172,7 +1180,8 @@ func (p *Pod) CheckLinuxOutboundConnection(sleep, timeout time.Duration) (bool, 
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- p.attemptOutboundConn():
+			default:
+				ch <- p.attemptOutboundConn()
 				time.Sleep(sleep)
 			}
 		}
@@ -1208,7 +1217,8 @@ func (p *Pod) ValidateCurlConnection(uri string, sleep, timeout time.Duration) (
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- p.curlURL(uri):
+			default:
+				ch <- p.curlURL(uri)
 				time.Sleep(sleep)
 			}
 		}
@@ -1244,7 +1254,8 @@ func (p *Pod) ValidateOmsAgentLogs(execCmdString string, sleep, timeout time.Dur
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- p.ExecAsync("grep", "-i", execCmdString, "/var/opt/microsoft/omsagent/log/omsagent.log"):
+			default:
+				ch <- p.ExecAsync("grep", "-i", execCmdString, "/var/opt/microsoft/omsagent/log/omsagent.log")
 				time.Sleep(sleep)
 			}
 		}
@@ -1285,7 +1296,8 @@ func (p *Pod) CheckWindowsOutboundConnection(sleep, timeout time.Duration) (bool
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- p.ExecAsync("--", "powershell", "New-Object", "System.Net.Sockets.TcpClient('8.8.8.8', 443)"):
+			default:
+				ch <- p.ExecAsync("--", "powershell", "New-Object", "System.Net.Sockets.TcpClient('8.8.8.8', 443)")
 				time.Sleep(sleep)
 			}
 		}
@@ -1375,7 +1387,8 @@ func (p *Pod) ValidateAzureFile(mountPath string, sleep, timeout time.Duration) 
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- p.powershellMkdir(mountPath):
+			default:
+				ch <- p.powershellMkdir(mountPath)
 				time.Sleep(sleep)
 			}
 		}
@@ -1411,7 +1424,8 @@ func (p *Pod) ValidatePVC(mountPath string, sleep, timeout time.Duration) (bool,
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- p.mkdir(mountPath):
+			default:
+				ch <- p.mkdir(mountPath)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -213,7 +213,8 @@ func (s *Service) WaitForIngress(timeout, sleep time.Duration) error {
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAsync(s.Metadata.Name, s.Metadata.Namespace):
+			default:
+				ch <- GetAsync(s.Metadata.Name, s.Metadata.Namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -251,7 +252,8 @@ func WaitOnDeleted(servicePrefix, namespace string, sleep, timeout time.Duration
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAllByPrefixAsync(servicePrefix, namespace):
+			default:
+				ch <- GetAllByPrefixAsync(servicePrefix, namespace)
 				time.Sleep(sleep)
 			}
 		}
@@ -284,7 +286,8 @@ func (s *Service) ValidateWithRetry(bodyResponseTextMatch string, sleep, timeout
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- s.Validate(bodyResponseTextMatch):
+			default:
+				ch <- s.Validate(bodyResponseTextMatch)
 				time.Sleep(sleep)
 			}
 		}

--- a/test/e2e/kubernetes/storageclass/storageclass.go
+++ b/test/e2e/kubernetes/storageclass/storageclass.go
@@ -101,7 +101,8 @@ func (sc *StorageClass) WaitOnReady(sleep, timeout time.Duration) (bool, error) 
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- GetAsync(sc.Metadata.Name):
+			default:
+				ch <- GetAsync(sc.Metadata.Name)
 				time.Sleep(sleep)
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

In response to observed E2E flakes in the kubectl portforward test, putting more of the "kubectl run" E2E conveniences behind async/retry interfaces.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
