### PR TITLE
test: don't test for static node count if add node pool context

### DIFF
--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -164,6 +164,7 @@ if [ -n "$ADD_NODE_POOL_INPUT" ]; then
     -e GINKGO_SKIP="${SKIP_AFTER_SCALE_DOWN}" \
     -e GINKGO_FOCUS="${GINKGO_FOCUS}" \
     -e SKIP_TEST=${SKIP_TESTS_AFTER_SCALE_DOWN} \
+    -e ADD_NODE_POOL_INPUT=${ADD_NODE_POOL_INPUT} \
     ${DEV_IMAGE} make test-kubernetes || exit 1
 fi
 
@@ -207,6 +208,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -e GINKGO_SKIP="${SKIP_AFTER_SCALE_DOWN}" \
     -e GINKGO_FOCUS="${GINKGO_FOCUS}" \
     -e SKIP_TEST=${SKIP_TESTS_AFTER_SCALE_DOWN} \
+    -e ADD_NODE_POOL_INPUT=${ADD_NODE_POOL_INPUT} \
     ${DEV_IMAGE} make test-kubernetes || exit 1
 fi
 
@@ -248,6 +250,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       -e GINKGO_SKIP="${SKIP_AFTER_UPGRADE}" \
       -e GINKGO_FOCUS="${GINKGO_FOCUS}" \
       -e SKIP_TEST=${SKIP_TESTS_AFTER_UPGRADE} \
+      -e ADD_NODE_POOL_INPUT=${ADD_NODE_POOL_INPUT} \
       ${DEV_IMAGE} make test-kubernetes || exit 1
   done
 fi
@@ -292,5 +295,6 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -e GINKGO_SKIP="${SKIP_AFTER_SCALE_UP}" \
     -e GINKGO_FOCUS="${GINKGO_FOCUS}" \
     -e SKIP_TEST=${SKIP_TESTS_AFTER_SCALE_DOWN} \
+    -e ADD_NODE_POOL_INPUT=${ADD_NODE_POOL_INPUT} \
     ${DEV_IMAGE} make test-kubernetes || exit 1
 fi

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	GinkgoSkip          string `envconfig:"GINKGO_SKIP"`
 	DebugAfterSuite     bool   `envconfig:"DEBUG_AFTERSUITE" default:"false"`
 	BlockSSHPort        bool   `envconfig:"BLOCK_SSH" default:"false"`
+	AddNodePoolInput    string `envconfig:"ADD_NODE_POOL_INPUT"`
 }
 
 // CustomCloudConfig holds configurations for custom clould

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	GinkgoSkip          string `envconfig:"GINKGO_SKIP"`
 	DebugAfterSuite     bool   `envconfig:"DEBUG_AFTERSUITE" default:"false"`
 	BlockSSHPort        bool   `envconfig:"BLOCK_SSH" default:"false"`
-	AddNodePoolInput    string `envconfig:"ADD_NODE_POOL_INPUT"`
+	AddNodePoolInput    string `envconfig:"ADD_NODE_POOL_INPUT" default:""`
 }
 
 // CustomCloudConfig holds configurations for custom clould

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -638,7 +638,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should report all nodes in a Ready state", func() {
 			var expectedReadyNodes int
-			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() && !clusterAutoscalerEngaged {
+			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() &&
+				!clusterAutoscalerEngaged &&
+				cfg.AddNodePoolInput != "" {
 				expectedReadyNodes = eng.NodeCount()
 				log.Printf("Checking for %d Ready nodes\n", expectedReadyNodes)
 			} else {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -640,7 +640,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			var expectedReadyNodes int
 			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() &&
 				!clusterAutoscalerEngaged &&
-				cfg.AddNodePoolInput != "" {
+				cfg.AddNodePoolInput == "" {
 				expectedReadyNodes = eng.NodeCount()
 				log.Printf("Checking for %d Ready nodes\n", expectedReadyNodes)
 			} else {
@@ -654,7 +654,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have node labels and annotations", func() {
-			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
+			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() &&
+				cfg.AddNodePoolInput == "" {
 				totalNodeCount := eng.NodeCount()
 				nodes := totalNodeCount - len(masterNodes)
 				nodeList, err := node.GetByLabel("foo")
@@ -671,7 +672,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should have node labels specific to masters or agents", func() {
 			nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
-			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
+			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() &&
+				cfg.AddNodePoolInput == "" {
 				Expect(len(nodes)).To(Equal(eng.NodeCount()))
 			}
 			for _, node := range nodes {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Until we make the E2E test runner more intelligent so that it is able to introspect the modified api model after a `addpool` operation, we should not check for a static node count in the E2E test job (because we are not correctly calculating the static count of nodes in the cluster in this context).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
