### PR TITLE
test: allow cluster-autoscaler more nodes in everything test config

### DIFF
--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -35,7 +35,7 @@
 									"name": "pool1",
 									"config": {
 										"min-nodes": "1",
-										"max-nodes": "3"
+										"max-nodes": "9"
 									}
 								}
 							],


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR grants cluster-autoscaler more tolerance to scale up pool1 on the "everything" test config.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
