### PR TITLE
fix: correct defaults order for setting IPAddressCount

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -197,12 +197,6 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--resolv-conf"] = "/run/systemd/resolve/resolv.conf"
 		}
 
-		// Allocate IP addresses for pods if VNET integration is enabled.
-		if cs.Properties.OrchestratorProfile.IsAzureCNI() {
-			masterMaxPods, _ := strconv.Atoi(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--max-pods"])
-			cs.Properties.MasterProfile.IPAddressCount += masterMaxPods
-		}
-
 		removeKubeletFlags(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)
 	}
 
@@ -256,12 +250,6 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		// Override the --resolv-conf kubelet config value for Ubuntu 18.04 after the distro value is set.
 		if profile.IsUbuntu1804() {
 			profile.KubernetesConfig.KubeletConfig["--resolv-conf"] = "/run/systemd/resolve/resolv.conf"
-		}
-
-		// Allocate IP addresses for pods if VNET integration is enabled.
-		if cs.Properties.OrchestratorProfile.IsAzureCNI() {
-			agentPoolMaxPods, _ := strconv.Atoi(profile.KubernetesConfig.KubeletConfig["--max-pods"])
-			profile.IPAddressCount += agentPoolMaxPods
 		}
 
 		removeKubeletFlags(profile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -498,13 +498,15 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 
 		// Master-specific defaults that depend upon kubelet defaults
 		// Set the default number of IP addresses allocated for masters.
-		if cs.Properties.MasterProfile.IPAddressCount == 0 {
-			// Allocate one IP address for the node.
-			cs.Properties.MasterProfile.IPAddressCount = 1
-			// Allocate IP addresses for pods if VNET integration is enabled.
-			if cs.Properties.OrchestratorProfile.IsAzureCNI() {
-				masterMaxPods, _ := strconv.Atoi(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--max-pods"])
-				cs.Properties.MasterProfile.IPAddressCount += masterMaxPods
+		if cs.Properties.MasterProfile != nil {
+			if cs.Properties.MasterProfile.IPAddressCount == 0 {
+				// Allocate one IP address for the node.
+				cs.Properties.MasterProfile.IPAddressCount = 1
+				// Allocate IP addresses for pods if VNET integration is enabled.
+				if cs.Properties.OrchestratorProfile.IsAzureCNI() {
+					masterMaxPods, _ := strconv.Atoi(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--max-pods"])
+					cs.Properties.MasterProfile.IPAddressCount += masterMaxPods
+				}
 			}
 		}
 		// Pool-specific defaults that depend upon kubelet defaults

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -415,11 +416,6 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 					}
 				}
 			}
-			// Set the default number of IP addresses allocated for masters.
-			if cs.Properties.MasterProfile.IPAddressCount == 0 {
-				// Allocate one IP address for the node.
-				cs.Properties.MasterProfile.IPAddressCount = 1
-			}
 
 			// Distro assignment for masterProfile
 			if cs.Properties.MasterProfile.Distro == "" && cs.Properties.MasterProfile.ImageRef == nil {
@@ -443,11 +439,6 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 
 		// Pool-specific defaults that depend upon OrchestratorProfile defaults
 		for _, profile := range cs.Properties.AgentPoolProfiles {
-			// Set the default number of IP addresses allocated for agents.
-			if profile.IPAddressCount == 0 {
-				// Allocate one IP address for the node.
-				profile.IPAddressCount = 1
-			}
 			if cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku {
 				cs.Properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = to.BoolPtr(DefaultExcludeMasterFromStandardLB)
 			}
@@ -504,6 +495,32 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 
 		// Configure kubelet
 		cs.setKubeletConfig(isUpgrade)
+
+		// Master-specific defaults that depend upon kubelet defaults
+		// Set the default number of IP addresses allocated for masters.
+		if cs.Properties.MasterProfile.IPAddressCount == 0 {
+			// Allocate one IP address for the node.
+			cs.Properties.MasterProfile.IPAddressCount = 1
+			// Allocate IP addresses for pods if VNET integration is enabled.
+			if cs.Properties.OrchestratorProfile.IsAzureCNI() {
+				masterMaxPods, _ := strconv.Atoi(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--max-pods"])
+				cs.Properties.MasterProfile.IPAddressCount += masterMaxPods
+			}
+		}
+		// Pool-specific defaults that depend upon kubelet defaults
+		for _, profile := range cs.Properties.AgentPoolProfiles {
+			// Set the default number of IP addresses allocated for agents.
+			if profile.IPAddressCount == 0 {
+				// Allocate one IP address for the node.
+				profile.IPAddressCount = 1
+				// Allocate IP addresses for pods if VNET integration is enabled.
+				if cs.Properties.OrchestratorProfile.IsAzureCNI() {
+					agentPoolMaxPods, _ := strconv.Atoi(profile.KubernetesConfig.KubeletConfig["--max-pods"])
+					profile.IPAddressCount += agentPoolMaxPods
+				}
+			}
+		}
+
 		// Configure controller-manager
 		cs.setControllerManagerConfig()
 		// Configure cloud-controller-manager

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -3978,12 +3978,15 @@ func TestDefaultIPAddressCount(t *testing.T) {
 		expectedPool1  int
 	}{
 		{
-			name: "default",
+			name: "kubenet",
 			cs: ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{
 						OrchestratorType:    Kubernetes,
 						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginKubenet,
+						},
 					},
 					MasterProfile: &MasterProfile{},
 					AgentPoolProfiles: []*AgentPoolProfile{
@@ -4055,6 +4058,110 @@ func TestDefaultIPAddressCount(t *testing.T) {
 			expectedMaster: 24,
 			expectedPool0:  24,
 			expectedPool1:  24,
+		},
+		{
+			name: "kubenet + custom IPAddressCount",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginKubenet,
+						},
+					},
+					MasterProfile: &MasterProfile{
+						IPAddressCount: 24,
+					},
+					AgentPoolProfiles: []*AgentPoolProfile{
+						{
+							Name:           "pool1",
+							IPAddressCount: 24,
+						},
+						{
+							Name:           "pool2",
+							IPAddressCount: 24,
+						},
+					},
+				},
+			},
+			expectedMaster: 24,
+			expectedPool0:  24,
+			expectedPool1:  24,
+		},
+		{
+			name: "Azure CNI + mixed config",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginAzure,
+						},
+					},
+					MasterProfile: &MasterProfile{
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--max-pods": "24",
+							},
+						},
+					},
+					AgentPoolProfiles: []*AgentPoolProfile{
+						{
+							Name: "pool1",
+							KubernetesConfig: &KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--max-pods": "128",
+								},
+							},
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: 25,
+			expectedPool0:  129,
+			expectedPool1:  DefaultKubernetesMaxPodsVNETIntegrated + 1,
+		},
+		{
+			name: "kubenet + mixed config",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginKubenet,
+						},
+					},
+					MasterProfile: &MasterProfile{
+						KubernetesConfig: &KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--max-pods": "24",
+							},
+						},
+					},
+					AgentPoolProfiles: []*AgentPoolProfile{
+						{
+							Name: "pool1",
+							KubernetesConfig: &KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--max-pods": "128",
+								},
+							},
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: 1,
+			expectedPool0:  1,
+			expectedPool1:  1,
 		},
 	}
 

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -3968,3 +3968,114 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultIPAddressCount(t *testing.T) {
+	cases := []struct {
+		name           string
+		cs             ContainerService
+		expectedMaster int
+		expectedPool0  int
+		expectedPool1  int
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+					},
+					MasterProfile: &MasterProfile{},
+					AgentPoolProfiles: []*AgentPoolProfile{
+						{
+							Name: "pool1",
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: 1,
+			expectedPool0:  1,
+			expectedPool1:  1,
+		},
+		{
+			name: "Azure CNI",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginAzure,
+						},
+					},
+					MasterProfile: &MasterProfile{},
+					AgentPoolProfiles: []*AgentPoolProfile{
+						{
+							Name: "pool1",
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: DefaultKubernetesMaxPodsVNETIntegrated + 1,
+			expectedPool0:  DefaultKubernetesMaxPodsVNETIntegrated + 1,
+			expectedPool1:  DefaultKubernetesMaxPodsVNETIntegrated + 1,
+		},
+		{
+			name: "Azure CNI + custom IPAddressCount",
+			cs: ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &KubernetesConfig{
+							NetworkPlugin: NetworkPluginAzure,
+						},
+					},
+					MasterProfile: &MasterProfile{
+						IPAddressCount: 24,
+					},
+					AgentPoolProfiles: []*AgentPoolProfile{
+						{
+							Name:           "pool1",
+							IPAddressCount: 24,
+						},
+						{
+							Name:           "pool2",
+							IPAddressCount: 24,
+						},
+					},
+				},
+			},
+			expectedMaster: 24,
+			expectedPool0:  24,
+			expectedPool1:  24,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.SetPropertiesDefaults(PropertiesDefaultsParams{
+				IsScale:    false,
+				IsUpgrade:  true,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			})
+			if c.cs.Properties.MasterProfile.IPAddressCount != c.expectedMaster {
+				t.Errorf("expected %d, but got %d", c.expectedMaster, c.cs.Properties.MasterProfile.IPAddressCount)
+			}
+			if c.cs.Properties.AgentPoolProfiles[0].IPAddressCount != c.expectedPool0 {
+				t.Errorf("expected %d, but got %d", c.expectedPool0, c.cs.Properties.AgentPoolProfiles[0].IPAddressCount)
+			}
+			if c.cs.Properties.AgentPoolProfiles[1].IPAddressCount != c.expectedPool1 {
+				t.Errorf("expected %d, but got %d", c.expectedPool1, c.cs.Properties.AgentPoolProfiles[1].IPAddressCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This fixes a regression that landed w/ #2274 

The IPAddressCount values in MasterProfile and each AgentPoolProfile depend (in part) upon the kublet configuration `--max-pods`; essentially these values are related and need to be configured in concert according to a deterministic ordinality.

This PR moves the IPAddressCount default enforcement for both masters and pools to occur after the kubelet defaults codeflow.

The primary fix here is missing UT. :(

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
