### PR TITLE
test: check k8s events to see if node-problem-detector works

### DIFF
--- a/test/e2e/kubernetes/event/event.go
+++ b/test/e2e/kubernetes/event/event.go
@@ -1,0 +1,108 @@
+//+build test
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os/exec"
+	"time"
+
+	"github.com/Azure/aks-engine/test/e2e/kubernetes/util"
+	"github.com/pkg/errors"
+)
+
+// List contains zero or more events.
+type List struct {
+	Events []Event `json:"items"`
+}
+
+// Event represents the basic fields of a Kubernetes event.
+type Event struct {
+	Message string `json:"message"`
+	Reason  string `json:"reason"`
+	Type    string `json:"type"`
+}
+
+// GetAll returns all events.
+func GetAll() (*List, error) {
+	cmd := exec.Command("k", "get", "events", "-o", "json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error getting event:\n")
+		util.PrintCommand(cmd)
+		return nil, err
+	}
+	hl := List{}
+	if err = json.Unmarshal(out, &hl); err != nil {
+		log.Printf("Error unmarshalling events json:%s\n", err)
+		return nil, err
+	}
+	return &hl, nil
+}
+
+// GetResult is a return struct for GetAsync.
+type GetResult struct {
+	Event *Event
+	Err   error
+}
+
+// GetAsync wraps Get with a struct response for goroutine + channel usage.
+func GetAsync(reason string) GetResult {
+	event, err := Get(reason)
+	return GetResult{
+		Event: event,
+		Err:   err,
+	}
+}
+
+// Get returns an event with the given message.
+func Get(message string) (*Event, error) {
+	list, err := GetAll()
+	if err != nil {
+		return nil, err
+	}
+	for _, event := range list.Events {
+		if event.Message == message {
+			return &event, nil
+		}
+	}
+	return nil, errors.Errorf("Event with message %s not found", message)
+}
+
+// GetWithRetry gets an event, retrying on failure.
+func GetWithRetry(reason string, sleep, timeout time.Duration) (*Event, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ch := make(chan GetResult)
+	var mostRecentGetWithRetryError error
+	var event *Event
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				ch <- GetAsync(reason)
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case result := <-ch:
+			mostRecentGetWithRetryError = result.Err
+			event = result.Event
+			if mostRecentGetWithRetryError == nil {
+				if event != nil {
+					return event, nil
+				}
+			}
+		case <-ctx.Done():
+			return nil, errors.Errorf("GetWithRetry timed out: %s\n", mostRecentGetWithRetryError)
+		}
+	}
+}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/aks-engine/test/e2e/config"
 	"github.com/Azure/aks-engine/test/e2e/engine"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/deployment"
+	"github.com/Azure/aks-engine/test/e2e/kubernetes/event"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/hpa"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/job"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/namespace"
@@ -804,6 +805,32 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				} else {
 					fmt.Printf("%s disabled for this cluster, will not test\n", addonName)
 				}
+			}
+		})
+
+		It("should have a working node-problem-detector configuration", func() {
+			if hasNpd, _ := eng.HasAddon("node-problem-detector"); hasNpd {
+				running, err := pod.WaitOnSuccesses("node-problem-detector", "kube-system", kubeSystemPodsReadinessChecks, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+				pods, err := pod.GetAllRunningByPrefixWithRetry("node-problem-detector", "kube-system", 3*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).NotTo(BeEmpty())
+				nodeName := pods[0].Spec.NodeName
+				// Create a fake kernel message on a node running node-problem-detector
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				msgId := r.Intn(999999999999)
+				msg := fmt.Sprintf("kernel: BUG: unable to handle kernel NULL pointer dereference at TESTING-%d", msgId)
+				kernelMsgTestCommand := fmt.Sprintf("sudo 'echo %s | sudo tee /dev/kmsg'", msg)
+				if cfg.BlockSSHPort {
+					Skip("SSH port is blocked")
+				}
+				err = sshConn.ExecuteRemoteWithRetry(nodeName, kernelMsgTestCommand, false, sleepBetweenRetriesRemoteSSHCommand, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				evt, err := event.GetWithRetry(msg, 5*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(evt.Type).To(Equal("Warning"))
+				Expect(evt.Reason).To(Equal("KernelOops"))
 			}
 		})
 


### PR DESCRIPTION
**Reason for Change**:
Adds an e2e test spec that creates a kernel message which node-problem-detector should turn into a Kubernetes event, if everything is wired up properly.

**Issue Fixed**:
Follows up on #2371
Refs #2389, #2411


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
