### PR TITLE
feat: add support for Kubernetes 1.17.0-rc.2 

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -161,6 +161,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.17.0-beta.1":  true,
 	"1.17.0-beta.2":  true,
 	"1.17.0-rc.1":    true,
+	"1.17.0-rc.2":    true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.17.md#changelog-since-v1170-rc1

~~Also updates cluster-autoscaler to 1.17.0, see https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.17.0~~

See also #2390 

**Issue Fixed**:

**Requirements**:
- [x] Windows artifacts uploaded to acsmirror blob store
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**: