### PR TITLE
test: only use 1 node per pool in no outbound test

### DIFF
--- a/test/e2e/test_cluster_configs/no_outbound.json
+++ b/test/e2e/test_cluster_configs/no_outbound.json
@@ -17,17 +17,15 @@
 			"agentPoolProfiles": [
 				{
 					"name": "agentpool1",
-					"count": 3,
+					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"availabilityProfile": "VirtualMachineScaleSets",
-					"scalesetPriority": "Spot"
 				},
 				{
 					"name": "agentwin",
-					"count": 3,
+					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"availabilityProfile": "VirtualMachineScaleSets",
-					"scalesetPriority": "Spot",
 					"osType": "Windows"
 				}
 			],

--- a/test/e2e/test_cluster_configs/no_outbound.json
+++ b/test/e2e/test_cluster_configs/no_outbound.json
@@ -19,7 +19,7 @@
 					"name": "agentpool1",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
-					"availabilityProfile": "VirtualMachineScaleSets",
+					"availabilityProfile": "VirtualMachineScaleSets"
 				},
 				{
 					"name": "agentwin",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR uses the minimum necessary node count (1) to determine whether or not locked-down clusters are deployable, and removes the spot configuration as that makes things more difficult to validate.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
