### PR TITLE
fix: only configAddons if addons enabled

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -185,9 +185,11 @@ time_metric "ConfigureK8sCustomCloud" configureK8sCustomCloud
 
 time_metric "ConfigureCNI" configureCNI
 
+{{if or IsClusterAutoscalerAddonEnabled IsACIConnectorAddonEnabled IsAzurePolicyAddonEnabled}}
 if [[ -n "${MASTER_NODE}" ]]; then
     time_metric "ConfigAddons" configAddons
 fi
+{{end}}
 
 {{- if NeedsContainerd}}
 time_metric "EnsureContainerd" ensureContainerd

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -36123,9 +36123,11 @@ time_metric "ConfigureK8sCustomCloud" configureK8sCustomCloud
 
 time_metric "ConfigureCNI" configureCNI
 
+{{if or IsClusterAutoscalerAddonEnabled IsACIConnectorAddonEnabled IsAzurePolicyAddonEnabled}}
 if [[ -n "${MASTER_NODE}" ]]; then
     time_metric "ConfigAddons" configAddons
 fi
+{{end}}
 
 {{- if NeedsContainerd}}
 time_metric "EnsureContainerd" ensureContainerd


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR fixes an anomolous invocation of `configAddons` during CSE, which only exists according to a particular set of conditions. E.g.:

```
+ time_metric ConfigAddons configAddons
+ local name start end diff tags
+ name=ConfigAddons
+ shift
++ apmz time unixnano
+ start=1582571554614609524
+ configAddons
/opt/azure/containers/provision.sh: line 69: configAddons: command not found
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
