### PR TITLE
test: configurable pvc E2E tests

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	DebugAfterSuite     bool   `envconfig:"DEBUG_AFTERSUITE" default:"false"`
 	BlockSSHPort        bool   `envconfig:"BLOCK_SSH" default:"false"`
 	AddNodePoolInput    string `envconfig:"ADD_NODE_POOL_INPUT" default:""`
+	TestPVC             bool   `envconfig:"TEST_PVC" default:"false"`
 }
 
 // CustomCloudConfig holds configurations for custom clould

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1255,7 +1255,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should create a pv by deploying a pod that consumes a pvc", func() {
 			if !util.IsUsingManagedDisks(eng.ExpandedDefinition.Properties.AgentPoolProfiles) {
 				Skip("Skip PV test for clusters using unmanaged disks")
-			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
+			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() &&
+				cfg.TestPVC {
 				By("Creating a persistent volume claim")
 				pvcName := "azure-disk" // should be the same as in pvc-azuredisk.yaml
 				pvc, err := persistentvolumeclaims.CreatePersistentVolumeClaimsFromFile(filepath.Join(WorkloadDir, "pvc-azuredisk.yaml"), pvcName, "default")

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -2,7 +2,8 @@
 	"env": {
 		"CREATE_VNET": true,
 		"REGION_OPTIONS": "eastus,westeurope,westus2",
-		"GINKGO_SKIP": "should report all nodes in a Ready state"
+		"GINKGO_SKIP": "should report all nodes in a Ready state",
+		"TEST_PVC": true
 	},
 	"options": {
 		"allowedOrchestratorVersions": [


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR modifies the PVC E2E test implementation so that it only runs if a `TEST_PVC` env var is set to `true` (in addition to other, pre-existing conditional criteria).

We will ship this change w/ a change to the "everything" test cluster configuration, so that that cluster config gets PVC test coverage.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
