### PR TITLE
feat: use kubernetesImageBase as the components prefix on Azure Stack

### DIFF
--- a/pkg/api/components.go
+++ b/pkg/api/components.go
@@ -220,7 +220,9 @@ func getComponentDefaultContainerImage(component string, cs *ContainerService) s
 	hyperkubeImageBase := kubernetesImageBase
 	hyperkubeImage := hyperkubeImageBase + k8sComponents[common.Hyperkube]
 	if cs.Properties.IsAzureStackCloud() {
-		hyperkubeImage = hyperkubeImage + common.AzureStackSuffix
+		hyperkubeImage = cs.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase +
+			k8sComponents[common.Hyperkube] +
+			common.AzureStackSuffix
 	}
 	if kubernetesConfig.CustomHyperkubeImage != "" {
 		hyperkubeImage = kubernetesConfig.CustomHyperkubeImage


### PR DESCRIPTION
**Reason for Change**:
Recent changes to how AKSe handles component images will prevent Azure Stack users from using their old cluster definitions moving forward. Being able to reuse the cluster definition would be ideal.

If that's the expected behavior, this PR is meant to fix that.
If users are supposed to change their cluster definitions, then I will update documentation.

**I will push tests later today once I know code changes are needed**
**I know this is currently breaking UTs**

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version


