### PR TITLE
fix: don't expire adminUser or etcd accounts

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -23,9 +23,16 @@ systemctlEnableAndStart() {
     fi
 }
 
+configureAdminUser(){
+    chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
+    chage -l "${ADMINUSER}"
+}
+
 configureEtcdUser(){
-    useradd -U "etcd"
-    id "etcd"
+    useradd -U etcd
+    chage -E -1 -I -1 -m 0 -M 99999 etcd
+    chage -l etcd
+    id etcd
 }
 
 configureSecrets(){

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -52,6 +52,8 @@ else
     REBOOTREQUIRED=false
 fi
 
+time_metric "ConfigureAdminUser" configureAdminUser
+
 {{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd
 {{end}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -36234,9 +36234,16 @@ systemctlEnableAndStart() {
     fi
 }
 
+configureAdminUser(){
+    chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
+    chage -l "${ADMINUSER}"
+}
+
 configureEtcdUser(){
-    useradd -U "etcd"
-    id "etcd"
+    useradd -U etcd
+    chage -E -1 -I -1 -m 0 -M 99999 etcd
+    chage -l etcd
+    id etcd
 }
 
 configureSecrets(){
@@ -37612,6 +37619,8 @@ if [ -f /var/run/reboot-required ]; then
 else
     REBOOTREQUIRED=false
 fi
+
+time_metric "ConfigureAdminUser" configureAdminUser
 
 {{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd


### PR DESCRIPTION
**Reason for Change**:
Removes password expiration for the Linux `adminUser` account, since it uses only public key auth. Same for the non-interactive `etcd` account. Leaves the default rotation policy intact for accounts that may be created with passwords.

```shell
$ sudo cat /etc/shadow  # before
root:*LOCK*:14600::::::
daemon:*:18268:0:99999:7:::
bin:*:18268:0:99999:7:::
sys:*:18268:0:99999:7:::
...
statd:*:18277:0:99999:7:::
azureuser:!:18292:7:90:7:30::
etcd:!:18292:7:90:7:30::

$ sudo cat /etc/shadow  # after
root:*LOCK*:14600::::::
daemon:*:18268:0:99999:7:::
bin:*:18268:0:99999:7:::
sys:*:18268:0:99999:7:::
...
statd:*:18277:0:99999:7:::
azureuser:!:18292:0:99999:7:::
etcd:!:18292:0:99999:7:::
```

**Issue Fixed**:
Closes #2569 
Fixes #2277

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
