### PR TITLE
fix: apply large ipv4 neigh GC settings to nodes of all sizes

### DIFF
--- a/parts/k8s/cloud-init/artifacts/kubelet.service
+++ b/parts/k8s/cloud-init/artifacts/kubelet.service
@@ -22,9 +22,9 @@ ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_max_syn_backlog=16384
 ExecStartPre=/sbin/sysctl -w net.core.message_cost=40
 ExecStartPre=/sbin/sysctl -w net.core.message_burst=80
 
-ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=4096; fi"
-ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh2=8192; fi"
-ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh3=16384; fi"
+ExecStartPre=/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=4096
+ExecStartPre=/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh2=8192
+ExecStartPre=/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh3=16384
 
 ExecStartPre=-/sbin/ebtables -t nat --list
 ExecStartPre=-/sbin/iptables -t nat --numeric --list

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -36659,9 +36659,9 @@ ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_max_syn_backlog=16384
 ExecStartPre=/sbin/sysctl -w net.core.message_cost=40
 ExecStartPre=/sbin/sysctl -w net.core.message_burst=80
 
-ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=4096; fi"
-ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh2=8192; fi"
-ExecStartPre=/bin/bash -c "if [ $(nproc) -gt 8 ]; then /sbin/sysctl -w net.ipv4.neigh.default.gc_thresh3=16384; fi"
+ExecStartPre=/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=4096
+ExecStartPre=/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh2=8192
+ExecStartPre=/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh3=16384
 
 ExecStartPre=-/sbin/ebtables -t nat --list
 ExecStartPre=-/sbin/iptables -t nat --numeric --list

--- a/test/e2e/kubernetes/scripts/net-config-validate.sh
+++ b/test/e2e/kubernetes/scripts/net-config-validate.sh
@@ -15,9 +15,9 @@ SOMAXCONN=16384
 TCP_MAX_SYN_BACKLOG=16384
 MESSAGE_COST=40
 MESSAGE_BURST=80
-GT_8_CORES_GC_THRESH1=4096
-GT_8_CORES_GC_THRESH2=8192
-GT_8_CORES_GC_THRESH3=16384
+IPV4_NEIGH_GC_THRESH1=4096
+IPV4_NEIGH_GC_THRESH2=8192
+IPV4_NEIGH_GC_THRESH3=16384
 
 set -x
 grep $IPV4_SEND_REDIRECTS_VALUE /proc/sys/net/ipv4/conf/all/send_redirects || exit 1
@@ -46,8 +46,6 @@ grep $TCP_MAX_SYN_BACKLOG /proc/sys/net/ipv4/tcp_max_syn_backlog || exit 1
 grep $MESSAGE_COST /proc/sys/net/core/message_cost || exit 1
 grep $MESSAGE_BURST /proc/sys/net/core/message_burst || exit 1
 
-if [[ "${GT_8_CORE_SKU}" == "true" ]]; then
-    grep $GT_8_CORES_GC_THRESH1 /proc/sys/net/ipv4/neigh/default/gc_thresh1 || exit 1
-    grep $GT_8_CORES_GC_THRESH2 /proc/sys/net/ipv4/neigh/default/gc_thresh2 || exit 1
-    grep $GT_8_CORES_GC_THRESH3 /proc/sys/net/ipv4/neigh/default/gc_thresh3 || exit 1
-fi
+grep $IPV4_NEIGH_GC_THRESH1 /proc/sys/net/ipv4/neigh/default/gc_thresh1 || exit 1
+grep $IPV4_NEIGH_GC_THRESH2 /proc/sys/net/ipv4/neigh/default/gc_thresh2 || exit 1
+grep $IPV4_NEIGH_GC_THRESH3 /proc/sys/net/ipv4/neigh/default/gc_thresh3 || exit 1


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
We should apply the large IPv4 neigh GC settings for all nodes (instead of just nodes with more than 8 cores). This is needed because we have seen many cases where CoreDNS is only working intermittently due to this issue. CoreDNS may not run on a large node but still has to handle many connections to it from many other pods.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
