### PR TITLE
fix: apiserver broken due to incorrect kms cachesize setting

### DIFF
--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -336,7 +336,7 @@ write_files:
         - kms:
             name: azurekmsprovider
             endpoint: unix:///opt/azurekms.socket
-            cachesize: 0
+            cachesize: 1000
         - identity: {}
 {{end}}
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37877,7 +37877,7 @@ write_files:
         - kms:
             name: azurekmsprovider
             endpoint: unix:///opt/azurekms.socket
-            cachesize: 0
+            cachesize: 1000
         - identity: {}
 {{end}}
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
fix: apiserver broken due to incorrect kms cachesize
When enabling KMS feature on aks-engine, apiserver could not start up due to incorrect kms cachesize

original error is like following:
```
I0222 14:21:26.635590       1 services.go:51] Setting service IP to "10.0.0.1" (read-write).
I0222 14:21:26.635604       1 server.go:596] external host was not specified, using 10.255.255.5
I0222 14:21:26.635609       1 server.go:639] Initializing cache sizes based on 0MB limit
I0222 14:21:26.635886       1 server.go:150] Version: v1.18.0-alpha.5
Error: error while parsing encryption provider configuration file "/etc/kubernetes/encryption-config.yaml": error while parsing file: resources[0].providers[0].kms.cachesize: Invalid value: 0: cachesize should be a positive value, or negative to disable
Usage:
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
