### PR TITLE
feat: add support for Kubernetes 1.17.2

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -165,8 +165,9 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.17.0-beta.2":  false,
 	"1.17.0-rc.1":    false,
 	"1.17.0-rc.2":    false,
-	"1.17.0":         true,
+	"1.17.0":         false,
 	"1.17.1":         true,
+	"1.17.2":         true,
 	"1.18.0-alpha.1": true,
 	"1.18.0-alpha.2": true,
 }

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -81,8 +81,8 @@ function Get-FilesToCacheOnVHD
             "https://acs-mirror.azureedge.net/wink8s/v1.16.1-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.16.2-1int.zip",
             "https://acs-mirror.azureedge.net/wink8s/v1.16.4-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/v1.17.0-1int.zip",
-            "https://acs-mirror.azureedge.net/wink8s/v1.17.1-1int.zip"
+            "https://acs-mirror.azureedge.net/wink8s/v1.17.1-1int.zip",
+            "https://acs-mirror.azureedge.net/wink8s/v1.17.2-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
             "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.28.zip",

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -422,8 +422,8 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="
+1.17.2
 1.17.1
-1.17.0
 1.16.4
 1.16.2
 1.16.1


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.17.md#changelog-since-v1171

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] Windows artifacts uploaded to acsmirror blob store
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This is considered a ["no-op" release](https://groups.google.com/forum/#!topic/kubernetes-dev/Mhpx-loSBns/discussion) to work out a build issue, so we may want not want to bother merging this since 1.17.1 wasn't actually affected in our CI pipeline.