### PR TITLE
fix: private cluster + multiple masters in backend ILB pool

### DIFF
--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -165,9 +165,9 @@ func createPrivateClusterMasterVMNetworkInterface(cs *api.ContainerService) Netw
 				ID: to.StringPtr("[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
 			}
 			lbBackendAddressPools = append(lbBackendAddressPools, publicLbPool)
-			loadBalancerIPConfig.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools = &lbBackendAddressPools
-			loadBalancerIPConfig.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules = &[]network.InboundNatRule{}
 		}
+		loadBalancerIPConfig.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools = &lbBackendAddressPools
+		loadBalancerIPConfig.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules = &[]network.InboundNatRule{}
 	}
 	ipConfigurations := []network.InterfaceIPConfiguration{loadBalancerIPConfig}
 

--- a/pkg/engine/networkinterfaces_test.go
+++ b/pkg/engine/networkinterfaces_test.go
@@ -420,9 +420,15 @@ func TestCreatePrivateClusterNetworkInterface(t *testing.T) {
 		{
 			Name: to.StringPtr("ipconfig1"),
 			InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-				PrivateIPAddress:          to.StringPtr("[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]"),
-				Primary:                   to.BoolPtr(true),
-				PrivateIPAllocationMethod: network.Static,
+				LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
+					{
+						ID: to.StringPtr("[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+					},
+				},
+				LoadBalancerInboundNatRules: &[]network.InboundNatRule{},
+				PrivateIPAddress:            to.StringPtr("[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]"),
+				Primary:                     to.BoolPtr(true),
+				PrivateIPAllocationMethod:   network.Static,
 				Subnet: &network.Subnet{
 					ID: to.StringPtr("[variables('vnetSubnetID')]"),
 				},
@@ -490,9 +496,15 @@ func TestCreatePrivateClusterNetworkInterface(t *testing.T) {
 		{
 			Name: to.StringPtr("ipconfig1"),
 			InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-				PrivateIPAddress:          to.StringPtr("[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]"),
-				Primary:                   to.BoolPtr(true),
-				PrivateIPAllocationMethod: network.Static,
+				LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
+					{
+						ID: to.StringPtr("[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"),
+					},
+				},
+				LoadBalancerInboundNatRules: &[]network.InboundNatRule{},
+				PrivateIPAddress:            to.StringPtr("[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]"),
+				Primary:                     to.BoolPtr(true),
+				PrivateIPAllocationMethod:   network.Static,
 				Subnet: &network.Subnet{
 					ID: to.StringPtr("[variables('vnetSubnetID')]"),
 				},


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR fixes a regression introduced in #2572 where multiple master VM + private cluster scenarios have an empty ILB backend pool when LB type is basic.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2645

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
