### PR TITLE
feat: Adds kubeconfig option to upgrade cmd

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -268,11 +268,13 @@ func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 
 	var kubeConfig string
 	if uc.kubeconfigPath != "" {
-		path, err := filepath.Abs(uc.kubeconfigPath)
+		var path string
+		var content []byte
+		path, err = filepath.Abs(uc.kubeconfigPath)
 		if err != nil {
 			return errors.Wrap(err, "reading --kubeconfig")
 		}
-		content, err := ioutil.ReadFile(path)
+		content, err = ioutil.ReadFile(path)
 		if err != nil {
 			return errors.Wrap(err, "reading --kubeconfig")
 		}

--- a/docs/topics/keyvault-secrets.md
+++ b/docs/topics/keyvault-secrets.md
@@ -107,4 +107,4 @@ az keyvault update -g $RG_NAME -n $KV_NAME --enabled-for-template-deployment
 
 ## Upgrade Considerations
 
-**Important** As of now, there is no working cluster upgrade implementation for clusters that were built according to the Key Vault-derived secrets. If you expect to use `aks-engine upgrade` to maintain a long-lived Kubernetes cluster built by `aks-engine`, you will not be able to take advantage of this feature at this time.
+AKS Engine is currently unable to read Key Vault secrets specified by the paths in the deployment ARM template. Thus, the only way to upgrade a cluster built using Key Vault-derived secrets is to specify a local [kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) when invoking `aks-engine upgrade`. Please see [steps to run when using Key Vault for secrets](./upgrade.md#steps-to-run-when-using-Key-Vault-for-secrets).

--- a/docs/topics/upgrade.md
+++ b/docs/topics/upgrade.md
@@ -94,6 +94,22 @@ For example,
   --client-secret xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
+### Steps to run when using Key Vault for secrets
+
+If you use Key Vault for secrets, you must specify a local [kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) to connect to the cluster because aks-engine is currently unable to read secrets from a Key Vault during an upgrade.
+
+```bash
+ ./bin/aks-engine upgrade \
+   --subscription-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+   --api-model _output/mycluster/apimodel.json \
+   --location westus \
+   --resource-group test-upgrade \
+   --upgrade-version 1.8.7 \
+   --client-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+   --client-secret xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+   --kubeconfig ./path/to/kubeconfig.json
+```
+
 ## Known Limitations
 
 ### Manual reconciliation

--- a/hack/tools/vendor/gopkg.in/tomb.v1/tomb.go
+++ b/hack/tools/vendor/gopkg.in/tomb.v1/tomb.go
@@ -1,10 +1,10 @@
 // Copyright (c) 2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
+//
 //     * Redistributions of source code must retain the above copyright notice,
 //       this list of conditions and the following disclaimer.
 //     * Redistributions in binary form must reproduce the above copyright notice,
@@ -13,7 +13,7 @@
 //     * Neither the name of the copyright holder nor the names of its
 //       contributors may be used to endorse or promote products derived from
 //       this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -79,7 +79,7 @@ type Tomb struct {
 
 var (
 	ErrStillAlive = errors.New("tomb: still alive")
-	ErrDying = errors.New("tomb: dying")
+	ErrDying      = errors.New("tomb: dying")
 )
 
 func (t *Tomb) init() {

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -840,7 +840,7 @@ func TestTemplateGenerator_FunctionMap(t *testing.T) {
 			FuncName: "GetApplicationInsightsTelemetryKey",
 			MutateFunc: func(cs api.ContainerService) api.ContainerService {
 				cs.Properties.TelemetryProfile = &api.TelemetryProfile{
-					ApplicationInsightsKey:"my_telemetry_key",
+					ApplicationInsightsKey: "my_telemetry_key",
 				}
 				return cs
 			},


### PR DESCRIPTION
This PR accounts for my second strategy to solve the limitation
described in #2396. Rather than introduce the KeyVault client, so we can
run `GetSecret` and fetch our certs and keys, I read a local config file
based on what's passed into the command line.

This is not a complete PR, because I think the same stuff would need to
be done anywhere else `GenerateKubeConfig` is called.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
See #2396 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See #2396  

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
