### PR TITLE
feat: cleaning up old kubelet/kubeproxy logs for Windows nodes

### DIFF
--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -136,3 +136,16 @@ function Get-NetworkLogCollectionScripts {
     DownloadFileOverHttp -Url 'https://github.com/microsoft/SDN/raw/master/Kubernetes/windows/debug/stoppacketcapture.cmd' -DestinationPath 'c:\k\debug\stoppacketcapture.cmd'
     DownloadFileOverHttp -Url 'https://github.com/microsoft/SDN/raw/master/Kubernetes/windows/helper.psm1' -DestinationPath 'c:\k\debug\helper.psm1'
 }
+
+function Register-LogsCleanupScriptTask {
+    Write-Log "Creating a scheduled task to run windowslogscleanup.ps1"
+
+    (Get-Content "c:\AzureData\k8s\windowslogscleanup.ps1") |
+    Out-File "c:\k\windowslogscleanup.ps1"
+
+    $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-File `"c:\k\windowslogscleanup.ps1`""
+    $principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest
+    $trigger = New-JobTrigger -Daily -At "00:00" -DaysInterval 1
+    $definition = New-ScheduledTask -Action $action -Principal $principal -Trigger $trigger -Description "log-cleanup-task"
+    Register-ScheduledTask -TaskName "log-cleanup-task" -InputObject $definition
+}

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -322,6 +322,8 @@ try
         Write-Log "Update service failure actions"
         Update-ServiceFailureActions
 
+        Register-LogsCleanupScriptTask
+
         if (Test-Path $CacheDir)
         {
             Write-Log "Removing aks-engine bits cache directory"

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -291,7 +291,7 @@ New-NSSMService {
     & "$KubeDir\nssm.exe" set Kubelet AppRotateFiles 1
     & "$KubeDir\nssm.exe" set Kubelet AppRotateOnline 1
     & "$KubeDir\nssm.exe" set Kubelet AppRotateSeconds 86400
-    & "$KubeDir\nssm.exe" set Kubelet AppRotateBytes 1048576
+    & "$KubeDir\nssm.exe" set Kubelet AppRotateBytes 10485760
 
     # setup kubeproxy
     & "$KubeDir\nssm.exe" install Kubeproxy C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
@@ -309,7 +309,7 @@ New-NSSMService {
     & "$KubeDir\nssm.exe" set Kubeproxy AppRotateFiles 1
     & "$KubeDir\nssm.exe" set Kubeproxy AppRotateOnline 1
     & "$KubeDir\nssm.exe" set Kubeproxy AppRotateSeconds 86400
-    & "$KubeDir\nssm.exe" set Kubeproxy AppRotateBytes 1048576
+    & "$KubeDir\nssm.exe" set Kubeproxy AppRotateBytes 10485760
 }
 
 # Renamed from Write-KubernetesStartFiles

--- a/parts/k8s/windowslogscleanup.ps1
+++ b/parts/k8s/windowslogscleanup.ps1
@@ -1,0 +1,25 @@
+<#
+.DESCRIPTION
+    This script cleans old rotated logs for various kubernetes components.
+#>
+
+$global:LogPath = "c:\k\windowslogscleanup.log"
+
+filter Timestamp { "$(Get-Date -Format o): $_" }
+
+function Write-Log ($message) {
+    $message | Timestamp | Tee-Object -FilePath $global:LogPath -Append
+}
+
+Write-Log "Entering windowslogscleanup.ps1"
+
+$logFilePrefixes = @("kubelet", "kubelet.err", "kubeproxy", "kubeproxy.err")
+
+foreach ($logFilePrefix in $logFilePrefixes) {
+    $oldLogs = [IO.Directory]::GetFiles("c:\temp\kubelogs\logs", "$($logFilePrefix)-*.log")
+    $oldLogs = $oldLogs | Sort-Object | Select-Object -SkipLast 5
+    foreach ($oldLog in $oldLogs) {
+        Write-Log "Removing $oldLog"
+        Remove-Item $oldLog
+    }
+}

--- a/parts/k8s/windowslogscleanup.ps1
+++ b/parts/k8s/windowslogscleanup.ps1
@@ -16,7 +16,7 @@ Write-Log "Entering windowslogscleanup.ps1"
 $logFilePrefixes = @("kubelet", "kubelet.err", "kubeproxy", "kubeproxy.err")
 
 foreach ($logFilePrefix in $logFilePrefixes) {
-    $oldLogs = [IO.Directory]::GetFiles("c:\temp\kubelogs\logs", "$($logFilePrefix)-*.log")
+    $oldLogs = [IO.Directory]::GetFiles("c:\k", "$($logFilePrefix)-*.log")
     $oldLogs = $oldLogs | Sort-Object | Select-Object -SkipLast 5
     foreach ($oldLog in $oldLogs) {
         Write-Log "Removing $oldLog"

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -93,6 +93,7 @@ const (
 	kubernetesWindowsCniFunctionsPS1      = "k8s/windowscnifunc.ps1"
 	kubernetesWindowsAzureCniFunctionsPS1 = "k8s/windowsazurecnifunc.ps1"
 	kubernetesWindowsOpenSSHFunctionPS1   = "k8s/windowsinstallopensshfunc.ps1"
+	kubernetesWindowsLogsCleanupPS1       = "k8s/windowslogscleanup.ps1"
 )
 
 // cloud-init (i.e. ARM customData) source file references

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -481,6 +481,7 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 				kubernetesWindowsKubeletFunctionsPS1,
 				kubernetesWindowsCniFunctionsPS1,
 				kubernetesWindowsAzureCniFunctionsPS1,
+				kubernetesWindowsLogsCleanupPS1,
 				kubernetesWindowsOpenSSHFunctionPS1}
 
 			// Create a buffer, new zip

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -35176,7 +35176,7 @@ Write-Log "Entering windowslogscleanup.ps1"
 $logFilePrefixes = @("kubelet", "kubelet.err", "kubeproxy", "kubeproxy.err")
 
 foreach ($logFilePrefix in $logFilePrefixes) {
-    $oldLogs = [IO.Directory]::GetFiles("c:\k\logs", "$($logFilePrefix)-*.log")
+    $oldLogs = [IO.Directory]::GetFiles("c:\k", "$($logFilePrefix)-*.log")
     $oldLogs = $oldLogs | Sort-Object | Select-Object -SkipLast 5
     foreach ($oldLog in $oldLogs) {
         Write-Log "Removing $oldLog"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -35176,7 +35176,7 @@ Write-Log "Entering windowslogscleanup.ps1"
 $logFilePrefixes = @("kubelet", "kubelet.err", "kubeproxy", "kubeproxy.err")
 
 foreach ($logFilePrefix in $logFilePrefixes) {
-    $oldLogs = [IO.Directory]::GetFiles("c:\temp\kubelogs\logs", "$($logFilePrefix)-*.log")
+    $oldLogs = [IO.Directory]::GetFiles("c:\k\logs", "$($logFilePrefix)-*.log")
     $oldLogs = $oldLogs | Sort-Object | Select-Object -SkipLast 5
     foreach ($oldLog in $oldLogs) {
         Write-Log "Removing $oldLog"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2470 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This change increases the size of kubelet.err.log/kubeproxu.err.log to 10Mb and adds a scheduled task to keep the 5 most recent rotated logs.