### PR TITLE
test: don't get vms before resource group exists

### DIFF
--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -481,7 +481,7 @@ func (a *Account) GetHosts(name string) ([]VM, error) {
 	} else {
 		resourceGroup = a.ResourceGroup.Name
 	}
-	err = cli.Account.ShowGroupWithRetry(resourceGroup, 3*time.Second, 10*time.Second)
+	err := a.ShowGroupWithRetry(resourceGroup, 3*time.Second, 10*time.Second)
 	if err != nil {
 		log.Printf("Unabled to validate that resource group %s already exists\n", resourceGroup)
 		return v, nil

--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -474,11 +474,17 @@ func (a *Account) UpdateRouteTables(subnet, vnet string) error {
 
 // GetHosts will get a list of vms in the resource group
 func (a *Account) GetHosts(name string) ([]VM, error) {
+	v := []VM{{}}
 	var resourceGroup string
 	if name != "" {
 		resourceGroup = name
 	} else {
 		resourceGroup = a.ResourceGroup.Name
+	}
+	err = cli.Account.ShowGroupWithRetry(resourceGroup, 3*time.Second, 10*time.Second)
+	if err != nil {
+		log.Printf("Unabled to validate that resource group %s already exists\n", resourceGroup)
+		return v, nil
 	}
 	var cmd *exec.Cmd
 	if a.TimeoutCommands {
@@ -492,7 +498,6 @@ func (a *Account) GetHosts(name string) ([]VM, error) {
 		log.Printf("Error while trying to get vm list:%s\n", out)
 		return nil, err
 	}
-	v := []VM{{}}
 	err = json.Unmarshal(out, &v)
 	if err != nil {
 		log.Printf("Error unmarshalling VM json:%s\n", err)

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -78,21 +78,23 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error while trying to build CLI Provisioner:%s", err)
 	}
-	// Store the hosts for future introspection
-	hosts, err := cliProvisioner.Account.GetHosts(cliProvisioner.Config.Name)
-	if err != nil {
-		log.Fatalf("Error while trying to get hosts in resource group:%s", err)
-	}
-	var masters, agents []azure.VM
-	for _, host := range hosts {
-		if strings.Contains(host.Name, "master") {
-			masters = append(masters, host)
-		} else if strings.Contains(host.Name, "agent") {
-			agents = append(agents, host)
+	if cliProvisioner.Config.Name != "" {
+		// Store the hosts for future introspection
+		hosts, err := cliProvisioner.Account.GetHosts(cliProvisioner.Config.Name)
+		if err != nil {
+			log.Fatalf("Error while trying to get hosts in resource group:%s", err)
 		}
+		var masters, agents []azure.VM
+		for _, host := range hosts {
+			if strings.Contains(host.Name, "master") {
+				masters = append(masters, host)
+			} else if strings.Contains(host.Name, "agent") {
+				agents = append(agents, host)
+			}
+		}
+		cliProvisioner.Masters = masters
+		cliProvisioner.Agents = agents
 	}
-	cliProvisioner.Masters = masters
-	cliProvisioner.Agents = agents
 
 	sa := acct.StorageAccount
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This fixes creating soak clusters from scratch (before a rg exists).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
