### PR TITLE
chore: rev Linux VHDs to 2020.03.10

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -154,17 +154,17 @@ var (
 	// AKSUbuntu1604OSImageConfig is the AKS image based on Ubuntu 16.04-LTS.
 	AKSUbuntu1604OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
-		ImageSku:       "aks-engine-ubuntu-1604-202002",
+		ImageSku:       "aks-engine-ubuntu-1604-202003",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.02.12",
+		ImageVersion:   "2020.03.10",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
 	AKSUbuntu1804OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
-		ImageSku:       "aks-engine-ubuntu-1804-202002",
+		ImageSku:       "aks-engine-ubuntu-1804-202003",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.02.12",
+		ImageVersion:   "2020.03.10",
 	}
 
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019

--- a/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202003_2020.03.10.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202003_2020.03.10.txt
@@ -1,0 +1,144 @@
+Starting build on  Tue Mar 10 18:52:51 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - apmz v0.5.0
+  - bpftrace
+  - moby v3.0.10
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.18
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.0.33
+  - Azure CNI version 1.0.30
+  - Azure CNI version 1.0.29
+  - CNI plugin version 0.8.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - mcr.microsoft.com/oss/kubernetes/kubernetes-dashboard:v1.10.1
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v8.9.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.17.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.4
+  - k8s.gcr.io/cluster-autoscaler:v1.15.5
+  - k8s.gcr.io/cluster-autoscaler:v1.14.7
+  - k8s.gcr.io/cluster-autoscaler:v1.13.9
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - k8s.gcr.io/coredns:1.6.7
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.32
+  - nvidia/k8s-device-plugin:1.11
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/kube-apiserver:v1.18.0-beta.1
+  - k8s.gcr.io/kube-controller-manager:v1.18.0-beta.1
+  - k8s.gcr.io/kube-proxy:v1.18.0-beta.1
+  - k8s.gcr.io/kube-scheduler:v1.18.0-beta.1
+  - k8s.gcr.io/kube-apiserver:v1.17.3
+  - k8s.gcr.io/kube-controller-manager:v1.17.3
+  - k8s.gcr.io/kube-proxy:v1.17.3
+  - k8s.gcr.io/kube-scheduler:v1.17.3
+  - k8s.gcr.io/kube-apiserver:v1.17.2
+  - k8s.gcr.io/kube-controller-manager:v1.17.2
+  - k8s.gcr.io/kube-proxy:v1.17.2
+  - k8s.gcr.io/kube-scheduler:v1.17.2
+  - k8s.gcr.io/hyperkube-amd64:v1.16.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.16.6
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.6-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.15.10
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.15.9
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.9
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.9-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.14.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+  - k8s.gcr.io/hyperkube-amd64:v1.14.7
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.13.12
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+  - k8s.gcr.io/hyperkube-amd64:v1.13.11
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.4.1
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.4.1
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar:v1.0.1
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - k8s.gcr.io/node-problem-detector:v0.8.1
+  - registry:2.7.1
+Using kernel:
+Linux version 4.15.0-1071-azure (buildd@lgw01-amd64-031) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)) #76-Ubuntu SMP Wed Feb 12 03:02:44 UTC 2020
+Install completed successfully on  Tue Mar 10 19:09:08 UTC 2020
+VSTS Build NUMBER: 20200310.8
+VSTS Build ID: 29342791
+Commit: 9aa78998354e9126aba6370d9c18544a52d8a318
+Feature flags:

--- a/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202003_2020.03.10.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202003_2020.03.10.txt
@@ -1,0 +1,144 @@
+Starting build on  Tue Mar 10 18:53:06 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - apmz v0.5.0
+  - bpftrace
+  - moby v3.0.10
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.18
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.0.33
+  - Azure CNI version 1.0.30
+  - Azure CNI version 1.0.29
+  - CNI plugin version 0.8.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - mcr.microsoft.com/oss/kubernetes/kubernetes-dashboard:v1.10.1
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v8.9.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.17.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.4
+  - k8s.gcr.io/cluster-autoscaler:v1.15.5
+  - k8s.gcr.io/cluster-autoscaler:v1.14.7
+  - k8s.gcr.io/cluster-autoscaler:v1.13.9
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - k8s.gcr.io/coredns:1.6.7
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.32
+  - nvidia/k8s-device-plugin:1.11
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/kube-apiserver:v1.18.0-beta.1
+  - k8s.gcr.io/kube-controller-manager:v1.18.0-beta.1
+  - k8s.gcr.io/kube-proxy:v1.18.0-beta.1
+  - k8s.gcr.io/kube-scheduler:v1.18.0-beta.1
+  - k8s.gcr.io/kube-apiserver:v1.17.3
+  - k8s.gcr.io/kube-controller-manager:v1.17.3
+  - k8s.gcr.io/kube-proxy:v1.17.3
+  - k8s.gcr.io/kube-scheduler:v1.17.3
+  - k8s.gcr.io/kube-apiserver:v1.17.2
+  - k8s.gcr.io/kube-controller-manager:v1.17.2
+  - k8s.gcr.io/kube-proxy:v1.17.2
+  - k8s.gcr.io/kube-scheduler:v1.17.2
+  - k8s.gcr.io/hyperkube-amd64:v1.16.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.16.6
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.6-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.15.10
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.15.9
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.9
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.9-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.14.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+  - k8s.gcr.io/hyperkube-amd64:v1.14.7
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.13.12
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+  - k8s.gcr.io/hyperkube-amd64:v1.13.11
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.4.1
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.4.1
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar:v1.0.1
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - k8s.gcr.io/node-problem-detector:v0.8.1
+  - registry:2.7.1
+Using kernel:
+Linux version 5.0.0-1032-azure (buildd@lcy01-amd64-016) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #34-Ubuntu SMP Mon Feb 10 19:37:25 UTC 2020
+Install completed successfully on  Tue Mar 10 19:10:45 UTC 2020
+VSTS Build NUMBER: 20200310.9
+VSTS Build ID: 29342801
+Commit: 9aa78998354e9126aba6370d9c18544a52d8a318
+Feature flags:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR references a new `2020.03.10` VHD for both Ubuntu 16.04-LTS and 18.04-LTS.

Includes the following apt packages pre-installed:

- dbus
- bpftrace
- bcc-tools
- libbcc-examples

Update apmz (telemetry) component to v0.5.0 (from v0.4.0).

Adds Azure CNI 1.0.33 pre-installed, and no longer includes the following versions of Azure CNI pre-installed:

- 1.0.28

Adds CNI plugin version 0.8.5, and no longer includes the following versions of CNI pre-installed:

- 0.7.1
- 0.7.5
- 0.7.6

No longer includes any pre-downloaded versions of containerd (previously included 1.2.4, 1.1.6, and 1.1.5).

Includes the following additional pre-downloaded container images:

- mcr.microsoft.com/oss/kubernetes/kubernetes-dashboard:v1.10.1
- mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
- mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
- mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
- mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
- mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
- mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
- mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v8.9.1
- mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
- mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
- k8s.gcr.io/cluster-autoscaler:v1.17.1
- k8s.gcr.io/cluster-autoscaler:v1.16.4
- k8s.gcr.io/cluster-autoscaler:v1.15.5
- mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
- k8s.gcr.io/coredns:1.6.7
- mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
- mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
- mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
- mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
- mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
- k8s.gcr.io/kube-apiserver:v1.18.0-beta.1
- k8s.gcr.io/kube-controller-manager:v1.18.0-beta.1
- k8s.gcr.io/kube-proxy:v1.18.0-beta.1
- k8s.gcr.io/kube-scheduler:v1.18.0-beta.1
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7-azs
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.6-azs
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10-azs
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.9-azs
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7-azs
- k8s.gcr.io/node-problem-detector:v0.8.1

No longer pre-downloading the following container images:

- k8s.gcr.io/exechealthz-amd64:1.2
- k8s.gcr.io/addon-resizer:1.8.5
- k8s.gcr.io/addon-resizer:1.8.1
- k8s.gcr.io/addon-resizer:1.7
- k8s.gcr.io/heapster-amd64:v1.5.4
- k8s.gcr.io/heapster-amd64:v1.5.3
- k8s.gcr.io/heapster-amd64:v1.5.1
- k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.0
- k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
- k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
- k8s.gcr.io/kube-addon-manager-amd64:v9.0.1
- k8s.gcr.io/kube-addon-manager-amd64:v9.0
- k8s.gcr.io/kube-addon-manager-amd64:v8.9
- k8s.gcr.io/kube-addon-manager-amd64:v8.8
- k8s.gcr.io/kube-addon-manager-amd64:v8.7
- k8s.gcr.io/kube-addon-manager-amd64:v8.6
- k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.0
- k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
- k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
- k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
- mcr.microsoft.com/k8s/azurestack/core/pause-amd64:3.1
- gcr.io/kubernetes-helm/tiller:v2.11.0
- gcr.io/kubernetes-helm/tiller:v2.8.1
- k8s.gcr.io/cluster-autoscaler:v1.17.0
- k8s.gcr.io/cluster-autoscaler:v1.16.3
- k8s.gcr.io/cluster-autoscaler:v1.16.2
- k8s.gcr.io/cluster-autoscaler:v1.16.1
- k8s.gcr.io/cluster-autoscaler:v1.16.0
- k8s.gcr.io/cluster-autoscaler:v1.15.4
- k8s.gcr.io/cluster-autoscaler:v1.15.3
- k8s.gcr.io/cluster-autoscaler:v1.15.2
- k8s.gcr.io/cluster-autoscaler:v1.15.1
- k8s.gcr.io/cluster-autoscaler:v1.15.0
- k8s.gcr.io/cluster-autoscaler:v1.14.6
- k8s.gcr.io/cluster-autoscaler:v1.14.5
- k8s.gcr.io/cluster-autoscaler:v1.14.4
- k8s.gcr.io/cluster-autoscaler:v1.14.2
- k8s.gcr.io/cluster-autoscaler:v1.14.0
- k8s.gcr.io/cluster-autoscaler:v1.13.7
- k8s.gcr.io/cluster-autoscaler:v1.13.6
- k8s.gcr.io/cluster-autoscaler:v1.13.4
- k8s.gcr.io/cluster-autoscaler:v1.13.2
- k8s.gcr.io/cluster-autoscaler:v1.13.1
- k8s.gcr.io/cluster-autoscaler:v1.12.8
- k8s.gcr.io/cluster-autoscaler:v1.12.7
- k8s.gcr.io/cluster-autoscaler:v1.12.5
- k8s.gcr.io/cluster-autoscaler:v1.12.3
- k8s.gcr.io/cluster-autoscaler:v1.12.2
- k8s.gcr.io/cluster-autoscaler:v1.3.9
- k8s.gcr.io/cluster-autoscaler:v1.3.8
- k8s.gcr.io/cluster-autoscaler:v1.3.7
- k8s.gcr.io/cluster-autoscaler:v1.3.4
- k8s.gcr.io/cluster-autoscaler:v1.3.3
- k8s.gcr.io/cluster-autoscaler:v1.2.5
- k8s.gcr.io/cluster-autoscaler:v1.2.2
- k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
- k8s.gcr.io/coredns:1.6.6
- k8s.gcr.io/coredns:1.6.5
- k8s.gcr.io/coredns:1.6.2
- k8s.gcr.io/coredns:1.5.0
- k8s.gcr.io/coredns:1.3.1
- k8s.gcr.io/coredns:1.2.6
- k8s.gcr.io/coredns:1.2.2
- k8s.gcr.io/rescheduler:v0.3.1
- mcr.microsoft.com/containernetworking/networkmonitor:v0.0.5
- mcr.microsoft.com/containernetworking/azure-npm:v1.0.31
- mcr.microsoft.com/containernetworking/azure-npm:v1.0.30
- mcr.microsoft.com/containernetworking/azure-npm:v1.0.29
- mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.29
- mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.28
- nvidia/k8s-device-plugin:1.10
- mcr.microsoft.com/aks/hcp/hcp-tunnel-front:v1.9.2-v3.0.11
- mcr.microsoft.com/aks/hcp/hcp-tunnel-front:v1.9.2-v4.0.11
- mcr.microsoft.com/aks/hcp/kube-svc-redirect:v1.0.5
- mcr.microsoft.com/aks/hcp/kube-svc-redirect:v1.0.7
- mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.13
- gcr.io/google-containers/ip-masq-agent-amd64:v2.5.0
- gcr.io/google-containers/ip-masq-agent-amd64:v2.3.0
- k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
- gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
- k8s.gcr.io/ip-masq-agent-amd64:v2.0.0
- nginx:1.13.12-alpine
- mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.15.9-azs
- mcr.microsoft.com/k8s/azurestack/core/hyperkube-amd64:v1.14.7-azs
- mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.4.0
- mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.4.0
- mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.3.0
- mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.3.0
- mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.4.0
- k8s.gcr.io/node-problem-detector:v0.8.0

Updated 16.04-LTS kernel version to:

- Linux version 4.15.0-1071-azure (buildd@lgw01-amd64-031) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)) #76-Ubuntu SMP Wed Feb 12 03:02:44 UTC 2020

Updated 18.04-LTS kernel version to:

- Linux version 5.0.0-1032-azure (buildd@lcy01-amd64-016) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #34-Ubuntu SMP Mon Feb 10 19:37:25 UTC 2020

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
