### PR TITLE
fix: don't expire nonexistent passwords

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -58,12 +58,12 @@ setPWExpiration() {
   grep 'PASS_MIN_DAYS' /etc/login.defs && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   sed -i "s|INACTIVE=||g" /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   grep 'INACTIVE=' /etc/default/useradd && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'PASS_MAX_DAYS 90' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MAX_DAYS 90' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  echo 'PASS_MAX_DAYS 99999' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  grep 'PASS_MAX_DAYS 99999' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   echo 'PASS_MIN_DAYS 7' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   grep 'PASS_MIN_DAYS 7' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'INACTIVE=30' >> /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'INACTIVE=30' /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  echo 'INACTIVE=0' >> /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  grep 'INACTIVE=0' /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
 }
 
 applyCIS() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -34010,12 +34010,12 @@ setPWExpiration() {
   grep 'PASS_MIN_DAYS' /etc/login.defs && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   sed -i "s|INACTIVE=||g" /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   grep 'INACTIVE=' /etc/default/useradd && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'PASS_MAX_DAYS 90' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MAX_DAYS 90' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  echo 'PASS_MAX_DAYS 99999' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  grep 'PASS_MAX_DAYS 99999' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   echo 'PASS_MIN_DAYS 7' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
   grep 'PASS_MIN_DAYS 7' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'INACTIVE=30' >> /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'INACTIVE=30' /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  echo 'INACTIVE=0' >> /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+  grep 'INACTIVE=0' /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
 }
 
 applyCIS() {


### PR DESCRIPTION
**Reason for Change**:
None of the Linux accounts on an AKS Engine node are intended to allow username/password login, yet having an expiration policy can apparently prevent access after that time passes even if public key authentication is used.

This disables inactivity and time-passed expiration (99999 is represented as "never" in the relevant Linux tools) to avoid users being inadvertently locked out of accounts.

**Issue Fixed**:
Fixes #2277

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
