### PR TITLE
fix: Fix some path handling in collect-windows-logs script

### DIFF
--- a/scripts/collect-windows-logs.ps1
+++ b/scripts/collect-windows-logs.ps1
@@ -1,11 +1,25 @@
-$lockedFiles = "kubelet.err.log", "kubelet.log", "kubeproxy.log", "kubeproxy.err.log", "containerd.err.log", "containerd.log", "azure-vnet-telemetry.log"
+$lockedFiles = "kubelet.err.log", "kubelet.log", "kubeproxy.log", "kubeproxy.err.log", "containerd.err.log", "containerd.log", "azure-vnet-telemetry.log", "azure-vnet.log"
 
 $timeStamp = get-date -format 'yyyyMMdd-hhmmss'
 $zipName = "$env:computername-$($timeStamp)_logs.zip"
 
-# The leading , forces array output. However, if there are no logs in c:\k\*.log, there's a null entry. That needs to be filtered later
-$paths = , (get-childitem c:\k\*.log -Exclude $lockedFiles)
-$paths += $lockedFiles | Foreach-Object { $src = "c:\k\$_" ; if (Test-Path $src) {Copy-Item $src . -Passthru -ErrorAction Ignore } }
+$paths = @()
+get-childitem c:\k\*.log* -Exclude $lockedFiles | Foreach-Object {
+  $paths += $_
+}
+$lockedTemp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -Type Directory $lockedTemp
+$lockedFiles | Foreach-Object {
+  Write-Host "Copying $_ to temp"
+  $src = "c:\k\$_"
+  if (Test-Path $src) {
+    $tempfile= Copy-Item $src $lockedTemp -Passthru -ErrorAction Ignore
+    if ($tempFile) {
+      $paths += $tempFile
+    }
+  }
+}
+Write-Host Exporting ETW events to CSV files
 $scm = Get-WinEvent -FilterHashtable @{logname='System';ProviderName='Service Control Manager'} | Where-Object { $_.Message -Like "*docker*" -or $_.Message -Like "*kub*" } | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message
 # 2004 = resource exhaustion, other 5 events related to reboots
 $reboots = Get-WinEvent -ErrorAction Ignore -FilterHashtable @{logname='System'; id=1074,1076,2004,6005,6006,6008} | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message
@@ -24,7 +38,7 @@ Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Microsoft/S
 & 'c:\k\debug\collectlogs.ps1' | write-Host
 $netLogs = Get-ChildItem (Get-ChildItem -Path c:\k\debug -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName | Select-Object -ExpandProperty FullName
 $paths += $netLogs
-$pathsFiltered = $paths | Where-Object { $_ -ne $null }
 Write-Host Compressing all logs to $zipName
-Compress-Archive -LiteralPath $pathsFiltered -DestinationPath $zipName
+$paths | Format-Table FullName, Length -AutoSize
+Compress-Archive -LiteralPath $paths -DestinationPath $zipName
 Get-ChildItem $zipName # this puts a FileInfo on the pipeline so that another script can get it on the pipeline


### PR DESCRIPTION
**Reason for Change**:

The previous method I used to create an array of files would sometimes end up creating a two-dimensional array. Allocating it separately as an empty array and always using += avoids this and is easier to read