### PR TITLE
fix: Moving publish release notes step after e2e test runs so windows …

### DIFF
--- a/.pipelines/vhd-builder-windows.yaml
+++ b/.pipelines/vhd-builder-windows.yaml
@@ -41,11 +41,6 @@ jobs:
       ${DEIS_GO_DEV_IMAGE} make run-packer-windows
     displayName: Building windows VHD
 
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifact: 'vhd-release-notes'
-      path: 'release-notes.txt'
-
   - script: |
       docker run --rm \
       -v ${PWD}:/go/src/github.com/Azure/aks-engine \
@@ -72,6 +67,11 @@ jobs:
       ${DEIS_GO_DEV_IMAGE} make test-kubernetes
     displayName: run e2e tests
     condition: eq(variables.COPY_VHD, 'False')
+
+  - task: PublishPipelineArtifact@1
+    inputs:
+      artifact: 'vhd-release-notes'
+      path: 'release-notes.txt'
 
   - script: |
       OS_DISK_SAS="$(cat packer-output | grep "OSDiskUriReadOnlySas:" | cut -d " " -f 2)" && \


### PR DESCRIPTION
…vhd pipeline can be re-run

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
