### PR TITLE
fix: persist new pool after addpool operation

### DIFF
--- a/cmd/addpool.go
+++ b/cmd/addpool.go
@@ -44,7 +44,6 @@ type addPoolCmd struct {
 	client           armhelpers.AKSEngineClient
 	locale           *gotext.Locale
 	nameSuffix       string
-	nodePoolIndex    int
 	logger           *log.Entry
 	apiserverURL     string
 	kubeconfig       string
@@ -305,7 +304,8 @@ func (apc *addPoolCmd) saveAPIModel() error {
 	if err != nil {
 		return err
 	}
-	apc.containerService.Properties.AgentPoolProfiles[apc.nodePoolIndex].Count = apc.nodePool.Count
+
+	apc.containerService.Properties.AgentPoolProfiles = append(apc.containerService.Properties.AgentPoolProfiles, apc.nodePool)
 
 	b, err := apiloader.SerializeContainerService(apc.containerService, apiVersion)
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR properly persists the additional node pool after a successful `aks-engine addpool` operation, so that subsequent operations (e.g., scale, upgrade) will be able to know about the new pool via the canonical api model JSON.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
