### PR TITLE
fix: honor custom{component}Image fields

### DIFF
--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -175,12 +175,6 @@
       },
       "type": "string"
     },
-    "kubeProxySpec": {
-      "metadata": {
-        "description": "The container spec for kube-proxy."
-      },
-      "type": "string"
-    },
     "kubeBinaryURL": {
       "defaultValue": "",
       "metadata": {

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -889,6 +889,13 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		}
 	}
 
+	// Honor customKubeProxyImage field
+	if o.KubernetesConfig.CustomKubeProxyImage != "" {
+		if i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.KubeProxyAddonName); i > -1 {
+			o.KubernetesConfig.Addons[i].Containers[0].Image = o.KubernetesConfig.CustomKubeProxyImage
+		}
+	}
+
 	for _, addon := range defaultAddons {
 		synthesizeAddonsConfig(o.KubernetesConfig.Addons, addon, isUpgrade)
 	}

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -3131,7 +3131,7 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
-			}, "1.15.4", "", common.KubernetesImageBaseTypeGCR),
+			}, "1.15.4"),
 		},
 		{
 			name: "kube-proxy disabled",
@@ -3466,7 +3466,7 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
-			}, "1.18.0", "", common.KubernetesImageBaseTypeGCR)),
+			}, "1.18.0")),
 		},
 		{
 			name: "addons with dual stack",
@@ -3535,7 +3535,7 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
-			}, "1.18.0", "", common.KubernetesImageBaseTypeGCR)),
+			}, "1.18.0")),
 		},
 		{
 			name: "kube proxy w/ customKubeProxyImage",
@@ -3574,7 +3574,7 @@ func TestSetAddonsConfig(t *testing.T) {
 						},
 					},
 				},
-			}, "1.15.4", "", common.KubernetesImageBaseTypeGCR),
+			}, "1.15.4"),
 		},
 	}
 
@@ -4030,14 +4030,14 @@ func concatenateDefaultAddons(addons []KubernetesAddon, version string) []Kubern
 	return defaults
 }
 
-func overwriteDefaultAddons(addons []KubernetesAddon, version, kubernetesImageBase, kubernetesImageBaseType string) []KubernetesAddon {
+func overwriteDefaultAddons(addons []KubernetesAddon, version string) []KubernetesAddon {
 	overrideAddons := make(map[string]KubernetesAddon)
 	for _, addonOverride := range addons {
 		overrideAddons[addonOverride.Name] = addonOverride
 	}
 
 	var ret []KubernetesAddon
-	defaults := getDefaultAddons(version, kubernetesImageBase, kubernetesImageBaseType)
+	defaults := getDefaultAddons(version, "", common.KubernetesImageBaseTypeGCR)
 
 	for _, addon := range defaults {
 		if _, exists := overrideAddons[addon.Name]; exists {

--- a/pkg/api/components.go
+++ b/pkg/api/components.go
@@ -97,9 +97,9 @@ func (cs *ContainerService) setComponentsConfig(isUpgrade bool) {
 	}
 
 	// Honor custom{component}Image fields
+	useHyperkube := !common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.0")
 	for _, component := range defaultComponents {
 		if i := getComponentsIndexByName(kubernetesConfig.Components, component.Name); i > -1 {
-			useHyperkube := !common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.0")
 			var customComponentImage string
 			switch component.Name {
 			case common.APIServerComponentName:
@@ -116,8 +116,6 @@ func (cs *ContainerService) setComponentsConfig(isUpgrade bool) {
 				}
 			case common.CloudControllerManagerComponentName:
 				customComponentImage = kubernetesConfig.CustomCcmImage
-			case common.Hyperkube:
-				customComponentImage = kubernetesConfig.CustomHyperkubeImage
 			case common.SchedulerComponentName:
 				if useHyperkube {
 					customComponentImage = kubernetesConfig.CustomHyperkubeImage

--- a/pkg/api/components.go
+++ b/pkg/api/components.go
@@ -96,6 +96,44 @@ func (cs *ContainerService) setComponentsConfig(isUpgrade bool) {
 		}
 	}
 
+	// Honor custom{component}Image fields
+	for _, component := range defaultComponents {
+		if i := getComponentsIndexByName(kubernetesConfig.Components, component.Name); i > -1 {
+			useHyperkube := !common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.0")
+			var customComponentImage string
+			switch component.Name {
+			case common.APIServerComponentName:
+				if useHyperkube {
+					customComponentImage = kubernetesConfig.CustomHyperkubeImage
+				} else {
+					customComponentImage = kubernetesConfig.CustomKubeAPIServerImage
+				}
+			case common.ControllerManagerComponentName:
+				if useHyperkube {
+					customComponentImage = kubernetesConfig.CustomHyperkubeImage
+				} else {
+					customComponentImage = kubernetesConfig.CustomKubeControllerManagerImage
+				}
+			case common.CloudControllerManagerComponentName:
+				customComponentImage = kubernetesConfig.CustomCcmImage
+			case common.Hyperkube:
+				customComponentImage = kubernetesConfig.CustomHyperkubeImage
+			case common.SchedulerComponentName:
+				if useHyperkube {
+					customComponentImage = kubernetesConfig.CustomHyperkubeImage
+				} else {
+					customComponentImage = kubernetesConfig.CustomKubeSchedulerImage
+				}
+			}
+
+			if customComponentImage != "" {
+				// Since there is only one container for all Kubernetes components,
+				// it is safe to access index 0 of the component's containers
+				kubernetesConfig.Components[i].Containers[0].Image = customComponentImage
+			}
+		}
+	}
+
 	for _, component := range defaultComponents {
 		synthesizeComponentsConfig(kubernetesConfig.Components, component, isUpgrade)
 	}
@@ -222,16 +260,9 @@ func getComponentDefaultContainerImage(component string, cs *ContainerService) s
 	if cs.Properties.IsAzureStackCloud() {
 		hyperkubeImage = hyperkubeImage + common.AzureStackSuffix
 	}
-	if kubernetesConfig.CustomHyperkubeImage != "" {
-		hyperkubeImage = kubernetesConfig.CustomHyperkubeImage
-	}
 	controllerManagerBase := kubernetesImageBase
 	if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.16.0") {
 		controllerManagerBase = kubernetesConfig.MCRKubernetesImageBase
-	}
-	ccmImage := controllerManagerBase + k8sComponents[common.CloudControllerManagerComponentName]
-	if kubernetesConfig.CustomCcmImage != "" {
-		ccmImage = kubernetesConfig.CustomCcmImage
 	}
 
 	switch component {
@@ -246,7 +277,7 @@ func getComponentDefaultContainerImage(component string, cs *ContainerService) s
 		}
 		return hyperkubeImage
 	case common.CloudControllerManagerComponentName:
-		return ccmImage
+		return controllerManagerBase + k8sComponents[common.CloudControllerManagerComponentName]
 	case common.SchedulerComponentName:
 		if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.0") {
 			return kubernetesImageBase + k8sComponents[common.SchedulerComponentName]

--- a/pkg/api/components_test.go
+++ b/pkg/api/components_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
+const (
+	customCcmImage                   = "my-custom-cloud-controller-manager-image"
+	customHyperkubeImage             = "my-custom-hyperkube-image"
+	customKubeAddonManagerImage      = "my-custom-kube-addon-manager-image"
+	customKubeAPIServerImage         = "my-custom-kube-apiserver-image"
+	customKubeControllerManagerImage = "my-custom-kube-controller-manager-image"
+	customKubeSchedulerImage         = "my-custom-kube-scheduler-image"
+)
+
 func TestSetComponentsConfig(t *testing.T) {
 	userConfiguredComponentsMap := getUserConfiguredComponentMap()
 	containerServiceMap := getContainerServicesMap()
@@ -40,24 +49,63 @@ func TestSetComponentsConfig(t *testing.T) {
 			}, containerServiceMap["1.13 user-configured"]), userConfiguredComponentsMap["user-configured cloud-controller-manager component"]),
 		},
 		{
-			name:      "1.13 + CCM",
-			cs:        containerServiceMap["1.13 + CCM"],
+			name:      "1.13 + customHyperkubeImage + customCcmImage",
+			cs:        containerServiceMap["1.13 + customHyperkubeImage + customCcmImage"],
 			isUpgrade: false,
 			expectedComponents: concatenateDefaultComponents([]KubernetesComponent{
+				{
+					Name:    common.APIServerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.APIServerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-apiserver\"",
+					},
+				},
+				{
+					Name:    common.ControllerManagerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.ControllerManagerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-controller-manager\"",
+					},
+				},
+				{
+					Name:    common.SchedulerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.SchedulerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-scheduler\"",
+					},
+				},
 				{
 					Name:    common.CloudControllerManagerComponentName,
 					Enabled: to.BoolPtr(true),
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CloudControllerManagerComponentName,
-							Image: getComponentDefaultContainerImage(common.CloudControllerManagerComponentName, containerServiceMap["1.13 + CCM"]),
+							Image: customCcmImage,
 						},
 					},
 					Config: map[string]string{
 						"command": "\"cloud-controller-manager\"",
 					},
 				},
-			}, containerServiceMap["1.13 + CCM"]),
+			}, containerServiceMap["1.13 + customHyperkubeImage + customCcmImage"]),
 		},
 		{
 			name:               "1.14",
@@ -77,24 +125,63 @@ func TestSetComponentsConfig(t *testing.T) {
 			}, containerServiceMap["1.14 user-configured"]), userConfiguredComponentsMap["user-configured cloud-controller-manager component"]),
 		},
 		{
-			name:      "1.14 + CCM",
-			cs:        containerServiceMap["1.14 + CCM"],
+			name:      "1.14 + customHyperkubeImage + customCcmImage",
+			cs:        containerServiceMap["1.14 + customHyperkubeImage + customCcmImage"],
 			isUpgrade: false,
 			expectedComponents: concatenateDefaultComponents([]KubernetesComponent{
+				{
+					Name:    common.APIServerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.APIServerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-apiserver\"",
+					},
+				},
+				{
+					Name:    common.ControllerManagerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.ControllerManagerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-controller-manager\"",
+					},
+				},
+				{
+					Name:    common.SchedulerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.SchedulerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-scheduler\"",
+					},
+				},
 				{
 					Name:    common.CloudControllerManagerComponentName,
 					Enabled: to.BoolPtr(true),
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CloudControllerManagerComponentName,
-							Image: getComponentDefaultContainerImage(common.CloudControllerManagerComponentName, containerServiceMap["1.14 + CCM"]),
+							Image: customCcmImage,
 						},
 					},
 					Config: map[string]string{
 						"command": "\"cloud-controller-manager\"",
 					},
 				},
-			}, containerServiceMap["1.14 + CCM"]),
+			}, containerServiceMap["1.14 + customHyperkubeImage + customCcmImage"]),
 		},
 		{
 			name:               "1.15",
@@ -114,24 +201,63 @@ func TestSetComponentsConfig(t *testing.T) {
 			}, containerServiceMap["1.15 user-configured"]), userConfiguredComponentsMap["user-configured cloud-controller-manager component"]),
 		},
 		{
-			name:      "1.15 + CCM",
-			cs:        containerServiceMap["1.15 + CCM"],
+			name:      "1.15 + customHyperkubeImage + customCcmImage",
+			cs:        containerServiceMap["1.15 + customHyperkubeImage + customCcmImage"],
 			isUpgrade: false,
 			expectedComponents: concatenateDefaultComponents([]KubernetesComponent{
+				{
+					Name:    common.APIServerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.APIServerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-apiserver\"",
+					},
+				},
+				{
+					Name:    common.ControllerManagerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.ControllerManagerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-controller-manager\"",
+					},
+				},
+				{
+					Name:    common.SchedulerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.SchedulerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-scheduler\"",
+					},
+				},
 				{
 					Name:    common.CloudControllerManagerComponentName,
 					Enabled: to.BoolPtr(true),
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CloudControllerManagerComponentName,
-							Image: getComponentDefaultContainerImage(common.CloudControllerManagerComponentName, containerServiceMap["1.15 + CCM"]),
+							Image: customCcmImage,
 						},
 					},
 					Config: map[string]string{
 						"command": "\"cloud-controller-manager\"",
 					},
 				},
-			}, containerServiceMap["1.15 + CCM"]),
+			}, containerServiceMap["1.15 + customHyperkubeImage + customCcmImage"]),
 		},
 		{
 			name:               "1.16",
@@ -151,24 +277,63 @@ func TestSetComponentsConfig(t *testing.T) {
 			}, containerServiceMap["1.16 user-configured"]), userConfiguredComponentsMap["user-configured cloud-controller-manager component"]),
 		},
 		{
-			name:      "1.16 + CCM",
-			cs:        containerServiceMap["1.16 + CCM"],
+			name:      "1.16 + customHyperkubeImage + customCcmImage",
+			cs:        containerServiceMap["1.16 + customHyperkubeImage + customCcmImage"],
 			isUpgrade: false,
 			expectedComponents: concatenateDefaultComponents([]KubernetesComponent{
+				{
+					Name:    common.APIServerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.APIServerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-apiserver\"",
+					},
+				},
+				{
+					Name:    common.ControllerManagerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.ControllerManagerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-controller-manager\"",
+					},
+				},
+				{
+					Name:    common.SchedulerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.SchedulerComponentName,
+							Image: customHyperkubeImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"/hyperkube\", \"kube-scheduler\"",
+					},
+				},
 				{
 					Name:    common.CloudControllerManagerComponentName,
 					Enabled: to.BoolPtr(true),
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CloudControllerManagerComponentName,
-							Image: getComponentDefaultContainerImage(common.CloudControllerManagerComponentName, containerServiceMap["1.16 + CCM"]),
+							Image: customCcmImage,
 						},
 					},
 					Config: map[string]string{
 						"command": "\"cloud-controller-manager\"",
 					},
 				},
-			}, containerServiceMap["1.16 + CCM"]),
+			}, containerServiceMap["1.16 + customHyperkubeImage + customCcmImage"]),
 		},
 		{
 			name:               "1.17",
@@ -188,24 +353,63 @@ func TestSetComponentsConfig(t *testing.T) {
 			}, containerServiceMap["1.17 user-configured"]), userConfiguredComponentsMap["user-configured cloud-controller-manager component"]),
 		},
 		{
-			name:      "1.17 + CCM",
-			cs:        containerServiceMap["1.17 + CCM"],
+			name:      "1.17 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage",
+			cs:        containerServiceMap["1.17 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage"],
 			isUpgrade: false,
 			expectedComponents: concatenateDefaultComponents([]KubernetesComponent{
+				{
+					Name:    common.APIServerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.APIServerComponentName,
+							Image: customKubeAPIServerImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"kube-apiserver\"",
+					},
+				},
+				{
+					Name:    common.ControllerManagerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.ControllerManagerComponentName,
+							Image: customKubeControllerManagerImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"kube-controller-manager\"",
+					},
+				},
+				{
+					Name:    common.SchedulerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.SchedulerComponentName,
+							Image: customKubeSchedulerImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"kube-scheduler\"",
+					},
+				},
 				{
 					Name:    common.CloudControllerManagerComponentName,
 					Enabled: to.BoolPtr(true),
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CloudControllerManagerComponentName,
-							Image: getComponentDefaultContainerImage(common.CloudControllerManagerComponentName, containerServiceMap["1.17 + CCM"]),
+							Image: customCcmImage,
 						},
 					},
 					Config: map[string]string{
 						"command": "\"cloud-controller-manager\"",
 					},
 				},
-			}, containerServiceMap["1.17 + CCM"]),
+			}, containerServiceMap["1.17 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage"]),
 		},
 		{
 			name:               "1.18",
@@ -225,24 +429,63 @@ func TestSetComponentsConfig(t *testing.T) {
 			}, containerServiceMap["1.18 user-configured"]), userConfiguredComponentsMap["user-configured cloud-controller-manager component"]),
 		},
 		{
-			name:      "1.18 + CCM",
-			cs:        containerServiceMap["1.18 + CCM"],
+			name:      "1.18 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage",
+			cs:        containerServiceMap["1.18 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage"],
 			isUpgrade: false,
 			expectedComponents: concatenateDefaultComponents([]KubernetesComponent{
+				{
+					Name:    common.APIServerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.APIServerComponentName,
+							Image: customKubeAPIServerImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"kube-apiserver\"",
+					},
+				},
+				{
+					Name:    common.ControllerManagerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.ControllerManagerComponentName,
+							Image: customKubeControllerManagerImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"kube-controller-manager\"",
+					},
+				},
+				{
+					Name:    common.SchedulerComponentName,
+					Enabled: to.BoolPtr(true),
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.SchedulerComponentName,
+							Image: customKubeSchedulerImage,
+						},
+					},
+					Config: map[string]string{
+						"command": "\"kube-scheduler\"",
+					},
+				},
 				{
 					Name:    common.CloudControllerManagerComponentName,
 					Enabled: to.BoolPtr(true),
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CloudControllerManagerComponentName,
-							Image: getComponentDefaultContainerImage(common.CloudControllerManagerComponentName, containerServiceMap["1.18 + CCM"]),
+							Image: customCcmImage,
 						},
 					},
 					Config: map[string]string{
 						"command": "\"cloud-controller-manager\"",
 					},
 				},
-			}, containerServiceMap["1.18 + CCM"]),
+			}, containerServiceMap["1.18 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage"]),
 		},
 	}
 
@@ -774,11 +1017,6 @@ func TestGetDefaultCommandStrings(t *testing.T) {
 func TestGetContainerImages(t *testing.T) {
 	specConfig := AzureCloudSpecEnvMap["AzurePublicCloud"].KubernetesSpecConfig
 	csOneDotThirteen := getContainerServicesMap()["1.13"]
-	csOneDotThirteenCustomImages := getContainerServicesMap()["1.13"]
-	csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage = "my-custom-hyperkube-image"
-	csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage = "my-custom-ccm-image"
-	csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/"
-	csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	csOneDotThirteenCustomImagesComponents := GetK8sComponentsByVersionMap(&KubernetesConfig{KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR})
 	csOneDotThirteenAzureStack := getContainerServicesMap()["1.13"]
 	csOneDotThirteenAzureStack.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -790,11 +1028,6 @@ func TestGetContainerImages(t *testing.T) {
 	csOneDotThirteenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	orchestratorVersionOneDotThirteen := csOneDotThirteen.Properties.OrchestratorProfile.OrchestratorVersion
 	csOneDotFourteen := getContainerServicesMap()["1.14"]
-	csOneDotFourteenCustomImages := getContainerServicesMap()["1.14"]
-	csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage = "my-custom-hyperkube-image"
-	csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage = "my-custom-ccm-image"
-	csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/"
-	csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	csOneDotFourteenCustomImagesComponents := GetK8sComponentsByVersionMap(&KubernetesConfig{KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR})
 	csOneDotFourteenAzureStack := getContainerServicesMap()["1.14"]
 	csOneDotFourteenAzureStack.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -806,11 +1039,6 @@ func TestGetContainerImages(t *testing.T) {
 	csOneDotFourteenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	orchestratorVersionOneDotFourteen := csOneDotFourteen.Properties.OrchestratorProfile.OrchestratorVersion
 	csOneDotFifteen := getContainerServicesMap()["1.15"]
-	csOneDotFifteenCustomImages := getContainerServicesMap()["1.15"]
-	csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage = "my-custom-hyperkube-image"
-	csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage = "my-custom-ccm-image"
-	csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/"
-	csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	csOneDotFifteenCustomImagesComponents := GetK8sComponentsByVersionMap(&KubernetesConfig{KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR})
 	csOneDotFifteenAzureStack := getContainerServicesMap()["1.15"]
 	csOneDotFifteenAzureStack.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -822,11 +1050,6 @@ func TestGetContainerImages(t *testing.T) {
 	csOneDotFifteenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	orchestratorVersionOneDotFifteen := csOneDotFifteen.Properties.OrchestratorProfile.OrchestratorVersion
 	csOneDotSixteen := getContainerServicesMap()["1.16"]
-	csOneDotSixteenCustomImages := getContainerServicesMap()["1.16"]
-	csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage = "my-custom-hyperkube-image"
-	csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage = "my-custom-ccm-image"
-	csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/"
-	csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	csOneDotSixteenCustomImagesComponents := GetK8sComponentsByVersionMap(&KubernetesConfig{KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR})
 	csOneDotSixteenAzureStack := getContainerServicesMap()["1.16"]
 	csOneDotSixteenAzureStack.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -838,10 +1061,6 @@ func TestGetContainerImages(t *testing.T) {
 	csOneDotSixteenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	orchestratorVersionOneDotSixteen := csOneDotSixteen.Properties.OrchestratorProfile.OrchestratorVersion
 	csOneDotSeventeen := getContainerServicesMap()["1.17"]
-	csOneDotSeventeenCustomImages := getContainerServicesMap()["1.17"]
-	csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage = "my-custom-ccm-image"
-	csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/"
-	csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	csOneDotSeventeenCustomImagesComponents := GetK8sComponentsByVersionMap(&KubernetesConfig{KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR})
 	csOneDotSeventeenAzureStack := getContainerServicesMap()["1.17"]
 	csOneDotSeventeenAzureStack.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -853,10 +1072,6 @@ func TestGetContainerImages(t *testing.T) {
 	csOneDotSeventeenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	orchestratorVersionOneDotSeventeen := csOneDotSeventeen.Properties.OrchestratorProfile.OrchestratorVersion
 	csOneDotEighteen := getContainerServicesMap()["1.18"]
-	csOneDotEighteenCustomImages := getContainerServicesMap()["1.18"]
-	csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage = "my-custom-ccm-image"
-	csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/"
-	csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	csOneDotEighteenCustomImagesComponents := GetK8sComponentsByVersionMap(&KubernetesConfig{KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR})
 	csOneDotEighteenAzureStack := getContainerServicesMap()["1.18"]
 	csOneDotEighteenAzureStack.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -887,15 +1102,6 @@ func TestGetContainerImages(t *testing.T) {
 			expectedAddonManagerImageString:           csOneDotThirteen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotThirteen][common.AddonManagerComponentName],
 		},
 		{
-			name:                                 "1.13 custom images in ContainerService",
-			cs:                                   csOneDotThirteenCustomImages,
-			expectedAPIServerImageString:         csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedControllerManagerImageString: csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedCloudControllerManagerImageString: csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage,
-			expectedSchedulerImageString:              csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedAddonManagerImageString:           csOneDotThirteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotThirteenCustomImagesComponents[orchestratorVersionOneDotThirteen][common.AddonManagerComponentName],
-		},
-		{
 			name:                                 "1.13 Azure Stack",
 			cs:                                   csOneDotThirteenAzureStack,
 			expectedAPIServerImageString:         csOneDotThirteenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotThirteenCustomImagesComponents[orchestratorVersionOneDotThirteen][common.Hyperkube] + common.AzureStackSuffix,
@@ -912,15 +1118,6 @@ func TestGetContainerImages(t *testing.T) {
 			expectedCloudControllerManagerImageString: csOneDotFourteen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotFourteen][common.CloudControllerManagerComponentName],
 			expectedSchedulerImageString:              specConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotFourteen][common.Hyperkube],
 			expectedAddonManagerImageString:           csOneDotFourteen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotFourteen][common.AddonManagerComponentName],
-		},
-		{
-			name:                                 "1.14 custom images in ContainerService",
-			cs:                                   csOneDotFourteenCustomImages,
-			expectedAPIServerImageString:         csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedControllerManagerImageString: csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedCloudControllerManagerImageString: csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage,
-			expectedSchedulerImageString:              csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedAddonManagerImageString:           csOneDotFourteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotFourteenCustomImagesComponents[orchestratorVersionOneDotFourteen][common.AddonManagerComponentName],
 		},
 		{
 			name:                                 "1.14 Azure Stack",
@@ -941,15 +1138,6 @@ func TestGetContainerImages(t *testing.T) {
 			expectedAddonManagerImageString:           csOneDotFifteen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotFifteen][common.AddonManagerComponentName],
 		},
 		{
-			name:                                 "1.15 custom images in ContainerService",
-			cs:                                   csOneDotFifteenCustomImages,
-			expectedAPIServerImageString:         csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedControllerManagerImageString: csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedCloudControllerManagerImageString: csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage,
-			expectedSchedulerImageString:              csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedAddonManagerImageString:           csOneDotFifteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotFifteenCustomImagesComponents[orchestratorVersionOneDotFifteen][common.AddonManagerComponentName],
-		},
-		{
 			name:                                 "1.15 Azure Stack",
 			cs:                                   csOneDotFifteenAzureStack,
 			expectedAPIServerImageString:         csOneDotFifteenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotFifteenCustomImagesComponents[orchestratorVersionOneDotFifteen][common.Hyperkube] + common.AzureStackSuffix,
@@ -966,15 +1154,6 @@ func TestGetContainerImages(t *testing.T) {
 			expectedCloudControllerManagerImageString: csOneDotSixteen.Properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotSixteen][common.CloudControllerManagerComponentName],
 			expectedSchedulerImageString:              specConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotSixteen][common.Hyperkube],
 			expectedAddonManagerImageString:           csOneDotSixteen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotSixteen][common.AddonManagerComponentName],
-		},
-		{
-			name:                                 "1.16 custom images in ContainerService",
-			cs:                                   csOneDotSixteenCustomImages,
-			expectedAPIServerImageString:         csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedControllerManagerImageString: csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedCloudControllerManagerImageString: csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage,
-			expectedSchedulerImageString:              csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage,
-			expectedAddonManagerImageString:           csOneDotSixteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotSixteenCustomImagesComponents[orchestratorVersionOneDotSixteen][common.AddonManagerComponentName],
 		},
 		{
 			name:                                 "1.16 Azure Stack",
@@ -995,15 +1174,6 @@ func TestGetContainerImages(t *testing.T) {
 			expectedAddonManagerImageString:           csOneDotSeventeen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotSeventeen][common.AddonManagerComponentName],
 		},
 		{
-			name:                                 "1.17 custom images in ContainerService",
-			cs:                                   csOneDotSeventeenCustomImages,
-			expectedAPIServerImageString:         csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotSeventeenCustomImagesComponents[orchestratorVersionOneDotSeventeen][common.APIServerComponentName],
-			expectedControllerManagerImageString: csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotSeventeenCustomImagesComponents[orchestratorVersionOneDotSeventeen][common.ControllerManagerComponentName],
-			expectedCloudControllerManagerImageString: csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage,
-			expectedSchedulerImageString:              csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotSeventeenCustomImagesComponents[orchestratorVersionOneDotSeventeen][common.SchedulerComponentName],
-			expectedAddonManagerImageString:           csOneDotSeventeenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotSeventeenCustomImagesComponents[orchestratorVersionOneDotSeventeen][common.AddonManagerComponentName],
-		},
-		{
 			name:                                 "1.17 Azure Stack",
 			cs:                                   csOneDotSeventeenAzureStack,
 			expectedAPIServerImageString:         csOneDotSeventeenAzureStack.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotSeventeenCustomImagesComponents[orchestratorVersionOneDotSeventeen][common.APIServerComponentName],
@@ -1020,15 +1190,6 @@ func TestGetContainerImages(t *testing.T) {
 			expectedCloudControllerManagerImageString: csOneDotEighteen.Properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotEighteen][common.CloudControllerManagerComponentName],
 			expectedSchedulerImageString:              csOneDotEighteen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotEighteen][common.SchedulerComponentName],
 			expectedAddonManagerImageString:           csOneDotEighteen.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + k8sComponentsByVersionMap[orchestratorVersionOneDotEighteen][common.AddonManagerComponentName],
-		},
-		{
-			name:                                 "1.18 custom images in ContainerService",
-			cs:                                   csOneDotEighteenCustomImages,
-			expectedAPIServerImageString:         csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotEighteenCustomImagesComponents[orchestratorVersionOneDotEighteen][common.APIServerComponentName],
-			expectedControllerManagerImageString: csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotEighteenCustomImagesComponents[orchestratorVersionOneDotEighteen][common.ControllerManagerComponentName],
-			expectedCloudControllerManagerImageString: csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.CustomCcmImage,
-			expectedSchedulerImageString:              csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotEighteenCustomImagesComponents[orchestratorVersionOneDotEighteen][common.SchedulerComponentName],
-			expectedAddonManagerImageString:           csOneDotEighteenCustomImages.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase + csOneDotEighteenCustomImagesComponents[orchestratorVersionOneDotEighteen][common.AddonManagerComponentName],
 		},
 		{
 			name:                                 "1.18 Azure Stack",
@@ -1127,7 +1288,7 @@ func getDefaultComponents(cs *ContainerService) []KubernetesComponent {
 
 func concatenateDefaultComponents(components []KubernetesComponent, cs *ContainerService) []KubernetesComponent {
 	defaults := getDefaultComponents(cs)
-	defaults = append(defaults, components...)
+	defaults = append(components, defaults...)
 	return defaults
 }
 
@@ -1153,7 +1314,7 @@ func getUserConfiguredComponentMap() map[string]KubernetesComponent {
 			Containers: []KubernetesContainerSpec{
 				{
 					Name:  common.SchedulerComponentName,
-					Image: "my-custom-kube-scheduler-image",
+					Image: customKubeSchedulerImage,
 				},
 			},
 			Config: map[string]string{
@@ -1167,7 +1328,7 @@ func getUserConfiguredComponentMap() map[string]KubernetesComponent {
 			Containers: []KubernetesContainerSpec{
 				{
 					Name:  common.ControllerManagerComponentName,
-					Image: "my-custom-controller-manager-image",
+					Image: customKubeControllerManagerImage,
 				},
 			},
 			Config: map[string]string{
@@ -1181,7 +1342,7 @@ func getUserConfiguredComponentMap() map[string]KubernetesComponent {
 			Containers: []KubernetesContainerSpec{
 				{
 					Name:  common.CloudControllerManagerComponentName,
-					Image: "my-custom-cloud-controller-manager-image",
+					Image: customCcmImage,
 				},
 			},
 			Config: map[string]string{
@@ -1195,7 +1356,7 @@ func getUserConfiguredComponentMap() map[string]KubernetesComponent {
 			Containers: []KubernetesContainerSpec{
 				{
 					Name:  common.APIServerComponentName,
-					Image: "my-custom-kube-apiserver-image",
+					Image: customKubeAPIServerImage,
 				},
 			},
 			Config: map[string]string{
@@ -1209,7 +1370,7 @@ func getUserConfiguredComponentMap() map[string]KubernetesComponent {
 			Containers: []KubernetesContainerSpec{
 				{
 					Name:  common.AddonManagerComponentName,
-					Image: "my-custom-kube-addon-manager-image",
+					Image: customKubeAddonManagerImage,
 				},
 			},
 			Config: map[string]string{
@@ -1254,14 +1415,13 @@ func getContainerServicesMap() map[string]*ContainerService {
 				},
 			},
 		},
-		"1.13 + CCM": {
+		"1.13 + customHyperkubeImage + customCcmImage": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorVersion: "1.13.11",
 					KubernetesConfig: &KubernetesConfig{
-						KubernetesImageBase:       specConfig.KubernetesImageBase,
-						KubernetesImageBaseType:   common.KubernetesImageBaseTypeGCR,
-						MCRKubernetesImageBase:    specConfig.MCRKubernetesImageBase,
+						CustomHyperkubeImage:      customHyperkubeImage,
+						CustomCcmImage:            customCcmImage,
 						UseCloudControllerManager: to.BoolPtr(true),
 					},
 				},
@@ -1298,14 +1458,13 @@ func getContainerServicesMap() map[string]*ContainerService {
 				},
 			},
 		},
-		"1.14 + CCM": {
+		"1.14 + customHyperkubeImage + customCcmImage": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorVersion: "1.14.7",
 					KubernetesConfig: &KubernetesConfig{
-						KubernetesImageBase:       specConfig.KubernetesImageBase,
-						KubernetesImageBaseType:   common.KubernetesImageBaseTypeGCR,
-						MCRKubernetesImageBase:    specConfig.MCRKubernetesImageBase,
+						CustomHyperkubeImage:      customHyperkubeImage,
+						CustomCcmImage:            customCcmImage,
 						UseCloudControllerManager: to.BoolPtr(true),
 					},
 				},
@@ -1342,14 +1501,13 @@ func getContainerServicesMap() map[string]*ContainerService {
 				},
 			},
 		},
-		"1.15 + CCM": {
+		"1.15 + customHyperkubeImage + customCcmImage": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorVersion: "1.15.9",
 					KubernetesConfig: &KubernetesConfig{
-						KubernetesImageBase:       specConfig.KubernetesImageBase,
-						KubernetesImageBaseType:   common.KubernetesImageBaseTypeGCR,
-						MCRKubernetesImageBase:    specConfig.MCRKubernetesImageBase,
+						CustomHyperkubeImage:      customHyperkubeImage,
+						CustomCcmImage:            customCcmImage,
 						UseCloudControllerManager: to.BoolPtr(true),
 					},
 				},
@@ -1386,14 +1544,13 @@ func getContainerServicesMap() map[string]*ContainerService {
 				},
 			},
 		},
-		"1.16 + CCM": {
+		"1.16 + customHyperkubeImage + customCcmImage": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorVersion: "1.16.6",
 					KubernetesConfig: &KubernetesConfig{
-						KubernetesImageBase:       specConfig.KubernetesImageBase,
-						KubernetesImageBaseType:   common.KubernetesImageBaseTypeGCR,
-						MCRKubernetesImageBase:    specConfig.MCRKubernetesImageBase,
+						CustomHyperkubeImage:      customHyperkubeImage,
+						CustomCcmImage:            customCcmImage,
 						UseCloudControllerManager: to.BoolPtr(true),
 					},
 				},
@@ -1430,15 +1587,16 @@ func getContainerServicesMap() map[string]*ContainerService {
 				},
 			},
 		},
-		"1.17 + CCM": {
+		"1.17 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorVersion: "1.17.2",
 					KubernetesConfig: &KubernetesConfig{
-						KubernetesImageBase:       specConfig.KubernetesImageBase,
-						KubernetesImageBaseType:   common.KubernetesImageBaseTypeGCR,
-						MCRKubernetesImageBase:    specConfig.MCRKubernetesImageBase,
-						UseCloudControllerManager: to.BoolPtr(true),
+						CustomCcmImage:                   customCcmImage,
+						CustomKubeAPIServerImage:         customKubeAPIServerImage,
+						CustomKubeControllerManagerImage: customKubeControllerManagerImage,
+						CustomKubeSchedulerImage:         customKubeSchedulerImage,
+						UseCloudControllerManager:        to.BoolPtr(true),
 					},
 				},
 			},
@@ -1474,15 +1632,16 @@ func getContainerServicesMap() map[string]*ContainerService {
 				},
 			},
 		},
-		"1.18 + CCM": {
+		"1.18 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorVersion: "1.18.0-alpha.1",
 					KubernetesConfig: &KubernetesConfig{
-						KubernetesImageBase:       specConfig.KubernetesImageBase,
-						KubernetesImageBaseType:   common.KubernetesImageBaseTypeGCR,
-						MCRKubernetesImageBase:    specConfig.MCRKubernetesImageBase,
-						UseCloudControllerManager: to.BoolPtr(true),
+						CustomCcmImage:                   customCcmImage,
+						CustomKubeAPIServerImage:         customKubeAPIServerImage,
+						CustomKubeControllerManagerImage: customKubeControllerManagerImage,
+						CustomKubeSchedulerImage:         customKubeSchedulerImage,
+						UseCloudControllerManager:        to.BoolPtr(true),
 					},
 				},
 			},

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -23,18 +23,8 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		k8sVersion := orchestratorProfile.OrchestratorVersion
 		k8sComponents := api.GetK8sComponentsByVersionMap(properties.OrchestratorProfile.KubernetesConfig)[k8sVersion]
 		kubernetesConfig := orchestratorProfile.KubernetesConfig
-		kubernetesImageBase := kubernetesConfig.KubernetesImageBase
-
-		if properties.IsAzureStackCloud() {
-			kubernetesImageBase = cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase
-		}
 
 		if kubernetesConfig != nil {
-			kubeProxySpec := kubernetesImageBase + k8sComponents[common.KubeProxyAddonName]
-			if kubernetesConfig.CustomKubeProxyImage != "" {
-				kubeProxySpec = kubernetesConfig.CustomKubeProxyImage
-			}
-			addValue(parametersMap, "kubeProxySpec", kubeProxySpec)
 			if kubernetesConfig.CustomKubeBinaryURL != "" {
 				addValue(parametersMap, "kubeBinaryURL", kubernetesConfig.CustomKubeBinaryURL)
 			}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -38876,12 +38876,6 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
       },
       "type": "string"
     },
-    "kubeProxySpec": {
-      "metadata": {
-        "description": "The container spec for kube-proxy."
-      },
-      "type": "string"
-    },
     "kubeBinaryURL": {
       "defaultValue": "",
       "metadata": {


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

`customKubeAPIServerImage`, `customKubeControllerManagerImage`, `customKubeSchedulerImage`, and `customKubeProxyImage` have no effect after https://github.com/Azure/aks-engine/pull/2540 was merged. We should honor them when specified.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
