### PR TITLE
[WIP] feat: install the azure.json file only on master node

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -165,6 +165,7 @@ configureK8s() {
     chmod 0644 "${APISERVER_PUBLIC_KEY_PATH}"
     chown root:root "${APISERVER_PUBLIC_KEY_PATH}"
 
+    set +x
     echo "${KUBELET_PRIVATE_KEY}" | base64 --decode > "${KUBELET_PRIVATE_KEY_PATH}"
     echo "${APISERVER_PUBLIC_KEY}" | base64 --decode > "${APISERVER_PUBLIC_KEY_PATH}"
     {{/* Perform the required JSON escaping */}}
@@ -176,8 +177,6 @@ configureK8s() {
         touch "${AZURE_JSON_PATH}"
         chmod 0600 "${AZURE_JSON_PATH}"
         chown root:root "${AZURE_JSON_PATH}"
-
-        set +x
         cat << EOF > "${AZURE_JSON_PATH}"
 {
     "cloud":"{{GetTargetEnvironment}}",

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -87,8 +87,6 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		"--image-gc-low-threshold":            strconv.Itoa(DefaultKubernetesGCLowThreshold),
 		"--non-masquerade-cidr":               DefaultNonMasqueradeCIDR,
 		"--cloud-provider":                    "azure",
-		"--cloud-config":                      "/etc/kubernetes/azure.json",
-		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
 		"--event-qps":                         DefaultKubeletEventQPS,
 		"--cadvisor-port":                     DefaultKubeletCadvisorPort,
 		"--pod-max-pids":                      strconv.Itoa(DefaultKubeletPodMaxPIDs),

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -87,6 +87,8 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		"--image-gc-low-threshold":            strconv.Itoa(DefaultKubernetesGCLowThreshold),
 		"--non-masquerade-cidr":               DefaultNonMasqueradeCIDR,
 		"--cloud-provider":                    "azure",
+		"--cloud-config":                      "/etc/kubernetes/azure.json",
+		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
 		"--event-qps":                         DefaultKubeletEventQPS,
 		"--cadvisor-port":                     DefaultKubeletCadvisorPort,
 		"--pod-max-pids":                      strconv.Itoa(DefaultKubeletPodMaxPIDs),
@@ -212,6 +214,9 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		}
 
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
+		profile.KubernetesConfig.KubeletConfig["--cloud-provider"] = ""
+		profile.KubernetesConfig.KubeletConfig["--cloud-config"] = ""
+		profile.KubernetesConfig.KubeletConfig["--azure-container-registry-config"] = ""
 
 		if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
 			hasSupportPodPidsLimitFeatureGate := strings.Contains(profile.KubernetesConfig.KubeletConfig["--feature-gates"], "SupportPodPidsLimit=true")

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -35,7 +35,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--cgroups-per-qos":                   "true",
 		"--client-ca-file":                    "/etc/kubernetes/certs/ca.crt",
 		"--cloud-provider":                    "azure",
-		"--cloud-config":                      "/etc/kubernetes/azure.json",
+//		"--cloud-config":                      "/etc/kubernetes/azure.json",
 		"--cluster-dns":                       DefaultKubernetesDNSServiceIP,
 		"--cluster-domain":                    "cluster.local",
 		"--enforce-node-allocatable":          "pods",
@@ -211,40 +211,40 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 
 }
 
-func TestKubeletConfigCloudConfig(t *testing.T) {
-	// Test default value and custom value for --cloud-config
-	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	cs.setKubeletConfig(false)
-	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	if k["--cloud-config"] != "/etc/kubernetes/azure.json" {
-		t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
-			k["--cloud-config"])
-	}
+ func TestKubeletConfigCloudConfig(t *testing.T) {
+// Test default value and custom value for --cloud-config
+	// cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	// cs.setKubeletConfig(false)
+	// k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	// if k["--cloud-config"] != "/etc/kubernetes/azure.json" {
+	// 	t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
+	// 		k["--cloud-config"])
+	// }
 
-	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--cloud-config"] = "custom.json"
 	cs.setKubeletConfig(false)
-	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--cloud-config"] != "custom.json" {
 		t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
 			k["--cloud-config"])
 	}
 }
 
-func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
-	// Test default value and custom value for --azure-container-registry-config
-	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	cs.setKubeletConfig(false)
-	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	if k["--azure-container-registry-config"] != "/etc/kubernetes/azure.json" {
-		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
-			k["--azure-container-registry-config"])
-	}
+ func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
+//  Test default value and custom value for --azure-container-registry-config
+// 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+// 	cs.setKubeletConfig(false)
+// 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+// 	if k["--azure-container-registry-config"] != "/etc/kubernetes/azure.json" {
+// 		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
+// 			k["--azure-container-registry-config"])
+// 	}
 
-	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--azure-container-registry-config"] = "custom.json"
 	cs.setKubeletConfig(false)
-	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--azure-container-registry-config"] != "custom.json" {
 		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
 			k["--azure-container-registry-config"])

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -212,15 +212,6 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 }
 
 func TestKubeletConfigCloudConfig(t *testing.T) {
-	// Test default value and custom value for --cloud-config
-	// cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	// cs.setKubeletConfig(false)
-	// k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	// if k["--cloud-config"] != "/etc/kubernetes/azure.json" {
-	// 	t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
-	// 		k["--cloud-config"])
-	// }
-
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--cloud-config"] = "custom.json"
 	cs.setKubeletConfig(false)
@@ -232,15 +223,6 @@ func TestKubeletConfigCloudConfig(t *testing.T) {
 }
 
 func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
-	//  Test default value and custom value for --azure-container-registry-config
-	// 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	// 	cs.setKubeletConfig(false)
-	// 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	// 	if k["--azure-container-registry-config"] != "/etc/kubernetes/azure.json" {
-	// 		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
-	// 			k["--azure-container-registry-config"])
-	// 	}
-
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--azure-container-registry-config"] = "custom.json"
 	cs.setKubeletConfig(false)
@@ -700,10 +682,10 @@ func TestStaticWindowsConfig(t *testing.T) {
 
 	// Add Windows-specific overrides
 	// Eventually paths should not be hardcoded here. They should be relative to $global:KubeDir in the PowerShell script
-	expected["--azure-container-registry-config"] = "c:\\k\\azure.json"
+	expected["--azure-container-registry-config"] = ""
 	expected["--pod-infra-container-image"] = "kubletwin/pause"
 	expected["--kubeconfig"] = "c:\\k\\config"
-	expected["--cloud-config"] = "c:\\k\\azure.json"
+	expected["--cloud-config"] = ""
 	expected["--cgroups-per-qos"] = "false"
 	expected["--enforce-node-allocatable"] = "\"\"\"\""
 	expected["--system-reserved"] = "memory=2Gi"

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -30,12 +30,12 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--allow-privileged":                  "true", // validate that we delete this key for >= 1.15 clusters
 		"--anonymous-auth":                    "false",
 		"--authorization-mode":                "Webhook",
-//		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
+		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
 		"--cadvisor-port":                     "", // Validate that we delete this key for >= 1.12 clusters
 		"--cgroups-per-qos":                   "true",
 		"--client-ca-file":                    "/etc/kubernetes/certs/ca.crt",
 		"--cloud-provider":                    "azure",
-//		"--cloud-config":                      "/etc/kubernetes/azure.json",
+		"--cloud-config":                      "/etc/kubernetes/azure.json",
 		"--cluster-dns":                       DefaultKubernetesDNSServiceIP,
 		"--cluster-domain":                    "cluster.local",
 		"--enforce-node-allocatable":          "pods",
@@ -211,8 +211,8 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 
 }
 
- func TestKubeletConfigCloudConfig(t *testing.T) {
-// Test default value and custom value for --cloud-config
+func TestKubeletConfigCloudConfig(t *testing.T) {
+	// Test default value and custom value for --cloud-config
 	// cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	// cs.setKubeletConfig(false)
 	// k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
@@ -231,15 +231,15 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 	}
 }
 
- func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
-//  Test default value and custom value for --azure-container-registry-config
-// 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-// 	cs.setKubeletConfig(false)
-// 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-// 	if k["--azure-container-registry-config"] != "/etc/kubernetes/azure.json" {
-// 		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
-// 			k["--azure-container-registry-config"])
-// 	}
+func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
+	//  Test default value and custom value for --azure-container-registry-config
+	// 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	// 	cs.setKubeletConfig(false)
+	// 	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	// 	if k["--azure-container-registry-config"] != "/etc/kubernetes/azure.json" {
+	// 		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
+	// 			k["--azure-container-registry-config"])
+	// 	}
 
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--azure-container-registry-config"] = "custom.json"

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -30,7 +30,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 		"--allow-privileged":                  "true", // validate that we delete this key for >= 1.15 clusters
 		"--anonymous-auth":                    "false",
 		"--authorization-mode":                "Webhook",
-		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
+//		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
 		"--cadvisor-port":                     "", // Validate that we delete this key for >= 1.12 clusters
 		"--cgroups-per-qos":                   "true",
 		"--client-ca-file":                    "/etc/kubernetes/certs/ca.crt",

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -34659,6 +34659,7 @@ configureK8s() {
     chmod 0644 "${APISERVER_PUBLIC_KEY_PATH}"
     chown root:root "${APISERVER_PUBLIC_KEY_PATH}"
 
+    set +x
     echo "${KUBELET_PRIVATE_KEY}" | base64 --decode > "${KUBELET_PRIVATE_KEY_PATH}"
     echo "${APISERVER_PUBLIC_KEY}" | base64 --decode > "${APISERVER_PUBLIC_KEY_PATH}"
     {{/* Perform the required JSON escaping */}}
@@ -34670,8 +34671,6 @@ configureK8s() {
         touch "${AZURE_JSON_PATH}"
         chmod 0600 "${AZURE_JSON_PATH}"
         chown root:root "${AZURE_JSON_PATH}"
-
-        set +x
         cat << EOF > "${AZURE_JSON_PATH}"
 {
     "cloud":"{{GetTargetEnvironment}}",

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -34659,18 +34659,20 @@ configureK8s() {
     chmod 0644 "${APISERVER_PUBLIC_KEY_PATH}"
     chown root:root "${APISERVER_PUBLIC_KEY_PATH}"
 
-    AZURE_JSON_PATH="/etc/kubernetes/azure.json"
-    touch "${AZURE_JSON_PATH}"
-    chmod 0600 "${AZURE_JSON_PATH}"
-    chown root:root "${AZURE_JSON_PATH}"
-
-    set +x
     echo "${KUBELET_PRIVATE_KEY}" | base64 --decode > "${KUBELET_PRIVATE_KEY_PATH}"
     echo "${APISERVER_PUBLIC_KEY}" | base64 --decode > "${APISERVER_PUBLIC_KEY_PATH}"
     {{/* Perform the required JSON escaping */}}
     SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\\/\\\\}
     SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\"/\\\"}
-    cat << EOF > "${AZURE_JSON_PATH}"
+
+    if [[ -n "${MASTER_NODE}" ]]; then
+        AZURE_JSON_PATH="/etc/kubernetes/azure.json"
+        touch "${AZURE_JSON_PATH}"
+        chmod 0600 "${AZURE_JSON_PATH}"
+        chown root:root "${AZURE_JSON_PATH}"
+
+        set +x
+        cat << EOF > "${AZURE_JSON_PATH}"
 {
     "cloud":"{{GetTargetEnvironment}}",
     "tenantId": "${TENANT_ID}",
@@ -34710,12 +34712,11 @@ configureK8s() {
     "providerKeyVersion": ""
 }
 EOF
-    set -x
-    if [[ "${CLOUDPROVIDER_BACKOFF_MODE}" = "v2" ]]; then
-        sed -i "/cloudProviderBackoffExponent/d" /etc/kubernetes/azure.json
-        sed -i "/cloudProviderBackoffJitter/d" /etc/kubernetes/azure.json
-    fi
-    if [[ -n "${MASTER_NODE}" ]]; then
+        set -x
+        if [[ "${CLOUDPROVIDER_BACKOFF_MODE}" = "v2" ]]; then
+            sed -i "/cloudProviderBackoffExponent/d" /etc/kubernetes/azure.json
+            sed -i "/cloudProviderBackoffJitter/d" /etc/kubernetes/azure.json
+        fi
         if [[ "${ENABLE_AGGREGATED_APIS}" = True ]]; then
             generateAggregatedAPICerts
         fi


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->
feat: install the Azure.json file only on Master node.

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Having the Azure.json file on all the nodes in the cluster might not be necessary for some cases and can be a security risk for other cases (if the node is compromised -it is better that the attacker won't have access to the ARM resources the service principal has access to)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
"Fixes #2747"

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This is work in progress, we will want to also add a feature flag to the agent pools definition  that will be set to 'true' for agent pools that we do want to install the azure.json on them (for example infra-nodes that are used for managing the resources etc.)