### PR TITLE
feat: Use default AKS Windows OS Image for k8s

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -672,6 +672,7 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 | ----------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | adminUsername                 | yes      | Username for the Windows adminstrator account created on each Windows node                                                                                                                                                                      |
 | adminPassword                 | yes      | Password for the Windows adminstrator account created on each Windows node                                                                                                                                                                      |
+| aksOSImageVersion             | no       | AKS Windows OS image version used to find Windows VM to deploy from marketplace. Default: `aks-windows-server-2019`. This will be always set to the latest image with the latest WIndows patches after being validated by the AKS Engine team. You can specify this or below 4 values. This value will be ignored if below 4 values are set.                          |
 | windowsPublisher              | no       | Publisher used to find Windows VM to deploy from marketplace. Default: `microsoft-aks`                                                                                                                                                          |
 | windowsOffer                  | no       | Offer used to find Windows VM to deploy from marketplace. Default: `aks-windows`                                                                                                                                                                |
 | windowsSku                    | no       | SKU usedto find Windows VM to deploy from marketplace. Default: `2019-datacenter-core-smalldisk`                                                                                                                                                |
@@ -717,6 +718,18 @@ If you want to use a specific image then `windowsPublisher`, `windowsOffer`, `wi
             "imageVersion": "2019.0.20181107"
      },
 ```
+
+Or leave `windowsPublisher`, `windowsOffer`, `windowsSku`, and `imageVersion` to empty and set `aksOSImageVersion`:
+
+```json
+"windowsProfile": {
+            "adminUsername": "...",
+            "adminPassword": "...",
+            "aksOSImageVersion": "aks-windows-server-2019"
+     },
+```
+
+You can find all avilable AKS images in [WindowsOSVersion string consts](../../pkg/api/const.go#L40).
 
 ##### Custom Images
 

--- a/examples/windows/kubernetes-windows-aks-os-version.json
+++ b/examples/windows/kubernetes-windows-aks-os-version.json
@@ -1,0 +1,50 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 1,
+        "vmSize": "Standard_D2_v3",
+        "osType": "Linux",
+        "availabilityProfile": "VirtualMachineScaleSets"
+      },
+      {
+        "name": "npwin",
+        "count": 2,
+        "vmSize": "Standard_D2_v3",
+        "osType": "Windows",
+        "availabilityProfile": "VirtualMachineScaleSets"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "enableAutomaticUpdates": false,
+      "sshEnabled": true,
+      "aksOSImageVersion": "aks-windows-server-2019"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -13,6 +13,7 @@ type AzureEnvironmentSpecConfig struct {
 	DCOSSpecConfig       DCOSSpecConfig                `json:"-"`
 	EndpointConfig       AzureEndpointConfig           `json:"endpointConfig,omitempty"`
 	OSImageConfig        map[Distro]AzureOSImageConfig `json:"osImageConfig,omitempty"`
+	AKSWindowsSpecConfig AKSWindowsSpecConfig          `json:"aksWindowsSpecConfig,omitempty"`
 }
 
 //DockerSpecConfig is the configurations of docker
@@ -64,6 +65,12 @@ type AzureOSImageConfig struct {
 	ImageSku       string `json:"imageSku,omitempty"`
 	ImagePublisher string `json:"imagePublisher,omitempty"`
 	ImageVersion   string `json:"imageVersion,omitempty"`
+}
+
+// AKSWindowsSpecConfig describes the configurations of AKS Windows
+type AKSWindowsSpecConfig struct {
+	OSImageConfig         map[WindowsOSVersion]AzureOSImageConfig `json:"osImageConfig,omitempty"`
+	DefaultOSImageVersion WindowsOSVersion                        `json:"defaultOSImageVersion,omitempty"`
 }
 
 // AzureTelemetryPID represents the current telemetry ID
@@ -213,6 +220,12 @@ var (
 			AKS1804Deprecated: AKSUbuntu1804OSImageConfig, // for back-compat
 			ACC1604:           ACC1604OSImageConfig,
 		},
+		AKSWindowsSpecConfig: AKSWindowsSpecConfig{
+			OSImageConfig: map[WindowsOSVersion]AzureOSImageConfig{
+				AKSWindowsServer2019: AKSWindowsServer2019OSImageConfig,
+			},
+			DefaultOSImageVersion: AKSWindowsServer2019,
+		},
 	}
 
 	//AzureGermanCloudSpec is the German cloud config.
@@ -234,6 +247,12 @@ var (
 			AKSUbuntu1804:     Ubuntu1604OSImageConfig, // workaround for https://github.com/Azure/aks-engine/issues/761
 			AKS1804Deprecated: Ubuntu1604OSImageConfig, // for back-compat
 		},
+		AKSWindowsSpecConfig: AKSWindowsSpecConfig{
+			OSImageConfig: map[WindowsOSVersion]AzureOSImageConfig{
+				AKSWindowsServer2019: AKSWindowsServer2019OSImageConfig,
+			},
+			DefaultOSImageVersion: AKSWindowsServer2019,
+		},
 	}
 
 	//AzureUSGovernmentCloudSpec is the US government config.
@@ -254,6 +273,12 @@ var (
 			AKS1604Deprecated: AKSUbuntu1604OSImageConfig, // for back-compat
 			AKSUbuntu1804:     AKSUbuntu1804OSImageConfig,
 			AKS1804Deprecated: AKSUbuntu1804OSImageConfig, // for back-compat
+		},
+		AKSWindowsSpecConfig: AKSWindowsSpecConfig{
+			OSImageConfig: map[WindowsOSVersion]AzureOSImageConfig{
+				AKSWindowsServer2019: AKSWindowsServer2019OSImageConfig,
+			},
+			DefaultOSImageVersion: AKSWindowsServer2019,
 		},
 	}
 
@@ -301,6 +326,12 @@ var (
 			AKS1604Deprecated: AKSUbuntu1604OSImageConfig, // for back-compat
 			AKSUbuntu1804:     AKSUbuntu1804OSImageConfig,
 			AKS1804Deprecated: AKSUbuntu1804OSImageConfig, // for back-compat
+		},
+		AKSWindowsSpecConfig: AKSWindowsSpecConfig{
+			OSImageConfig: map[WindowsOSVersion]AzureOSImageConfig{
+				AKSWindowsServer2019: AKSWindowsServer2019OSImageConfig,
+			},
+			DefaultOSImageVersion: AKSWindowsServer2019,
 		},
 	}
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -37,6 +37,11 @@ const (
 	ACC1604           Distro = "acc-16.04"
 )
 
+// WindowsOSVersion string consts
+const (
+	AKSWindowsServer2019 WindowsOSVersion = "aks-windows-server-2019"
+)
+
 const (
 	// SwarmVersion is the Swarm orchestrator version
 	SwarmVersion = "swarm:1.1.0"
@@ -48,8 +53,6 @@ const (
 	DockerCEDockerComposeVersion = "1.14.0"
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
 	KubernetesWindowsDockerVersion = "19.03.2"
-	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
-	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 )
 
 // validation values

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -65,7 +65,8 @@ func (cs *ContainerService) SetPropertiesDefaults(params PropertiesDefaultsParam
 	}
 
 	if cs.Properties.WindowsProfile != nil {
-		properties.setWindowsProfileDefaults(params.IsUpgrade, params.IsScale)
+		cloudSpecConfig := cs.GetCloudSpecConfig()
+		properties.setWindowsProfileDefaults(params.IsUpgrade, params.IsScale, cloudSpecConfig)
 	}
 
 	properties.setTelemetryProfileDefaults()
@@ -692,29 +693,22 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 	}
 }
 
-// setWindowsProfileDefaults sets default WindowsProfile values
-func (p *Properties) setWindowsProfileDefaults(isUpgrade, isScale bool) {
+// setWindowsProfileDefaults sets default Windows OS image version
+func (p *Properties) setWindowsProfileDefaults(isUpgrade, isScale bool, cloudSpecConfig AzureEnvironmentSpecConfig) {
 	windowsProfile := p.WindowsProfile
 	if !isUpgrade && !isScale {
-		if windowsProfile.WindowsPublisher == "" {
-			windowsProfile.WindowsPublisher = AKSWindowsServer2019OSImageConfig.ImagePublisher
-		}
-		if windowsProfile.WindowsOffer == "" {
-			windowsProfile.WindowsOffer = AKSWindowsServer2019OSImageConfig.ImageOffer
-		}
-		if windowsProfile.WindowsSku == "" {
-			windowsProfile.WindowsSku = AKSWindowsServer2019OSImageConfig.ImageSku
-		}
-
-		if windowsProfile.ImageVersion == "" {
-			// default versions are specific to a publisher/offer/sku
-			if windowsProfile.WindowsPublisher == AKSWindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == AKSWindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == AKSWindowsServer2019OSImageConfig.ImageSku {
-				windowsProfile.ImageVersion = AKSWindowsServer2019OSImageConfig.ImageVersion
-			} else if windowsProfile.WindowsPublisher == WindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == WindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == WindowsServer2019OSImageConfig.ImageSku {
-				windowsProfile.ImageVersion = WindowsServer2019OSImageConfig.ImageVersion
-			} else {
-				windowsProfile.ImageVersion = "latest"
+		if windowsProfile.WindowsPublisher != "" && windowsProfile.WindowsOffer != "" && windowsProfile.WindowsSku != "" && windowsProfile.ImageVersion == "" {
+			// default versions are specific to a publisher/offer/sku	
+			if windowsProfile.WindowsPublisher == AKSWindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == AKSWindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == AKSWindowsServer2019OSImageConfig.ImageSku {	
+				windowsProfile.ImageVersion = AKSWindowsServer2019OSImageConfig.ImageVersion	
+			} else if windowsProfile.WindowsPublisher == WindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == WindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == WindowsServer2019OSImageConfig.ImageSku {	
+				windowsProfile.ImageVersion = WindowsServer2019OSImageConfig.ImageVersion	
+			} else {	
+				windowsProfile.ImageVersion = "latest"	
 			}
+		}
+		if windowsProfile.AKSOSImageVersion == "" {
+			windowsProfile.AKSOSImageVersion = cloudSpecConfig.AKSWindowsSpecConfig.DefaultOSImageVersion
 		}
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1664,6 +1664,12 @@ func TestDistroDefaults(t *testing.T) {
 
 func TestWindowsProfileDefaults(t *testing.T) {
 
+	var mockAzureEnvironmentSpecConfig = AzureEnvironmentSpecConfig{
+		AKSWindowsSpecConfig: AKSWindowsSpecConfig{
+			DefaultOSImageVersion: AKSWindowsServer2019,
+		},
+	}
+
 	var tests = []struct {
 		name                   string // test case name
 		windowsProfile         WindowsProfile
@@ -1674,138 +1680,131 @@ func TestWindowsProfileDefaults(t *testing.T) {
 			"defaults",
 			WindowsProfile{},
 			WindowsProfile{
-				WindowsPublisher:      AKSWindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:          AKSWindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:            AKSWindowsServer2019OSImageConfig.ImageSku,
-				ImageVersion:          AKSWindowsServer2019OSImageConfig.ImageVersion,
+				AKSOSImageVersion:     AKSWindowsServer2019,
 				AdminUsername:         "",
 				AdminPassword:         "",
 				WindowsImageSourceURL: "",
 				WindowsDockerVersion:  "",
 				SSHEnabled:            false,
+				WindowsPublisher:      "",
+				WindowsOffer:          "",
+				WindowsSku:            "",
+				ImageVersion:          "",
 			},
 			false,
 		},
 		{
 			"aks vhd current version",
 			WindowsProfile{
-				WindowsPublisher: AKSWindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:     AKSWindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:       AKSWindowsServer2019OSImageConfig.ImageSku,
+				AKSOSImageVersion: AKSWindowsServer2019,
+				WindowsPublisher:  "FooPublisher",
+				WindowsOffer:      "FooOffer",
+				WindowsSku:        "FooSku",
+				ImageVersion:      "",
 			},
 			WindowsProfile{
-				WindowsPublisher:      AKSWindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:          AKSWindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:            AKSWindowsServer2019OSImageConfig.ImageSku,
-				ImageVersion:          AKSWindowsServer2019OSImageConfig.ImageVersion,
+				AKSOSImageVersion:     AKSWindowsServer2019,
 				AdminUsername:         "",
 				AdminPassword:         "",
 				WindowsImageSourceURL: "",
 				WindowsDockerVersion:  "",
 				SSHEnabled:            false,
+				WindowsPublisher:      "FooPublisher",
+				WindowsOffer:          "FooOffer",
+				WindowsSku:            "FooSku",
+				ImageVersion:          "latest",
 			},
 			false,
 		},
 		{
 			"aks vhd specific version",
 			WindowsProfile{
-				WindowsPublisher: AKSWindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:     AKSWindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:       AKSWindowsServer2019OSImageConfig.ImageSku,
-				ImageVersion:     "override",
+				AKSOSImageVersion: "override",
+				WindowsPublisher:  "FooPublisher",
+				WindowsOffer:      "FooOffer",
+				WindowsSku:        "FooSku",
+				ImageVersion:      "FooVersion",
 			},
 			WindowsProfile{
-				WindowsPublisher:      AKSWindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:          AKSWindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:            AKSWindowsServer2019OSImageConfig.ImageSku,
-				ImageVersion:          "override",
+				AKSOSImageVersion:     "override",
 				AdminUsername:         "",
 				AdminPassword:         "",
 				WindowsImageSourceURL: "",
 				WindowsDockerVersion:  "",
 				SSHEnabled:            false,
+				WindowsPublisher:      "FooPublisher",
+				WindowsOffer:          "FooOffer",
+				WindowsSku:            "FooSku",
+				ImageVersion:          "FooVersion",
 			},
 			false,
 		},
 		{
-			"vanilla vhd current version",
+			"aks vhd specific version",
 			WindowsProfile{
-				WindowsPublisher: WindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:     WindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:       WindowsServer2019OSImageConfig.ImageSku,
+				AKSOSImageVersion: "override",
+				WindowsPublisher:  "",
+				WindowsOffer:      "",
+				WindowsSku:        "",
+				ImageVersion:      "",
 			},
 			WindowsProfile{
+				AKSOSImageVersion:     "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            false,
+				WindowsPublisher:      "",
+				WindowsOffer:          "",
+				WindowsSku:            "",
+				ImageVersion:          "",
+			},
+			false,
+		},
+		{
+			"aks vhd specify AKSWindowsServer2019OSImageConfig",
+			WindowsProfile{
+				AKSOSImageVersion: "override",
+				WindowsPublisher:  AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:      AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:        AKSWindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:      "",
+			},
+			WindowsProfile{
+				AKSOSImageVersion:     "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            false,
+				WindowsPublisher:      AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            AKSWindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          AKSWindowsServer2019OSImageConfig.ImageVersion,
+			},
+			false,
+		},
+		{
+			"aks vhd specific WindowsServer2019OSImageConfig",
+			WindowsProfile{
+				AKSOSImageVersion: "override",
+				WindowsPublisher:  WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:      WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:        WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:      "",
+			},
+			WindowsProfile{
+				AKSOSImageVersion:     "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            false,
 				WindowsPublisher:      WindowsServer2019OSImageConfig.ImagePublisher,
 				WindowsOffer:          WindowsServer2019OSImageConfig.ImageOffer,
 				WindowsSku:            WindowsServer2019OSImageConfig.ImageSku,
 				ImageVersion:          WindowsServer2019OSImageConfig.ImageVersion,
-				AdminUsername:         "",
-				AdminPassword:         "",
-				WindowsImageSourceURL: "",
-				WindowsDockerVersion:  "",
-				SSHEnabled:            false,
-			},
-			false,
-		},
-		{
-			"vanilla vhd spepcific version",
-			WindowsProfile{
-				WindowsPublisher: WindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:     WindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:       WindowsServer2019OSImageConfig.ImageSku,
-				ImageVersion:     "override",
-			},
-			WindowsProfile{
-				WindowsPublisher:      WindowsServer2019OSImageConfig.ImagePublisher,
-				WindowsOffer:          WindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:            WindowsServer2019OSImageConfig.ImageSku,
-				ImageVersion:          "override",
-				AdminUsername:         "",
-				AdminPassword:         "",
-				WindowsImageSourceURL: "",
-				WindowsDockerVersion:  "",
-				SSHEnabled:            false,
-			},
-			false,
-		},
-		{
-			"user overrides latest version",
-			WindowsProfile{
-				WindowsPublisher: "override",
-				WindowsOffer:     "override",
-				WindowsSku:       "override",
-			},
-			WindowsProfile{
-				WindowsPublisher:      "override",
-				WindowsOffer:          "override",
-				WindowsSku:            "override",
-				ImageVersion:          "latest",
-				AdminUsername:         "",
-				AdminPassword:         "",
-				WindowsImageSourceURL: "",
-				WindowsDockerVersion:  "",
-				SSHEnabled:            false,
-			},
-			false,
-		},
-		{
-			"user overrides specific version",
-			WindowsProfile{
-				WindowsPublisher: "override",
-				WindowsOffer:     "override",
-				WindowsSku:       "override",
-				ImageVersion:     "override",
-			},
-			WindowsProfile{
-				WindowsPublisher:      "override",
-				WindowsOffer:          "override",
-				WindowsSku:            "override",
-				ImageVersion:          "override",
-				AdminUsername:         "",
-				AdminPassword:         "",
-				WindowsImageSourceURL: "",
-				WindowsDockerVersion:  "",
-				SSHEnabled:            false,
 			},
 			false,
 		},
@@ -1821,7 +1820,7 @@ func TestWindowsProfileDefaults(t *testing.T) {
 			if test.isAzureStack {
 				mockAPI.CustomCloudProfile = &CustomCloudProfile{}
 			}
-			mockAPI.setWindowsProfileDefaults(false, false)
+			mockAPI.setWindowsProfileDefaults(false, false, mockAzureEnvironmentSpecConfig)
 
 			actual := mockAPI.WindowsProfile
 			expected := &test.expectedWindowsProfile
@@ -2501,6 +2500,12 @@ func TestSetCustomCloudProfileDefaults(t *testing.T) {
 			},
 			AKSUbuntu1604: AKSUbuntu1604OSImageConfig,
 		},
+		AKSWindowsSpecConfig: AKSWindowsSpecConfig{
+			OSImageConfig: map[WindowsOSVersion]AzureOSImageConfig{
+				AKSWindowsServer2019: AKSWindowsServer2019OSImageConfig,
+			},
+			DefaultOSImageVersion: AKSWindowsServer2019,
+		},
 	}
 	mockCSPCustom.CustomCloudProfile.AzureEnvironmentSpecConfig = &customCloudSpec
 	mockCSCustom.Properties.CustomCloudProfile = mockCSPCustom.CustomCloudProfile
@@ -2511,11 +2516,11 @@ func TestSetCustomCloudProfileDefaults(t *testing.T) {
 	})
 
 	if diff := cmp.Diff(AzureCloudSpecEnvMap[AzureStackCloud], customCloudSpec); diff != "" {
-		t.Errorf("setCustomCloudProfileDefaults(): did not set AzureStackCloudSpec as default when azureEnvironmentSpecConfig is empty in api model JSON file")
+		t.Errorf("setCustomCloudProfileDefaults(): did not set AzureStackCloudSpec as default when azureEnvironmentSpecConfig is empty in api model JSON file %s", diff)
 	}
 
 	if diff := cmp.Diff(mockCSCustom.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig, &customCloudSpec); diff != "" {
-		t.Errorf("setCustomCloudProfileDefaults(): did not set CustomCloudProfile.AzureEnvironmentSpecConfig with customer input")
+		t.Errorf("setCustomCloudProfileDefaults(): did not set CustomCloudProfile.AzureEnvironmentSpecConfig with customer input %s", diff)
 	}
 
 	// Test that default assignment flow set the value if the field is partially  missing in user-provided config

--- a/pkg/api/vlabs/azenvtypes.go
+++ b/pkg/api/vlabs/azenvtypes.go
@@ -11,6 +11,7 @@ type AzureEnvironmentSpecConfig struct {
 	DCOSSpecConfig       DCOSSpecConfig                `json:"-"`
 	EndpointConfig       AzureEndpointConfig           `json:"endpointConfig,omitempty"`
 	OSImageConfig        map[Distro]AzureOSImageConfig `json:"osImageConfig,omitempty"`
+	AKSWindowsSpecConfig AKSWindowsSpecConfig		   `json:"aksWindowsSpecConfig,omitempty"`
 }
 
 //DockerSpecConfig is the configurations of docker
@@ -62,4 +63,10 @@ type AzureOSImageConfig struct {
 	ImageSku       string `json:"imageSku,omitempty"`
 	ImagePublisher string `json:"imagePublisher,omitempty"`
 	ImageVersion   string `json:"imageVersion,omitempty"`
+}
+
+// AKSWindowsSpecConfig describes the configurations of AKS Windows
+type AKSWindowsSpecConfig struct {
+	OSImageConfig         map[WindowsOSVersion]AzureOSImageConfig `json:"osImageConfig,omitempty"`
+	DefaultOSImageVersion WindowsOSVersion                        `json:"defaultOSImageVersion,omitempty"`
 }

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -26,7 +26,7 @@ const (
 	Linux   OSType = "Linux"
 )
 
-// the LinuxDistros supported by vlabs
+// Distro string consts supported by vlabs
 const (
 	Ubuntu            Distro = "ubuntu"
 	Ubuntu1804        Distro = "ubuntu-18.04"
@@ -38,6 +38,11 @@ const (
 	AKSUbuntu1604     Distro = "aks-ubuntu-16.04"
 	AKSUbuntu1804     Distro = "aks-ubuntu-18.04"
 	ACC1604           Distro = "acc-16.04"
+)
+
+// WindowsOSVersion string consts
+const (
+	AKSWindowsServer2019 WindowsOSVersion = "aks-windows-server-2019"
 )
 
 // validation values

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -171,6 +171,9 @@ type WindowsProfile struct {
 	Secrets                []KeyVaultSecrets `json:"secrets,omitempty"`
 	SSHEnabled             bool              `json:"sshEnabled,omitempty"`
 	EnableAutomaticUpdates *bool             `json:"enableAutomaticUpdates,omitempty"`
+	// AKSOSImageVersion represents the AKS Windows OS image version for all Windows agent pools. For back-compatible,
+	// it is only used to fill non-empty ImageVersion, WindowsPublisher, WindowsOffer and WindowsSku.
+	AKSOSImageVersion WindowsOSVersion `json:"aksOSImageVersion,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.
@@ -552,6 +555,9 @@ type OSType string
 
 // Distro represents Linux distro to use for Linux VMs
 type Distro string
+
+// WindowsOSVersion represents Windows OS version to use for Windows VMs
+type WindowsOSVersion string
 
 // DependenciesLocation represents location to retrieve the dependencies.
 type DependenciesLocation string

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -221,11 +221,10 @@ func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVers
 			addValue(parametersMap, "agentWindowsImageResourceGroup", properties.WindowsProfile.ImageRef.ResourceGroup)
 			addValue(parametersMap, "agentWindowsImageName", properties.WindowsProfile.ImageRef.Name)
 		} else {
-			addValue(parametersMap, "agentWindowsPublisher", properties.WindowsProfile.WindowsPublisher)
-			addValue(parametersMap, "agentWindowsOffer", properties.WindowsProfile.WindowsOffer)
-			addValue(parametersMap, "agentWindowsSku", properties.WindowsProfile.GetWindowsSku())
-			addValue(parametersMap, "agentWindowsVersion", properties.WindowsProfile.ImageVersion)
-
+			addValue(parametersMap, "agentWindowsPublisher", properties.WindowsProfile.GetWindowsPublisher(cloudSpecConfig))
+			addValue(parametersMap, "agentWindowsOffer", properties.WindowsProfile.GetWindowsOffer(cloudSpecConfig))
+			addValue(parametersMap, "agentWindowsSku", properties.WindowsProfile.GetWindowsSku(cloudSpecConfig))
+			addValue(parametersMap, "agentWindowsVersion", properties.WindowsProfile.GetWindowsImageVersion(cloudSpecConfig))
 		}
 
 		addValue(parametersMap, "windowsDockerVersion", properties.WindowsProfile.GetWindowsDockerVersion())

--- a/pkg/engine/params_test.go
+++ b/pkg/engine/params_test.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/leonelquinteros/gotext"
@@ -51,5 +52,183 @@ func TestAssignParameters(t *testing.T) {
 				t.Errorf("got a pointer to bool in paramsMap value, this is dangerous!: %s: %v", k, val)
 			}
 		}
+	}
+}
+
+func TestWindowsProfileWithOSImageSettings(t *testing.T) {
+
+	var tests = []struct {
+		name           string // test case name
+		windowsProfile api.WindowsProfile
+		expectedResult map[string]string
+	}{
+		{
+			"specify CustomImage",
+			api.WindowsProfile{
+				AKSOSImageVersion:     "",
+				AdminUsername:         "FooUsername",
+				AdminPassword:         "FooPassword",
+				WindowsImageSourceURL: "FooWindowsImageSourceURL",
+				WindowsPublisher:      "FooWindowsPublisher",
+				WindowsOffer:          "FooWindowsOffer",
+				WindowsSku:            "FooWindowsSku",
+				ImageVersion:          "FooImageVersion",
+			},
+			map[string]string{
+				"windowsAdminUsername":           "FooUsername",
+				"windowsAdminPassword":           "FooPassword",
+				"agentWindowsSourceUrl":          "FooWindowsImageSourceURL",
+				"agentWindowsImageName":          "nil",
+				"agentWindowsImageResourceGroup": "nil",
+				"agentWindowsPublisher":          "nil",
+				"agentWindowsOffer":              "nil",
+				"agentWindowsSku":                "nil",
+				"agentWindowsVersion":            "nil",
+			},
+		},
+		{
+			"specify ImageRef",
+			api.WindowsProfile{
+				AKSOSImageVersion: "",
+				AdminUsername:     "FooUsername",
+				AdminPassword:     "FooPassword",
+				ImageRef: &api.ImageReference{
+					Name:          "FooImageRefName",
+					ResourceGroup: "FooImageRefResourceGroup",
+				},
+				WindowsPublisher: "FooWindowsPublisher",
+				WindowsOffer:     "FooWindowsOffer",
+				WindowsSku:       "FooWindowsSku",
+				ImageVersion:     "FooImageVersion",
+			},
+			map[string]string{
+				"windowsAdminUsername":           "FooUsername",
+				"windowsAdminPassword":           "FooPassword",
+				"agentWindowsSourceUrl":          "nil",
+				"agentWindowsImageName":          "FooImageRefName",
+				"agentWindowsImageResourceGroup": "FooImageRefResourceGroup",
+				"agentWindowsPublisher":          "nil",
+				"agentWindowsOffer":              "nil",
+				"agentWindowsSku":                "nil",
+				"agentWindowsVersion":            "nil",
+			},
+		},
+		{
+			"specify vhd",
+			api.WindowsProfile{
+				AKSOSImageVersion:    "",
+				AdminUsername:        "FooUsername",
+				AdminPassword:        "FooPassword",
+				WindowsDockerVersion: "",
+				WindowsPublisher:     "FooWindowsPublisher",
+				WindowsOffer:         "FooWindowsOffer",
+				WindowsSku:           "FooWindowsSku",
+				ImageVersion:         "FooImageVersion",
+			},
+			map[string]string{
+				"windowsAdminUsername":           "FooUsername",
+				"windowsAdminPassword":           "FooPassword",
+				"agentWindowsImageName":          "nil",
+				"agentWindowsImageResourceGroup": "nil",
+				"agentWindowsSourceUrl":          "nil",
+				"agentWindowsPublisher":          "FooWindowsPublisher",
+				"agentWindowsOffer":              "FooWindowsOffer",
+				"agentWindowsSku":                "FooWindowsSku",
+				"agentWindowsVersion":            "FooImageVersion",
+			},
+		},
+		{
+			"specify vhd with distro",
+			api.WindowsProfile{
+				AKSOSImageVersion:    api.AKSWindowsServer2019,
+				AdminUsername:        "FooUsername",
+				AdminPassword:        "FooPassword",
+				WindowsDockerVersion: "",
+				WindowsPublisher:     "",
+				WindowsOffer:         "",
+				WindowsSku:           "",
+				ImageVersion:         "",
+			},
+			map[string]string{
+				"windowsAdminUsername":           "FooUsername",
+				"windowsAdminPassword":           "FooPassword",
+				"agentWindowsImageName":          "nil",
+				"agentWindowsImageResourceGroup": "nil",
+				"agentWindowsSourceUrl":          "nil",
+				"agentWindowsPublisher":          api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				"agentWindowsOffer":              api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				"agentWindowsSku":                api.AKSWindowsServer2019OSImageConfig.ImageSku,
+				"agentWindowsVersion":            api.AKSWindowsServer2019OSImageConfig.ImageVersion,
+			},
+		},
+		{
+			"do not specify vhd",
+			api.WindowsProfile{
+				AKSOSImageVersion: "",
+				AdminUsername:     "FooUsername",
+				AdminPassword:     "FooPassword",
+				WindowsPublisher:  "",
+				WindowsOffer:      "",
+				WindowsSku:        "",
+				ImageVersion:      "",
+			},
+			map[string]string{
+				"windowsAdminUsername":           "FooUsername",
+				"windowsAdminPassword":           "FooPassword",
+				"agentWindowsImageName":          "nil",
+				"agentWindowsImageResourceGroup": "nil",
+				"agentWindowsSourceUrl":          "nil",
+				"agentWindowsPublisher":          "",
+				"agentWindowsOffer":              "",
+				"agentWindowsSku":                "",
+				"agentWindowsVersion":            "",
+			},
+		},
+	}
+
+	// Initialize locale for translation
+	locale := gotext.NewLocale(path.Join("..", "..", "translations"), "en_US")
+	i18n.Initialize(locale)
+
+	apiloader := &api.Apiloader{
+		Translator: &i18n.Translator{
+			Locale: locale,
+		},
+	}
+
+	apiModelFileName := filepath.Join(TestDataDir, "windows", "kubernetes-vmss.json")
+	containerService, _, err := apiloader.LoadContainerServiceFromFile(apiModelFileName, true, false, nil)
+	if err != nil {
+		t.Fatalf("Loading file %s got error: %s", apiModelFileName, err.Error())
+	}
+
+	containerService.Location = "eastus"
+	containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			containerService.Properties.WindowsProfile = &test.windowsProfile
+			parametersMap := getParameters(containerService, DefaultGeneratorCode, "testversion")
+
+			for k, v := range test.expectedResult {
+				if v == "nil" {
+					if parametersMap[k] != nil {
+						t.Errorf("unexpected key for %s: expect non-exist but actual %s", k, parametersMap[k].(paramsMap)["value"])
+					}
+				} else {
+					if parametersMap[k] == nil {
+						t.Errorf("unexpected value for %s: expect %s but actual nil", k, v)
+					} else if parametersMap[k].(paramsMap)["value"] != v {
+						t.Errorf("unexpected value for %s: expect %s but actual %s", k, v, parametersMap[k].(paramsMap)["value"])
+					}
+				}
+			}
+		})
 	}
 }

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -285,14 +285,14 @@ func (e *Engine) GetWindowsTestImages() (*WindowsTestImages, error) {
 		return nil, errors.New("Can't guess a Windows version without Windows nodes in the cluster")
 	}
 
-	windowsSku := e.ExpandedDefinition.Properties.WindowsProfile.GetWindowsSku()
+	windowsSku := e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku
 	// tip: curl -L https://mcr.microsoft.com/v2/windows/servercore/tags/list
 	//      curl -L https://mcr.microsoft.com/v2/windows/servercore/iis/tags/list
 	switch {
 	case strings.Contains(windowsSku, "1903"):
 		return &WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-1903",
 			ServerCore: "mcr.microsoft.com/windows/servercore:1903"}, nil
-	case strings.Contains(windowsSku, "1809"), strings.Contains(windowsSku, "2019"):
+	case windowsSku == "", strings.Contains(windowsSku, "1809"), strings.Contains(windowsSku, "2019"):
 		return &WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",
 			ServerCore: "mcr.microsoft.com/windows/servercore:ltsc2019"}, nil
 	case strings.Contains(windowsSku, "1803"):
@@ -301,7 +301,7 @@ func (e *Engine) GetWindowsTestImages() (*WindowsTestImages, error) {
 	case strings.Contains(windowsSku, "1709"):
 		return nil, errors.New("Windows Server version 1709 is out of support")
 	}
-	return nil, errors.New("Unknown Windows version. GetWindowsSku() = " + windowsSku)
+	return nil, errors.New("Unknown Windows version. WindowsProfile.WindowsSku = " + windowsSku)
 }
 
 // HasAddon will return true if an addon is enabled


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
With this change, users do not need to specify a Windows OS image when creating Windows agent pools in kubernetes. It will always uses a default Windows OS image per Azure cloud environment.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I build it and create a k8s cluster on Azure with a Windows agent pool. And I also run e2e test and all test cases passed.

E2E test results:
```
JUnit report was created: /aks-engine/test/e2e/kubernetes/junit.xml

Ran 34 of 50 Specs in 1608.712 seconds
SUCCESS! -- 34 Passed | 0 Failed | 0 Pending | 16 Skipped
PASS
```

Below is Windows agent pool I used for testing.
```
      {
        "name": "npwin",
        "count": 1,
        "vmSize": "Standard_D2_v3",
        "osType": "Windows",
        "availabilityProfile": "VirtualMachineScaleSets"
      }
```

Result of `k get no -o wide`:
```
NAME                                 STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION      CONTAINER-RUNTIME
2185k8s01000000                      Ready    agent    10m   v1.14.7   10.240.0.96    <none>        Windows Server 2019 Datacenter   10.0.17763.864      docker://19.3.2
k8s-agentpool1-21854569-vmss000000   Ready    agent    13m   v1.14.7   10.240.0.34    <none>        Ubuntu 16.04.6 LTS               4.15.0-1064-azure   docker://3.0.8
k8s-agentpool1-21854569-vmss000001   Ready    agent    13m   v1.14.7   10.240.0.65    <none>        Ubuntu 16.04.6 LTS               4.15.0-1064-azure   docker://3.0.8
k8s-master-21854569-0                Ready    master   13m   v1.14.7   10.255.255.5   <none>        Ubuntu 16.04.6 LTS               4.15.0-1064-azure   docker://3.0.8
```