### PR TITLE
build: fetch cni-plugins from kubernetesartifacts storage

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -200,7 +200,7 @@ ensureAPMZ() {
 }
 
 installCNI() {
-    CNI_TGZ_TMP=$(echo ${CNI_PLUGINS_URL} | cut -d "/" -f 7)
+    CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/} # Use bash builtin ## to remove all chars ("*") up to the final "/"
     if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
         downloadCNI
     fi
@@ -211,7 +211,7 @@ installCNI() {
 }
 
 installAzureCNI() {
-    CNI_TGZ_TMP=$(echo ${VNET_CNI_PLUGINS_URL} | cut -d "/" -f 5)
+    CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/} # Use bash builtin ## to remove all chars ("*") up to the final "/"
     if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
         downloadAzureCNI
     fi

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -200,7 +200,7 @@ ensureAPMZ() {
 }
 
 installCNI() {
-    CNI_TGZ_TMP=$(echo ${CNI_PLUGINS_URL} | cut -d "/" -f 5)
+    CNI_TGZ_TMP=$(echo ${CNI_PLUGINS_URL} | cut -d "/" -f 7)
     if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
         downloadCNI
     fi

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -327,7 +327,7 @@
       "type": "string"
     },
     "cniPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
       "type": "string"
     },
     "vnetCniLinuxPluginsURL": {

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -93,7 +93,7 @@ var (
 		EtcdDownloadURLBase:              "https://acs-mirror.azureedge.net/github-coreos",
 		KubeBinariesSASURLBase:           "https://acs-mirror.azureedge.net/wink8s/",
 		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
-		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
+		CNIPluginsDownloadURL:            "https://kubernetesartifacts.azureedge.net/cni-plugins/" + CNIPluginVer + "/binaries/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
 		VnetCNILinuxPluginsDownloadURL:   "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerLinux + "/binaries/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerLinux + ".tgz",
 		VnetCNIWindowsPluginsDownloadURL: "https://kubernetesartifacts.azureedge.net/azure-cni/" + AzureCniPluginVerWindows + "/binaries/azure-vnet-cni-windows-amd64-" + AzureCniPluginVerWindows + ".zip",
 		ContainerdDownloadURLBase:        "https://storage.googleapis.com/cri-containerd-release/",

--- a/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
@@ -105,7 +105,7 @@
                     "type": "object"
                 },
                 "cniPluginsURL": {
-                    "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+                    "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
                     "type": "string"
                 },
                 "containerRuntime": {
@@ -1699,7 +1699,7 @@
                 }
             },
             "cniPluginsURL": {
-                "value": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v0.7.1.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz"
             },
             "containerRuntime": {
                 "value": "docker"

--- a/pkg/armhelpers/azurestack/httpMockClientData/deployVMResponse.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/deployVMResponse.json
@@ -48,7 +48,7 @@
             },
             "cniPluginsURL": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v0.7.1.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz"
             },
             "containerRuntime": {
                 "type": "String",

--- a/pkg/armhelpers/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/httpMockClientData/deployVMRequest.json
@@ -105,7 +105,7 @@
                     "type": "object"
                 },
                 "cniPluginsURL": {
-                    "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+                    "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
                     "type": "string"
                 },
                 "containerRuntime": {
@@ -1665,7 +1665,7 @@
                 }
             },
             "cniPluginsURL": {
-                "value": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v0.7.1.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz"
             },
             "containerRuntime": {
                 "value": "docker"

--- a/pkg/armhelpers/httpMockClientData/deployVMResponse.json
+++ b/pkg/armhelpers/httpMockClientData/deployVMResponse.json
@@ -48,7 +48,7 @@
             },
             "cniPluginsURL": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v0.7.1.tgz"
+                "value": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz"
             },
             "containerRuntime": {
                 "type": "String",

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37389,7 +37389,7 @@ ensureAPMZ() {
 }
 
 installCNI() {
-    CNI_TGZ_TMP=$(echo ${CNI_PLUGINS_URL} | cut -d "/" -f 5)
+    CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/} # Use bash builtin ## to remove all chars ("*") up to the final "/"
     if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
         downloadCNI
     fi
@@ -37400,7 +37400,7 @@ installCNI() {
 }
 
 installAzureCNI() {
-    CNI_TGZ_TMP=$(echo ${VNET_CNI_PLUGINS_URL} | cut -d "/" -f 5)
+    CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/} # Use bash builtin ## to remove all chars ("*") up to the final "/"
     if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
         downloadAzureCNI
     fi

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40503,7 +40503,7 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
       "type": "string"
     },
     "cniPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
       "type": "string"
     },
     "vnetCniLinuxPluginsURL": {

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_scale_template.json
@@ -363,7 +363,7 @@
         "type": "object"
       },
       "cniPluginsURL": {
-        "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+        "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
         "type": "string"
       },
       "containerRuntime": {

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_template.json
@@ -363,7 +363,7 @@
         "type": "object"
       },
       "cniPluginsURL": {
-        "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+        "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
         "type": "string"
       },
       "containerRuntime": {

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_scale_template.json
@@ -356,7 +356,7 @@
       "type": "object"
     },
     "cniPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
       "type": "string"
     },
     "containerRuntime": {

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_template.json
@@ -356,7 +356,7 @@
       "type": "object"
     },
     "cniPluginsURL": {
-      "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+      "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
       "type": "string"
     },
     "containerRuntime": {

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -82,7 +82,7 @@ CNI_PLUGIN_VERSIONS="
 0.7.1
 "
 for CNI_PLUGIN_VERSION in $CNI_PLUGIN_VERSIONS; do
-    CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v${CNI_PLUGIN_VERSION}.tgz"
+    CNI_PLUGINS_URL="https://kubernetesartifacts.azureedge.net/cni-plugins/v${CNI_PLUGIN_VERSION}/binaries/cni-plugins-amd64-v${CNI_PLUGIN_VERSION}.tgz"
     downloadCNI
     echo "  - CNI plugin version ${CNI_PLUGIN_VERSION}" >> ${VHD_LOGS_FILEPATH}
 done


### PR DESCRIPTION
**Reason for Change**:
Moves the download source for `cni-plugins` archives to our preferred production blob storage.

This is third step in an effort to move off the `acs-mirror` blob storage (and replace manual steps with automated pipelines).

**Issue Fixed**:
Refs #2545

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
