### PR TITLE
fix: Check microsoft-aks based os publisher for windows in scale scenario.

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -269,7 +269,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				}
 
 				osPublisher := vm.StorageProfile.ImageReference.Publisher
-				if osPublisher != nil && strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") {
+				if osPublisher != nil && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
 					_, _, winPoolIndex, index, err = utils.WindowsVMNameParts(vmName)
 				} else {
 					_, _, index, err = utils.K8sLinuxVMNameParts(vmName)
@@ -390,7 +390,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				}
 
 				osPublisher := vmss.VirtualMachineProfile.StorageProfile.ImageReference.Publisher
-				if osPublisher != nil && strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") {
+				if osPublisher != nil && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
 					_, _, winPoolIndex, _, err = utils.WindowsVMNameParts(vmName)
 					log.Errorln(err)
 				}


### PR DESCRIPTION
fix: If K8s cluster deployed with microsoft-aks windows vhd then scale up scenario fail with error "resource name was missing from identifier" because current code is only checking for MicrosoftWindowsServer based publisher.

**Issue Fixed**:
Fixes #2482 


**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
