### PR TITLE
fix: default LB AllocatedOutboundPorts to 0

### DIFF
--- a/examples/kubernetes.json
+++ b/examples/kubernetes.json
@@ -2,10 +2,24 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "loadBalancerSku": "Standard",
+        "excludeMasterFromStandardLB": true,
+        "privateCluster": {
+          "enabled": true,
+          "jumpboxProfile": {
+            "name": "jumpbox",
+            "vmSize": "Standard_D2_v3",
+            "osDiskSizeGB": 30,
+            "username": "azureuser",
+            "publickey": ""
+          }
+        }
+      }
     },
     "masterProfile": {
-      "count": 1,
+      "count": 3,
       "dnsPrefix": "",
       "vmSize": "Standard_D2_v3"
     },

--- a/examples/kubernetes.json
+++ b/examples/kubernetes.json
@@ -2,24 +2,10 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-      "kubernetesConfig": {
-        "loadBalancerSku": "Standard",
-        "excludeMasterFromStandardLB": true,
-        "privateCluster": {
-          "enabled": true,
-          "jumpboxProfile": {
-            "name": "jumpbox",
-            "vmSize": "Standard_D2_v3",
-            "osDiskSizeGB": 30,
-            "username": "azureuser",
-            "publickey": ""
-          }
-        }
-      }
+      "orchestratorType": "Kubernetes"
     },
     "masterProfile": {
-      "count": 3,
+      "count": 1,
       "dnsPrefix": "",
       "vmSize": "Standard_D2_v3"
     },

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -1858,8 +1858,9 @@ func TestGenerateARMResourcesWithVMSSAgentPoolAndSLB(t *testing.T) {
 							BackendAddressPool: &network.SubResource{
 								ID: to.StringPtr("[concat(variables('agentLbID'), '/backendAddressPools/', variables('agentLbBackendPoolName'))]"),
 							},
-							Protocol:             network.Protocol1All,
-							IdleTimeoutInMinutes: to.Int32Ptr(cs.Properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
+							Protocol:               network.Protocol1All,
+							IdleTimeoutInMinutes:   to.Int32Ptr(cs.Properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
+							AllocatedOutboundPorts: to.Int32Ptr(4096),
 						},
 						Name: to.StringPtr("LBOutboundRule"),
 					},

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -1860,7 +1860,7 @@ func TestGenerateARMResourcesWithVMSSAgentPoolAndSLB(t *testing.T) {
 							},
 							Protocol:               network.Protocol1All,
 							IdleTimeoutInMinutes:   to.Int32Ptr(cs.Properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
-							AllocatedOutboundPorts: to.Int32Ptr(4096),
+							AllocatedOutboundPorts: to.Int32Ptr(0),
 						},
 						Name: to.StringPtr("LBOutboundRule"),
 					},

--- a/pkg/engine/loadbalancers.go
+++ b/pkg/engine/loadbalancers.go
@@ -243,8 +243,9 @@ func createOutboundRules(prop *api.Properties) *[]network.OutboundRule {
 					BackendAddressPool: &network.SubResource{
 						ID: to.StringPtr("[concat(variables('agentLbID'), '/backendAddressPools/', variables('agentLbBackendPoolName'))]"),
 					},
-					Protocol:             network.Protocol1All,
-					IdleTimeoutInMinutes: to.Int32Ptr(prop.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
+					Protocol:               network.Protocol1All,
+					IdleTimeoutInMinutes:   to.Int32Ptr(prop.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
+					AllocatedOutboundPorts: to.Int32Ptr(4096),
 				},
 			},
 		}
@@ -261,9 +262,10 @@ func createOutboundRules(prop *api.Properties) *[]network.OutboundRule {
 				BackendAddressPool: &network.SubResource{
 					ID: to.StringPtr("[concat(variables('agentLbID'), '/backendAddressPools/', variables('agentLbBackendPoolName'))]"),
 				},
-				Protocol:             network.Protocol1All,
-				IdleTimeoutInMinutes: to.Int32Ptr(prop.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
-				EnableTCPReset:       to.BoolPtr(true),
+				Protocol:               network.Protocol1All,
+				IdleTimeoutInMinutes:   to.Int32Ptr(prop.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
+				EnableTCPReset:         to.BoolPtr(true),
+				AllocatedOutboundPorts: to.Int32Ptr(4096),
 			},
 		},
 	}

--- a/pkg/engine/loadbalancers.go
+++ b/pkg/engine/loadbalancers.go
@@ -245,7 +245,7 @@ func createOutboundRules(prop *api.Properties) *[]network.OutboundRule {
 					},
 					Protocol:               network.Protocol1All,
 					IdleTimeoutInMinutes:   to.Int32Ptr(prop.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
-					AllocatedOutboundPorts: to.Int32Ptr(4096),
+					AllocatedOutboundPorts: to.Int32Ptr(0),
 				},
 			},
 		}
@@ -265,7 +265,7 @@ func createOutboundRules(prop *api.Properties) *[]network.OutboundRule {
 				Protocol:               network.Protocol1All,
 				IdleTimeoutInMinutes:   to.Int32Ptr(prop.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
 				EnableTCPReset:         to.BoolPtr(true),
-				AllocatedOutboundPorts: to.Int32Ptr(4096),
+				AllocatedOutboundPorts: to.Int32Ptr(0),
 			},
 		},
 	}

--- a/pkg/engine/loadbalancers_test.go
+++ b/pkg/engine/loadbalancers_test.go
@@ -757,9 +757,10 @@ func TestCreateAgentLoadBalancer(t *testing.T) {
 							BackendAddressPool: &network.SubResource{
 								ID: to.StringPtr("[concat(variables('agentLbID'), '/backendAddressPools/', variables('agentLbBackendPoolName'))]"),
 							},
-							Protocol:             network.Protocol1All,
-							IdleTimeoutInMinutes: to.Int32Ptr(cs.Properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
-							EnableTCPReset:       to.BoolPtr(true),
+							Protocol:               network.Protocol1All,
+							IdleTimeoutInMinutes:   to.Int32Ptr(cs.Properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
+							EnableTCPReset:         to.BoolPtr(true),
+							AllocatedOutboundPorts: to.Int32Ptr(4096),
 						},
 					},
 				},

--- a/pkg/engine/loadbalancers_test.go
+++ b/pkg/engine/loadbalancers_test.go
@@ -176,9 +176,10 @@ func TestCreateMasterLoadBalancerPrivate(t *testing.T) {
 							BackendAddressPool: &network.SubResource{
 								ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
 							},
-							Protocol:             network.Protocol1All,
-							IdleTimeoutInMinutes: to.Int32Ptr(0),
-							EnableTCPReset:       to.BoolPtr(true),
+							Protocol:               network.Protocol1All,
+							IdleTimeoutInMinutes:   to.Int32Ptr(0),
+							AllocatedOutboundPorts: to.Int32Ptr(0),
+							EnableTCPReset:         to.BoolPtr(true),
 						},
 					},
 				},

--- a/pkg/engine/loadbalancers_test.go
+++ b/pkg/engine/loadbalancers_test.go
@@ -760,7 +760,7 @@ func TestCreateAgentLoadBalancer(t *testing.T) {
 							Protocol:               network.Protocol1All,
 							IdleTimeoutInMinutes:   to.Int32Ptr(cs.Properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes),
 							EnableTCPReset:         to.BoolPtr(true),
-							AllocatedOutboundPorts: to.Int32Ptr(4096),
+							AllocatedOutboundPorts: to.Int32Ptr(0),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR sets the `AllocatedOutboundPorts` configuration to `0`, as this is a preferred default configuration for LB outbound rules.

`0` is equivalent to "automatic", which means is preferable to the Azure-provided default of `1024` , which essentially caps SNAT ports at that number.

See here for more info:

https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-rules-overview

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2558

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
