### PR TITLE
fix: configure addons before setting kubelet config

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -98,8 +98,9 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		"--tls-cipher-suites":                 TLSStrongCipherSuitesKubelet,
 	}
 
-	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS
-	if !cs.Properties.IsIPMasqAgentEnabled() {
+	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS or
+	// explicitly disabled in kubernetes config
+	if cs.Properties.IsIPMasqAgentDisabled() {
 		defaultKubeletConfig["--non-masquerade-cidr"] = cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet
 	}
 

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -519,6 +519,15 @@ func TestKubeletIPMasqAgentEnabledOrDisabled(t *testing.T) {
 		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
 			k["--non-masquerade-cidr"], DefaultNonMasqueradeCIDR)
 	}
+
+	// No ip-masq-agent addon configuration specified, --non-masquerade-cidr should be 0.0.0.0/0
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--non-masquerade-cidr"] != DefaultNonMasqueradeCIDR {
+		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
+			k["--non-masquerade-cidr"], DefaultNonMasqueradeCIDR)
+	}
 }
 
 func TestEnforceNodeAllocatable(t *testing.T) {

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -48,7 +48,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--max-pods":                          strconv.Itoa(DefaultKubernetesMaxPods),
 		"--network-plugin":                    NetworkPluginKubenet,
 		"--node-status-update-frequency":      K8sComponentsByVersionMap[cs.Properties.OrchestratorProfile.OrchestratorVersion]["nodestatusfreq"],
-		"--non-masquerade-cidr":               DefaultKubernetesSubnet,
+		"--non-masquerade-cidr":               DefaultNonMasqueradeCIDR,
 		"--pod-manifest-path":                 "/etc/kubernetes/manifests",
 		"--pod-infra-container-image":         cs.Properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase + K8sComponentsByVersionMap[cs.Properties.OrchestratorProfile.OrchestratorVersion]["pause"],
 		"--pod-max-pids":                      strconv.Itoa(DefaultKubeletPodMaxPIDs),
@@ -80,6 +80,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 				key, val, expected[key])
 		}
 	}
+
 	windowsProfileKubeletConfig := cs.Properties.AgentPoolProfiles[1].KubernetesConfig.KubeletConfig
 	expected["--azure-container-registry-config"] = "c:\\k\\azure.json"
 	expected["--pod-infra-container-image"] = "kubletwin/pause"
@@ -104,6 +105,25 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		}
 	}
 
+	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(Kubernetes, common.KubernetesDefaultRelease, "", false, false), 3, 2, false)
+	// check when ip-masq-agent is explicitly disabled in kubernetes config
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []KubernetesAddon{
+		{
+			Name:    common.IPMASQAgentAddonName,
+			Enabled: to.BoolPtr(false),
+		},
+	}
+
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+
+	for key, val := range map[string]string{"--non-masquerade-cidr": DefaultKubernetesSubnet} {
+		if k[key] != val {
+			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
+				key, k[key], val)
+		}
+	}
+
 	cs = CreateMockContainerService("testcluster", "1.8.6", 3, 2, false)
 	// TODO test all default overrides
 	overrideVal := "/etc/override"
@@ -111,7 +131,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--azure-container-registry-config": overrideVal,
 	}
 	cs.setKubeletConfig(false)
-	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	for key, val := range map[string]string{"--azure-container-registry-config": overrideVal} {
 		if k[key] != val {
 			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -480,11 +480,13 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			}
 		}
 
+		// Configure addons
+		// This needs to be configured first as set kubelet config depends
+		// on certains default addons to be populated (eg. ip-masq-agent)
+		cs.setAddonsConfig(isUpgrade)
+
 		// Configure kubelet
 		cs.setKubeletConfig(isUpgrade)
-
-		// Configure addons
-		cs.setAddonsConfig(isUpgrade)
 
 		// Master-specific defaults that depend upon kubelet defaults
 		// Set the default number of IP addresses allocated for masters.

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -480,13 +480,11 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			}
 		}
 
-		// Configure addons
-		// This needs to be configured first as set kubelet config depends
-		// on certains default addons to be populated (eg. ip-masq-agent)
-		cs.setAddonsConfig(isUpgrade)
-
 		// Configure kubelet
 		cs.setKubeletConfig(isUpgrade)
+
+		// Configure addons
+		cs.setAddonsConfig(isUpgrade)
 
 		// Master-specific defaults that depend upon kubelet defaults
 		// Set the default number of IP addresses allocated for masters.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1011,12 +1011,15 @@ func (p *Properties) IsIPMasqAgentEnabled() bool {
 	return p.OrchestratorProfile.KubernetesConfig.IsIPMasqAgentEnabled()
 }
 
-// IsIPMasqAgentDisabled ...
+// IsIPMasqAgentDisabled returns true if the ip-masq-agent functionality is disabled
 func (p *Properties) IsIPMasqAgentDisabled() bool {
 	if p.HostedMasterProfile != nil {
 		return !p.HostedMasterProfile.IPMasqAgent
 	}
-	return p.OrchestratorProfile.KubernetesConfig.IsIPMasqAgentDisabled()
+	if p.OrchestratorProfile != nil && p.OrchestratorProfile.KubernetesConfig != nil {
+		return p.OrchestratorProfile.KubernetesConfig.IsIPMasqAgentDisabled()
+	}
+	return false
 }
 
 // GetVNetResourceGroupName returns the virtual network resource group name of the cluster

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1011,6 +1011,14 @@ func (p *Properties) IsIPMasqAgentEnabled() bool {
 	return p.OrchestratorProfile.KubernetesConfig.IsIPMasqAgentEnabled()
 }
 
+// IsIPMasqAgentDisabled ...
+func (p *Properties) IsIPMasqAgentDisabled() bool {
+	if p.HostedMasterProfile != nil {
+		return !p.HostedMasterProfile.IPMasqAgent
+	}
+	return p.OrchestratorProfile.KubernetesConfig.IsIPMasqAgentDisabled()
+}
+
 // GetVNetResourceGroupName returns the virtual network resource group name of the cluster
 func (p *Properties) GetVNetResourceGroupName() string {
 	var vnetResourceGroupName string
@@ -1798,6 +1806,11 @@ func (k *KubernetesConfig) IsAppGWIngressEnabled() bool {
 // IsIPMasqAgentEnabled checks if the ip-masq-agent addon is enabled
 func (k *KubernetesConfig) IsIPMasqAgentEnabled() bool {
 	return k.IsAddonEnabled(common.IPMASQAgentAddonName)
+}
+
+// IsIPMasqAgentDisabled checks if the ip-masq-agent addon is disabled
+func (k *KubernetesConfig) IsIPMasqAgentDisabled() bool {
+	return k.IsAddonDisabled(common.IPMASQAgentAddonName)
 }
 
 // IsRBACEnabled checks if RBAC is enabled

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -6866,3 +6866,183 @@ func TestPropertiesHasDCSeriesSKU(t *testing.T) {
 		}
 	}
 }
+
+func TestPropertiesIsIPMasqAgentDisabled(t *testing.T) {
+	cases := []struct {
+		name             string
+		p                *Properties
+		expectedDisabled bool
+	}{
+		{
+			name:             "default",
+			p:                &Properties{},
+			expectedDisabled: false,
+		},
+		{
+			name: "hostedMasterProfile disabled",
+			p: &Properties{
+				HostedMasterProfile: &HostedMasterProfile{
+					IPMasqAgent: false,
+				},
+			},
+			expectedDisabled: true,
+		},
+		{
+			name: "hostedMasterProfile enabled",
+			p: &Properties{
+				HostedMasterProfile: &HostedMasterProfile{
+					IPMasqAgent: true,
+				},
+			},
+			expectedDisabled: false,
+		},
+		{
+			name: "nil KubernetesConfig",
+			p: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{},
+			},
+			expectedDisabled: false,
+		},
+		{
+			name: "default KubernetesConfig",
+			p: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					KubernetesConfig: &KubernetesConfig{},
+				},
+			},
+			expectedDisabled: false,
+		},
+		{
+			name: "addons configured but no ip-masq-agent configuration",
+			p: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					KubernetesConfig: &KubernetesConfig{
+						Addons: []KubernetesAddon{
+							{
+								Name:    common.CoreDNSAddonName,
+								Enabled: to.BoolPtr(true),
+							},
+						},
+					},
+				},
+			},
+			expectedDisabled: false,
+		},
+		{
+			name: "ip-masq-agent explicitly disabled",
+			p: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					KubernetesConfig: &KubernetesConfig{
+						Addons: []KubernetesAddon{
+							{
+								Name:    common.IPMASQAgentAddonName,
+								Enabled: to.BoolPtr(false),
+							},
+						},
+					},
+				},
+			},
+			expectedDisabled: true,
+		},
+		{
+			name: "ip-masq-agent present but no configuration",
+			p: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					KubernetesConfig: &KubernetesConfig{
+						Addons: []KubernetesAddon{
+							{
+								Name: common.IPMASQAgentAddonName,
+							},
+						},
+					},
+				},
+			},
+			expectedDisabled: false,
+		},
+		{
+			name: "ip-masq-agent explicitly enabled",
+			p: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					KubernetesConfig: &KubernetesConfig{
+						Addons: []KubernetesAddon{
+							{
+								Name:    common.IPMASQAgentAddonName,
+								Enabled: to.BoolPtr(true),
+							},
+						},
+					},
+				},
+			},
+			expectedDisabled: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if c.p.IsIPMasqAgentDisabled() != c.expectedDisabled {
+				t.Fatalf("expected Properties.IsIPMasqAgentDisabled() to return %t but instead returned %t", c.expectedDisabled, c.p.IsIPMasqAgentDisabled())
+			}
+		})
+	}
+}
+
+func TestKubernetesConfigIsIPMasqAgentDisabled(t *testing.T) {
+	cases := []struct {
+		name             string
+		k                *KubernetesConfig
+		expectedDisabled bool
+	}{
+		{
+			name:             "default",
+			k:                &KubernetesConfig{},
+			expectedDisabled: false,
+		},
+		{
+			name: "ip-masq-agent present but no configuration",
+			k: &KubernetesConfig{
+				Addons: []KubernetesAddon{
+					{
+						Name: common.IPMASQAgentAddonName,
+					},
+				},
+			},
+			expectedDisabled: false,
+		},
+		{
+			name: "ip-masq-agent explicitly disabled",
+			k: &KubernetesConfig{
+				Addons: []KubernetesAddon{
+					{
+						Name:    common.IPMASQAgentAddonName,
+						Enabled: to.BoolPtr(false),
+					},
+				},
+			},
+			expectedDisabled: true,
+		},
+		{
+			name: "ip-masq-agent explicitly enabled",
+			k: &KubernetesConfig{
+				Addons: []KubernetesAddon{
+					{
+						Name:    common.IPMASQAgentAddonName,
+						Enabled: to.BoolPtr(true),
+					},
+				},
+			},
+			expectedDisabled: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if c.k.IsIPMasqAgentDisabled() != c.expectedDisabled {
+				t.Fatalf("expected KubernetesConfig.IsIPMasqAgentDisabled() to return %t but instead returned %t", c.expectedDisabled, c.k.IsIPMasqAgentDisabled())
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
As part of PR #2393, the following change was made to move addon configuration after setting kubelet config - https://github.com/Azure/aks-engine/commit/691e3d3c3a837abbb4f607d5e6b040b517af0f2a#diff-fd43f080184ed15731e5d7e0d917d6e1L486-L490. This change breaks setting kubelet config as kubelet configuration checks for addon configs while setting defaults. For instance `--non-masquerade-cidr` in kubelet is set to cluster subnet if `ip-masq-agent` is not enabled. But since the addon was configured after, kubelet assumes masq-agent is not enabled and sets the `--non-masquerade-cidr` to cluster subnet. This results in `ip-masq-agent` and `kubelet` both configuring iptables which could possibly break things.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:


cc @lachie83 