### PR TITLE
revert: "feat: read vm size from instance metadata service for window…

### DIFF
--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -86,24 +86,6 @@ function Get-CniVersion {
     }
 }
 
-function Get-InstanceMetadataServiceTelemetry {
-    $keys = @{}
-
-    try {
-        # Write-Log "Querying instance metadata service..."
-        # Note: 2019-04-30 is latest api available in all clouds
-        $metadata = Invoke-RestMethod -Headers @{"Metadata"="true"} -URI "http://169.254.169.254/metadata/instance?api-version=2019-04-30" -Method get
-        # Write-Log ($metadata | ConvertTo-Json)
-
-        $keys.Add("vm_size", $metadata.compute.vmSize)
-    }
-    catch {
-        Write-Log "Error querying instance metadata service."
-    }
-
-    return $keys
-}
-
 # https://stackoverflow.com/a/34559554/697126
 function New-TemporaryDirectory {
     $parent = [System.IO.Path]::GetTempPath()

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -193,11 +193,6 @@ try
         }
         $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
 
-        $imdsProperties = Get-InstanceMetadataServiceTelemetry
-        foreach ($key in $imdsProperties.keys) {
-            $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-        }
-
         $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
 
         # Install OpenSSH if SSH enabled

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39112,24 +39112,6 @@ function Get-CniVersion {
     }
 }
 
-function Get-InstanceMetadataServiceTelemetry {
-    $keys = @{}
-
-    try {
-        # Write-Log "Querying instance metadata service..."
-        # Note: 2019-04-30 is latest api available in all clouds
-        $metadata = Invoke-RestMethod -Headers @{"Metadata"="true"} -URI "http://169.254.169.254/metadata/instance?api-version=2019-04-30" -Method get
-        # Write-Log ($metadata | ConvertTo-Json)
-
-        $keys.Add("vm_size", $metadata.compute.vmSize)
-    }
-    catch {
-        Write-Log "Error querying instance metadata service."
-    }
-
-    return $keys
-}
-
 # https://stackoverflow.com/a/34559554/697126
 function New-TemporaryDirectory {
     $parent = [System.IO.Path]::GetTempPath()
@@ -39440,11 +39422,6 @@ try
             $vhdId = Get-Content "c:\vhd-id.txt"
         }
         $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-        $imdsProperties = Get-InstanceMetadataServiceTelemetry
-        foreach ($key in $imdsProperties.keys) {
-            $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-        }
 
         $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
 


### PR DESCRIPTION
…s cse telemetry (#2663)"

This reverts commit 59c2ce09bf9549fd6779303ece5bdd7180176b32.
After this change e2e port forward tests started occasionally failing so
reverting to investigate.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
