### PR TITLE
build: fetch azure-vnet-cni from kubernetesartifacts storage

### DIFF
--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -330,11 +330,11 @@
       "type": "string"
     },
     "vnetCniLinuxPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
       "type": "string"
     },
     "vnetCniWindowsPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
       "type": "string"
     },
     "maxPods": {

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -95,7 +95,7 @@ var (
 		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
 		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
 		VnetCNILinuxPluginsDownloadURL:   "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerLinux + "/binaries/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerLinux + ".tgz",
-		VnetCNIWindowsPluginsDownloadURL: "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerWindows + "/binaries/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerWindows + ".zip",
+		VnetCNIWindowsPluginsDownloadURL: "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerWindows + "/binaries/azure-vnet-cni-windows-amd64-" + AzureCniPluginVerWindows + ".zip",
 		ContainerdDownloadURLBase:        "https://storage.googleapis.com/cri-containerd-release/",
 	}
 

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -94,8 +94,8 @@ var (
 		KubeBinariesSASURLBase:           "https://acs-mirror.azureedge.net/wink8s/",
 		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
 		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
-		VnetCNILinuxPluginsDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerLinux + ".tgz",
-		VnetCNIWindowsPluginsDownloadURL: "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-" + AzureCniPluginVerWindows + ".zip",
+		VnetCNILinuxPluginsDownloadURL:   "https://kubernetesartifacts.azureedge.net/azure-cni/" + CNIPluginVer + "/binaries/azure-vnet-cni-linux-amd64-" + CNIPluginVer + ".tgz",
+		VnetCNIWindowsPluginsDownloadURL: "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerWindows + "/binaries/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerWindows + ".zip",
 		ContainerdDownloadURLBase:        "https://storage.googleapis.com/cri-containerd-release/",
 	}
 

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -94,7 +94,7 @@ var (
 		KubeBinariesSASURLBase:           "https://acs-mirror.azureedge.net/wink8s/",
 		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
 		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
-		VnetCNILinuxPluginsDownloadURL:   "https://kubernetesartifacts.azureedge.net/azure-cni/" + CNIPluginVer + "/binaries/azure-vnet-cni-linux-amd64-" + CNIPluginVer + ".tgz",
+		VnetCNILinuxPluginsDownloadURL:   "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerLinux + "/binaries/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerLinux + ".tgz",
 		VnetCNIWindowsPluginsDownloadURL: "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerWindows + "/binaries/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerWindows + ".zip",
 		ContainerdDownloadURLBase:        "https://storage.googleapis.com/cri-containerd-release/",
 	}

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -299,11 +299,11 @@ const (
 const (
 	// AzureCniPluginVerLinux specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-linux-amd64-${AZURE_PLUGIN_VER}.tgz
-	// to https://acs-mirror.azureedge.net/cni
+	// to https://kubernetesartifacts.azureedge.net/azure-cni
 	AzureCniPluginVerLinux = "v1.0.30"
 	// AzureCniPluginVerWindows specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-windows-amd64-${AZURE_PLUGIN_VER}.zip
-	// to https://acs-mirror.azureedge.net/cni
+	// to https://kubernetesartifacts.azureedge.net/azure-cni
 	AzureCniPluginVerWindows = "v1.0.30"
 	// CNIPluginVer specifies the version of CNI implementation
 	// https://github.com/containernetworking/plugins

--- a/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
@@ -1041,11 +1041,11 @@
                     "type": "string"
                 },
                 "vnetCniLinuxPluginsURL": {
-                    "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+                    "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
                     "type": "string"
                 },
                 "vnetCniWindowsPluginsURL": {
-                    "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+                    "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
                     "type": "string"
                 }
             },
@@ -1870,10 +1870,10 @@
                 "value": "AzureStackCloud"
             },
             "vnetCniLinuxPluginsURL": {
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.17.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-linux-amd64-v1.0.17.zip"
             },
             "vnetCniWindowsPluginsURL": {
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.17.zip"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-windows-amd64-v1.0.17.zip"
             }
         },
         "mode": "Incremental"

--- a/pkg/armhelpers/azurestack/httpMockClientData/deployVMResponse.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/deployVMResponse.json
@@ -318,11 +318,11 @@
             },
             "vnetCniLinuxPluginsURL": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.17.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-linux-amd64-v1.0.17.zip"
             },
             "vnetCniWindowsPluginsURL": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.17.zip"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-windows-amd64-v1.0.17.zip"
             }
         },
         "mode": "Incremental",

--- a/pkg/armhelpers/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/httpMockClientData/deployVMRequest.json
@@ -1007,11 +1007,11 @@
                     "type": "string"
                 },
                 "vnetCniLinuxPluginsURL": {
-                    "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+                    "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
                     "type": "string"
                 },
                 "vnetCniWindowsPluginsURL": {
-                    "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+                    "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
                     "type": "string"
                 }
             },
@@ -1836,10 +1836,10 @@
                 "value": "AzureStackCloud"
             },
             "vnetCniLinuxPluginsURL": {
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.17.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-linux-amd64-v1.0.17.zip"
             },
             "vnetCniWindowsPluginsURL": {
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.17.zip"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-windows-amd64-v1.0.17.zip"
             }
         },
         "mode": "Incremental"

--- a/pkg/armhelpers/httpMockClientData/deployVMResponse.json
+++ b/pkg/armhelpers/httpMockClientData/deployVMResponse.json
@@ -318,11 +318,11 @@
             },
             "vnetCniLinuxPluginsURL": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.17.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-linux-amd64-v1.0.17.zip"
             },
             "vnetCniWindowsPluginsURL": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.17.zip"
+                "value": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.17/binaries/azure-vnet-cni-windows-amd64-v1.0.17.zip"
             }
         },
         "mode": "Incremental",

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40498,11 +40498,11 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
       "type": "string"
     },
     "vnetCniLinuxPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
       "type": "string"
     },
     "vnetCniWindowsPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
       "type": "string"
     },
     "maxPods": {

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_scale_template.json
@@ -1004,11 +1004,11 @@
         "type": "string"
       },
       "vnetCniLinuxPluginsURL": {
-        "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+        "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
         "type": "string"
       },
       "vnetCniWindowsPluginsURL": {
-        "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+        "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
         "type": "string"
       }
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_template.json
@@ -1004,11 +1004,11 @@
         "type": "string"
       },
       "vnetCniLinuxPluginsURL": {
-        "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+        "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
         "type": "string"
       },
       "vnetCniWindowsPluginsURL": {
-        "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+        "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
         "type": "string"
       }
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_scale_template.json
@@ -1004,11 +1004,11 @@
       "type": "string"
     },
     "vnetCniLinuxPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
       "type": "string"
     },
     "vnetCniWindowsPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
       "type": "string"
     }
   },

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_template.json
@@ -1004,11 +1004,11 @@
       "type": "string"
     },
     "vnetCniLinuxPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
       "type": "string"
     },
     "vnetCniWindowsPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
       "type": "string"
     }
   },

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -84,9 +84,9 @@ function Get-FilesToCacheOnVHD
             "https://acs-mirror.azureedge.net/wink8s/v1.17.2-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
-            "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.28.zip",
-            "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.29.zip",
-            "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.30.zip"
+            "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.28/binaries/azure-vnet-cni-windows-amd64-v1.0.28.zip",
+            "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.29/binaries/azure-vnet-cni-windows-amd64-v1.0.29.zip",
+            "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip"
         )
     }
 

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -71,7 +71,7 @@ VNET_CNI_VERSIONS="
 1.0.28
 "
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do
-    VNET_CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"
+    VNET_CNI_PLUGINS_URL="https://kubernetesartifacts.azureedge.net/azure-cni/${VNET_CNI_VERSION}/binaries/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"
     downloadAzureCNI
     echo "  - Azure CNI version ${VNET_CNI_VERSION}" >> ${VHD_LOGS_FILEPATH}
 done

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -71,7 +71,7 @@ VNET_CNI_VERSIONS="
 1.0.28
 "
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do
-    VNET_CNI_PLUGINS_URL="https://kubernetesartifacts.azureedge.net/azure-cni/${VNET_CNI_VERSION}/binaries/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"
+    VNET_CNI_PLUGINS_URL="https://kubernetesartifacts.azureedge.net/azure-cni/v${VNET_CNI_VERSION}/binaries/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"
     downloadAzureCNI
     echo "  - Azure CNI version ${VNET_CNI_VERSION}" >> ${VHD_LOGS_FILEPATH}
 done


### PR DESCRIPTION
**Reason for Change**:
Moves the download source for `azure-cni` archives to our preferred production blob storage.

This is second step in an effort to move off the `acs-mirror` blob storage (and replace manual steps with automated pipelines).

**Issue Fixed**:
Refs #2545

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Note that the cni-plugins archive is a different beast not tamed in this PR. This is just azure-vnet-cni.