### PR TITLE
fix: scale cannot find VM index for the VMAS+VHD+Linux case

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -269,7 +269,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					continue
 				}
 
-				if vm.OsProfile != nil && vm.OsProfile.WindowsConfiguration != nil {
+				if sc.agentPool.OSType == api.Windows {
 					_, _, winPoolIndex, index, err = utils.WindowsVMNameParts(vmName)
 				} else {
 					_, _, index, err = utils.K8sLinuxVMNameParts(vmName)

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -269,8 +269,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					continue
 				}
 
-				osPublisher := vm.StorageProfile.ImageReference.Publisher
-				if osPublisher != nil && (strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") || strings.EqualFold(*osPublisher, "microsoft-aks")) {
+				if vm.OsProfile != nil && vm.OsProfile.WindowsConfiguration != nil {
 					_, _, winPoolIndex, index, err = utils.WindowsVMNameParts(vmName)
 				} else {
 					_, _, index, err = utils.K8sLinuxVMNameParts(vmName)

--- a/test/e2e/test_cluster_configs/availabilityset.json
+++ b/test/e2e/test_cluster_configs/availabilityset.json
@@ -1,6 +1,7 @@
 {
 	"env": {
-		"CREATE_VNET": true
+		"CREATE_VNET": true,
+		"SCALE_CLUSTER": true
 	},
 	"apiModel": {
 		"apiVersion": "vlabs",
@@ -43,12 +44,23 @@
 					"name": "agent1",
 					"count": 3,
 					"vmSize": "Standard_D2_v3",
+					"osType": "Linux",
 					"OSDiskSizeGB": 200,
 					"storageProfile": "ManagedDisks",
 					"diskSizesGB": [
 						128,
 						128
 					],
+					"availabilityProfile": "AvailabilitySet",
+					"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
+				},
+				{
+					"name": "poolwin",
+					"count": 2,
+					"vmSize": "Standard_D2_v3",
+					"osType": "Windows",
+					"OSDiskSizeGB": 200,
+					"storageProfile": "ManagedDisks",
 					"availabilityProfile": "AvailabilitySet",
 					"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
 				}

--- a/test/e2e/test_cluster_configs/availabilityset.json
+++ b/test/e2e/test_cluster_configs/availabilityset.json
@@ -75,6 +75,12 @@
 					]
 				}
 			},
+			"windowsProfile": {
+				"adminUsername": "azureuser",
+				"adminPassword": "replacepassword1234$",
+				"enableAutomaticUpdates": false,
+				"sshEnabled": true
+			},
 			"servicePrincipalProfile": {
 				"clientId": "",
 				"secret": ""


### PR DESCRIPTION
**Reason for Change**:
Scaling fails if the target pool is a VMAS pool of VHD-based linux nodes.
VM `osPublisher` is not enought to distinguish between Linux and Windows.

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
