### PR TITLE
feat: abort/warn if apimodel contains properties not supported by Azure Stack

### DIFF
--- a/pkg/engine/testdata/azurestack/kubernetes.json
+++ b/pkg/engine/testdata/azurestack/kubernetes.json
@@ -40,6 +40,7 @@
             "distro": "ubuntu",
             "osDiskSizeGB": 200,
             "count": 3,
+            "availabilityProfile": "AvailabilitySet",
             "vmSize": "Standard_D2_v2"
         },
         "agentPoolProfiles": [


### PR DESCRIPTION
**Reason for Change**:
Block Azure Stack deployments if apimodel contains unsupported features.
Warn users if they enabled/selected preview features.  

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version