### PR TITLE
test: resilient az group create during E2E provisioning

### DIFF
--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -119,9 +119,13 @@ func (cli *CLIProvisioner) provision() error {
 
 	os.Setenv("DNS_PREFIX", cli.Config.Name)
 
-	err := cli.Account.CreateGroup(cli.Config.Name, cli.Config.Location)
+	err := cli.Account.CreateGroupWithRetry(cli.Config.Name, cli.Config.Location, 30*time.Second, cli.Config.Timeout)
 	if err != nil {
 		return errors.Wrap(err, "Error while trying to create resource group")
+	}
+	err = cli.Account.ShowGroupWithRetry(cli.Account.ResourceGroup.Name, 10*time.Second, cli.Config.Timeout)
+	if err != nil {
+		return errors.Wrap(err, "Unable to successfully get the resource group using the az CLI")
 	}
 
 	subnetID := ""


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

The most common `az` CLI flake during E2E runs is doing an operation against a resource group that was created just moments earlier:

```

$ timeout 60 az group create --name kubernetes-westeurope-71037 --location westeurope --tags now=1574462830

$ timeout 60 az network vnet create -g kubernetes-westeurope-71037 -n kubernetes-westeurope-71037CustomVnet --address-prefixes 10.239.0.0/16
2019/11/22 22:47:15 Error while trying to create vnet with the following command:
 az network vnet create -g kubernetes-westeurope-71037 -n kubernetes-westeurope-71037CustomVnet --address-prefixes 10.239.0.0/16
 Output:ERROR: error retrieving default location: Resource group 'kubernetes-westeurope-71037' could not be found.
```

This PR does an `az group show` until it gets a successful response, before proceeding to do `az` operations against that resource group. Also adds retries for the original `az group create` operation.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
