### PR TITLE
fix: custom kube-controller-manager template should reference hyperkube

### DIFF
--- a/parts/k8s/manifests/kubernetesmaster-kube-controller-manager-custom.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-controller-manager-custom.yaml
@@ -11,7 +11,7 @@ spec:
   hostNetwork: true
   containers:
     - name: kube-controller-manager
-      image: {{GetCCMImageReference}}
+      image: {{GetHyperkubeImageReference}}
       imagePullPolicy: IfNotPresent
       command: ["/hyperkube", "kube-controller-manager"]
       args: [{{GetK8sRuntimeConfigKeyVals .Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}]

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -41875,7 +41875,7 @@ spec:
   hostNetwork: true
   containers:
     - name: kube-controller-manager
-      image: {{GetCCMImageReference}}
+      image: {{GetHyperkubeImageReference}}
       imagePullPolicy: IfNotPresent
       command: ["/hyperkube", "kube-controller-manager"]
       args: [{{GetK8sRuntimeConfigKeyVals .Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}]


### PR DESCRIPTION
**Reason for Change**:
Custom kube-controller-manager template should reference hyperkube