### PR TITLE
fix: add "Standard_DS3_v2" to "AcceleratedNetworking" supported list

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -114,7 +114,7 @@ func AcceleratedNetworkingSupported(sku string) bool {
 	// Trim the optional _Promo suffix.
 	sku = strings.TrimSuffix(sku, "_Promo")
 	switch sku {
-	case "Standard_D3_v2", "Standard_D12_v2", "Standard_DS13-4_v2", "Standard_DS14-4_v2", "Standard_F4", "Standard_F4s", "Standard_D8_v3", "Standard_D8s_v3",
+	case "Standard_D3_v2", "Standard_DS3_v2", "Standard_D12_v2", "Standard_DS13-4_v2", "Standard_DS14-4_v2", "Standard_F4", "Standard_F4s", "Standard_D8_v3", "Standard_D8s_v3",
 		"Standard_D32-8s_v3", "Standard_E8_v3", "Standard_E8s_v3", "Standard_D3_v2_ABC",
 		"Standard_D12_v2_ABC", "Standard_F4_ABC", "Standard_F8s_v2", "Standard_D4_v2",
 		"Standard_D13_v2", "Standard_DS4_v2",

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -223,6 +223,10 @@ func TestAcceleratedNetworkingSupported(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			input:          "Standard_DS3_v2",
+			expectedResult: true,
+		},
+		{
 			input:          "",
 			expectedResult: false,
 		},


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
according to [Accelerated Networking doc](https://azure.microsoft.com/en-us/blog/maximize-your-vm-s-performance-with-accelerated-networking-now-generally-available-for-both-windows-and-linux/), DSv2 supports accelerated networking feature, "DS3 v2" is one of the [DSv2 SKU](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/#d-series), this change is to add this SKU in to the supported list.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2508

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
