### PR TITLE
chore: update default to recommended cluster settings on Azure Stack

### DIFF
--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -6,10 +6,26 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.14",
             "kubernetesConfig": {
-                "kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
+				"cloudProviderBackoff": true,
+				"cloudProviderBackoffRetries": 1,
+				"cloudProviderBackoffDuration": 30,
+				"cloudProviderRateLimit": true,
+				"cloudProviderRateLimitQPS": 3,
+				"cloudProviderRateLimitBucket": 10,
+				"cloudProviderRateLimitQPSWrite": 3,
+				"cloudProviderRateLimitBucketWrite": 10,
+				"kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
                 "useInstanceMetadata": false,
-                "networkPlugin": "kubenet"
-            }
+                "networkPlugin": "kubenet",
+				"kubeletConfig": {
+				  "--node-status-update-frequency": "1m"
+				},
+				"controllerManagerConfig": {
+				  "--node-monitor-grace-period": "5m",
+				  "--pod-eviction-timeout": "5m",
+				  "--route-reconciliation-period": "1m"
+				}
+			}
         },
         "customCloudProfile": {
             "portalURL": "",

--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -6,24 +6,24 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.14",
             "kubernetesConfig": {
-				"cloudProviderBackoff": true,
-				"cloudProviderBackoffRetries": 1,
-				"cloudProviderBackoffDuration": 30,
-				"cloudProviderRateLimit": true,
-				"cloudProviderRateLimitQPS": 3,
-				"cloudProviderRateLimitBucket": 10,
-				"cloudProviderRateLimitQPSWrite": 3,
-				"cloudProviderRateLimitBucketWrite": 10,
-				"kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
+                "cloudProviderBackoff": true,
+                "cloudProviderBackoffRetries": 1,
+                "cloudProviderBackoffDuration": 30,
+                "cloudProviderRateLimit": true,
+                "cloudProviderRateLimitQPS": 3,
+                "cloudProviderRateLimitBucket": 10,
+                "cloudProviderRateLimitQPSWrite": 3,
+                "cloudProviderRateLimitBucketWrite": 10,
+                "kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
                 "useInstanceMetadata": false,
                 "networkPlugin": "kubenet",
-				"kubeletConfig": {
-				  "--node-status-update-frequency": "1m"
-				},
-				"controllerManagerConfig": {
-				  "--node-monitor-grace-period": "5m",
-				  "--pod-eviction-timeout": "5m",
-				  "--route-reconciliation-period": "1m"
+                "kubeletConfig": {
+                    "--node-status-update-frequency": "1m"
+                },
+                "controllerManagerConfig": {
+                    "--node-monitor-grace-period": "5m",
+                    "--pod-eviction-timeout": "5m",
+                    "--route-reconciliation-period": "1m"
 				}
 			}
         },

--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -24,8 +24,8 @@
                     "--node-monitor-grace-period": "5m",
                     "--pod-eviction-timeout": "5m",
                     "--route-reconciliation-period": "1m"
-				}
-			}
+                }
+            }
         },
         "customCloudProfile": {
             "portalURL": "",

--- a/examples/azure-stack/kubernetes-windows.json
+++ b/examples/azure-stack/kubernetes-windows.json
@@ -6,24 +6,24 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.14",
             "kubernetesConfig": {
-				"cloudProviderBackoff": true,
-				"cloudProviderBackoffRetries": 1,
-				"cloudProviderBackoffDuration": 30,
-				"cloudProviderRateLimit": true,
-				"cloudProviderRateLimitQPS": 3,
-				"cloudProviderRateLimitBucket": 10,
-				"cloudProviderRateLimitQPSWrite": 3,
-				"cloudProviderRateLimitBucketWrite": 10,
-				"kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
+                "cloudProviderBackoff": true,
+                "cloudProviderBackoffRetries": 1,
+                "cloudProviderBackoffDuration": 30,
+                "cloudProviderRateLimit": true,
+                "cloudProviderRateLimitQPS": 3,
+                "cloudProviderRateLimitBucket": 10,
+                "cloudProviderRateLimitQPSWrite": 3,
+                "cloudProviderRateLimitBucketWrite": 10,
+                "kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
                 "useInstanceMetadata": false,
                 "networkPlugin": "azure",
-				"kubeletConfig": {
-				  "--node-status-update-frequency": "1m"
-				},
-				"controllerManagerConfig": {
-				  "--node-monitor-grace-period": "5m",
-				  "--pod-eviction-timeout": "5m",
-				  "--route-reconciliation-period": "1m"
+                "kubeletConfig": {
+                    "--node-status-update-frequency": "1m"
+                },
+                "controllerManagerConfig": {
+                    "--node-monitor-grace-period": "5m",
+                    "--pod-eviction-timeout": "5m",
+                    "--route-reconciliation-period": "1m"
 				}
 			}
         },

--- a/examples/azure-stack/kubernetes-windows.json
+++ b/examples/azure-stack/kubernetes-windows.json
@@ -6,10 +6,26 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.14",
             "kubernetesConfig": {
-                "kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
+				"cloudProviderBackoff": true,
+				"cloudProviderBackoffRetries": 1,
+				"cloudProviderBackoffDuration": 30,
+				"cloudProviderRateLimit": true,
+				"cloudProviderRateLimitQPS": 3,
+				"cloudProviderRateLimitBucket": 10,
+				"cloudProviderRateLimitQPSWrite": 3,
+				"cloudProviderRateLimitBucketWrite": 10,
+				"kubernetesImageBase": "mcr.microsoft.com/k8s/azurestack/core/",
                 "useInstanceMetadata": false,
-                "networkPlugin": "azure"
-            }
+                "networkPlugin": "azure",
+				"kubeletConfig": {
+				  "--node-status-update-frequency": "1m"
+				},
+				"controllerManagerConfig": {
+				  "--node-monitor-grace-period": "5m",
+				  "--pod-eviction-timeout": "5m",
+				  "--route-reconciliation-period": "1m"
+				}
+			}
         },
         "customCloudProfile": {
             "portalURL": "",

--- a/examples/azure-stack/kubernetes-windows.json
+++ b/examples/azure-stack/kubernetes-windows.json
@@ -24,8 +24,8 @@
                     "--node-monitor-grace-period": "5m",
                     "--pod-eviction-timeout": "5m",
                     "--route-reconciliation-period": "1m"
-				}
-			}
+                }
+            }
         },
         "customCloudProfile": {
             "portalURL": "",

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -319,7 +319,7 @@ const (
 	DefaultAzureStackKubernetesNodeStatusUpdateFrequency         = "1m"
 	DefaultAzureStackKubernetesCtrlMgrRouteReconciliationPeriod  = "1m"
 	DefaultAzureStackKubernetesCtrlMgrNodeMonitorGracePeriod     = "5m"
-	DefaultAzureStackKubernetesCtrlMgrPodEvictionTimeout         = "1m"
+	DefaultAzureStackKubernetesCtrlMgrPodEvictionTimeout         = "5m"
 )
 
 const (

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -308,9 +308,9 @@ const (
 
 // Azure Stack configures all clusters as if they were large clusters.
 const (
-	DefaultAzureStackKubernetesCloudProviderBackoffRetries       = 6
+	DefaultAzureStackKubernetesCloudProviderBackoffRetries       = 1
 	DefaultAzureStackKubernetesCloudProviderBackoffJitter        = 1.0
-	DefaultAzureStackKubernetesCloudProviderBackoffDuration      = 5
+	DefaultAzureStackKubernetesCloudProviderBackoffDuration      = 30
 	DefaultAzureStackKubernetesCloudProviderBackoffExponent      = 1.5
 	DefaultAzureStackKubernetesCloudProviderRateLimitQPS         = 3.0
 	DefaultAzureStackKubernetesCloudProviderRateLimitQPSWrite    = 3.0


### PR DESCRIPTION
Reason for Change:
Default AKSe settings do not play well with Azure Stack limits. This PR changes defaults for Azure Stack Hub to reduce the retry load to ARM.

**Issue Fixed**:
Fixes #2860 


**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
