### PR TITLE
fix: make master availabilityProfile an optional field for Azure Stack

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -258,10 +258,11 @@ const (
 	DefaultAzureStackUseInstanceMetadata = false
 	// DefaultAzureStackAcceleratedNetworking set to false as Azure Stack today doesn't support accelerated networking
 	DefaultAzureStackAcceleratedNetworking = false
-	DefaultAzureStackAvailabilityProfile   = AvailabilitySet
-	// DefaultAzureStackFaultDomainCount set to 3 as Azure Stack today has minimum 4 node deployment.
+	// DefaultAzureStackAvailabilityProfile set to AvailabilitySet as VMSS clusters are not suppored on Azure Stack
+	DefaultAzureStackAvailabilityProfile = AvailabilitySet
+	// DefaultAzureStackFaultDomainCount set to 3 as Azure Stack today has minimum 4 node deployment
 	DefaultAzureStackFaultDomainCount = 3
-	// MaxAzureStackManagedDiskSize = size for Kubernetes master etcd disk volumes in GB if > 10 nodes as this is max what Azure Stack supports today.
+	// MaxAzureStackManagedDiskSize is the size in GB of the etcd disk volumes when total nodes count is greater than 10
 	MaxAzureStackManagedDiskSize = "1023"
 	// AzureStackSuffix is appended to kubernetes version on Azure Stack instances
 	AzureStackSuffix = "-azs"

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -256,13 +256,11 @@ const (
 const (
 	// DefaultUseInstanceMetadata set to false as Azure Stack today doesn't support instance metadata service
 	DefaultAzureStackUseInstanceMetadata = false
-
 	// DefaultAzureStackAcceleratedNetworking set to false as Azure Stack today doesn't support accelerated networking
 	DefaultAzureStackAcceleratedNetworking = false
-
+	DefaultAzureStackAvailabilityProfile   = AvailabilitySet
 	// DefaultAzureStackFaultDomainCount set to 3 as Azure Stack today has minimum 4 node deployment.
 	DefaultAzureStackFaultDomainCount = 3
-
 	// MaxAzureStackManagedDiskSize = size for Kubernetes master etcd disk volumes in GB if > 10 nodes as this is max what Azure Stack supports today.
 	MaxAzureStackManagedDiskSize = "1023"
 	// AzureStackSuffix is appended to kubernetes version on Azure Stack instances

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -599,6 +599,9 @@ func (p *Properties) setMasterProfileDefaults(isUpgrade bool) {
 	// set default to VMAS for now
 	if p.MasterProfile.AvailabilityProfile == "" {
 		p.MasterProfile.AvailabilityProfile = AvailabilitySet
+		if p.IsAzureStackCloud() {
+			p.MasterProfile.AvailabilityProfile = DefaultAzureStackAvailabilityProfile
+		}
 	}
 
 	if p.MasterProfile.IsVirtualMachineScaleSets() {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1857,7 +1857,7 @@ func (a *Properties) validateAzureStackSupport() error {
 		if networkPlugin != "azure" && networkPlugin != "kubenet" && networkPlugin != "" {
 			return errors.Errorf("kubernetesConfig.networkPlugin '%s' is not supported on Azure Stack clouds", networkPlugin)
 		}
-		if a.MasterProfile.AvailabilityProfile != AvailabilitySet {
+		if a.MasterProfile.AvailabilityProfile == VirtualMachineScaleSets {
 			return errors.Errorf("masterProfile.availabilityProfile should be set to '%s' on Azure Stack clouds", AvailabilitySet)
 		}
 		for _, agentPool := range a.AgentPoolProfiles {

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -4500,6 +4500,13 @@ func TestValidateAzureStackSupport(t *testing.T) {
 			agentAvailability:  VirtualMachineScaleSets,
 			expectedErr:        errors.New("agentPoolProfiles[agentpool].availabilityProfile should be set to 'AvailabilitySet' on Azure Stack clouds"),
 		},
+		{
+			name:               "AzureStack defaults masterAvailabilityProfile to 'AvailabilitySet'",
+			networkPlugin:      "kubenet",
+			masterAvailability: "",
+			agentAvailability:  AvailabilitySet,
+			expectedErr:        nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/engine/testdata/azurestack/kubernetes.json
+++ b/pkg/engine/testdata/azurestack/kubernetes.json
@@ -40,7 +40,6 @@
             "distro": "ubuntu",
             "osDiskSizeGB": 200,
             "count": 3,
-            "availabilityProfile": "AvailabilitySet",
             "vmSize": "Standard_D2_v2"
         },
         "agentPoolProfiles": [


### PR DESCRIPTION
**Reason for Change**:
PR #2717 made master.availabilityProfile a required field.

**Issue Fixed**:
#2855

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version