### PR TITLE
chore: use IsVMSSToBeUpgraded func to validate vmss pools in upgrade

### DIFF
--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -295,3 +295,209 @@ func TestUpgradeForceDowngradeShouldSetVersionOnContainerService(t *testing.T) {
 	g.Expect(upgradeCmd.containerService.Properties.OrchestratorProfile.OrchestratorVersion).To(Equal("1.10.12"))
 	resetValidVersions()
 }
+
+func TestIsVMSSNameInAgentPoolsArray(t *testing.T) {
+	cases := []struct {
+		vmssName string
+		cs       *api.ContainerService
+		expected bool
+		name     string
+	}{
+		{
+			vmssName: "k8s-agentpool1-41325566-vmss",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime: api.Docker,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "agentpool1",
+							Count:               1,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expected: true,
+			name:     "vmss is in the api model spec",
+		},
+		{
+			vmssName: "my-vmss",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime: api.Docker,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "agentpool1",
+							Count:               1,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expected: false,
+			name:     "vmss unrecognized",
+		},
+		{
+			vmssName: "k8s-frontendpool-41325566-vmss",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime: api.Docker,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "frontendpool",
+							Count:               30,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "backendpool",
+							Count:               7,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "canary",
+							Count:               5,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expected: true,
+			name:     "multiple pools, frontendpool vmss is in spec",
+		},
+		{
+			vmssName: "k8s-backendpool-41325566-vmss",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime: api.Docker,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "frontendpool",
+							Count:               30,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "backendpool",
+							Count:               7,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "canary",
+							Count:               5,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expected: true,
+			name:     "multiple pools, backendpool vmss is in spec",
+		},
+		{
+			vmssName: "k8s-canary-41325566-vmss",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime: api.Docker,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "frontendpool",
+							Count:               30,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "backendpool",
+							Count:               7,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "canary",
+							Count:               5,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expected: true,
+			name:     "multiple pools, canary vmss is in spec",
+		},
+		{
+			vmssName: "k8s-canary-41325566-vmss",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime: api.Docker,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{},
+				},
+			},
+			expected: false,
+			name:     "no pools",
+		},
+		{
+			vmssName: "k8s-canary-41325566-vmss",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime: api.Docker,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "canary",
+							Count:               1,
+							AvailabilityProfile: api.AvailabilitySet,
+						},
+					},
+				},
+			},
+			expected: false,
+			name:     "availability set",
+		},
+	}
+
+	for _, tc := range cases {
+		c := tc
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			ret := isVMSSNameInAgentPoolsArray(c.vmssName, c.cs)
+			if ret != c.expected {
+				t.Errorf("expected %t to be %t", ret, c.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR evolves the CLI upgrade functionality so that we include a `IsVMSSToBeUpgraded` method spec to the `UpgradeCluster` struct object. This method spec will ensure that the upgrade operationa is able to determine at runtime whether or not a VMSS present in the cluster resource group is actually a VMSS that correlates with an `AgentPoolProfile` of type `"VirtualMachineScaleSets"` in the cluster spec.

At present (passing in no method spec), the `aks-engine upgrade` operation is subject to edge case scenarios where VMSS instances in the resource group *not* created by `aks-engine` are evaluated as Kubernetes nodes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
