### PR TITLE
fix: promote system addons to system-cluster-critical

### DIFF
--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -76,7 +76,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -92,7 +92,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -104,6 +104,7 @@ spec:
         component: nmi
         tier: node
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -141,7 +142,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -181,7 +182,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -196,7 +197,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
@@ -16,6 +16,7 @@ spec:
         name: blobfuse
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -20,6 +20,7 @@ spec:
         kubernetes.io/cluster-service: "true"
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -76,7 +76,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -92,7 +92,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -106,6 +106,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -143,7 +144,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -183,7 +184,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -198,7 +199,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -76,7 +76,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -92,7 +92,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -106,6 +106,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -143,7 +144,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -183,7 +184,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -198,7 +199,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume

--- a/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -76,7 +76,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -92,7 +92,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   template:
     metadata:
@@ -100,6 +100,7 @@ spec:
         component: nmi
         tier: node
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -137,7 +138,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -177,7 +178,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -192,7 +193,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   template:
     metadata:

--- a/parts/k8s/addons/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
@@ -16,6 +16,7 @@ spec:
         name: blobfuse
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}
@@ -31,11 +32,11 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/      
+          mountPath: /var/log/
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/              
+          path: /var/log/
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/

--- a/parts/k8s/addons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -17,6 +17,7 @@ spec:
         kubernetes.io/cluster-service: "true"
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -9508,7 +9508,7 @@ var _k8sAddons116KubernetesmasteraddonsAadPodIdentityDeploymentYaml = []byte(`ap
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -9582,7 +9582,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -9598,7 +9598,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -9610,6 +9610,7 @@ spec:
         component: nmi
         tier: node
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -9647,7 +9648,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -9687,7 +9688,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -9702,7 +9703,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -10301,6 +10302,7 @@ spec:
         name: blobfuse
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}
@@ -12747,6 +12749,7 @@ spec:
         kubernetes.io/cluster-service: "true"
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume
@@ -14757,7 +14760,7 @@ var _k8sAddons117KubernetesmasteraddonsAadPodIdentityDeploymentYaml = []byte(`ap
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -14831,7 +14834,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -14847,7 +14850,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -14861,6 +14864,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -14898,7 +14902,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -14938,7 +14942,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -14953,7 +14957,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -15556,6 +15560,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}
@@ -18016,6 +18021,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume
@@ -20034,7 +20040,7 @@ var _k8sAddons118KubernetesmasteraddonsAadPodIdentityDeploymentYaml = []byte(`ap
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -20108,7 +20114,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -20124,7 +20130,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -20138,6 +20144,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -20175,7 +20182,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -20215,7 +20222,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -20230,7 +20237,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -20833,6 +20840,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}
@@ -23293,6 +23301,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume
@@ -27422,7 +27431,7 @@ var _k8sAddonsKubernetesmasteraddonsAadPodIdentityDeploymentYaml = []byte(`apiVe
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -27496,7 +27505,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-nmi-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-nmi-role
@@ -27512,7 +27521,7 @@ metadata:
     tier: node
     k8s-app: aad-pod-id
   name: nmi
-  namespace: default
+  namespace: kube-system
 spec:
   template:
     metadata:
@@ -27520,6 +27529,7 @@ spec:
         component: nmi
         tier: node
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
       containers:
@@ -27557,7 +27567,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -27597,7 +27607,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: aad-pod-id-mic-service-account
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: aad-pod-id-mic-role
@@ -27612,7 +27622,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   name: mic
-  namespace: default
+  namespace: kube-system
 spec:
   template:
     metadata:
@@ -29164,6 +29174,7 @@ spec:
         name: blobfuse
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: blobfuse-flexvol-installer
         image: {{ContainerImage "blobfuse-flexvolume"}}
@@ -29179,11 +29190,11 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/      
+          mountPath: /var/log/
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/              
+          path: /var/log/
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/
@@ -31524,6 +31535,7 @@ spec:
         kubernetes.io/cluster-service: "true"
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       containers:
       - name: keyvault-flexvolume


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR updates blobfuse-flexvolume and keyvault-flexvolume daemonsets to the `system-cluster-critical` PriorityClass to ensure that they are properly prioritized during pod scheduling.

For the `nmi` daemonset in the aad-pod-identity addon, we migrated the namespace to `kube-system`, as `system-cluster-critical` isn't allowed in the default namespace.

Specifically, during scale up events in response to more pods than available scheduleable nodes (e.g., cluster-autoscaler), we want to ensure that system daemonsets are scheduled first of all on new nodes, so that nodes don't reach pod capacity w/ non-system-critical pods before these daemonsets have a chance to be scheduled.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

https://github.com/Azure/aad-pod-identity/issues/471
Fixes #2532
Fixes #2531

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
