### PR TITLE
chore: default to large cluster settings on Azure Stack

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -306,6 +306,22 @@ const (
 	DefaultKubernetesCloudProviderRateLimitBucketWrite = DefaultKubernetesCloudProviderRateLimitBucket
 )
 
+// Azure Stack configures all clusters as if they were large clusters.
+const (
+	DefaultAzureStackKubernetesCloudProviderBackoffRetries       = 6
+	DefaultAzureStackKubernetesCloudProviderBackoffJitter        = 1.0
+	DefaultAzureStackKubernetesCloudProviderBackoffDuration      = 5
+	DefaultAzureStackKubernetesCloudProviderBackoffExponent      = 1.5
+	DefaultAzureStackKubernetesCloudProviderRateLimitQPS         = 3.0
+	DefaultAzureStackKubernetesCloudProviderRateLimitQPSWrite    = 3.0
+	DefaultAzureStackKubernetesCloudProviderRateLimitBucket      = 10
+	DefaultAzureStackKubernetesCloudProviderRateLimitBucketWrite = 10
+	DefaultAzureStackKubernetesNodeStatusUpdateFrequency         = "1m"
+	DefaultAzureStackKubernetesCtrlMgrRouteReconciliationPeriod  = "1m"
+	DefaultAzureStackKubernetesCtrlMgrNodeMonitorGracePeriod     = "5m"
+	DefaultAzureStackKubernetesCtrlMgrPodEvictionTimeout         = "1m"
+)
+
 const (
 	//AzureEdgeDCOSBootstrapDownloadURL is the azure edge CDN download url
 	AzureEdgeDCOSBootstrapDownloadURL = "https://dcosio.azureedge.net/dcos/%s/bootstrap/%s.bootstrap.tar.xz"

--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -40,11 +40,21 @@ func (cs *ContainerService) setControllerManagerConfig() {
 		staticControllerManagerConfig["--cloud-provider"] = "external"
 	}
 
+	ctrlMgrNodeMonitorGracePeriod := DefaultKubernetesCtrlMgrNodeMonitorGracePeriod
+	ctrlMgrPodEvictionTimeout := DefaultKubernetesCtrlMgrPodEvictionTimeout
+	ctrlMgrRouteReconciliationPeriod := DefaultKubernetesCtrlMgrRouteReconciliationPeriod
+
+	if cs.Properties.IsAzureStackCloud() {
+		ctrlMgrNodeMonitorGracePeriod = DefaultAzureStackKubernetesCtrlMgrNodeMonitorGracePeriod
+		ctrlMgrPodEvictionTimeout = DefaultAzureStackKubernetesCtrlMgrPodEvictionTimeout
+		ctrlMgrRouteReconciliationPeriod = DefaultAzureStackKubernetesCtrlMgrRouteReconciliationPeriod
+	}
+
 	// Default controller-manager config
 	defaultControllerManagerConfig := map[string]string{
-		"--node-monitor-grace-period":       DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
-		"--pod-eviction-timeout":            DefaultKubernetesCtrlMgrPodEvictionTimeout,
-		"--route-reconciliation-period":     DefaultKubernetesCtrlMgrRouteReconciliationPeriod,
+		"--node-monitor-grace-period":       ctrlMgrNodeMonitorGracePeriod,
+		"--pod-eviction-timeout":            ctrlMgrPodEvictionTimeout,
+		"--route-reconciliation-period":     ctrlMgrRouteReconciliationPeriod,
 		"--terminated-pod-gc-threshold":     DefaultKubernetesCtrlMgrTerminatedPodGcThreshold,
 		"--use-service-account-credentials": DefaultKubernetesCtrlMgrUseSvcAccountCreds,
 		"--profiling":                       DefaultKubernetesCtrMgrEnableProfiling,

--- a/pkg/api/defaults-controller-manager_test.go
+++ b/pkg/api/defaults-controller-manager_test.go
@@ -139,3 +139,34 @@ func TestControllerManagerConfigHostedMasterProfile(t *testing.T) {
 		t.Fatalf("expected controller-manager to have cluster-name foodns when using HostedMasterProfile")
 	}
 }
+
+func TestControllerManagerDefaultConfig(t *testing.T) {
+	// Azure defaults
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--node-monitor-grace-period"] != string(DefaultKubernetesCtrlMgrNodeMonitorGracePeriod) {
+		t.Fatalf("expected controller-manager to have node-monitor-grace-period set to its default value")
+	}
+	if cm["--pod-eviction-timeout"] != string(DefaultKubernetesCtrlMgrPodEvictionTimeout) {
+		t.Fatalf("expected controller-manager to have pod-eviction-timeout set to its default value")
+	}
+	if cm["--route-reconciliation-period"] != string(DefaultKubernetesCtrlMgrRouteReconciliationPeriod) {
+		t.Fatalf("expected controller-manager to have route-reconciliation-period set to its default value")
+	}
+
+	// Azure Stack defaults
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.CustomCloudProfile = &CustomCloudProfile{}
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--node-monitor-grace-period"] != string(DefaultAzureStackKubernetesCtrlMgrNodeMonitorGracePeriod) {
+		t.Fatalf("expected controller-manager to have node-monitor-grace-period set to its default value")
+	}
+	if cm["--pod-eviction-timeout"] != string(DefaultAzureStackKubernetesCtrlMgrPodEvictionTimeout) {
+		t.Fatalf("expected controller-manager to have pod-eviction-timeout set to its default value")
+	}
+	if cm["--route-reconciliation-period"] != string(DefaultAzureStackKubernetesCtrlMgrRouteReconciliationPeriod) {
+		t.Fatalf("expected controller-manager to have route-reconciliation-period set to its default value")
+	}
+}

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -75,6 +75,11 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	staticWindowsKubeletConfig["--resolv-conf"] = "\"\"\"\""
 	staticWindowsKubeletConfig["--eviction-hard"] = "\"\"\"\""
 
+	nodeStatusUpdateFrequency := GetK8sComponentsByVersionMap(o.KubernetesConfig)[o.OrchestratorVersion]["nodestatusfreq"]
+	if cs.Properties.IsAzureStackCloud() {
+		nodeStatusUpdateFrequency = DefaultAzureStackKubernetesNodeStatusUpdateFrequency
+	}
+
 	// Default Kubelet config
 	defaultKubeletConfig := map[string]string{
 		"--cluster-domain":                    "cluster.local",
@@ -82,7 +87,7 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		"--pod-infra-container-image":         o.KubernetesConfig.MCRKubernetesImageBase + GetK8sComponentsByVersionMap(o.KubernetesConfig)[o.OrchestratorVersion][common.PauseComponentName],
 		"--max-pods":                          strconv.Itoa(DefaultKubernetesMaxPods),
 		"--eviction-hard":                     DefaultKubernetesHardEvictionThreshold,
-		"--node-status-update-frequency":      GetK8sComponentsByVersionMap(o.KubernetesConfig)[o.OrchestratorVersion]["nodestatusfreq"],
+		"--node-status-update-frequency":      nodeStatusUpdateFrequency,
 		"--image-gc-high-threshold":           strconv.Itoa(DefaultKubernetesGCHighThreshold),
 		"--image-gc-low-threshold":            strconv.Itoa(DefaultKubernetesGCLowThreshold),
 		"--non-masquerade-cidr":               DefaultNonMasqueradeCIDR,

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -267,7 +267,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		}
 
 		// Enforce sane cloudprovider backoff defaults.
-		o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+		a.SetCloudProviderBackoffDefaults()
 
 		if o.KubernetesConfig.CloudProviderRateLimit == nil {
 			o.KubernetesConfig.CloudProviderRateLimit = to.BoolPtr(DefaultKubernetesCloudProviderRateLimit)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2118,12 +2118,18 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = agentPoolProfilesCount * common.MaxAgentCount
 		}
+		if p.IsAzureStackCloud() {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultAzureStackKubernetesCloudProviderRateLimitBucket
+		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS == 0 {
 		if (DefaultKubernetesCloudProviderRateLimitQPS / float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket)) < common.MinCloudProviderQPSToBucketFactor {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket) * common.MinCloudProviderQPSToBucketFactor
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = DefaultKubernetesCloudProviderRateLimitQPS
+		}
+		if p.IsAzureStackCloud() {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS = DefaultAzureStackKubernetesCloudProviderRateLimitQPS
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite == 0 {
@@ -2133,12 +2139,18 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = agentPoolProfilesCount * common.MaxAgentCount
 		}
+		if p.IsAzureStackCloud() {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = DefaultAzureStackKubernetesCloudProviderRateLimitBucketWrite
+		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPSWrite == 0 {
 		if (DefaultKubernetesCloudProviderRateLimitQPSWrite / float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite)) < common.MinCloudProviderQPSToBucketFactor {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPSWrite = float64(p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite) * common.MinCloudProviderQPSToBucketFactor
 		} else {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPSWrite = DefaultKubernetesCloudProviderRateLimitQPSWrite
+		}
+		if p.IsAzureStackCloud() {
+			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPSWrite = DefaultAzureStackKubernetesCloudProviderRateLimitQPSWrite
 		}
 	}
 }
@@ -2167,19 +2179,32 @@ func (k *KubernetesConfig) RequiresDocker() bool {
 }
 
 // SetCloudProviderBackoffDefaults sets default cloudprovider backoff config
-func (k *KubernetesConfig) SetCloudProviderBackoffDefaults() {
+func (p *Properties) SetCloudProviderBackoffDefaults() {
+	k := p.OrchestratorProfile.KubernetesConfig
 	if k.CloudProviderBackoffDuration == 0 {
 		k.CloudProviderBackoffDuration = DefaultKubernetesCloudProviderBackoffDuration
+		if p.IsAzureStackCloud() {
+			k.CloudProviderBackoffDuration = DefaultAzureStackKubernetesCloudProviderBackoffDuration
+		}
 	}
 	if k.CloudProviderBackoffRetries == 0 {
 		k.CloudProviderBackoffRetries = DefaultKubernetesCloudProviderBackoffRetries
+		if p.IsAzureStackCloud() {
+			k.CloudProviderBackoffRetries = DefaultAzureStackKubernetesCloudProviderBackoffRetries
+		}
 	}
 	if k.CloudProviderBackoffMode != CloudProviderBackoffModeV2 {
 		if k.CloudProviderBackoffExponent == 0 {
 			k.CloudProviderBackoffExponent = DefaultKubernetesCloudProviderBackoffExponent
+			if p.IsAzureStackCloud() {
+				k.CloudProviderBackoffExponent = DefaultAzureStackKubernetesCloudProviderBackoffExponent
+			}
 		}
 		if k.CloudProviderBackoffJitter == 0 {
 			k.CloudProviderBackoffJitter = DefaultKubernetesCloudProviderBackoffJitter
+			if p.IsAzureStackCloud() {
+				k.CloudProviderBackoffJitter = DefaultAzureStackKubernetesCloudProviderBackoffJitter
+			}
 		}
 	}
 }

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3985,7 +3985,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o := p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCases := []struct {
@@ -4044,6 +4044,76 @@ func TestCloudProviderDefaults(t *testing.T) {
 		}
 	}
 
+	// Test cloudprovider Azure Stack defaults when no user-provided values
+	v = "1.14.0"
+	p = Properties{
+		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    "Kubernetes",
+			OrchestratorVersion: v,
+			KubernetesConfig:    &KubernetesConfig{},
+		},
+		CustomCloudProfile: &CustomCloudProfile{},
+	}
+	o = p.OrchestratorProfile
+	p.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderRateLimitDefaults()
+
+	intCases = []struct {
+		defaultVal  int
+		computedVal int
+	}{
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderBackoffRetries,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffRetries,
+		},
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderBackoffDuration,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffDuration,
+		},
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderRateLimitBucket,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitBucket,
+		},
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderRateLimitBucketWrite,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitBucketWrite,
+		},
+	}
+
+	for _, c := range intCases {
+		if c.computedVal != c.defaultVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect Azure Stack default values after SetCloudProviderBackoffDefaults(), expected %d, got %d", c.defaultVal, c.computedVal)
+		}
+	}
+
+	floatCases = []struct {
+		defaultVal  float64
+		computedVal float64
+	}{
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderBackoffJitter,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffJitter,
+		},
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderBackoffExponent,
+			computedVal: o.KubernetesConfig.CloudProviderBackoffExponent,
+		},
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderRateLimitQPS,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitQPS,
+		},
+		{
+			defaultVal:  DefaultAzureStackKubernetesCloudProviderRateLimitQPSWrite,
+			computedVal: o.KubernetesConfig.CloudProviderRateLimitQPSWrite,
+		},
+	}
+
+	for _, c := range floatCases {
+		if c.computedVal != c.defaultVal {
+			t.Fatalf("KubernetesConfig empty cloudprovider configs should reflect Azure Stack default values after SetCloudProviderBackoffDefaults(), expected %f, got %f", c.defaultVal, c.computedVal)
+		}
+	}
+
 	customCloudProviderBackoffDuration := 99
 	customCloudProviderBackoffExponent := 10.0
 	customCloudProviderBackoffJitter := 11.9
@@ -4072,7 +4142,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesCustom := []struct {
@@ -4145,7 +4215,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesMixed := []struct {
@@ -4203,7 +4273,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesMixed = []struct {
@@ -4275,7 +4345,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesMixed = []struct {
@@ -4344,7 +4414,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesMixed = []struct {
@@ -4410,7 +4480,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesMixed = []struct {
@@ -4479,7 +4549,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 	p.SetCloudProviderRateLimitDefaults()
 
 	intCasesMixed = []struct {
@@ -4542,7 +4612,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 		},
 	}
 	o = p.OrchestratorProfile
-	o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+	p.SetCloudProviderBackoffDefaults()
 
 	floatCasesMixed = []struct {
 		expectedVal float64
@@ -4563,7 +4633,6 @@ func TestCloudProviderDefaults(t *testing.T) {
 			t.Fatalf("KubernetesConfig cloudprovider backoff v2 configs should reflect default values after SetCloudProviderBackoffDefaults(), expected %f, got %f", c.expectedVal, c.computedVal)
 		}
 	}
-
 }
 
 func TestGetKubernetesVersion(t *testing.T) {


### PR DESCRIPTION
**Reason for Change**:
Default AKSe settings do not play well with Azure Stack limits. This PR changes defaults for Azure Stack to reduce the load to ARM.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version
