### PR TITLE
chore: Bump moby to 3.0.11

### DIFF
--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -228,7 +228,7 @@
       }
     },
     "mobyVersion": {
-      "defaultValue": "3.0.10",
+      "defaultValue": "3.0.11",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -241,7 +241,8 @@
          "3.0.6",
          "3.0.7",
          "3.0.8",
-         "3.0.10"
+         "3.0.10",
+         "3.0.11"
        ],
       "type": "string"
     },

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -463,7 +463,7 @@ const (
 	// DefaultKubernetesDNSServiceIPv6 specifies the IPv6 address that kube-dns listens on by default. must by in the default Service CIDR range.
 	DefaultKubernetesDNSServiceIPv6 = "fd00::10"
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
-	DefaultMobyVersion = "3.0.10"
+	DefaultMobyVersion = "3.0.11"
 	// DefaultContainerdVersion specifies the default containerd version to install.
 	DefaultContainerdVersion = "1.3.2"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -38937,7 +38937,7 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
       }
     },
     "mobyVersion": {
-      "defaultValue": "3.0.10",
+      "defaultValue": "3.0.11",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -38950,7 +38950,8 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
          "3.0.6",
          "3.0.7",
          "3.0.8",
-         "3.0.10"
+         "3.0.10",
+         "3.0.11"
        ],
       "type": "string"
     },

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -58,7 +58,7 @@ echo "  - apmz $apmz_version" >> ${VHD_LOGS_FILEPATH}
 installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
-MOBY_VERSION="3.0.10"
+MOBY_VERSION="3.0.11"
 installMoby
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
 installGPUDrivers


### PR DESCRIPTION
This includes a handful of bug fixes as well as another mitigation for an edge case discovered for [CVE-2019-14271](https://nvd.nist.gov/vuln/detail/CVE-2019-14271).

Reference: https://github.com/moby/moby/issues/40211