### PR TITLE
chore: only forward packets on azure0

### DIFF
--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -166,7 +166,8 @@ write_files:
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -205,7 +206,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -161,13 +161,13 @@ write_files:
   content: |
     [Service]
     ExecStart=
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     {{if .MasterProfile.IsCoreOS}}
     ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}} $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -206,8 +206,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -155,13 +155,13 @@ write_files:
   content: |
     [Service]
     ExecStart=
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     {{if .IsCoreOS}}
     ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}} $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -207,8 +207,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -160,7 +160,8 @@ write_files:
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -206,7 +207,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -684,6 +684,16 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"IsDockerContainerRuntime": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime == api.Docker
 		},
+		"GetIptablesForwardingInterface": func() string {
+			var iptablesForwardingInterface string
+			switch cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin {
+			case NetworkPluginKubenet:
+				iptablesForwardingInterface = "cbr0"
+			case NetworkPluginAzure:
+				iptablesForwardingInterface = "azure0"
+			}
+			return iptablesForwardingInterface
+		},
 		"HasNSeriesSKU": func() bool {
 			return cs.Properties.HasNSeriesSKU()
 		},

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37752,13 +37752,13 @@ write_files:
   content: |
     [Service]
     ExecStart=
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     {{if .MasterProfile.IsCoreOS}}
     ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}} $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -37797,8 +37797,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml
@@ -38368,13 +38368,13 @@ write_files:
   content: |
     [Service]
     ExecStart=
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     {{if .IsCoreOS}}
     ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}} $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -38420,8 +38420,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
-    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} -o {{GetIptablesForwardingInterface}} -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i {{GetIptablesForwardingInterface}} ! -o {{GetIptablesForwardingInterface}} -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37757,7 +37757,8 @@ write_files:
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -37796,7 +37797,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml
@@ -38371,7 +38373,8 @@ write_files:
     {{else}}
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     {{end}}
-    ExecStartPost=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPost=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/docker/daemon.json
@@ -38417,7 +38420,8 @@ write_files:
   owner: root
   content: |
     [Service]
-    ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 -o azure0 -j ACCEPT
+    ExecStartPre=/sbin/iptables -A FORWARD -i azure0 ! -o azure0 -j ACCEPT
     #EOF
 
 - path: /etc/containerd/config.toml


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR updates iptables configurations for both docker and containerd so that only packets destined for azure0 are forwarded.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
