### PR TITLE
test: include node-problem-detector in addons config test

### DIFF
--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -404,6 +404,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -622,6 +626,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -844,6 +852,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -1111,6 +1123,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -1382,6 +1398,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -1671,6 +1691,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -1964,6 +1988,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -2313,6 +2341,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -2661,6 +2693,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -2958,6 +2994,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -3261,6 +3301,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -3476,6 +3520,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -3693,6 +3741,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -3907,6 +3959,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -4131,6 +4187,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -4342,6 +4402,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -4548,6 +4612,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.16.0"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -4772,6 +4840,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -4985,6 +5057,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -5202,6 +5278,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -5448,6 +5528,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -5671,6 +5755,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -5900,6 +5988,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -6078,6 +6170,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -6269,6 +6365,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -6454,6 +6554,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -6708,6 +6812,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -6961,6 +7069,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -7213,6 +7325,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.17.0"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -7481,6 +7597,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -7748,6 +7868,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -7948,6 +8072,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.13.11"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -8163,6 +8291,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -8368,6 +8500,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.13.11"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -8583,6 +8719,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -8788,6 +8928,10 @@ func TestSetAddonsConfig(t *testing.T) {
 							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
 						},
 					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
 				},
 			},
 		},
@@ -9006,6 +9150,10 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
 			},
 		},
 		{
@@ -9201,6 +9349,226 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    common.KubeProxyAddonName,
 					Enabled: to.BoolPtr(false),
 				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(DefaultNodeProblemDetectorAddonEnabled),
+				},
+			},
+		},
+		{
+			name: "node-problem-detector addon enabled",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &KubernetesConfig{
+							DNSServiceIP: DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: DefaultKubernetesSubnet,
+							ProxyMode:     KubeProxyModeIPTables,
+							NetworkPlugin: NetworkPluginAzure,
+							Addons: []KubernetesAddon{
+								{
+									Name:    common.NodeProblemDetectorAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: []KubernetesAddon{
+				{
+					Name:    common.HeapsterAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.TillerAddonName,
+					Enabled: to.BoolPtr(DefaultTillerAddonEnabled),
+				},
+				{
+					Name:    common.ACIConnectorAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.BlobfuseFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           common.BlobfuseFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8",
+						},
+					},
+				},
+				{
+					Name:    common.SMBFlexVolumeAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.KeyVaultFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           common.KeyVaultFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13",
+						},
+					},
+				},
+				{
+					Name:    common.DashboardAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           common.DashboardAddonName,
+							CPURequests:    "300m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "300m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.DashboardAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.ReschedulerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.MetricsServerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.MetricsServerAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.MetricsServerAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.NVIDIADevicePluginAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.ContainerMonitoringAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:           common.IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + "ip-masq-agent-amd64:v2.5.0",
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr": DefaultVNETCIDR,
+						"non-masq-cni-cidr":   DefaultCNICIDR,
+						"enable-ipv6":         "false",
+					},
+				},
+				{
+					Name:    common.AzureCNINetworkMonitorAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.AzureCNINetworkMonitorAddonName,
+							Image: specConfig.AzureCNIImageBase + K8sComponentsByVersionMap["1.15.4"][common.AzureCNINetworkMonitorAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.CalicoAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.AADPodIdentityAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.AzurePolicyAddonName,
+					Enabled: to.BoolPtr(DefaultAzurePolicyAddonEnabled),
+				},
+				{
+					Name:    common.AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.KubeDNSAddonName,
+					Enabled: to.BoolPtr(false),
+				},
+				{
+					Name:    common.CoreDNSAddonName,
+					Enabled: to.BoolPtr(DefaultCoreDNSAddonEnabled),
+					Config: map[string]string{
+						"domain":    "cluster.local",
+						"clusterIP": DefaultKubernetesDNSServiceIP,
+					},
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.CoreDNSAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.CoreDNSAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.KubeProxyAddonName,
+					Enabled: to.BoolPtr(DefaultKubeProxyAddonEnabled),
+					Config: map[string]string{
+						"cluster-cidr": DefaultKubernetesSubnet,
+						"proxy-mode":   string(KubeProxyModeIPTables),
+						"featureGates": "{}",
+					},
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.KubeProxyAddonName,
+							Image: specConfig.KubernetesImageBase + K8sComponentsByVersionMap["1.15.4"][common.KubeProxyAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"customPluginMonitor": "/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json",
+						"systemLogMonitor":    "/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json",
+						"systemStatsMonitor":  "/config/system-stats-monitor.json",
+						"versionLabel":        "v0.8.0",
+					},
+				},
 			},
 		},
 	}
@@ -9236,6 +9604,7 @@ func TestSetAddonsConfig(t *testing.T) {
 				common.CoreDNSAddonName,
 				common.KubeDNSAddonName,
 				common.KubeProxyAddonName,
+				common.NodeProblemDetectorAddonName,
 			} {
 				addon := test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons[getAddonsIndexByName(test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons, addonName)]
 				expectedAddon := test.expectedAddons[getAddonsIndexByName(test.expectedAddons, addonName)]


### PR DESCRIPTION
**Reason for Change**:
The `node-problem-detector` addon should have been part of the `TestSetAddonsConfig` unit test.


**Issue Fixed**:


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
