### PR TITLE
fix: add ProgressPreference=SilentlyContinue to disable progress bar

### DIFF
--- a/scripts/collect-windows-logs.ps1
+++ b/scripts/collect-windows-logs.ps1
@@ -1,3 +1,5 @@
+$ProgressPreference="SilentlyContinue"
+
 $lockedFiles = "kubelet.err.log", "kubelet.log", "kubeproxy.log", "kubeproxy.err.log", "containerd.err.log", "containerd.log", "azure-vnet-telemetry.log", "azure-vnet.log"
 
 $timeStamp = get-date -format 'yyyyMMdd-hhmmss'


### PR DESCRIPTION
When running this script remotely via ssh, Compress-Archive will fail because of the progress bar which can't be displayed.
This adds $ProgressPreference="SilentlyContinue" to logs collector script for Windows so that the script won't error out.
