### PR TITLE
fix: default useCloudControllerManager to false for 1.17

### DIFF
--- a/parts/k8s/manifests/1.17/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/k8s/manifests/1.17/kubernetesmaster-kube-controller-manager.yaml
@@ -18,6 +18,9 @@ spec:
       volumeMounts:
         - name: etc-kubernetes
           mountPath: /etc/kubernetes
+        - name: etc-ssl
+          mountPath: /etc/ssl
+          readOnly: true
         - name: var-lib-kubelet
           mountPath: /var/lib/kubelet
         - name: msi
@@ -27,6 +30,9 @@ spec:
     - name: etc-kubernetes
       hostPath:
         path: /etc/kubernetes
+    - name: etc-ssl
+      hostPath:
+        path: /etc/ssl
     - name: var-lib-kubelet
       hostPath:
         path: /var/lib/kubelet

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -6769,7 +6769,7 @@ func TestSetAddonsConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "azure cloud-node-manager enabled for k8s >= 1.17.0",
+			name: "azure cloud-node-manager enabled for k8s == 1.17.0 and useCloudControllerManager is true",
 			cs: &ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -224,11 +224,6 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			o.KubernetesConfig.ServiceCIDR = DefaultKubernetesServiceCIDR
 		}
 
-		// K8s 1.17 and later require Azure cloud-controller-manager components
-		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.17.0-alpha.1") {
-			o.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
-		}
-
 		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
 			o.KubernetesConfig.CloudProviderBackoffMode = CloudProviderBackoffModeV2
 			if o.KubernetesConfig.CloudProviderBackoff == nil {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2007,11 +2007,11 @@ func TestCloudControllerManagerEnabled(t *testing.T) {
 		t.Fatal("expected UseCloudControllerManager to default to false")
 	}
 
-	// test that 1.17 defaults to true
+	// test that 1.17 defaults to false
 	cs = CreateMockContainerService("testcluster", "1.17.0", 3, 2, false)
 	cs.setOrchestratorDefaults(false, false)
-	if cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager == to.BoolPtr(false) {
-		t.Fatal("expected UseCloudControllerManager to default to true")
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager == to.BoolPtr(true) {
+		t.Fatal("expected UseCloudControllerManager to default to false")
 	}
 }
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -32893,6 +32893,9 @@ spec:
       volumeMounts:
         - name: etc-kubernetes
           mountPath: /etc/kubernetes
+        - name: etc-ssl
+          mountPath: /etc/ssl
+          readOnly: true
         - name: var-lib-kubelet
           mountPath: /var/lib/kubelet
         - name: msi
@@ -32906,6 +32909,9 @@ spec:
     - name: etc-kubernetes
       hostPath:
         path: /etc/kubernetes
+    - name: etc-ssl
+      hostPath:
+        path: /etc/ssl
     - name: var-lib-kubelet
       hostPath:
         path: /var/lib/kubelet

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -32893,9 +32893,6 @@ spec:
       volumeMounts:
         - name: etc-kubernetes
           mountPath: /etc/kubernetes
-        - name: etc-ssl
-          mountPath: /etc/ssl
-          readOnly: true
         - name: var-lib-kubelet
           mountPath: /var/lib/kubelet
         - name: msi
@@ -32909,9 +32906,6 @@ spec:
     - name: etc-kubernetes
       hostPath:
         path: /etc/kubernetes
-    - name: etc-ssl
-      hostPath:
-        path: /etc/ssl
     - name: var-lib-kubelet
       hostPath:
         path: /var/lib/kubelet
@@ -32961,6 +32955,9 @@ spec:
       volumeMounts:
         - name: etc-kubernetes
           mountPath: /etc/kubernetes
+        - name: etc-ssl
+          mountPath: /etc/ssl
+          readOnly: true
         - name: var-lib-kubelet
           mountPath: /var/lib/kubelet
         - name: msi
@@ -32970,6 +32967,9 @@ spec:
     - name: etc-kubernetes
       hostPath:
         path: /etc/kubernetes
+    - name: etc-ssl
+      hostPath:
+        path: /etc/ssl
     - name: var-lib-kubelet
       hostPath:
         path: /var/lib/kubelet

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1780,7 +1780,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					By("Creating an AzureFile storage class")
 					storageclassName := "azurefile" // should be the same as in storageclass-azurefile.yaml
 					scFilename := "storageclass-azurefile.yaml"
-					if common.IsKubernetesVersionGe(orchestratorVersion, "1.17.0-alpha.1") {
+					useCloudControllerManager := to.Bool(eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager)
+					if useCloudControllerManager && common.IsKubernetesVersionGe(orchestratorVersion, "1.16.0") {
 						scFilename = "storageclass-azurefile-external.yaml"
 					}
 					sc, err := storageclass.CreateStorageClassFromFile(filepath.Join(WorkloadDir, scFilename), storageclassName)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1766,9 +1766,6 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should be able to attach azure file", func() {
 			if eng.HasWindowsAgents() {
 				orchestratorVersion := eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion
-				if common.IsKubernetesVersionGe(orchestratorVersion, "1.17.0-alpha.1") {
-					Skip("Azure disk and file CSI drivers are not yet supported on Windows")
-				}
 				if orchestratorVersion == "1.11.0" {
 					// Failure in 1.11.0 - https://github.com/kubernetes/kubernetes/issues/65845, fixed in 1.11.1
 					Skip("Kubernetes 1.11.0 has a known issue creating Azure PersistentVolumeClaim")

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1258,7 +1258,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should create pv with zone labels and node affinity", func() {
 			if !eng.ExpandedDefinition.Properties.HasLowPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.HasZonesForAllAgentPools() {
-					if !common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.0-alpha.1") {
+					if !(common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.16.0") &&
+						to.Bool(eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager)) {
 						By("Creating a persistent volume claim")
 						pvcName := "azure-managed-disk" // should be the same as in pvc-standard.yaml
 						pvc, err := persistentvolumeclaims.CreatePersistentVolumeClaimsFromFile(filepath.Join(WorkloadDir, "pvc-standard.yaml"), pvcName, "default")
@@ -1317,7 +1318,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						err = pvc.Delete(util.DefaultDeleteRetries)
 						Expect(err).NotTo(HaveOccurred())
 					} else {
-						Skip("Zones aren't yet supported in CSI disk driver for v1.17")
+						Skip("Zones aren't yet supported in CSI disk driver")
 					}
 				} else {
 					Skip("Availability zones was not configured for this Cluster Definition")


### PR DESCRIPTION
**Reason for Change**:
Defaults `useCloudControllerManager` to false for Kubernetes 1.17, and restores e2e tests that were being skipped.

**Issue Fixed**:
Fixes #2369 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
