### PR TITLE
feat: install bpftrace + bcc by default

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -61,6 +61,13 @@ ERR_AZURE_STACK_GET_ARM_TOKEN=120 {{/* Error generating a token to use with Azur
 ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION=121 {{/* Error fetching the network configuration for the node */}}
 ERR_AZURE_STACK_GET_SUBNET_PREFIX=122 {{/* Error fetching the subnet address prefix for a subnet ID */}}
 
+{{/* BCC/BPF-related error codes */}}
+ERR_IOVISOR_KEY_DOWNLOAD_TIMEOUT=126 {{/* Timeout waiting to download IOVisor repo key */}}
+ERR_IOVISOR_APT_KEY_TIMEOUT=127 {{/* Timeout waiting for IOVisor apt-key */}}
+ERR_BCC_INSTALL_TIMEOUT=128 {{/* Timeout waiting for bcc install */}}
+ERR_BPFTRACE_BIN_DOWNLOAD_FAIL=129 {{/* Failed to download bpftrace binary */}}
+ERR_BPFTRACE_TOOLS_DOWNLOAD_FAIL=130 {{/* Failed to download bpftrace default programs */}}
+
 OS=$(sort -r /etc/*-release | gawk 'match($0, /^(ID_LIKE=(coreos)|ID=(.*))$/, a) { print toupper(a[2] a[3]); exit }')
 UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -8,7 +8,9 @@ CNI_DOWNLOADS_DIR="/opt/cni/downloads"
 CONTAINERD_DOWNLOADS_DIR="/opt/containerd/downloads"
 K8S_DOWNLOADS_DIR="/opt/kubernetes/downloads"
 APMZ_DOWNLOADS_DIR="/opt/apmz/downloads"
+BPFTRACE_DOWNLOADS_DIR="/opt/bpftrace/downloads"
 UBUNTU_RELEASE=$(lsb_release -r -s)
+UBUNTU_CODENAME=$(lsb_release -c -s)
 
 removeEtcd() {
     if [[ $OS == $COREOS_OS_NAME ]]; then
@@ -169,6 +171,18 @@ installNetworkPlugin() {
     rm -rf $CNI_DOWNLOADS_DIR &
 }
 
+installBcc() {
+    echo "Installing BCC tools..."
+    IOVISOR_KEY_TMP=/tmp/iovisor-release.key
+    IOVISOR_URL=https://repo.iovisor.org/GPG-KEY
+    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL $IOVISOR_URL > $IOVISOR_KEY_TMP || exit $ERR_IOVISOR_KEY_DOWNLOAD_TIMEOUT
+    wait_for_apt_locks
+    retrycmd_if_failure 30 5 30 apt-key add $IOVISOR_KEY_TMP || exit $ERR_IOVISOR_APT_KEY_TIMEOUT
+    echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/iovisor.list
+    apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
+    apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit $ERR_BCC_INSTALL_TIMEOUT
+}
+
 downloadCNI() {
     mkdir -p $CNI_DOWNLOADS_DIR
     CNI_TGZ_TMP=$(echo ${CNI_PLUGINS_URL} | cut -d "/" -f 5)
@@ -207,6 +221,34 @@ ensureAPMZ() {
     bin_path="$install_dir/apmz_linux_amd64"
     chmod +x "$bin_path"
     ln -Ffs "$bin_path" "$apmz_filepath" # symlink apmz into /usr/local/bin/apmz
+}
+
+installBpftrace() {
+    local version="v0.9.4"
+    local bpftrace_bin="bpftrace"
+    local bpftrace_tools="bpftrace-tools.tar"
+    local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
+    local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
+    local tools_filepath="/usr/local/share/$bpftrace_bin"
+    if [[ -f "$bpftrace_filepath" ]]; then
+        installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
+        if [[ "$version" == "$installed_version" ]]; then
+            return
+        fi
+        rm "$bpftrace_filepath"
+        if [[ -d "$tools_filepath" ]]; then
+            rm -r  "$tools_filepath"
+        fi
+    fi
+    mkdir -p "$tools_filepath"
+    install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
+    mkdir -p "$install_dir"
+    download_path="$install_dir/$bpftrace_tools"
+    retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit $ERR_BPFTRACE_BIN_DOWNLOAD_FAIL
+    retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit $ERR_BPFTRACE_TOOLS_DOWNLOAD_FAIL
+    tar -xvf "$download_path" -C "$tools_filepath"
+    chmod +x "$bpftrace_filepath"
+    chmod -R +x "$tools_filepath/tools"
 }
 
 installCNI() {

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -77,12 +77,17 @@ fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]] && [ "$FULL_INSTALL_REQUIRED" = "true" ]; then
     time_metric "InstallDeps" installDeps
+    time_metric "InstallBcc" installBcc
 else
     echo "Golden image; skipping dependencies installation"
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then
     time_metric "EnsureAuditD" ensureAuditD
+fi
+
+if [[ "$FULL_INSTALL_REQUIRED" = "true" ]]; then
+    time_metric "InstallBpftrace" installBpftrace
 fi
 
 {{- if not HasCoreOS}}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1807,7 +1807,7 @@ func TestWindowsProfileDefaults(t *testing.T) {
 			WindowsProfile{
 				WindowsPublisher: WindowsServer2019OSImageConfig.ImagePublisher,
 				WindowsOffer:     WindowsServer2019OSImageConfig.ImageOffer,
-				WindowsSku:     "override",
+				WindowsSku:       "override",
 			},
 			WindowsProfile{
 				WindowsPublisher:      WindowsServer2019OSImageConfig.ImagePublisher,

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -54,6 +54,9 @@ apmz_version="v0.4.0"
 ensureAPMZ "${apmz_version}"
 echo "  - apmz $apmz_version" >> ${VHD_LOGS_FILEPATH}
 
+installBpftrace
+echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
+
 MOBY_VERSION="3.0.10"
 installMoby
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
@@ -64,6 +67,12 @@ ETCD_VERSION="3.3.18"
 ETCD_DOWNLOAD_URL="mcr.microsoft.com/oss/etcd-io/"
 installEtcd "docker"
 echo "  - etcd v${ETCD_VERSION}" >> ${VHD_LOGS_FILEPATH}
+
+installBcc
+cat << EOF >> ${VHD_LOGS_FILEPATH}
+  - bcc-tools
+  - libbcc-examples
+EOF
 
 VNET_CNI_VERSIONS="
 1.0.30


### PR DESCRIPTION
**Reason for Change**:
This PR adds base layer of bpf debugging tools to aks-engine vhd + and cse install script. We'd like every cluster we bootstrap to have these tools available to do deep performance analysis and debugging, both ad-hoc and via automation. While we'd ultimately like to get bpftrace binaries on the system, we can immediately get benefit by using the lower-level bcc tools now. These also have much quicker install time, so it's easy to add them into the normal install path.

update: added bpftrace binary! for automation use cases and programmable interaction with the data, we will still want to keep the bcc libs installed. so this change can be purely additive.

**Issue Fixed**:
n/a

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
