### PR TITLE
fix: don't configure password for "etcd" user

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -25,8 +25,6 @@ systemctlEnableAndStart() {
 
 configureEtcdUser(){
     useradd -U "etcd"
-    usermod -p "$(head -c 32 /dev/urandom | base64)" "etcd"
-    passwd -u "etcd"
     id "etcd"
 }
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -34071,8 +34071,6 @@ systemctlEnableAndStart() {
 
 configureEtcdUser(){
     useradd -U "etcd"
-    usermod -p "$(head -c 32 /dev/urandom | base64)" "etcd"
-    passwd -u "etcd"
     id "etcd"
 }
 


### PR DESCRIPTION
**Reason for Change**:
Removes the random password configuration for the `etcd` user, so it has an empty password. Since we don't intend any Linux account to log in with username and password, adding a random one here is just confusing things. This makes /etc/passwd and /etc/shadow look consistent for the passwd field.

**Issue Fixed**:
Refs #2569

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
