### PR TITLE
fix: unknown ostype when getting an index should probably create an error

### DIFF
--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -155,15 +155,18 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 			log.Errorln(err)
 			return 0, err
 		}
-	} else if osType == compute.Windows {
+		return agentIndex, nil
+	} 
+	if osType == compute.Windows {
 		_, _, _, agentIndex, err = WindowsVMNameParts(vmName)
 		if err != nil {
 			log.Errorln(err)
 			return 0, err
 		}
-	}
+		return agentIndex, nil 
+	} 
 
-	return agentIndex, nil
+	return 0, errors.Errorf("Unknown os type. Can't determine vm index")
 }
 
 // GetK8sVMName reconstructs the VM name

--- a/pkg/armhelpers/utils/util.go
+++ b/pkg/armhelpers/utils/util.go
@@ -156,15 +156,15 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 			return 0, err
 		}
 		return agentIndex, nil
-	} 
+	}
 	if osType == compute.Windows {
 		_, _, _, agentIndex, err = WindowsVMNameParts(vmName)
 		if err != nil {
 			log.Errorln(err)
 			return 0, err
 		}
-		return agentIndex, nil 
-	} 
+		return agentIndex, nil
+	}
 
 	return 0, errors.Errorf("Unknown os type. Can't determine vm index")
 }

--- a/pkg/armhelpers/utils/util_test.go
+++ b/pkg/armhelpers/utils/util_test.go
@@ -133,6 +133,14 @@ func Test_WindowsVMNameParts(t *testing.T) {
 	}
 }
 
+func Test_GetVMNameIndexUnknown(t *testing.T) {
+	var ostype compute.OperatingSystemTypes
+	_, err := GetVMNameIndex(ostype, "k8s-agentpool1-38988164-65")
+	if err == nil {
+		t.Fatalf("unexpected error but got none")
+	}
+}
+
 func Test_GetVMNameIndexLinux(t *testing.T) {
 	expectedAgentIndex := 65
 


### PR DESCRIPTION

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Unknown ostype when getting an index should probably create an error
Today it just returns zero. Not sure if this is a real problem but popped up in our unittests that consume this package. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Can create an issue but my face was already in the code :)

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [fix ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
