### PR TITLE
revert: "fix: raising dynamic port range for windows to better suppor…

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -370,7 +370,6 @@ try
         Write-Log "Update service failure actions"
         Update-ServiceFailureActions
 
-        Adjust-DynamicPortRange
         Register-LogsCleanupScriptTask
 
         if (Test-Path $CacheDir)

--- a/parts/k8s/windowsconfigfunc.ps1
+++ b/parts/k8s/windowsconfigfunc.ps1
@@ -134,13 +134,3 @@ function Adjust-PageFileSize()
 {
     wmic pagefileset set InitialSize=8096,MaximumSize=8096
 }
-
-function Adjust-DynamicPortRange()
-{
-    # Kube-proxy reserves 63 ports per service which limits clusters with Windows nodes
-    # to ~225 services if default port reservations are used.
-    # https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#load-balancers-are-plumbed-inconsistently-across-the-cluster-nodes
-    # Kube-proxy load balancing should be set to DSR mode when it releases with future versions of the OS
-
-    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "16385", "49151")
-}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39618,7 +39618,6 @@ try
         Write-Log "Update service failure actions"
         Update-ServiceFailureActions
 
-        Adjust-DynamicPortRange
         Register-LogsCleanupScriptTask
 
         if (Test-Path $CacheDir)
@@ -40486,16 +40485,7 @@ function Adjust-PageFileSize()
 {
     wmic pagefileset set InitialSize=8096,MaximumSize=8096
 }
-
-function Adjust-DynamicPortRange()
-{
-    # Kube-proxy reserves 63 ports per service which limits clusters with Windows nodes
-    # to ~225 services if default port reservations are used.
-    # https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#load-balancers-are-plumbed-inconsistently-across-the-cluster-nodes
-    # Kube-proxy load balancing should be set to DSR mode when it releases with future versions of the OS
-
-    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "16385", "49151")
-}`)
+`)
 
 func k8sWindowsconfigfuncPs1Bytes() ([]byte, error) {
 	return _k8sWindowsconfigfuncPs1, nil


### PR DESCRIPTION
…t clusters with 200+ services (#2688)"

This reverts commit 30a473ca6ec91182cf15fbfcc51ebd0f5390fec8.
Port forwarding tests started occasionally failing after this PR merged
so reverting and will investigate.

<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
