### PR TITLE
fix: update apiserver encryption provider config flag

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -543,8 +543,8 @@ Below is a list of apiserver options that are _not_ currently user-configurable,
 | "--service-cluster-ip-range"                | _see serviceCIDR_                                                                       |
 | "--storage-backend"                         | _calculated value that represents etcd version_                                         |
 | "--v"                                       | "4"                                                                                     |
-| "--experimental-encryption-provider-config" | "/etc/kubernetes/encryption-config.yaml" (_if enableDataEncryptionAtRest is true_)      |
-| "--experimental-encryption-provider-config" | "/etc/kubernetes/encryption-config.yaml" (_if enableEncryptionWithExternalKms is true_) |
+| "--encryption-provider-config"              | "/etc/kubernetes/encryption-config.yaml" (_if enableDataEncryptionAtRest is true_)      |
+| "--encryption-provider-config"              | "/etc/kubernetes/encryption-config.yaml" (_if enableEncryptionWithExternalKms is true_) |
 | "--requestheader-client-ca-file"            | "/etc/kubernetes/certs/proxy-ca.crt" (_if enableAggregatedAPIs is true_)                |
 | "--proxy-client-cert-file"                  | "/etc/kubernetes/certs/proxy.crt" (_if enableAggregatedAPIs is true_)                   |
 | "--proxy-client-key-file"                   | "/etc/kubernetes/certs/proxy.key" (_if enableAggregatedAPIs is true_)                   |

--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -61,7 +61,7 @@ func (cs *ContainerService) setAPIServerConfig() {
 
 	// Data Encryption at REST configuration conditions
 	if to.Bool(o.KubernetesConfig.EnableDataEncryptionAtRest) || to.Bool(o.KubernetesConfig.EnableEncryptionWithExternalKms) {
-		staticAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
+		staticAPIServerConfig["--encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
 	}
 
 	// Aggregated API configuration

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -21,9 +21,9 @@ func TestAPIServerConfigEnableDataEncryptionAtRest(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = to.BoolPtr(true)
 	cs.setAPIServerConfig()
 	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
-	if a["--experimental-encryption-provider-config"] != "/etc/kubernetes/encryption-config.yaml" {
-		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableDataEncryptionAtRest=true: %s",
-			a["--experimental-encryption-provider-config"])
+	if a["--encryption-provider-config"] != "/etc/kubernetes/encryption-config.yaml" {
+		t.Fatalf("got unexpected '--encryption-provider-config' API server config value for EnableDataEncryptionAtRest=true: %s",
+			a["--encryption-provider-config"])
 	}
 
 	// Test EnableDataEncryptionAtRest = false
@@ -31,9 +31,9 @@ func TestAPIServerConfigEnableDataEncryptionAtRest(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = to.BoolPtr(false)
 	cs.setAPIServerConfig()
 	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
-	if _, ok := a["--experimental-encryption-provider-config"]; ok {
-		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableDataEncryptionAtRest=false: %s",
-			a["--experimental-encryption-provider-config"])
+	if _, ok := a["--encryption-provider-config"]; ok {
+		t.Fatalf("got unexpected '--encryption-provider-config' API server config value for EnableDataEncryptionAtRest=false: %s",
+			a["--encryption-provider-config"])
 	}
 }
 
@@ -43,9 +43,9 @@ func TestAPIServerConfigEnableEncryptionWithExternalKms(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms = to.BoolPtr(true)
 	cs.setAPIServerConfig()
 	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
-	if a["--experimental-encryption-provider-config"] != "/etc/kubernetes/encryption-config.yaml" {
-		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableEncryptionWithExternalKms=true: %s",
-			a["--experimental-encryption-provider-config"])
+	if a["--encryption-provider-config"] != "/etc/kubernetes/encryption-config.yaml" {
+		t.Fatalf("got unexpected '--encryption-provider-config' API server config value for EnableEncryptionWithExternalKms=true: %s",
+			a["--encryption-provider-config"])
 	}
 
 	// Test EnableEncryptionWithExternalKms = false
@@ -53,9 +53,9 @@ func TestAPIServerConfigEnableEncryptionWithExternalKms(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms = to.BoolPtr(false)
 	cs.setAPIServerConfig()
 	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
-	if _, ok := a["--experimental-encryption-provider-config"]; ok {
-		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableEncryptionWithExternalKms=false: %s",
-			a["--experimental-encryption-provider-config"])
+	if _, ok := a["--encryption-provider-config"]; ok {
+		t.Fatalf("got unexpected '--encryption-provider-config' API server config value for EnableEncryptionWithExternalKms=false: %s",
+			a["--encryption-provider-config"])
 	}
 }
 


### PR DESCRIPTION
**Reason for Change**:
Updates a kube-apiserver flag to its non-experimental name, which has been in effect since k8s 1.13.

**Issue Fixed**:
Fixes #2720


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
