### PR TITLE
fix: explicitly set kubeconfig when using KUBECTL in CSE

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -409,6 +409,7 @@ users:
     client-key-data: \"$KUBECONFIG_KEY\"
 " > $KUBECONFIGFILE
     set -x
+    KUBECTL="$KUBECTL --kubeconfig=$KUBECONFIGFILE"
 }
 
 configClusterAutoscalerAddon() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -34903,6 +34903,7 @@ users:
     client-key-data: \"$KUBECONFIG_KEY\"
 " > $KUBECONFIGFILE
     set -x
+    KUBECTL="$KUBECTL --kubeconfig=$KUBECONFIGFILE"
 }
 
 configClusterAutoscalerAddon() {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

The latest `kubectl` built from k/k master branch causes `/usr/local/bin/kubectl cluster-info` in CSE to time out due to a new validation logic introduced in https://github.com/kubernetes/kubernetes/pull/86173/commits/b19ad9e7a78fea0ecdffe7aa53bbe309d9d346ee. This PR explicitly set kubeconfig when using kubectl to avoid this problem.

**Issue Fixed**: https://github.com/Azure/aks-engine/issues/2845
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
