### PR TITLE
fix: apply new master node labels for k8s v1.18+ compatibility

### DIFF
--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -278,6 +278,8 @@ func IsSgxEnabledSKU(vmSize string) bool {
 func GetMasterKubernetesLabels(rg string, deprecated bool) string {
 	var buf bytes.Buffer
 	buf.WriteString("kubernetes.azure.com/role=master")
+	buf.WriteString(",node.kubernetes.io/exclude-from-external-load-balancers=true")
+	buf.WriteString(",node.kubernetes.io/exclude-disruption=true")
 	if deprecated {
 		buf.WriteString(",kubernetes.io/role=master")
 		buf.WriteString(",node-role.kubernetes.io/master=")

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -148,25 +148,25 @@ func TestGetMasterKubernetesLabelsDeprecated(t *testing.T) {
 			"valid rg string",
 			"my-resource-group",
 			false,
-			"kubernetes.azure.com/role=master,kubernetes.azure.com/cluster=my-resource-group",
+			"kubernetes.azure.com/role=master,node.kubernetes.io/exclude-from-external-load-balancers=true,node.kubernetes.io/exclude-disruption=true,kubernetes.azure.com/cluster=my-resource-group",
 		},
 		{
 			"valid rg string",
 			"my-resource-group",
 			true,
-			"kubernetes.azure.com/role=master,kubernetes.io/role=master,node-role.kubernetes.io/master=,kubernetes.azure.com/cluster=my-resource-group",
+			"kubernetes.azure.com/role=master,node.kubernetes.io/exclude-from-external-load-balancers=true,node.kubernetes.io/exclude-disruption=true,kubernetes.io/role=master,node-role.kubernetes.io/master=,kubernetes.azure.com/cluster=my-resource-group",
 		},
 		{
 			"empty string",
 			"",
 			false,
-			"kubernetes.azure.com/role=master,kubernetes.azure.com/cluster=",
+			"kubernetes.azure.com/role=master,node.kubernetes.io/exclude-from-external-load-balancers=true,node.kubernetes.io/exclude-disruption=true,kubernetes.azure.com/cluster=",
 		},
 		{
 			"empty string",
 			"",
 			true,
-			"kubernetes.azure.com/role=master,kubernetes.io/role=master,node-role.kubernetes.io/master=,kubernetes.azure.com/cluster=",
+			"kubernetes.azure.com/role=master,node.kubernetes.io/exclude-from-external-load-balancers=true,node.kubernetes.io/exclude-disruption=true,kubernetes.io/role=master,node-role.kubernetes.io/master=,kubernetes.azure.com/cluster=",
 		},
 	}
 

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -684,7 +684,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				labels := node.Metadata.Labels
 				Expect(labels).To(HaveKeyWithValue("kubernetes.io/role", role))
 				Expect(labels).To(HaveKey(fmt.Sprintf("node-role.kubernetes.io/%s", role)))
-				if role == "master" {
+				if role == "master" && common.IsKubernetesVersionGe(
+					eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.1") {
 					Expect(labels).To(HaveKeyWithValue("node.kubernetes.io/exclude-from-external-load-balancers", "true"))
 					Expect(labels).To(HaveKeyWithValue("node.kubernetes.io/exclude-disruption", "true"))
 				}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -684,6 +684,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				labels := node.Metadata.Labels
 				Expect(labels).To(HaveKeyWithValue("kubernetes.io/role", role))
 				Expect(labels).To(HaveKey(fmt.Sprintf("node-role.kubernetes.io/%s", role)))
+				if role == "master" {
+					Expect(labels).To(HaveKeyWithValue("node.kubernetes.io/exclude-from-external-load-balancers", "true"))
+					Expect(labels).To(HaveKeyWithValue("node.kubernetes.io/exclude-disruption", "true"))
+				}
 			}
 		})
 


### PR DESCRIPTION
**Reason for Change**:
To preserve the existing behavior of the deprecated `node-role.kubernetes.io/master`, future versions of Kubernetes will use these two [more targeted labels](https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/2019-07-16-node-role-label-use.md#instructions-for-deployers).

**Issue Fixed**:
Fixes #2265

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
These do no harm to apply to earlier versions of Kubernetes, so this is the simplest implementation.

The added e2e spec will fail eventually in upgrade testing, which builds clusters with earlier versions of AKS Engine but may run tests from master. To fix that, we can skip that part of the test unless the k8s version is 1.17.1 (not released yet) or greater.
