### PR TITLE
fix: use explicit kubeconfig in label-nodes.sh

### DIFF
--- a/parts/k8s/cloud-init/artifacts/label-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/label-nodes.sh
@@ -8,11 +8,14 @@
 
 set -euo pipefail
 
+KUBECONFIG="$(find /home/*/.kube/config)"
+KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+
 MASTER_SELECTOR="kubernetes.azure.com/role!=agent,kubernetes.io/role!=agent"
 MASTER_LABELS="kubernetes.azure.com/role=master kubernetes.io/role=master node-role.kubernetes.io/master="
 AGENT_SELECTOR="kubernetes.azure.com/role!=master,kubernetes.io/role!=master"
 AGENT_LABELS="kubernetes.azure.com/role=agent kubernetes.io/role=agent node-role.kubernetes.io/agent="
 
-kubectl label nodes --overwrite -l $MASTER_SELECTOR $MASTER_LABELS
-kubectl label nodes --overwrite -l $AGENT_SELECTOR $AGENT_LABELS
+${KUBECTL} label nodes --overwrite -l $MASTER_SELECTOR $MASTER_LABELS
+${KUBECTL} label nodes --overwrite -l $AGENT_SELECTOR $AGENT_LABELS
 #EOF

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -36856,13 +36856,16 @@ var _k8sCloudInitArtifactsLabelNodesSh = []byte(`#!/usr/bin/env bash
 
 set -euo pipefail
 
+KUBECONFIG="$(find /home/*/.kube/config)"
+KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+
 MASTER_SELECTOR="kubernetes.azure.com/role!=agent,kubernetes.io/role!=agent"
 MASTER_LABELS="kubernetes.azure.com/role=master kubernetes.io/role=master node-role.kubernetes.io/master="
 AGENT_SELECTOR="kubernetes.azure.com/role!=master,kubernetes.io/role!=master"
 AGENT_LABELS="kubernetes.azure.com/role=agent kubernetes.io/role=agent node-role.kubernetes.io/agent="
 
-kubectl label nodes --overwrite -l $MASTER_SELECTOR $MASTER_LABELS
-kubectl label nodes --overwrite -l $AGENT_SELECTOR $AGENT_LABELS
+${KUBECTL} label nodes --overwrite -l $MASTER_SELECTOR $MASTER_LABELS
+${KUBECTL} label nodes --overwrite -l $AGENT_SELECTOR $AGENT_LABELS
 #EOF
 `)
 


### PR DESCRIPTION
**Reason for Change**:
Fixes this script so it works in Kubernetes 1.18.0-rc.1 (and others), now that `kubectl` doesn't find a default config as we assumed before.

**Issue Fixed**:
See #2923
See kubernetes-sigs/windows-testing#141

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This change to `label-nodes.sh` isn't actually being tested in this PR since it's skipped over in VHD deploys, but the hacky commits in #2923 did test and validate this change.