### PR TITLE
test: wait for "Ready" nodes, where appropriate

### DIFF
--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -116,6 +116,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
   git branch -D $UPGRADE_FORK/$UPGRADE_BRANCH
   git checkout -b $UPGRADE_FORK/$UPGRADE_BRANCH --track $UPGRADE_FORK/$UPGRADE_BRANCH
   git pull
+  git log -1
   docker run --rm \
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -176,8 +176,8 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
-    -e HOST_USER=${USER} \
-    -e HOST_GROUP=${USER} \
+    -e HOST_USER=$(id -u ${USER}) \
+    -e HOST_GROUP=:$(id -g ${USER}) \
     ${DEV_IMAGE} \
     /bin/bash -c "chown $HOST_USER:$HOST_USER _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -103,7 +103,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
     ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP" || exit 1
+    /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP" || exit 1
   # shellcheck disable=SC2012
   RESOURCE_GROUP=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2)
   # shellcheck disable=SC2012
@@ -184,7 +184,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
     ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
+    /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
@@ -291,7 +291,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
     ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
+    /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
     -v $(pwd):${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -98,14 +98,14 @@ docker run --rm \
 "${DEV_IMAGE}" make test-kubernetes || exit 1
 
 if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n "$ADD_NODE_POOL_INPUT" ]; then
+  # shellcheck disable=SC2012
+  RESOURCE_GROUP=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2)
   docker run --rm \
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
     ${DEV_IMAGE} \
     /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP" || exit 1
-  # shellcheck disable=SC2012
-  RESOURCE_GROUP=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2)
   # shellcheck disable=SC2012
   REGION=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2 | cut -d- -f2)
   if [ $(( RANDOM % 4 )) -eq 3 ]; then
@@ -292,7 +292,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
     ${DEV_IMAGE} \
     /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
-  for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
+  for nodepool in $(jq -r '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -111,6 +111,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
     done
   fi
   git reset --hard
+  git remote rm $UPGRADE_FORK
   git remote add $UPGRADE_FORK https://github.com/$UPGRADE_FORK/aks-engine.git
   git fetch --prune $UPGRADE_FORK
   git branch -D $UPGRADE_FORK/$UPGRADE_BRANCH

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -183,10 +183,8 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
-    -e HOST_USER=$(id -u ${USER}) \
-    -e HOST_GROUP=:$(id -g ${USER}) \
     ${DEV_IMAGE} \
-    /bin/bash -c "chown $HOST_USER:$HOST_USER _output/$RESOURCE_GROUP/apimodel.json" || exit 1
+    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
       -v $(pwd):${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -172,7 +172,7 @@ if [ -n "$ADD_NODE_POOL_INPUT" ]; then
 fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
-  for nodepool in $(echo "${API_MODEL_INPUT}" | jq -r '.properties.agentPoolProfiles[].name'); do
+  for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \
@@ -284,7 +284,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
 fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
-  for nodepool in $(echo ${API_MODEL_INPUT} | jq -r '.properties.agentPoolProfiles[].name'); do
+  for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -240,8 +240,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       --auth-method client_secret \
       --client-id ${AZURE_CLIENT_ID} \
       --client-secret ${AZURE_CLIENT_SECRET} || exit 1
-    # wait a few mins for added/deleted vms to sync with the k8s api node registration state
-    sleep 5m
+
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -105,7 +105,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
     ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP" || exit 1
+    /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   # shellcheck disable=SC2012
   REGION=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2 | cut -d- -f2)
   if [ $(( RANDOM % 4 )) -eq 3 ]; then
@@ -179,12 +179,6 @@ if [ -n "$ADD_NODE_POOL_INPUT" ]; then
 fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
-  docker run --rm \
-    -v $(pwd):${WORK_DIR} \
-    -w ${WORK_DIR} \
-    -e RESOURCE_GROUP=$RESOURCE_GROUP \
-    ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
@@ -286,12 +280,6 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
 fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
-  docker run --rm \
-    -v $(pwd):${WORK_DIR} \
-    -w ${WORK_DIR} \
-    -e RESOURCE_GROUP=$RESOURCE_GROUP \
-    ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 777 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
     -v $(pwd):${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -232,7 +232,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       -e REGION=$REGION \
       -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
       ${DEV_IMAGE} \
-      /bin/bash -c "chmod -R 766 _output/" || exit 1
+      /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   docker run --rm \
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -176,8 +176,10 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
+    -e HOST_USER=${USER} \
+    -e HOST_GROUP=${USER} \
     ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
+    /bin/bash -c "chown $HOST_USER:$HOST_USER _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
       -v $(pwd):${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -99,12 +99,6 @@ docker run --rm \
 if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n "$ADD_NODE_POOL_INPUT" ]; then
   # shellcheck disable=SC2012
   RESOURCE_GROUP=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2)
-  docker run --rm \
-    -v $(pwd):${WORK_DIR} \
-    -w ${WORK_DIR} \
-    -e RESOURCE_GROUP=$RESOURCE_GROUP \
-    ${DEV_IMAGE} \
-    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   # shellcheck disable=SC2012
   REGION=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2 | cut -d- -f2)
   if [ $(( RANDOM % 4 )) -eq 3 ]; then
@@ -178,6 +172,12 @@ if [ -n "$ADD_NODE_POOL_INPUT" ]; then
 fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
+  docker run --rm \
+    -v $(pwd):${WORK_DIR} \
+    -w ${WORK_DIR} \
+    -e RESOURCE_GROUP=$RESOURCE_GROUP \
+    ${DEV_IMAGE} \
+    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
@@ -223,6 +223,12 @@ fi
 
 if [ "${UPGRADE_CLUSTER}" = "true" ]; then
   # modify the master VM SKU to simulate vertical vm scaling via upgrade
+  docker run --rm \
+    -v $(pwd):${WORK_DIR} \
+    -w ${WORK_DIR} \
+    -e RESOURCE_GROUP=$RESOURCE_GROUP \
+    ${DEV_IMAGE} \
+    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   docker run --rm \
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \
@@ -279,6 +285,12 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
 fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
+  docker run --rm \
+    -v $(pwd):${WORK_DIR} \
+    -w ${WORK_DIR} \
+    -e RESOURCE_GROUP=$RESOURCE_GROUP \
+    ${DEV_IMAGE} \
+    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for nodepool in $(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json); do
     docker run --rm \
     -v $(pwd):${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -240,7 +240,8 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       --auth-method client_secret \
       --client-id ${AZURE_CLIENT_ID} \
       --client-secret ${AZURE_CLIENT_SECRET} || exit 1
-
+    # wait a few mins for added/deleted vms to sync with the k8s api node registration state
+    sleep 5m
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -223,6 +223,22 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
       ${DEV_IMAGE} \
       /bin/bash -c "jq --arg sku \"$MASTER_VM_UPGRADE_SKU\" '. | .properties.masterProfile.vmSize = \$sku' < _output/$RESOURCE_GROUP/apimodel.json > _output/$RESOURCE_GROUP/apimodel-upgrade.json" || exit 1
+  docker run --rm \
+      -v $(pwd):${WORK_DIR} \
+      -w ${WORK_DIR} \
+      -e RESOURCE_GROUP=$RESOURCE_GROUP \
+      -e REGION=$REGION \
+      -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
+      ${DEV_IMAGE} \
+      /bin/bash -c "chmod -R 766 _output/" || exit 1
+  docker run --rm \
+      -v $(pwd):${WORK_DIR} \
+      -w ${WORK_DIR} \
+      -e RESOURCE_GROUP=$RESOURCE_GROUP \
+      -e REGION=$REGION \
+      -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
+      ${DEV_IMAGE} \
+      /bin/bash -c "mv _output/$RESOURCE_GROUP/apimodel-upgrade.json _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for ver_target in $UPGRADE_VERSIONS; do
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
@@ -232,7 +248,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       ${DEV_IMAGE} \
       ./bin/aks-engine upgrade --force \
       --subscription-id ${AZURE_SUBSCRIPTION_ID} \
-      --api-model _output/$RESOURCE_GROUP/apimodel-upgrade.json \
+      --api-model _output/$RESOURCE_GROUP/apimodel.json \
       --location $REGION \
       --resource-group $RESOURCE_GROUP \
       --upgrade-version $ver_target \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -97,16 +97,14 @@ docker run --rm \
 "${DEV_IMAGE}" make test-kubernetes || exit 1
 
 if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n "$ADD_NODE_POOL_INPUT" ]; then
+  # shellcheck disable=SC2012
+  RESOURCE_GROUP=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2)
   docker run --rm \
     -v $(pwd):${WORK_DIR} \
     -w ${WORK_DIR} \
     -e RESOURCE_GROUP=$RESOURCE_GROUP \
-    -e REGION=$REGION \
-    -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
     ${DEV_IMAGE} \
     /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
-  # shellcheck disable=SC2012
-  RESOURCE_GROUP=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2)
   # shellcheck disable=SC2012
   REGION=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2 | cut -d- -f2)
   if [ $(( RANDOM % 4 )) -eq 3 ]; then
@@ -229,7 +227,6 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \
       -e RESOURCE_GROUP=$RESOURCE_GROUP \
-      -e REGION=$REGION \
       -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
       ${DEV_IMAGE} \
       /bin/bash -c "jq --arg sku \"$MASTER_VM_UPGRADE_SKU\" '. | .properties.masterProfile.vmSize = \$sku' < _output/$RESOURCE_GROUP/apimodel.json > _output/$RESOURCE_GROUP/apimodel-upgrade.json" || exit 1
@@ -237,8 +234,6 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \
       -e RESOURCE_GROUP=$RESOURCE_GROUP \
-      -e REGION=$REGION \
-      -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
       ${DEV_IMAGE} \
       /bin/bash -c "mv _output/$RESOURCE_GROUP/apimodel-upgrade.json _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   for ver_target in $UPGRADE_VERSIONS; do

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -166,7 +166,7 @@ if [ -n "$ADD_NODE_POOL_INPUT" ]; then
     -e SKIP_LOGS_COLLECTION=true \
     -e GINKGO_SKIP="${SKIP_AFTER_SCALE_DOWN}" \
     -e GINKGO_FOCUS="${GINKGO_FOCUS}" \
-    -e SKIP_TEST=${SKIP_TESTS_AFTER_SCALE_DOWN} \
+    -e SKIP_TEST=${SKIP_TESTS_AFTER_ADD_POOL} \
     -e ADD_NODE_POOL_INPUT=${ADD_NODE_POOL_INPUT} \
     ${DEV_IMAGE} make test-kubernetes || exit 1
 fi
@@ -322,7 +322,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -e SKIP_LOGS_COLLECTION=${SKIP_LOGS_COLLECTION} \
     -e GINKGO_SKIP="${SKIP_AFTER_SCALE_UP}" \
     -e GINKGO_FOCUS="${GINKGO_FOCUS}" \
-    -e SKIP_TEST=${SKIP_TESTS_AFTER_SCALE_DOWN} \
+    -e SKIP_TEST=${SKIP_TESTS_AFTER_SCALE_UP} \
     -e ADD_NODE_POOL_INPUT=${ADD_NODE_POOL_INPUT} \
     ${DEV_IMAGE} make test-kubernetes || exit 1
 fi

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -97,6 +97,14 @@ docker run --rm \
 "${DEV_IMAGE}" make test-kubernetes || exit 1
 
 if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n "$ADD_NODE_POOL_INPUT" ]; then
+  docker run --rm \
+    -v $(pwd):${WORK_DIR} \
+    -w ${WORK_DIR} \
+    -e RESOURCE_GROUP=$RESOURCE_GROUP \
+    -e REGION=$REGION \
+    -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
+    ${DEV_IMAGE} \
+    /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   # shellcheck disable=SC2012
   RESOURCE_GROUP=$(ls -dt1 _output/* | head -n 1 | cut -d/ -f2)
   # shellcheck disable=SC2012
@@ -225,14 +233,6 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
       ${DEV_IMAGE} \
       /bin/bash -c "jq --arg sku \"$MASTER_VM_UPGRADE_SKU\" '. | .properties.masterProfile.vmSize = \$sku' < _output/$RESOURCE_GROUP/apimodel.json > _output/$RESOURCE_GROUP/apimodel-upgrade.json" || exit 1
-  docker run --rm \
-      -v $(pwd):${WORK_DIR} \
-      -w ${WORK_DIR} \
-      -e RESOURCE_GROUP=$RESOURCE_GROUP \
-      -e REGION=$REGION \
-      -e MASTER_VM_UPGRADE_SKU=$MASTER_VM_UPGRADE_SKU \
-      ${DEV_IMAGE} \
-      /bin/bash -c "chmod -R 766 _output/$RESOURCE_GROUP/apimodel.json" || exit 1
   docker run --rm \
       -v $(pwd):${WORK_DIR} \
       -w ${WORK_DIR} \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -112,7 +112,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
   fi
   git reset --hard
   git remote add $UPGRADE_FORK https://github.com/$UPGRADE_FORK/aks-engine.git
-  git fetch $UPGRADE_FORK
+  git fetch --prune $UPGRADE_FORK
   git branch -D $UPGRADE_FORK/$UPGRADE_BRANCH
   git checkout -b $UPGRADE_FORK/$UPGRADE_BRANCH --track $UPGRADE_FORK/$UPGRADE_BRANCH
   git pull

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -240,6 +240,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
 				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
+				node.DescribeNodes()
 				for _, node := range nodes {
 					Expect("v" + eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion).To(Equal(node.Version()))
 				}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				var nodes []node.Node
 				var err error
 				if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
-					nodes, err = node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err = node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				} else {
 					nodes = masterNodes
 				}
@@ -213,7 +213,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if cfg.BlockSSHPort {
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
-				nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				cloudproviderConfigValidateScript := "cloudprovider-config-validate.sh"
 				err = sshConn.CopyTo(cloudproviderConfigValidateScript)
@@ -238,7 +238,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should have the expected k8s version", func() {
 			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
-				nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				for _, node := range nodes {
 					Expect("v" + eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion).To(Equal(node.Version()))
@@ -268,7 +268,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.RequiresDocker() {
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					dockerVersionCmd := fmt.Sprintf("\"docker version\"")
 					for _, node := range nodes {
@@ -294,7 +294,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.IsVHDDistroForAllNodes() {
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					rootPasswdCmd := fmt.Sprintf("\"sudo grep '^root:[!*]:' /etc/shadow\" && exit 1 || exit 0")
 					for _, node := range nodes {
@@ -327,7 +327,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 							largeSKUPrefixes = append(largeSKUPrefixes, "k8s-"+profile.Name)
 						}
 					}
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					netConfigValidateScript := "net-config-validate.sh"
 					err = sshConn.CopyTo(netConfigValidateScript)
@@ -358,7 +358,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.IsVHDDistroForAllNodes() {
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					CISFilesValidateScript := "CIS-files-validate.sh"
 					err = sshConn.CopyTo(CISFilesValidateScript)
@@ -388,7 +388,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.IsVHDDistroForAllNodes() {
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					modprobeConfigValidateScript := "modprobe-config-validate.sh"
 					err = sshConn.CopyTo(modprobeConfigValidateScript)
@@ -416,7 +416,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if cfg.BlockSSHPort {
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
-				nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				installedPackagesValidateScript := "ubuntu-installed-packages-validate.sh"
 				err = sshConn.CopyTo(installedPackagesValidateScript)
@@ -442,7 +442,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.IsVHDDistroForAllNodes() {
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					sshdConfigValidateScript := "sshd-config-validate.sh"
 					err = sshConn.CopyTo(sshdConfigValidateScript)
@@ -471,7 +471,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.IsVHDDistroForAllNodes() {
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					pwQualityValidateScript := "pwquality-validate.sh"
 					err = sshConn.CopyTo(pwQualityValidateScript)
@@ -513,7 +513,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						auditDNodePrefixes = append(auditDNodePrefixes, profile.Name)
 					}
 				}
-				nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				auditdValidateScript := "auditd-validate.sh"
 				err = sshConn.CopyTo(auditdValidateScript)
@@ -672,7 +672,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have node labels specific to masters or agents", func() {
-			nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+			nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
 			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() &&
 				cfg.AddNodePoolInput == "" {
@@ -1018,7 +1018,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					By("Ensuring that we can connect via HTTPS to the dashboard on any one node")
 					dashboardPort := 443
 					port := s.GetNodePort(dashboardPort)
-					nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					var success bool
 					for _, node := range nodes {
@@ -1107,7 +1107,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.HasWindowsAgents() {
 					if eng.ExpandedDefinition.Properties.WindowsProfile != nil && eng.ExpandedDefinition.Properties.WindowsProfile.SSHEnabled {
-						nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+						nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 						Expect(err).NotTo(HaveOccurred())
 						simulateDockerdCrashScript := "simulate-dockerd-crash.cmd"
 						err = sshConn.CopyTo(simulateDockerdCrashScript)
@@ -1371,7 +1371,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 	Describe("with zoned master profile", func() {
 		It("should be labeled with zones for each masternode", func() {
 			if eng.ExpandedDefinition.Properties.MasterProfile.HasAvailabilityZones() {
-				nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				for _, node := range nodes {
 					role := node.Metadata.Labels["kubernetes.io/role"]
@@ -1391,7 +1391,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 	Describe("with all zoned agent pools", func() {
 		It("should be labeled with zones for each node", func() {
 			if eng.ExpandedDefinition.Properties.HasZonesForAllAgentPools() {
-				nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				for _, node := range nodes {
 					role := node.Metadata.Labels["kubernetes.io/role"]
@@ -1926,7 +1926,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if cfg.BlockSSHPort {
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
-				nodes, err := node.GetWithRetry(1*time.Second, cfg.Timeout)
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				timeSyncValidateScript := "time-sync-validate.sh"
 				err = sshConn.CopyTo(timeSyncValidateScript)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -240,8 +240,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
 				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
-				node.DescribeNodes()
 				for _, node := range nodes {
+					err := node.Describe()
+					if err != nil {
+						log.Printf("Unable to describe node %s: %s", node.Metadata.Name, err)
+					}
 					Expect("v" + eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion).To(Equal(node.Version()))
 				}
 			} else {

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -136,19 +136,13 @@ func GetByRegexAsync(regex string) GetNodesResult {
 // IsReady returns if the node is in a Ready state
 func (n *Node) IsReady() bool {
 	if n.Spec.Unschedulable {
-		log.Printf("Unready node\n")
-		log.Printf("%#v\n", n)
 		return false
 	}
 	for _, condition := range n.Status.Conditions {
 		if condition.Type == "Ready" && condition.Status == "True" {
-			log.Printf("Ready node\n")
-			log.Printf("%#v\n", n)
 			return true
 		}
 	}
-	log.Printf("Unready node\n")
-	log.Printf("%#v\n", n)
 	return false
 }
 

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -39,7 +39,8 @@ type Metadata struct {
 
 // Spec contains things like taints
 type Spec struct {
-	Taints []Taint `json:"taints"`
+	Taints        []Taint `json:"taints"`
+	Unschedulable bool    `json:"unschedulable"`
 }
 
 // Taint defines a Node Taint
@@ -135,7 +136,7 @@ func GetByRegexAsync(regex string) GetNodesResult {
 // IsReady returns if the node is in a Ready state
 func (n *Node) IsReady() bool {
 	for _, condition := range n.Status.Conditions {
-		if condition.Type == "Ready" && condition.Status == "True" {
+		if condition.Type == "Ready" && condition.Status == "True" && !n.Spec.Unschedulable {
 			return true
 		}
 	}

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -135,8 +135,11 @@ func GetByRegexAsync(regex string) GetNodesResult {
 
 // IsReady returns if the node is in a Ready state
 func (n *Node) IsReady() bool {
+	if n.Spec.Unschedulable {
+		return false
+	}
 	for _, condition := range n.Status.Conditions {
-		if condition.Type == "Ready" && condition.Status == "True" && !n.Spec.Unschedulable {
+		if condition.Type == "Ready" && condition.Status == "True" {
 			return true
 		}
 	}

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -136,13 +136,19 @@ func GetByRegexAsync(regex string) GetNodesResult {
 // IsReady returns if the node is in a Ready state
 func (n *Node) IsReady() bool {
 	if n.Spec.Unschedulable {
+		log.Printf("Unready node\n")
+		log.Printf("%#v\n", n)
 		return false
 	}
 	for _, condition := range n.Status.Conditions {
 		if condition.Type == "Ready" && condition.Status == "True" {
+			log.Printf("Ready node\n")
+			log.Printf("%#v\n", n)
 			return true
 		}
 	}
+	log.Printf("Unready node\n")
+	log.Printf("%#v\n", n)
 	return false
 }
 
@@ -501,6 +507,8 @@ func GetReady() (*List, error) {
 	for _, node := range l.Nodes {
 		if node.IsReady() {
 			nl.Nodes = append(nl.Nodes, node)
+		} else {
+			log.Printf("found an unready node!")
 		}
 	}
 	return nl, nil


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

Use `Ready` as a required node status before determining to test it. This is more sane in general, and specifically, should help improve test flakes when running E2E immediately after running `aks-engine upgrade`, which may finish before all deleted vms have been unregistered as nodes in the cluster.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
