### PR TITLE
fix: override components command config during upgrade

### DIFF
--- a/pkg/api/components.go
+++ b/pkg/api/components.go
@@ -163,9 +163,12 @@ func assignDefaultComponentVals(component, defaultComponent KubernetesComponent,
 			}
 		}
 	}
+	if component.Config == nil {
+		component.Config = make(map[string]string)
+	}
 	for key, val := range defaultComponent.Config {
-		if component.Config == nil {
-			component.Config = make(map[string]string)
+		if key == "command" && isUpgrade {
+			component.Config[key] = val
 		}
 		if v, ok := component.Config[key]; !ok || v == "" {
 			component.Config[key] = val

--- a/pkg/api/components_test.go
+++ b/pkg/api/components_test.go
@@ -600,7 +600,8 @@ func TestAssignDefaultComponentVals(t *testing.T) {
 					},
 				},
 				Config: map[string]string{
-					"foo": "bar",
+					"foo":     "bar",
+					"command": "/bin/custom-command/overwrite-me",
 				},
 			},
 			defaultComponent: controllerManagerComponent,


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR enforces component command configuration override during upgrade, which is documented here:

https://github.com/Azure/aks-engine/blob/master/docs/topics/clusterdefinitions.md#components

Specifically:

> this configurable vector is designed for cluster creation only. Using aks-engine upgrade on a cluster will override the original, user-configured settings during the upgrade operation, rendering an upgraded cluster with the AKS Engine defaults for kube-controller-manager, cloud-controller-manager, kube-apiserver, kube-scheduler, and kube-addon-manager.

We would be true to the above documentation to statically override all configuraiton key/vals in an upgrade flow, but in the event that we want to enable some subset of the components container configuration to be user-configurable across upgrade, this PR only enforces the config override for the "command" config, which is the only config key that our yaml manifests currently recognize.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
