### PR TITLE
test: get pod network info if dns validation fails

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1022,7 +1022,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			validateDNSLinuxNamespace := "default"
 			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, fmt.Sprintf("%s.yaml", validateDNSLinuxName)), validateDNSLinuxName, validateDNSLinuxNamespace, 3*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
-			ready, err := j.WaitOnSucceeded(sleepBetweenRetriesWhenWaitingForPodReady, 10*time.Second) //validateDNSTimeout
+			ready, err := j.WaitOnSucceeded(sleepBetweenRetriesWhenWaitingForPodReady, validateDNSTimeout)
 			if err != nil {
 				pod.PrintPodsLogs(validateDNSLinuxName, validateDNSLinuxNamespace, 5*time.Second, 1*time.Minute)
 				pods, err := pod.GetAllByPrefixWithRetry(validateDNSLinuxName, validateDNSLinuxNamespace, 3*time.Second, cfg.Timeout)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1018,16 +1018,23 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should have functional container networking DNS", func() {
 			By("Ensuring that we have functional DNS resolution from a linux container")
-			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "validate-dns-linux.yaml"), "validate-dns-linux", "default", 3*time.Second, cfg.Timeout)
+			validateDNSLinuxName := "validate-dns-linux"
+			validateDNSLinuxNamespace := "default"
+			j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, fmt.Sprintf("%s.yaml", validateDNSLinuxName)), validateDNSLinuxName, validateDNSLinuxNamespace, 3*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
-			ready, err := j.WaitOnSucceeded(sleepBetweenRetriesWhenWaitingForPodReady, validateDNSTimeout)
+			ready, err := j.WaitOnSucceeded(sleepBetweenRetriesWhenWaitingForPodReady, 10*time.Second) //validateDNSTimeout
 			if err != nil {
-				pod.PrintPodsLogs("validate-dns-linux", "default", 5*time.Second, 1*time.Minute)
-			}
-			delErr := j.Delete(util.DefaultDeleteRetries)
-			if delErr != nil {
-				fmt.Printf("could not delete job %s\n", j.Metadata.Name)
-				fmt.Println(delErr)
+				pod.PrintPodsLogs(validateDNSLinuxName, validateDNSLinuxNamespace, 5*time.Second, 1*time.Minute)
+				pods, err := pod.GetAllByPrefixWithRetry(validateDNSLinuxName, validateDNSLinuxNamespace, 3*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				for _, p := range pods {
+					out, err := p.Exec("cat", "/etc/resolv.conf")
+					log.Printf("%s\n", string(out))
+					Expect(err).NotTo(HaveOccurred())
+					out, err = p.Exec("ifconfig")
+					log.Printf("%s\n", string(out))
+					Expect(err).NotTo(HaveOccurred())
+				}
 			}
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ready).To(Equal(true))
@@ -1041,11 +1048,6 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				ready, err = j.WaitOnSucceeded(sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				if err != nil {
 					pod.PrintPodsLogs("validate-dns-windows", "default", 5*time.Second, 1*time.Minute)
-				}
-				delErr = j.Delete(util.DefaultDeleteRetries)
-				if delErr != nil {
-					fmt.Printf("could not delete job %s\n", j.Metadata.Name)
-					fmt.Println(delErr)
 				}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ready).To(Equal(true))

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1034,7 +1034,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					out, err = p.Exec("--", "ifconfig")
 					log.Printf("%s\n", string(out))
 					Expect(err).NotTo(HaveOccurred())
-					out, err = p.Exec("--", "nc", "-v", eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.DNSServiceIP, "53")
+					out, err = p.Exec("--", "nc", "-vz", eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.DNSServiceIP, "53")
 					log.Printf("%s\n", string(out))
 					Expect(err).NotTo(HaveOccurred())
 				}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1028,10 +1028,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				pods, err := pod.GetAllByPrefixWithRetry(validateDNSLinuxName, validateDNSLinuxNamespace, 3*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				for _, p := range pods {
-					out, err := p.Exec("cat", "/etc/resolv.conf")
+					out, err := p.Exec("--", "cat", "/etc/resolv.conf")
 					log.Printf("%s\n", string(out))
 					Expect(err).NotTo(HaveOccurred())
-					out, err = p.Exec("ifconfig")
+					out, err = p.Exec("--", "ifconfig")
+					log.Printf("%s\n", string(out))
+					Expect(err).NotTo(HaveOccurred())
+					out, err = p.Exec("--", "nc", "-v", eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.DNSServiceIP, "53")
 					log.Printf("%s\n", string(out))
 					Expect(err).NotTo(HaveOccurred())
 				}

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -294,7 +294,7 @@ func GetAll(namespace string) (*List, error) {
 }
 
 // GetWithRetry gets a pod, allowing for retries
-func GetWithRetry(podPrefix, namespace string, sleep, timeout time.Duration) (*Pod, error) {
+func GetWithRetry(podName, namespace string, sleep, timeout time.Duration) (*Pod, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	ch := make(chan GetResult)
@@ -306,7 +306,7 @@ func GetWithRetry(podPrefix, namespace string, sleep, timeout time.Duration) (*P
 			case <-ctx.Done():
 				return
 			default:
-				ch <- GetAsync(podPrefix, namespace)
+				ch <- GetAsync(podName, namespace)
 				time.Sleep(sleep)
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR prints more debug info to stdout if linux pod DNS validation fails.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
