### PR TITLE
ci: stop testing k8s 1.13

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -74,14 +74,6 @@ jobs:
 
 - template: e2e-job-template.yaml
   parameters:
-    name: 'k8s_1_13_release_e2e'
-    k8sRelease: '1.13'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
-    enableKMSEncryption: true
-
-- template: e2e-job-template.yaml
-  parameters:
     name: 'k8s_1_14_release_e2e'
     k8sRelease: '1.14'
     apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ defaultEnv = [
 	CREATE_VNET: false,
 	] + params
 
-def k8sVersions = ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18"]
+def k8sVersions = ["1.14", "1.15", "1.16", "1.17", "1.18"]
 def latestReleasedVersion = "1.17"
 def tasks = [:]
 def testConfigs = []


### PR DESCRIPTION
**Reason for Change**:
Kubernetes 1.13 has been off the support matrix for a while, so in advance of disabling it, let's stop using CI resources to test it.

AKS is dropping support for 1.13 on [Feb. 28th](https://github.com/Azure/AKS/releases/tag/2020-02-03).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
