### PR TITLE
fix: remove extra param from 'systemctl_restart' invocation

### DIFF
--- a/parts/k8s/cloud-init/artifacts/setup-custom-search-domains.sh
+++ b/parts/k8s/cloud-init/artifacts/setup-custom-search-domains.sh
@@ -3,7 +3,7 @@ set -x
 source {{GetCSEHelpersScriptFilepath}}
 
 echo "  dns-search {{GetSearchDomainName}}" | tee -a /etc/network/interfaces.d/50-cloud-init.cfg
-systemctl_restart 20 5 10 restart networking
+systemctl_restart 20 5 10 networking
 wait_for_apt_locks
 retrycmd_if_failure 10 5 120 apt-get -y install realmd sssd sssd-tools samba-common samba samba-common python2.7 samba-libs packagekit
 wait_for_apt_locks

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -38797,7 +38797,7 @@ set -x
 source {{GetCSEHelpersScriptFilepath}}
 
 echo "  dns-search {{GetSearchDomainName}}" | tee -a /etc/network/interfaces.d/50-cloud-init.cfg
-systemctl_restart 20 5 10 restart networking
+systemctl_restart 20 5 10 networking
 wait_for_apt_locks
 retrycmd_if_failure 10 5 120 apt-get -y install realmd sssd sssd-tools samba-common samba samba-common python2.7 samba-libs packagekit
 wait_for_apt_locks


### PR DESCRIPTION
**Reason for Change**:
Script `setup-custom-search-domains.sh` is passing an unexpected param to `systemctl_restart`.

**Issue Fixed**:
Same change-set as #1562