### PR TITLE
fix: add package name for the constant

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1713,7 +1713,7 @@ func (w *WindowsProfile) IsCSIProxyEnabled() bool {
 	if w.EnableCSIProxy != nil {
 		return *w.EnableCSIProxy
 	}
-	return DefaultEnableCSIProxyWindows
+	return common.DefaultEnableCSIProxyWindows
 }
 
 // HasSecrets returns true if the customer specified secrets to install


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
There is an error when making the master branch.
```
root@xxx:~/go/src/github.com/Azure/aks-engine# make
make -C hack/tools/
make[1]: Entering directory '/root/go/src/github.com/Azure/aks-engine/hack/tools'
GOBIN=/root/go/src/github.com/Azure/aks-engine/hack/tools/bin go get github.com/go-bindata/go-bindata/...@v3.1.2
go: finding github.com/go-bindata/go-bindata v3.1.2
GOBIN=/root/go/src/github.com/Azure/aks-engine/hack/tools/bin go get github.com/mitchellh/gox/...@v1.0.1
GOBIN=/root/go/src/github.com/Azure/aks-engine/hack/tools/bin go get github.com/onsi/ginkgo/ginkgo/...@v1.10.1
curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /root/go/src/github.com/Azure/aks-engine/hack/tools/bin v1.23.7
golangci/golangci-lint info checking GitHub for tag 'v1.23.7'
golangci/golangci-lint info found version: 1.23.7 for v1.23.7/linux/amd64
golangci/golangci-lint info installed /root/go/src/github.com/Azure/aks-engine/hack/tools/bin/golangci-lint
GOBIN=/root/go/src/github.com/Azure/aks-engine/hack/tools/bin go get github.com/devigned/pub/...@v0.2.0
make[1]: Leaving directory '/root/go/src/github.com/Azure/aks-engine/hack/tools'
go-bindata 3.1.2 (Go runtime go1.13.8).
Copyright (c) 2010-2013, Jim Teeuwen.
go generate -mod=vendor -v ./... > /dev/null 2>&1
go build -mod=vendor -ldflags '-s -X main.version=3e6b593c7d5e2878be2e536b62a596ad7e530ed7 -X github.com/Azure/aks-engine/pkg/telemetry.AKSEngineAppInsightsKey=c92d8284-b550-4b06-b7ba-e80fd7178faa -X github.com/Azure/aks-engine/pkg/test.JUnitOutDir=/root/go/src/github.com/Azure/aks-engine/test/junit -X github.com/Azure/aks-engine/cmd.BuildSHA=3e6b593c7 -X github.com/Azure/aks-engine/cmd.GitTreeState=clean -X github.com/Azure/aks-engine/cmd.BuildTag=canary' -o /root/go/src/github.com/Azure/aks-engine/bin/aks-engine
# github.com/Azure/aks-engine/pkg/api
pkg/api/types.go:1716:9: undefined: DefaultEnableCSIProxyWindows
note: module requires Go 1.14
Makefile:95: recipe for target 'go-build' failed
make: *** [go-build] Error 2
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
