### PR TITLE
add upgrade settings to agent pool profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -647,6 +647,11 @@ type AgentPoolProfile struct {
 	AuditDEnabled                       *bool                `json:"auditDEnabled,omitempty"`
 	CustomVMTags                        map[string]string    `json:"customVMTags,omitempty"`
 	DiskEncryptionSetID                 string               `json:"diskEncryptionSetID,omitempty"`
+	Upgrade                             *PoolUpgradeSettings `json:"upgrade,omitempty"`
+}
+
+type PoolUpgradeSettings struct {
+	MaxSurge string `json:"maxSurge,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
AKS is looking to add surging to upgrading. However our agentpool profiles are still locked to aks-engine. (Discussing changing that but it's a large change). 
So for now we're seeing if just adding upgradesettings to aks-engine's api package is a good idea or not. 

**Issue Fixed**:
None

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
