### PR TITLE
fix: change kernel settings based on number of cores

### DIFF
--- a/parts/k8s/cloud-init/artifacts/kubelet.service
+++ b/parts/k8s/cloud-init/artifacts/kubelet.service
@@ -17,6 +17,15 @@ ExecStartPre=/bin/mount --make-shared /var/lib/kubelet
 {{/* This is a partial workaround to this upstream Kubernetes issue: */}}
 {{/* https://github.com/kubernetes/kubernetes/issues/41916#issuecomment-312428731 */}}
 ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_retries2=8
+ExecStartPre=/sbin/sysctl -w net.core.somaxconn=16384
+ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_max_syn_backlog=16384
+ExecStartPre=/sbin/sysctl -w net.core.message_cost=40
+ExecStartPre=/sbin/sysctl -w net.core.message_burst=80
+
+ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=4096; fi"
+ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh2=8192; fi"
+ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh3=16384; fi"
+
 ExecStartPre=-/sbin/ebtables -t nat --list
 ExecStartPre=-/sbin/iptables -t nat --numeric --list
 ExecStart=/usr/local/bin/kubelet \

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -15078,6 +15078,15 @@ ExecStartPre=/bin/mount --make-shared /var/lib/kubelet
 {{/* This is a partial workaround to this upstream Kubernetes issue: */}}
 {{/* https://github.com/kubernetes/kubernetes/issues/41916#issuecomment-312428731 */}}
 ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_retries2=8
+ExecStartPre=/sbin/sysctl -w net.core.somaxconn=16384
+ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_max_syn_backlog=16384
+ExecStartPre=/sbin/sysctl -w net.core.message_cost=40
+ExecStartPre=/sbin/sysctl -w net.core.message_burst=80
+
+ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=4096; fi"
+ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh2=8192; fi"
+ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh3=16384; fi"
+
 ExecStartPre=-/sbin/ebtables -t nat --list
 ExecStartPre=-/sbin/iptables -t nat --numeric --list
 ExecStart=/usr/local/bin/kubelet \

--- a/test/e2e/kubernetes/scripts/net-config-validate.sh
+++ b/test/e2e/kubernetes/scripts/net-config-validate.sh
@@ -11,6 +11,13 @@ KERNEL_PANIC_VALUE=10
 KERNEL_PANIC_ON_OOPS_VALUE=1
 VM_OVERCOMMIT_MEMORY_VALUE=1
 INOTIFY_MAX_USER_WATCHES=1048576
+SOMAXCONN=16384
+TCP_MAX_SYN_BACKLOG=16384
+MESSAGE_COST=40
+MESSAGE_BURST=80
+GT_8_CORES_GC_THRESH1=4096
+GT_8_CORES_GC_THRESH2=8192
+GT_8_CORES_GC_THRESH3=16384
 
 set -x
 grep $IPV4_SEND_REDIRECTS_VALUE /proc/sys/net/ipv4/conf/all/send_redirects || exit 1
@@ -28,9 +35,19 @@ grep $IPV6_ACCEPT_RA_VALUE /proc/sys/net/ipv6/conf/default/accept_ra || exit 1
 grep $IPV6_ACCEPT_REDIRECTS_VALUE /proc/sys/net/ipv6/conf/all/accept_redirects || exit 1
 grep $IPV6_ACCEPT_REDIRECTS_VALUE /proc/sys/net/ipv6/conf/default/accept_redirects || exit 1
 
-# validate net config workaround from kubelet.service
+# validate kubelet.service configs
 grep $IPV4_TCP_RETRIES2_VALUE /proc/sys/net/ipv4/tcp_retries2 || exit 1
 grep $KERNEL_PANIC_VALUE /proc/sys/kernel/panic || exit 1
 grep $KERNEL_PANIC_ON_OOPS_VALUE /proc/sys/kernel/panic_on_oops || exit 1
 grep $VM_OVERCOMMIT_MEMORY_VALUE /proc/sys/vm/overcommit_memory || exit 1
 grep $INOTIFY_MAX_USER_WATCHES /proc/sys/fs/inotify/max_user_watches || exit 1
+grep $SOMAXCONN /proc/sys/net/core/somaxconn || exit 1
+grep $TCP_MAX_SYN_BACKLOG /proc/sys/net/ipv4/tcp_max_syn_backlog || exit 1
+grep $MESSAGE_COST /proc/sys/net/core/message_cost || exit 1
+grep $MESSAGE_BURST /proc/sys/net/core/message_burst || exit 1
+
+if [[ "${GT_8_CORE_SKU}" == "true" ]]; then
+    grep $GT_8_CORES_GC_THRESH1 /proc/sys/net/ipv4/neigh/default/gc_thresh1 || exit 1
+    grep $GT_8_CORES_GC_THRESH2 /proc/sys/net/ipv4/neigh/default/gc_thresh2 || exit 1
+    grep $GT_8_CORES_GC_THRESH3 /proc/sys/net/ipv4/neigh/default/gc_thresh3 || exit 1
+fi

--- a/test/e2e/kubernetes/util/util.go
+++ b/test/e2e/kubernetes/util/util.go
@@ -60,3 +60,13 @@ func AddToSSHKeyChain(keyfile string) error {
 	}
 	return nil
 }
+
+// IsLargeVMSKU returns if the VM SKU is a known, > 8 core SKU
+func IsLargeVMSKU(sku string) bool {
+	switch sku {
+	case "Standard_D16_v3":
+		return true
+	default:
+		return false
+	}
+}

--- a/test/e2e/test_cluster_configs/large-vm-sku.json
+++ b/test/e2e/test_cluster_configs/large-vm-sku.json
@@ -1,0 +1,41 @@
+{
+	"env": {
+		"REGION_OPTIONS": "eastus,westeurope,southeastasia,westus2"
+	},
+	"apiModel": {
+		"apiVersion": "vlabs",
+		"properties": {
+			"orchestratorProfile": {
+				"orchestratorType": "Kubernetes"
+			},
+			"masterProfile": {
+				"count": 1,
+				"dnsPrefix": "",
+				"vmSize": "Standard_D2_v3"
+			},
+			"agentPoolProfiles": [
+				{
+					"name": "agentpool1",
+					"count": 2,
+					"vmSize": "Standard_D16_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Low"
+				}
+			],
+			"linuxProfile": {
+				"adminUsername": "azureuser",
+				"ssh": {
+					"publicKeys": [
+						{
+							"keyData": ""
+						}
+					]
+				}
+			},
+			"servicePrincipalProfile": {
+				"clientId": "",
+				"secret": ""
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
For nodes with more CPU/Memory, the default kernel settings for  ubuntu is not big enough for high-performance server scenarios.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
We changed the values for ARP table, network connections. These optimizations are applied widely in the industry.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X ] includes documentation
- [X] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
