### PR TITLE
test: use SLB in E2E cluster configs

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -40,7 +40,9 @@
             "name": "aad-pod-identity",
             "enabled": true
           }
-        ]
+        ],
+        "loadBalancerSku": "Standard",
+        "excludeMasterFromStandardLB": true
       }
     },
     "masterProfile": {
@@ -50,7 +52,8 @@
       "OSDiskSizeGB": 200,
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
       "firstConsecutiveStaticIP": "10.239.255.239",
-      "vnetCidr": "10.239.0.0/16"
+      "vnetCidr": "10.239.0.0/16",
+      "availabilityZones": ["1", "2"]
     },
     "agentPoolProfiles": [
       {
@@ -60,13 +63,11 @@
         "OSDiskSizeGB": 200,
         "storageProfile": "ManagedDisks",
         "diskSizesGB": [
-          128,
-          128,
-          128,
           128
         ],
         "availabilityProfile": "VirtualMachineScaleSets",
-        "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
+        "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
+        "availabilityZones": ["1"]
       },
       {
         "name": "agentwfast",
@@ -75,7 +76,8 @@
         "availabilityProfile": "VirtualMachineScaleSets",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "osType": "Windows",
-        "storageProfile": "Ephemeral"
+        "storageProfile": "Ephemeral",
+        "availabilityZones": ["1"]
       }
     ],
     "linuxProfile": {

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -186,7 +186,7 @@ func CreatePodFromFileIfNotExist(filename, name, namespace string, sleep, timeou
 }
 
 // RunLinuxPod will create a pod that runs a bash command
-// --overrides := `"spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}`
+// --overrides := `"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}`
 func RunLinuxPod(image, name, namespace, command string, printOutput bool, sleep, commandTimeout, podGetTimeout time.Duration) (*Pod, error) {
 	overrides := `{ "spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}`
 	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--restart=Never", "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command)

--- a/test/e2e/kubernetes/workloads/nginx-master.yaml
+++ b/test/e2e/kubernetes/workloads/nginx-master.yaml
@@ -21,3 +21,4 @@ spec:
     effect: NoSchedule
   nodeSelector:
     kubernetes.io/role: master
+    beta.kubernetes.io/os: linux

--- a/test/e2e/kubernetes/workloads/pod-pvc.yaml
+++ b/test/e2e/kubernetes/workloads/pod-pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 metadata:
   name: zone-pv-pod
 spec:
+  nodeSelector:
+    beta.kubernetes.io/os: linux
   containers:
     - name: myfrontend
       image: nginx


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR adds SLB-appropriate config to the cluster configuration used in PR E2E tests. Also updates some test manifests, where appropriate.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
