### PR TITLE
feat: Configuring docker log rotation for Windows nodes

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -182,6 +182,7 @@ try
 
         Write-Log "Install docker"
         Install-Docker -DockerVersion $global:DockerVersion
+        Set-DockerLogFileOptions
 
         Write-Log "Download kubelet binaries and unzip"
         Get-KubePackage -KubeBinariesSASURL $global:KubeBinariesPackageSASURL

--- a/parts/k8s/windowsconfigfunc.ps1
+++ b/parts/k8s/windowsconfigfunc.ps1
@@ -104,6 +104,31 @@ function Install-Docker
     }
 }
 
+function Set-DockerLogFileOptions {
+    Write-Log "Updating log file options in docker config"
+    $dockerConfigPath = "C:\ProgramData\docker\config\daemon.json"
+
+    if (-not (Test-Path $dockerConfigPath)) {
+        "{}" | Out-File $dockerConfigPath
+    }
+
+    $dockerConfig = Get-Content $dockerConfigPath | ConvertFrom-Json
+    $dockerConfig | Add-Member -Name "log-driver" -Value "json-file" -MemberType NoteProperty
+    $logOpts = @{ "max-size" = "50m"; "max-file" = "5" }
+    $dockerConfig | Add-Member -Name "log-opts" -Value $logOpts -MemberType NoteProperty
+    $dockerConfig = $dockerConfig | ConvertTo-Json -Depth 10
+
+    Write-Log "New docker config:"
+    Write-Log $dockerConfig
+
+    # daemon.json MUST be encoded as UTF8-no-BOM!
+    Remove-Item $dockerConfigPath
+    $fileEncoding = New-Object System.Text.UTF8Encoding $false
+    [IO.File]::WriteAllLInes($dockerConfigPath, $dockerConfig, $fileEncoding)
+
+    Restart-Service docker
+}
+
 # Pagefile adjustments
 function Adjust-PageFileSize()
 {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -32682,6 +32682,7 @@ try
 
         Write-Log "Install docker"
         Install-Docker -DockerVersion $global:DockerVersion
+        Set-DockerLogFileOptions
 
         Write-Log "Download kubelet binaries and unzip"
         Get-KubePackage -KubeBinariesSASURL $global:KubeBinariesPackageSASURL
@@ -33812,6 +33813,31 @@ function Install-Docker
         $currentDockerVersion = (Get-Package -Name Docker -ProviderName DockerMsftProvider).Version
         Write-Log "Not able to install docker version. Using default version $currentDockerVersion"
     }
+}
+
+function Set-DockerLogFileOptions {
+    Write-Log "Updating log file options in docker config"
+    $dockerConfigPath = "C:\ProgramData\docker\config\daemon.json"
+
+    if (-not (Test-Path $dockerConfigPath)) {
+        "{}" | Out-File $dockerConfigPath
+    }
+
+    $dockerConfig = Get-Content $dockerConfigPath | ConvertFrom-Json
+    $dockerConfig | Add-Member -Name "log-driver" -Value "json-file" -MemberType NoteProperty
+    $logOpts = @{ "max-size" = "50m"; "max-file" = "5" }
+    $dockerConfig | Add-Member -Name "log-opts" -Value $logOpts -MemberType NoteProperty
+    $dockerConfig = $dockerConfig | ConvertTo-Json -Depth 10
+
+    Write-Log "New docker config:"
+    Write-Log $dockerConfig
+
+    # daemon.json MUST be encoded as UTF8-no-BOM!
+    Remove-Item $dockerConfigPath
+    $fileEncoding = New-Object System.Text.UTF8Encoding $false
+    [IO.File]::WriteAllLInes($dockerConfigPath, $dockerConfig, $fileEncoding)
+
+    Restart-Service docker
 }
 
 # Pagefile adjustments


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Windows nodes are configured with no log rotation and this can lead to disks filling up for long running clusters.
This PR sets the log rotation setting to be the same as what is set as default for linux machines.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes issue #373

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
