### PR TITLE
fix: scale operation looks for windows name for linux pool

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -268,10 +268,9 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					continue
 				}
 
-				osPublisher := vm.StorageProfile.ImageReference.Publisher
-				if osPublisher != nil && sc.agentPool.OSType == api.Windows && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
+				if sc.agentPool.OSType == api.Windows {
 					_, _, winPoolIndex, index, err = utils.WindowsVMNameParts(vmName)
-				} else {
+				} else if sc.agentPool.OSType == api.Linux {
 					_, _, index, err = utils.K8sLinuxVMNameParts(vmName)
 				}
 				if err != nil {
@@ -389,8 +388,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					}
 				}
 
-				osPublisher := vmss.VirtualMachineProfile.StorageProfile.ImageReference.Publisher
-				if osPublisher != nil && sc.agentPool.OSType == api.Windows && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
+				if sc.agentPool.OSType == api.Windows {
 					_, _, winPoolIndex, _, err = utils.WindowsVMNameParts(vmName)
 					log.Errorln(err)
 				}

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -269,7 +269,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				}
 
 				osPublisher := vm.StorageProfile.ImageReference.Publisher
-				if osPublisher != nil && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
+				if osPublisher != nil && sc.agentPool.OSType == api.Windows && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
 					_, _, winPoolIndex, index, err = utils.WindowsVMNameParts(vmName)
 				} else {
 					_, _, index, err = utils.K8sLinuxVMNameParts(vmName)
@@ -390,7 +390,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				}
 
 				osPublisher := vmss.VirtualMachineProfile.StorageProfile.ImageReference.Publisher
-				if osPublisher != nil && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
+				if osPublisher != nil && sc.agentPool.OSType == api.Windows && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
 					_, _, winPoolIndex, _, err = utils.WindowsVMNameParts(vmName)
 					log.Errorln(err)
 				}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR ensures we don't parse for a Windows name during scale operations unless we are running in the context of a Windows node pool.

This fixes a regression introduced in #2483

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2637

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
