### PR TITLE
refactor: stop using type nesting in billing extensions 

### DIFF
--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -776,16 +776,16 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 		if cs.Properties.IsHostedMasterProfile() {
 			if profile.IsWindows() {
 				aksBillingExtension.Name = to.StringPtr(fmt.Sprintf("[concat(variables('%sVMNamePrefix'), '-AKSWindowsBilling')]", profile.Name))
-				aksBillingExtension.Type = to.StringPtr("Compute.AKS.Windows.Billing")
+				aksBillingExtension.VirtualMachineScaleSetExtensionProperties.Type = to.StringPtr("Compute.AKS.Windows.Billing")
 			} else {
 				aksBillingExtension.Name = to.StringPtr(fmt.Sprintf("[concat(variables('%sVMNamePrefix'), '-AKSLinuxBilling')]", profile.Name))
-				aksBillingExtension.Type = to.StringPtr("Compute.AKS.Linux.Billing")
+				aksBillingExtension.VirtualMachineScaleSetExtensionProperties.Type = to.StringPtr("Compute.AKS.Linux.Billing")
 			}
 		} else {
 			if profile.IsWindows() {
-				aksBillingExtension.Type = to.StringPtr("Compute.AKS-Engine.Windows.Billing")
+				aksBillingExtension.VirtualMachineScaleSetExtensionProperties.Type = to.StringPtr("Compute.AKS-Engine.Windows.Billing")
 			} else {
-				aksBillingExtension.Type = to.StringPtr("Compute.AKS-Engine.Linux.Billing")
+				aksBillingExtension.VirtualMachineScaleSetExtensionProperties.Type = to.StringPtr("Compute.AKS-Engine.Linux.Billing")
 			}
 		}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Addresses breaking change in Azure SDK for Go that causes the struct nesting in vmss extensions to not work properly anymore as the `Type` field is now both present in `VirtualMachineScaleSetExtensionProperties`  and `VirtualMachineScaleSetExtension`. See https://github.com/Azure/azure-rest-api-specs/pull/7724#issuecomment-576961394 for more details.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2605 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
