### PR TITLE
test: ensure cluster-autoscaler tests don't run if min-nodes is > nodes in pool

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -130,7 +130,9 @@ var _ = BeforeSuite(func() {
 				for _, pool := range addon.Pools {
 					p := eng.ExpandedDefinition.Properties.GetAgentPoolIndexByName(pool.Name)
 					maxNodes, _ := strconv.Atoi(pool.Config["max-nodes"])
-					if maxNodes > eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count {
+					minNodes, _ := strconv.Atoi(pool.Config["min-nodes"])
+					if maxNodes > eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count &&
+						minNodes < eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count {
 						clusterAutoscalerEngaged = true
 						break
 					}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -132,7 +132,7 @@ var _ = BeforeSuite(func() {
 					maxNodes, _ := strconv.Atoi(pool.Config["max-nodes"])
 					minNodes, _ := strconv.Atoi(pool.Config["min-nodes"])
 					if maxNodes > eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count &&
-						minNodes < eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count {
+						minNodes <= eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count {
 						clusterAutoscalerEngaged = true
 						break
 					}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This change fixes some of our upgrade/scale and back-compat test flows, which by convention scale down node pools before upgrading them. In the scale down case, we need to skip cluster-autoscaler tests because the out-of-band (from the perspective of cluster-autoscaler) scaling operation sort of turns the cluster-autoscaler enforcement vector into a no op (i.e., the node count changes in our tests don't currently manually update the cluster-autoscaler configs as well).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
