### PR TITLE
fix: template error when there is no SPN in AKS MSI clusters

### DIFF
--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -128,8 +128,7 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		}
 
 		if kubernetesConfig == nil ||
-			!kubernetesConfig.UseManagedIdentity ||
-			properties.IsHostedMasterProfile() {
+			!kubernetesConfig.UseManagedIdentity {
 			servicePrincipalProfile := properties.ServicePrincipalProfile
 
 			if servicePrincipalProfile != nil {
@@ -152,6 +151,17 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 						addValue(parametersMap, "servicePrincipalObjectId", servicePrincipalProfile.ObjectID)
 					}
 				}
+			}
+		}
+		// The cluster is AKS-hosted cluster and it uses managed identity
+		if kubernetesConfig.UseManagedIdentity && properties.IsHostedMasterProfile() {
+			servicePrincipalProfile := properties.ServicePrincipalProfile
+			if servicePrincipalProfile == nil || servicePrincipalProfile.ClientID == "" || servicePrincipalProfile.Secret == "" {
+				addValue(parametersMap, "servicePrincipalClientId", "msi")
+				addValue(parametersMap, "servicePrincipalClientSecret", "msi")
+			} else {
+				addValue(parametersMap, "servicePrincipalClientId", servicePrincipalProfile.ClientID)
+				addValue(parametersMap, "servicePrincipalClientSecret", servicePrincipalProfile.Secret)
 			}
 		}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This PR fixes a defeat in https://github.com/Azure/aks-engine/pull/1935/files. In that PR, it always adds `servicePrincipalClientId` and `servicePrincipalClientSecret` in parameters map for AKS clusters which enables user assigned identity(call it AKS MSI cluster below). However, this will cause a defeat: for AKS MSI clusters, if its `servicePrincipalProfile` is nil or its clientID is an empty string, the generated ARM template will have syntax error:

> Template deployment reached terminal state with error: Code="InvalidTemplate" Message="Deployment template validation failed: 'The value for the template parameter 'servicePrincipalClientId' at line '1' and column '14858' is not provided. Please see https://aka.ms/resource-manager-parameter-files for usage details.'." AdditionalInfo=[{"info":{"lineNumber":1,"linePosition":14858,"path":"properties.template.parameters.servicePrincipalClientId"},"type":"TemplateViolation"}]

We have to provide a default value for AKS MSI clusters if its servicePrincipalProfile is empty. This PR fixes the bug.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
