### PR TITLE
test: fix unset ADD_NODE_POOL_INPUT var in cluster.sh test script

### DIFF
--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -19,9 +19,12 @@ cat > ${TMP_DIR}/apimodel-input.json <<END
 ${API_MODEL_INPUT}
 END
 
-if [ -z "$ADD_NODE_POOL_INPUT" ]; then
-  echo Will not add node pool
-elif [ -n "$ADD_NODE_POOL_INPUT" ]; then
+# Jenkinsfile will yield a null $ADD_NODE_POOL_INPUT if not set in the test job config
+if [ "$ADD_NODE_POOL_INPUT" == "null" ]; then
+  $ADD_NODE_POOL_INPUT=""
+fi
+
+if [ -n "$ADD_NODE_POOL_INPUT" ]; then
   cat > ${TMP_DIR}/addpool-input.json <<END
 ${ADD_NODE_POOL_INPUT}
 END
@@ -120,9 +123,7 @@ else
   exit 0
 fi
 
-if [ -z "$ADD_NODE_POOL_INPUT" ]; then
-  echo Will not add node pool
-elif [ -n "$ADD_NODE_POOL_INPUT" ]; then
+if [ -n "$ADD_NODE_POOL_INPUT" ]; then
   docker run --rm \
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -19,7 +19,9 @@ cat > ${TMP_DIR}/apimodel-input.json <<END
 ${API_MODEL_INPUT}
 END
 
-if [ -n "$ADD_NODE_POOL_INPUT" ]; then
+if [ -z "$ADD_NODE_POOL_INPUT" ]; then
+  echo Will not add node pool
+elif [ -n "$ADD_NODE_POOL_INPUT" ]; then
   cat > ${TMP_DIR}/addpool-input.json <<END
 ${ADD_NODE_POOL_INPUT}
 END
@@ -118,7 +120,9 @@ else
   exit 0
 fi
 
-if [ -n "$ADD_NODE_POOL_INPUT" ]; then
+if [ -z "$ADD_NODE_POOL_INPUT" ]; then
+  echo Will not add node pool
+elif [ -n "$ADD_NODE_POOL_INPUT" ]; then
   docker run --rm \
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -21,7 +21,7 @@ END
 
 # Jenkinsfile will yield a null $ADD_NODE_POOL_INPUT if not set in the test job config
 if [ "$ADD_NODE_POOL_INPUT" == "null" ]; then
-  $ADD_NODE_POOL_INPUT=""
+  ADD_NODE_POOL_INPUT=""
 fi
 
 if [ -n "$ADD_NODE_POOL_INPUT" ]; then


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

More resilient cluster.sh implementation when ADD_NODE_POOL_INPUT var is unset 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
