### PR TITLE
ci: work around linter by building binary first

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -49,10 +49,10 @@ jobs:
     displayName: Check if imports, Gopkg.toml, and Gopkg.lock are in sync
   - script: make ensure-generated
     displayName: Check if generated code is up to date
-  - script: make generate test-style
-    displayName: Run linting rules
   - script: make build-cross
     displayName: Build cross-architectural binaries
+  - script: make test-style
+    displayName: Run linting rules
   - script: |
         export CODECOV_TOKEN=$(CODECOV_TOKEN)
         make coverage


### PR DESCRIPTION
**Reason for Change**:
#2534 broke the CI unit test step because of a `golangci-lint` bootstrap issue. This works around it by building the binary first, which I've verified fixes it locally.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
