### PR TITLE
fix: Set vnetCidr by the address space of the vnet (#2725)

### DIFF
--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -78,6 +78,14 @@ func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVers
 	}
 	if properties.HostedMasterProfile != nil {
 		addValue(parametersMap, "masterSubnet", properties.HostedMasterProfile.Subnet)
+
+		// For AKS, VnetCidrs of the default (the first) agent pool will be set when users create a k8s
+		// cluster with a custom vnet. Set vnetCidr if a custom vnet is used so the address space can be
+		// added into the ExceptionList of Windows nodes. Otherwise, the default value `10.0.0.0/8` will
+		// be added into the ExceptionList and it does not work if users use other ip address ranges.
+		if len(properties.AgentPoolProfiles) > 0 && len(properties.AgentPoolProfiles[0].VnetCidrs) > 0 {
+			addValue(parametersMap, "vnetCidr", properties.AgentPoolProfiles[0].VnetCidrs[0])
+		}
 	}
 
 	if linuxProfile != nil {

--- a/pkg/engine/params_test.go
+++ b/pkg/engine/params_test.go
@@ -53,3 +53,63 @@ func TestAssignParameters(t *testing.T) {
 		}
 	}
 }
+
+func TestAssignVnetCidr(t *testing.T) {
+	// Initialize locale for translation
+	locale := gotext.NewLocale(path.Join("..", "..", "translations"), "en_US")
+	i18n.Initialize(locale)
+
+	apiloader := &api.Apiloader{
+		Translator: &i18n.Translator{
+			Locale: locale,
+		},
+	}
+	// iterate the test data directory
+	apiModelTestFiles := &[]APIModelTestFile{}
+	if e := IterateTestFilesDirectory(TestDataDir, apiModelTestFiles); e != nil {
+		t.Error(e.Error())
+		return
+	}
+
+	for _, tuple := range *apiModelTestFiles {
+		containerService, _, err := apiloader.LoadContainerServiceFromFile(tuple.APIModelFilename, true, false, nil)
+		if err != nil {
+			t.Errorf("Loading file %s got error: %s", tuple.APIModelFilename, err.Error())
+			continue
+		}
+
+		containerService.Location = "eastus"
+		containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+			IsScale:    false,
+			IsUpgrade:  false,
+			PkiKeySize: helpers.DefaultPkiKeySize,
+		})
+		containerService.Properties.HostedMasterProfile = &api.HostedMasterProfile{}
+		if len(containerService.Properties.AgentPoolProfiles) == 0 {
+			containerService.Properties.AgentPoolProfiles = []*api.AgentPoolProfile{
+				{
+					Name: "default",
+				},
+			}
+		}
+		containerService.Properties.AgentPoolProfiles[0].VnetCidrs = []string{"172.18.0.0/16", "10.240.0.0/16"}
+		isSetVnetCidr := false
+		parametersMap := getParameters(containerService, DefaultGeneratorCode, "testversion")
+		for k, v := range parametersMap {
+			switch val := v.(paramsMap)["value"].(type) {
+			case *bool:
+				t.Errorf("got a pointer to bool in paramsMap value, this is dangerous!: %s: %v", k, val)
+			}
+			if k == "vnetCidr" {
+				isSetVnetCidr = true
+				if v.(paramsMap)["value"] != "172.18.0.0/16" {
+					t.Errorf("vnetCidr is not set to the first value in containerService.Properties.AgentPoolProfiles[0].VnetCidrs. %s", v.(paramsMap)["value"])
+				}
+			}
+		}
+
+		if !isSetVnetCidr {
+			t.Error("vnetCidr is not added to parametersMap")
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Fix #2712

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Set vnetCidr by the address space of the vnet

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
