### PR TITLE
fix: common defaults flow for ip-masq-agent addon and --non-masquerad…

### DIFF
--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -279,10 +279,8 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 	}
 
 	defaultIPMasqAgentAddonsConfig := KubernetesAddon{
-		Name: common.IPMASQAgentAddonName,
-		Enabled: to.BoolPtr(DefaultIPMasqAgentAddonEnabled &&
-			(o.KubernetesConfig.NetworkPlugin != NetworkPluginCilium &&
-				o.KubernetesConfig.NetworkPlugin != NetworkPluginAntrea)),
+		Name:    common.IPMASQAgentAddonName,
+		Enabled: to.BoolPtr(o.KubernetesConfig.EnableIPMasqAgentByDefault()),
 		Containers: []KubernetesContainerSpec{
 			{
 				Name:           common.IPMASQAgentAddonName,

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -99,7 +99,7 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	}
 
 	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS
-	if !cs.Properties.IsIPMasqAgentEnabled() {
+	if !o.KubernetesConfig.EnableIPMasqAgentByDefault() {
 		defaultKubeletConfig["--non-masquerade-cidr"] = cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet
 	}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1800,6 +1800,13 @@ func (k *KubernetesConfig) IsIPMasqAgentEnabled() bool {
 	return k.IsAddonEnabled(common.IPMASQAgentAddonName)
 }
 
+// EnableIPMasqAgentByDefault checks if the default conditions are true to enable the ip-masq-agent addon
+func (k *KubernetesConfig) EnableIPMasqAgentByDefault() bool {
+	return DefaultIPMasqAgentAddonEnabled &&
+		(k.NetworkPlugin != NetworkPluginCilium &&
+			k.NetworkPlugin != NetworkPluginAntrea)
+}
+
 // IsRBACEnabled checks if RBAC is enabled
 func (k *KubernetesConfig) IsRBACEnabled() bool {
 	if k.EnableRbac != nil {

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3842,6 +3842,44 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 	}
 }
 
+func TestEnableIPMasqAgentByDefault(t *testing.T) {
+	cases := []struct {
+		name            string
+		k               *KubernetesConfig
+		expectedEnabled bool
+	}{
+		{
+			name:            "default",
+			k:               &KubernetesConfig{},
+			expectedEnabled: true,
+		},
+		{
+			name: "cilium",
+			k: &KubernetesConfig{
+				NetworkPlugin: NetworkPluginCilium,
+			},
+			expectedEnabled: false,
+		},
+		{
+			name: "antrea",
+			k: &KubernetesConfig{
+				NetworkPlugin: NetworkPluginAntrea,
+			},
+			expectedEnabled: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if c.k.EnableIPMasqAgentByDefault() != c.expectedEnabled {
+				t.Fatalf("expected KubernetesConfig.EnableIPMasqAgentByDefault() to return %t but instead returned %t", c.expectedEnabled, c.k.EnableIPMasqAgentByDefault())
+			}
+		})
+	}
+}
+
 func TestGetAzureCNIURLFuncs(t *testing.T) {
 	// Default case
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 1, 3, false)


### PR DESCRIPTION
…e-cidr

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR ensures that the ip-masq-agent addon is enabled according to the same default criteria as the kubelet `"--non-masquerade-cidr": "0.0.0.0/0"` configuration, as the two of those configurations are expected to be delivered in common.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
