### PR TITLE
feat: enable user-configurable platformUpdateDomainCount

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -485,6 +485,7 @@ func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterP
 	vlabsProfile.AgentSubnet = api.AgentSubnet
 	vlabsProfile.AvailabilityZones = api.AvailabilityZones
 	vlabsProfile.PlatformFaultDomainCount = api.PlatformFaultDomainCount
+	vlabsProfile.PlatformUpdateDomainCount = api.PlatformUpdateDomainCount
 	vlabsProfile.SinglePlacementGroup = api.SinglePlacementGroup
 	vlabsProfile.CosmosEtcd = api.CosmosEtcd
 	vlabsProfile.AuditDEnabled = api.AuditDEnabled
@@ -528,6 +529,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	p.AvailabilityZones = api.AvailabilityZones
 	p.SinglePlacementGroup = api.SinglePlacementGroup
 	p.PlatformFaultDomainCount = api.PlatformFaultDomainCount
+	p.PlatformUpdateDomainCount = api.PlatformUpdateDomainCount
 	p.EnableVMSSNodePublicIP = api.EnableVMSSNodePublicIP
 	p.LoadBalancerBackendAddressPoolIDs = api.LoadBalancerBackendAddressPoolIDs
 	p.AuditDEnabled = api.AuditDEnabled

--- a/pkg/api/converterfromapi_test.go
+++ b/pkg/api/converterfromapi_test.go
@@ -690,6 +690,22 @@ func TestPlatformFaultDomainCountToVLabs(t *testing.T) {
 	}
 }
 
+func TestPlatformUpdateDomainCountToVLabs(t *testing.T) {
+	cs := getDefaultContainerService()
+	cs.Properties.MasterProfile.PlatformUpdateDomainCount = to.IntPtr(3)
+	cs.Properties.AgentPoolProfiles[0].PlatformUpdateDomainCount = to.IntPtr(3)
+	vlabsCS := ConvertContainerServiceToVLabs(cs)
+	if vlabsCS == nil {
+		t.Errorf("expected the converted containerService struct to be non-nil")
+	}
+	if *vlabsCS.Properties.MasterProfile.PlatformUpdateDomainCount != 3 {
+		t.Errorf("expected the master profile platform FD to be 3")
+	}
+	if *vlabsCS.Properties.AgentPoolProfiles[0].PlatformUpdateDomainCount != 3 {
+		t.Errorf("expected the agent pool profile platform FD to be 3")
+	}
+}
+
 func TestConvertTelemetryProfileToVLabs(t *testing.T) {
 	cs := getDefaultContainerService()
 	cs.Properties.TelemetryProfile = &TelemetryProfile{

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -537,6 +537,7 @@ func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 	api.AgentSubnet = vlabs.AgentSubnet
 	api.AvailabilityZones = vlabs.AvailabilityZones
 	api.PlatformFaultDomainCount = vlabs.PlatformFaultDomainCount
+	api.PlatformUpdateDomainCount = vlabs.PlatformUpdateDomainCount
 	api.SinglePlacementGroup = vlabs.SinglePlacementGroup
 	api.CosmosEtcd = vlabs.CosmosEtcd
 	api.AuditDEnabled = vlabs.AuditDEnabled
@@ -568,6 +569,7 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 	api.VMSSOverProvisioningEnabled = vlabs.VMSSOverProvisioningEnabled
 	api.AvailabilityZones = vlabs.AvailabilityZones
 	api.PlatformFaultDomainCount = vlabs.PlatformFaultDomainCount
+	api.PlatformUpdateDomainCount = vlabs.PlatformUpdateDomainCount
 	api.SinglePlacementGroup = vlabs.SinglePlacementGroup
 	api.EnableVMSSNodePublicIP = vlabs.EnableVMSSNodePublicIP
 	api.LoadBalancerBackendAddressPoolIDs = vlabs.LoadBalancerBackendAddressPoolIDs

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -1084,3 +1084,34 @@ func TestConvertVLabsTelemetryProfile(t *testing.T) {
 		t.Error("Expected TelemetryProfile.ApplicationInsightsKey to be set")
 	}
 }
+
+func TestConvertVlabsPlatformUpdateDomain(t *testing.T) {
+	vlabscs := &vlabs.ContainerService{
+		Properties: &vlabs.Properties{
+			OrchestratorProfile: &vlabs.OrchestratorProfile{
+				OrchestratorType: vlabs.Kubernetes,
+			},
+			MasterProfile: &vlabs.MasterProfile{
+				PlatformUpdateDomainCount: to.IntPtr(3),
+			},
+			AgentPoolProfiles: []*vlabs.AgentPoolProfile{
+				{
+					PlatformUpdateDomainCount: to.IntPtr(3),
+				},
+			},
+		},
+	}
+	cs, err := ConvertVLabsContainerService(vlabscs, false)
+	if err != nil {
+		t.Errorf("Error converting ContainerService: %s", err)
+	}
+	if cs == nil {
+		t.Errorf("expected the converted containerService struct to be non-nil")
+	}
+	if *cs.Properties.MasterProfile.PlatformUpdateDomainCount != 3 {
+		t.Errorf("expected the master profile platform FD to be 3")
+	}
+	if *cs.Properties.AgentPoolProfiles[0].PlatformUpdateDomainCount != 3 {
+		t.Errorf("expected the agent pool profile platform FD to be 3")
+	}
+}

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -614,6 +614,9 @@ func (p *Properties) setMasterProfileDefaults(isUpgrade bool) {
 	if p.IsAzureStackCloud() && p.MasterProfile.PlatformFaultDomainCount == nil {
 		p.MasterProfile.PlatformFaultDomainCount = to.IntPtr(DefaultAzureStackFaultDomainCount)
 	}
+	if p.MasterProfile.PlatformUpdateDomainCount == nil {
+		p.MasterProfile.PlatformUpdateDomainCount = to.IntPtr(3)
+	}
 }
 
 func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
@@ -643,6 +646,9 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 		// Update default fault domain value for Azure Stack
 		if p.IsAzureStackCloud() && profile.PlatformFaultDomainCount == nil {
 			profile.PlatformFaultDomainCount = to.IntPtr(DefaultAzureStackFaultDomainCount)
+		}
+		if profile.PlatformUpdateDomainCount == nil {
+			profile.PlatformUpdateDomainCount = to.IntPtr(3)
 		}
 
 		// Accelerated Networking is supported on most general purpose and compute-optimized instance sizes with 2 or more vCPUs.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -492,34 +492,35 @@ func (d *DcosConfig) HasBootstrap() bool {
 
 // MasterProfile represents the definition of the master cluster
 type MasterProfile struct {
-	Count                    int               `json:"count"`
-	DNSPrefix                string            `json:"dnsPrefix"`
-	SubjectAltNames          []string          `json:"subjectAltNames"`
-	VMSize                   string            `json:"vmSize"`
-	OSDiskSizeGB             int               `json:"osDiskSizeGB,omitempty"`
-	VnetSubnetID             string            `json:"vnetSubnetID,omitempty"`
-	VnetCidr                 string            `json:"vnetCidr,omitempty"`
-	AgentVnetSubnetID        string            `json:"agentVnetSubnetID,omitempty"`
-	FirstConsecutiveStaticIP string            `json:"firstConsecutiveStaticIP,omitempty"`
-	Subnet                   string            `json:"subnet"`
-	SubnetIPv6               string            `json:"subnetIPv6"`
-	IPAddressCount           int               `json:"ipAddressCount,omitempty"`
-	StorageProfile           string            `json:"storageProfile,omitempty"`
-	HTTPSourceAddressPrefix  string            `json:"HTTPSourceAddressPrefix,omitempty"`
-	OAuthEnabled             bool              `json:"oauthEnabled"`
-	PreprovisionExtension    *Extension        `json:"preProvisionExtension"`
-	Extensions               []Extension       `json:"extensions"`
-	Distro                   Distro            `json:"distro,omitempty"`
-	KubernetesConfig         *KubernetesConfig `json:"kubernetesConfig,omitempty"`
-	ImageRef                 *ImageReference   `json:"imageReference,omitempty"`
-	CustomFiles              *[]CustomFile     `json:"customFiles,omitempty"`
-	AvailabilityProfile      string            `json:"availabilityProfile"`
-	PlatformFaultDomainCount *int              `json:"platformFaultDomainCount"`
-	AgentSubnet              string            `json:"agentSubnet,omitempty"`
-	AvailabilityZones        []string          `json:"availabilityZones,omitempty"`
-	SinglePlacementGroup     *bool             `json:"singlePlacementGroup,omitempty"`
-	AuditDEnabled            *bool             `json:"auditDEnabled,omitempty"`
-	CustomVMTags             map[string]string `json:"customVMTags,omitempty"`
+	Count                     int               `json:"count"`
+	DNSPrefix                 string            `json:"dnsPrefix"`
+	SubjectAltNames           []string          `json:"subjectAltNames"`
+	VMSize                    string            `json:"vmSize"`
+	OSDiskSizeGB              int               `json:"osDiskSizeGB,omitempty"`
+	VnetSubnetID              string            `json:"vnetSubnetID,omitempty"`
+	VnetCidr                  string            `json:"vnetCidr,omitempty"`
+	AgentVnetSubnetID         string            `json:"agentVnetSubnetID,omitempty"`
+	FirstConsecutiveStaticIP  string            `json:"firstConsecutiveStaticIP,omitempty"`
+	Subnet                    string            `json:"subnet"`
+	SubnetIPv6                string            `json:"subnetIPv6"`
+	IPAddressCount            int               `json:"ipAddressCount,omitempty"`
+	StorageProfile            string            `json:"storageProfile,omitempty"`
+	HTTPSourceAddressPrefix   string            `json:"HTTPSourceAddressPrefix,omitempty"`
+	OAuthEnabled              bool              `json:"oauthEnabled"`
+	PreprovisionExtension     *Extension        `json:"preProvisionExtension"`
+	Extensions                []Extension       `json:"extensions"`
+	Distro                    Distro            `json:"distro,omitempty"`
+	KubernetesConfig          *KubernetesConfig `json:"kubernetesConfig,omitempty"`
+	ImageRef                  *ImageReference   `json:"imageReference,omitempty"`
+	CustomFiles               *[]CustomFile     `json:"customFiles,omitempty"`
+	AvailabilityProfile       string            `json:"availabilityProfile"`
+	PlatformFaultDomainCount  *int              `json:"platformFaultDomainCount"`
+	PlatformUpdateDomainCount *int              `json:"platformUpdateDomainCount"`
+	AgentSubnet               string            `json:"agentSubnet,omitempty"`
+	AvailabilityZones         []string          `json:"availabilityZones,omitempty"`
+	SinglePlacementGroup      *bool             `json:"singlePlacementGroup,omitempty"`
+	AuditDEnabled             *bool             `json:"auditDEnabled,omitempty"`
+	CustomVMTags              map[string]string `json:"customVMTags,omitempty"`
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376
 	// Not used during PUT, returned as part of GET
@@ -591,6 +592,7 @@ type AgentPoolProfile struct {
 	EnableAutoScaling                   *bool                `json:"enableAutoScaling,omitempty"`
 	AvailabilityZones                   []string             `json:"availabilityZones,omitempty"`
 	PlatformFaultDomainCount            *int                 `json:"platformFaultDomainCount"`
+	PlatformUpdateDomainCount           *int                 `json:"platformUpdateDomainCount"`
 	SinglePlacementGroup                *bool                `json:"singlePlacementGroup,omitempty"`
 	VnetCidrs                           []string             `json:"vnetCidrs,omitempty"`
 	PreserveNodesProperties             *bool                `json:"preserveNodesProperties,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -385,32 +385,33 @@ type DcosConfig struct {
 
 // MasterProfile represents the definition of the master cluster
 type MasterProfile struct {
-	Count                    int               `json:"count" validate:"required,eq=1|eq=3|eq=5"`
-	DNSPrefix                string            `json:"dnsPrefix" validate:"required"`
-	SubjectAltNames          []string          `json:"subjectAltNames"`
-	VMSize                   string            `json:"vmSize" validate:"required"`
-	OSDiskSizeGB             int               `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
-	VnetSubnetID             string            `json:"vnetSubnetID,omitempty"`
-	VnetCidr                 string            `json:"vnetCidr,omitempty"`
-	AgentVnetSubnetID        string            `json:"agentVnetSubnetID,omitempty"`
-	FirstConsecutiveStaticIP string            `json:"firstConsecutiveStaticIP,omitempty"`
-	IPAddressCount           int               `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
-	StorageProfile           string            `json:"storageProfile,omitempty" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
-	HTTPSourceAddressPrefix  string            `json:"HTTPSourceAddressPrefix,omitempty"`
-	OAuthEnabled             bool              `json:"oauthEnabled"`
-	PreProvisionExtension    *Extension        `json:"preProvisionExtension"`
-	Extensions               []Extension       `json:"extensions"`
-	Distro                   Distro            `json:"distro,omitempty"`
-	KubernetesConfig         *KubernetesConfig `json:"kubernetesConfig,omitempty"`
-	ImageRef                 *ImageReference   `json:"imageReference,omitempty"`
-	CustomFiles              *[]CustomFile     `json:"customFiles,omitempty"`
-	AvailabilityProfile      string            `json:"availabilityProfile"`
-	AgentSubnet              string            `json:"agentSubnet,omitempty"`
-	AvailabilityZones        []string          `json:"availabilityZones,omitempty"`
-	SinglePlacementGroup     *bool             `json:"singlePlacementGroup,omitempty"`
-	PlatformFaultDomainCount *int              `json:"platformFaultDomainCount,omitEmpty"`
-	AuditDEnabled            *bool             `json:"auditDEnabled,omitempty"`
-	CustomVMTags             map[string]string `json:"customVMTags,omitempty"`
+	Count                     int               `json:"count" validate:"required,eq=1|eq=3|eq=5"`
+	DNSPrefix                 string            `json:"dnsPrefix" validate:"required"`
+	SubjectAltNames           []string          `json:"subjectAltNames"`
+	VMSize                    string            `json:"vmSize" validate:"required"`
+	OSDiskSizeGB              int               `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
+	VnetSubnetID              string            `json:"vnetSubnetID,omitempty"`
+	VnetCidr                  string            `json:"vnetCidr,omitempty"`
+	AgentVnetSubnetID         string            `json:"agentVnetSubnetID,omitempty"`
+	FirstConsecutiveStaticIP  string            `json:"firstConsecutiveStaticIP,omitempty"`
+	IPAddressCount            int               `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
+	StorageProfile            string            `json:"storageProfile,omitempty" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
+	HTTPSourceAddressPrefix   string            `json:"HTTPSourceAddressPrefix,omitempty"`
+	OAuthEnabled              bool              `json:"oauthEnabled"`
+	PreProvisionExtension     *Extension        `json:"preProvisionExtension"`
+	Extensions                []Extension       `json:"extensions"`
+	Distro                    Distro            `json:"distro,omitempty"`
+	KubernetesConfig          *KubernetesConfig `json:"kubernetesConfig,omitempty"`
+	ImageRef                  *ImageReference   `json:"imageReference,omitempty"`
+	CustomFiles               *[]CustomFile     `json:"customFiles,omitempty"`
+	AvailabilityProfile       string            `json:"availabilityProfile"`
+	AgentSubnet               string            `json:"agentSubnet,omitempty"`
+	AvailabilityZones         []string          `json:"availabilityZones,omitempty"`
+	SinglePlacementGroup      *bool             `json:"singlePlacementGroup,omitempty"`
+	PlatformFaultDomainCount  *int              `json:"platformFaultDomainCount,omitEmpty"`
+	PlatformUpdateDomainCount *int              `json:"platformUpdateDomainCount"`
+	AuditDEnabled             *bool             `json:"auditDEnabled,omitempty"`
+	CustomVMTags              map[string]string `json:"customVMTags,omitempty"`
 
 	// subnet is internal
 	subnet string
@@ -489,6 +490,7 @@ type AgentPoolProfile struct {
 	Extensions                        []Extension       `json:"extensions"`
 	SinglePlacementGroup              *bool             `json:"singlePlacementGroup,omitempty"`
 	PlatformFaultDomainCount          *int              `json:"platformFaultDomainCount,omitEmpty"`
+	PlatformUpdateDomainCount         *int              `json:"platformUpdateDomainCount"`
 	AvailabilityZones                 []string          `json:"availabilityZones,omitempty"`
 	EnableVMSSNodePublicIP            *bool             `json:"enableVMSSNodePublicIP,omitempty"`
 	LoadBalancerBackendAddressPoolIDs []string          `json:"loadBalancerBackendAddressPoolIDs,omitempty"`

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -28,6 +28,7 @@ func TestGenerateARMResourcesWithVMSSAgentPool(t *testing.T) {
 	var cs api.ContainerService
 
 	json.Unmarshal([]byte(apiModelStr), &cs)
+	cs.Properties.MasterProfile.PlatformUpdateDomainCount = to.IntPtr(3)
 
 	armResources := GenerateARMResources(&cs)
 
@@ -707,6 +708,7 @@ func TestGenerateARMResourceWithVMASAgents(t *testing.T) {
 	var cs api.ContainerService
 
 	json.Unmarshal([]byte(apiModelStr), &cs)
+	cs.Properties.MasterProfile.PlatformUpdateDomainCount = to.IntPtr(3)
 
 	armResources := GenerateARMResources(&cs)
 
@@ -1257,6 +1259,7 @@ func TestGenerateARMResourcesWithVMSSAgentPoolAndSLB(t *testing.T) {
 	var cs api.ContainerService
 
 	json.Unmarshal([]byte(apiModelStr), &cs)
+	cs.Properties.MasterProfile.PlatformUpdateDomainCount = to.IntPtr(3)
 
 	armResources := GenerateARMResources(&cs)
 

--- a/pkg/engine/armtype_test.go
+++ b/pkg/engine/armtype_test.go
@@ -22,10 +22,11 @@ func TestMarshalJSON(t *testing.T) {
 				Secret:   "bazSecret",
 			},
 			MasterProfile: &api.MasterProfile{
-				Count:               3,
-				DNSPrefix:           "myprefix1",
-				VMSize:              "Standard_DS2_v2",
-				AvailabilityProfile: api.VirtualMachineScaleSets,
+				Count:                     3,
+				DNSPrefix:                 "myprefix1",
+				VMSize:                    "Standard_DS2_v2",
+				AvailabilityProfile:       api.VirtualMachineScaleSets,
+				PlatformUpdateDomainCount: to.IntPtr(3),
 			},
 			OrchestratorProfile: &api.OrchestratorProfile{
 				OrchestratorType:    api.Kubernetes,

--- a/pkg/engine/availabilitysets.go
+++ b/pkg/engine/availabilitysets.go
@@ -25,12 +25,14 @@ func CreateAvailabilitySet(cs *api.ContainerService, isManagedDisks bool) Availa
 
 	if !cs.Properties.MasterProfile.HasAvailabilityZones() {
 		if isManagedDisks {
-			avSet.AvailabilitySetProperties = &compute.AvailabilitySetProperties{
-				PlatformUpdateDomainCount: to.Int32Ptr(3),
-			}
+			avSet.AvailabilitySetProperties = &compute.AvailabilitySetProperties{}
 			if cs.Properties.MasterProfile.PlatformFaultDomainCount != nil {
 				p := int32(*cs.Properties.MasterProfile.PlatformFaultDomainCount)
 				avSet.PlatformFaultDomainCount = to.Int32Ptr(p)
+			}
+			if cs.Properties.MasterProfile.PlatformUpdateDomainCount != nil {
+				p := int32(*cs.Properties.MasterProfile.PlatformUpdateDomainCount)
+				avSet.PlatformUpdateDomainCount = to.Int32Ptr(p)
 			}
 			avSet.Sku = &compute.Sku{
 				Name: to.StringPtr("Aligned"),
@@ -64,7 +66,10 @@ func createAgentAvailabilitySets(profile *api.AgentPoolProfile) AvailabilitySetA
 			p := int32(*profile.PlatformFaultDomainCount)
 			avSet.PlatformFaultDomainCount = to.Int32Ptr(p)
 		}
-		avSet.PlatformUpdateDomainCount = to.Int32Ptr(3)
+		if profile.PlatformUpdateDomainCount != nil {
+			p := int32(*profile.PlatformUpdateDomainCount)
+			avSet.PlatformUpdateDomainCount = to.Int32Ptr(p)
+		}
 		avSet.Sku = &compute.Sku{
 			Name: to.StringPtr("Aligned"),
 		}

--- a/pkg/engine/availabilitysets_test.go
+++ b/pkg/engine/availabilitysets_test.go
@@ -47,7 +47,9 @@ func TestCreateAvailabilitySet(t *testing.T) {
 
 	cs = &api.ContainerService{
 		Properties: &api.Properties{
-			MasterProfile: &api.MasterProfile{},
+			MasterProfile: &api.MasterProfile{
+				PlatformUpdateDomainCount: to.IntPtr(3),
+			},
 		},
 	}
 
@@ -105,12 +107,13 @@ func TestCreateAvailabilitySet(t *testing.T) {
 		t.Errorf("unexpected error while comparing availability sets: %s", diff)
 	}
 
-	// Test availability set with platform fault domain count set
+	// Test availability set with platform fault domain+update count  set
 	count := 3
 	cs = &api.ContainerService{
 		Properties: &api.Properties{
 			MasterProfile: &api.MasterProfile{
-				PlatformFaultDomainCount: &count,
+				PlatformFaultDomainCount:  &count,
+				PlatformUpdateDomainCount: &count,
 			},
 		},
 	}
@@ -171,8 +174,9 @@ func TestCreateAgentAvailabilitySets(t *testing.T) {
 
 	//Test AvSet wit ManagedDisk
 	profile = &api.AgentPoolProfile{
-		Name:           "foobar",
-		StorageProfile: api.ManagedDisks,
+		Name:                      "foobar",
+		StorageProfile:            api.ManagedDisks,
+		PlatformUpdateDomainCount: to.IntPtr(3),
 	}
 
 	avSet = createAgentAvailabilitySets(profile)
@@ -200,12 +204,13 @@ func TestCreateAgentAvailabilitySets(t *testing.T) {
 		t.Errorf("unexpected error while comparing availability sets: %s", diff)
 	}
 
-	// Test availability set with platform fault domain count set
+	// Test availability set with platform fault+update domain count set
 	count := 3
 	profile = &api.AgentPoolProfile{
-		Name:                     "foobar",
-		StorageProfile:           api.ManagedDisks,
-		PlatformFaultDomainCount: &count,
+		Name:                      "foobar",
+		StorageProfile:            api.ManagedDisks,
+		PlatformFaultDomainCount:  &count,
+		PlatformUpdateDomainCount: &count,
 	}
 
 	avSet = createAgentAvailabilitySets(profile)

--- a/pkg/engine/masterarmresources_test.go
+++ b/pkg/engine/masterarmresources_test.go
@@ -32,6 +32,7 @@ func TestCreateKubernetesMasterResourcesPVC(t *testing.T) {
 			StorageProfile: api.StorageAccount,
 		},
 	}
+	cs.Properties.MasterProfile.PlatformUpdateDomainCount = to.IntPtr(3)
 
 	actualResources := createKubernetesMasterResourcesVMAS(&cs)
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Allow user-overridable `platformUpdateDomainCount` to accommodate Azure regions that are unable to accommodate the static default `3` (e.g., `centraluseuap`).

This PR essentially keeps the static `3` configuration in place (via defaults enforcement), i.e., it does not auto-configure the platform update domain count value based on region.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
