### PR TITLE
test: HPA/cluster-autoscaler fixes so we don't scale up too many pods

### DIFF
--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -7,6 +7,8 @@
 	},
 	"options": {
 		"allowedOrchestratorVersions": [
+			"1.14",
+			"1.15",
 			"1.16",
 			"1.17",
 			"1.18"

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -7,8 +7,6 @@
 	},
 	"options": {
 		"allowedOrchestratorVersions": [
-			"1.14",
-			"1.15",
 			"1.16",
 			"1.17",
 			"1.18"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

It seems that due to this issue our increase of node pools has revealed a bug in HPA, where it doesn't scale down if pods are Pending:

https://github.com/kubernetes/kubernetes/issues/85506

This PR only calculates cluster-autoscaler-engaged node pools when determining how to configure HPA for scale up, so that there aren't Pending pods when we stop load.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
