### PR TITLE
docs: refer to kubernetesartifacts storage in examples and comments

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -29,7 +29,7 @@ var (
 	labelValueRegex          *regexp.Regexp
 	labelKeyRegex            *regexp.Regexp
 	diskEncryptionSetIDRegex *regexp.Regexp
-	// Any version has to be mirrored in https://acs-mirror.azureedge.net/github-coreos/etcd-v[Version]-linux-amd64.tar.gz
+	// Any version has to be available in a container image from mcr.microsoft.com/oss/etcd-io/etcd:v[Version]
 	etcdValidVersions = [...]string{"2.2.5", "2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4", "2.3.5", "2.3.6", "2.3.7", "2.3.8",
 		"3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.9", "3.0.10", "3.0.11", "3.0.12", "3.0.13", "3.0.14", "3.0.15", "3.0.16", "3.0.17",
 		"3.1.0", "3.1.1", "3.1.2", "3.1.2", "3.1.3", "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8", "3.1.9", "3.1.10",

--- a/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
@@ -1726,7 +1726,7 @@
                 "value": "512"
             },
             "etcdDownloadURLBase": {
-                "value": "https://acs-mirror.azureedge.net/github-coreos"
+                "value": "mcr.microsoft.com/oss/etcd-io/"
             },
             "etcdEncryptionKey": {
                 "value": ""

--- a/pkg/armhelpers/azurestack/httpMockClientData/deployVMResponse.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/deployVMResponse.json
@@ -87,7 +87,7 @@
             },
             "etcdDownloadURLBase": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/github-coreos"
+                "value": "mcr.microsoft.com/oss/etcd-io/"
             },
             "etcdEncryptionKey": {
                 "type": "String",

--- a/pkg/armhelpers/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/httpMockClientData/deployVMRequest.json
@@ -1692,7 +1692,7 @@
                 "value": "512"
             },
             "etcdDownloadURLBase": {
-                "value": "https://acs-mirror.azureedge.net/github-coreos"
+                "value": "mcr.microsoft.com/oss/etcd-io/"
             },
             "etcdEncryptionKey": {
                 "value": ""

--- a/pkg/armhelpers/httpMockClientData/deployVMResponse.json
+++ b/pkg/armhelpers/httpMockClientData/deployVMResponse.json
@@ -87,7 +87,7 @@
             },
             "etcdDownloadURLBase": {
                 "type": "String",
-                "value": "https://acs-mirror.azureedge.net/github-coreos"
+                "value": "mcr.microsoft.com/oss/etcd-io/"
             },
             "etcdEncryptionKey": {
                 "type": "String",

--- a/pkg/engine/transform/transformtestfiles/k8s_template_jumpbox.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_template_jumpbox.json
@@ -462,7 +462,7 @@
             "type": "Object"
         },
         "cniPluginsURL": {
-            "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+            "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
             "type": "String"
         },
         "containerRuntime": {
@@ -1576,11 +1576,11 @@
             }
         },
         "vnetCniLinuxPluginsURL": {
-            "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+            "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
             "type": "String"
         },
         "vnetCniWindowsPluginsURL": {
-            "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+            "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.tgz",
             "type": "String"
         }
     },

--- a/pkg/engine/transform/transformtestfiles/k8s_upgrade_template_jumpbox.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_upgrade_template_jumpbox.json
@@ -462,7 +462,7 @@
             "type": "Object"
         },
         "cniPluginsURL": {
-            "defaultValue": "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+            "defaultValue": "https://kubernetesartifacts.azureedge.net/cni-plugins/v0.7.6/binaries/cni-plugins-amd64-v0.7.6.tgz",
             "type": "String"
         },
         "containerRuntime": {
@@ -1576,11 +1576,11 @@
             }
         },
         "vnetCniLinuxPluginsURL": {
-            "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+            "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
             "type": "String"
         },
         "vnetCniWindowsPluginsURL": {
-            "defaultValue": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-latest.zip",
+            "defaultValue": "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.tgz",
             "type": "String"
         }
     },


### PR DESCRIPTION
**Reason for Change**:
Changes references to the deprecated acs-mirror storage to point to the approved locations.

**Issue Fixed**:
Refs #2545 


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
