### PR TITLE
test: use LOCATION env var for api model in E2E tests

### DIFF
--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -49,6 +49,7 @@ type Config struct {
 	Distro                         string `envconfig:"DISTRO"`
 	SubscriptionID                 string `envconfig:"SUBSCRIPTION_ID"`
 	InfraResourceGroup             string `envconfig:"INFRA_RESOURCE_GROUP"`
+	Location                       string `envconfig:"LOCATION"`
 	TenantID                       string `envconfig:"TENANT_ID"`
 	ImageName                      string `envconfig:"IMAGE_NAME"`
 	ImageResourceGroup             string `envconfig:"IMAGE_RESOURCE_GROUP"`
@@ -102,6 +103,9 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 	cs, err := ParseInput(config.ClusterDefinitionPath)
 	if err != nil {
 		return nil, err
+	}
+	if cs.Location == "" {
+		cs.Location = config.Location
 	}
 	prop := cs.ContainerService.Properties
 	var hasWindows bool


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR injects the `LOCATION` env var in an E2E test run into the api model for convenient cloud-specific template generation value add.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
