### PR TITLE
chore: improve --client-id flag validation message

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,7 +157,8 @@ func (authArgs *authArgs) validateAuthArgs() error {
 
 	authArgs.SubscriptionID, _ = uuid.Parse(authArgs.rawSubscriptionID)
 	if authArgs.SubscriptionID.String() == "00000000-0000-0000-0000-000000000000" {
-		subID, err := getSubFromAzDir(filepath.Join(helpers.GetHomeDir(), ".azure"))
+		var subID uuid.UUID
+		subID, err = getSubFromAzDir(filepath.Join(helpers.GetHomeDir(), ".azure"))
 		if err != nil || subID.String() == "00000000-0000-0000-0000-000000000000" {
 			return errors.New("--subscription-id is required (and must be a valid UUID)")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -137,20 +137,25 @@ func (authArgs *authArgs) isAzureStackCloud() bool {
 }
 
 func (authArgs *authArgs) validateAuthArgs() error {
-	authArgs.ClientID, _ = uuid.Parse(authArgs.rawClientID)
-	authArgs.SubscriptionID, _ = uuid.Parse(authArgs.rawSubscriptionID)
+	var err error
 
-	if authArgs.AuthMethod == "client_secret" {
-		if authArgs.ClientID.String() == "00000000-0000-0000-0000-000000000000" || authArgs.ClientSecret == "" {
-			return errors.New(`--client-id and --client-secret must be specified when --auth-method="client_secret"`)
+	if authArgs.AuthMethod != "" {
+		authArgs.ClientID, err = uuid.Parse(authArgs.rawClientID)
+		if err != nil {
+			return errors.Wrap(err, "parsing --client-id")
 		}
-		// try parse the UUID
-	} else if authArgs.AuthMethod == "client_certificate" {
-		if authArgs.ClientID.String() == "00000000-0000-0000-0000-000000000000" || authArgs.CertificatePath == "" || authArgs.PrivateKeyPath == "" {
-			return errors.New(`--client-id and --certificate-path, and --private-key-path must be specified when --auth-method="client_certificate"`)
+		if authArgs.AuthMethod == "client_secret" {
+			if authArgs.ClientSecret == "" {
+				return errors.New(`--client-secret must be specified when --auth-method="client_secret"`)
+			}
+		} else if authArgs.AuthMethod == "client_certificate" {
+			if authArgs.CertificatePath == "" || authArgs.PrivateKeyPath == "" {
+				return errors.New(`--certificate-path and --private-key-path must be specified when --auth-method="client_certificate"`)
+			}
 		}
 	}
 
+	authArgs.SubscriptionID, _ = uuid.Parse(authArgs.rawSubscriptionID)
 	if authArgs.SubscriptionID.String() == "00000000-0000-0000-0000-000000000000" {
 		subID, err := getSubFromAzDir(filepath.Join(helpers.GetHomeDir(), ".azure"))
 		if err != nil || subID.String() == "00000000-0000-0000-0000-000000000000" {
@@ -160,8 +165,7 @@ func (authArgs *authArgs) validateAuthArgs() error {
 		authArgs.SubscriptionID = subID
 	}
 
-	_, err := azure.EnvironmentFromName(authArgs.RawAzureEnvironment)
-	if err != nil {
+	if _, err = azure.EnvironmentFromName(authArgs.RawAzureEnvironment); err != nil {
 		return errors.New("failed to parse --azure-env as a valid target Azure cloud environment")
 	}
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,7 +139,11 @@ func (authArgs *authArgs) isAzureStackCloud() bool {
 func (authArgs *authArgs) validateAuthArgs() error {
 	var err error
 
-	if authArgs.AuthMethod != "" {
+	if authArgs.AuthMethod == "" {
+		return errors.New("--auth-method is a required parameter")
+	}
+
+	if authArgs.AuthMethod == "client_secret" || authArgs.AuthMethod == "client_certificate" {
 		authArgs.ClientID, err = uuid.Parse(authArgs.rawClientID)
 		if err != nil {
 			return errors.Wrap(err, "parsing --client-id")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -372,7 +372,7 @@ func TestValidateAuthArgs(t *testing.T) {
 			expected: errors.New(`--certificate-path and --private-key-path must be specified when --auth-method="client_certificate"`),
 		},
 		{
-			name: "ClientCertificateAuthExpectsCertificatePath",
+			name: "ValidClientCertificateAuth",
 			authArgs: authArgs{
 				rawSubscriptionID:   validID,
 				rawClientID:         validID,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/Azure/aks-engine/pkg/armhelpers"
 	"github.com/Azure/aks-engine/pkg/armhelpers/azurestack/testserver"
 	"github.com/Azure/aks-engine/pkg/helpers"
+	. "github.com/onsi/gomega"
 )
 
 //mockAuthProvider implements AuthProvider and allows in particular to stub out getClient()
@@ -284,6 +286,111 @@ func TestGetAzureStackClientWithClientSecret(t *testing.T) {
 				if err == nil || !strings.HasPrefix(err.Error(), "--auth-method") {
 					t.Fatalf("failed to return error with invalid identity-system")
 				}
+			}
+		})
+	}
+}
+
+func TestValidateAuthArgs(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	validID := "cc6b141e-6afc-4786-9bf6-e3b9a5601460"
+	invalidID := "invalidID"
+
+	for _, tc := range []struct {
+		name     string
+		authArgs authArgs
+		expected error
+	}{
+		{
+			name: "AlwaysExpectValidClientID",
+			authArgs: authArgs{
+				rawSubscriptionID:   validID,
+				rawClientID:         invalidID,
+				ClientSecret:        "secret",
+				AuthMethod:          "client_secret",
+				RawAzureEnvironment: "AZUREPUBLICCLOUD",
+			},
+			expected: errors.New(`parsing --client-id: invalid UUID length: 9`),
+		},
+		{
+			name: "AlwaysExpectValidClientID",
+			authArgs: authArgs{
+				rawSubscriptionID:   validID,
+				rawClientID:         invalidID,
+				ClientSecret:        "secret",
+				AuthMethod:          "client_certificate",
+				RawAzureEnvironment: "AZUREPUBLICCLOUD",
+			},
+			expected: errors.New(`parsing --client-id: invalid UUID length: 9`),
+		},
+		{
+			name: "ClientSecretAuthExpectsClientSecret",
+			authArgs: authArgs{
+				rawSubscriptionID:   validID,
+				rawClientID:         validID,
+				ClientSecret:        "",
+				AuthMethod:          "client_secret",
+				RawAzureEnvironment: "AZUREPUBLICCLOUD",
+			},
+			expected: errors.New(`--client-secret must be specified when --auth-method="client_secret"`),
+		},
+		{
+			name: "ValidClientSecretAuth",
+			authArgs: authArgs{
+				rawSubscriptionID:   validID,
+				rawClientID:         validID,
+				ClientSecret:        "secret",
+				AuthMethod:          "client_secret",
+				RawAzureEnvironment: "AZUREPUBLICCLOUD",
+			},
+			expected: nil,
+		},
+		{
+			name: "ClientCertificateAuthExpectsCertificatePath",
+			authArgs: authArgs{
+				rawSubscriptionID:   validID,
+				rawClientID:         validID,
+				CertificatePath:     "",
+				PrivateKeyPath:      "/a/path",
+				AuthMethod:          "client_certificate",
+				RawAzureEnvironment: "AZUREPUBLICCLOUD",
+			},
+			expected: errors.New(`--certificate-path and --private-key-path must be specified when --auth-method="client_certificate"`),
+		},
+		{
+			name: "ClientCertificateAuthExpectsPrivateKeyPath",
+			authArgs: authArgs{
+				rawSubscriptionID:   validID,
+				rawClientID:         validID,
+				CertificatePath:     "/a/path",
+				PrivateKeyPath:      "",
+				AuthMethod:          "client_certificate",
+				RawAzureEnvironment: "AZUREPUBLICCLOUD",
+			},
+			expected: errors.New(`--certificate-path and --private-key-path must be specified when --auth-method="client_certificate"`),
+		},
+		{
+			name: "ClientCertificateAuthExpectsCertificatePath",
+			authArgs: authArgs{
+				rawSubscriptionID:   validID,
+				rawClientID:         validID,
+				CertificatePath:     "/a/path",
+				PrivateKeyPath:      "/a/path",
+				AuthMethod:          "client_certificate",
+				RawAzureEnvironment: "AZUREPUBLICCLOUD",
+			},
+			expected: nil,
+		},
+	} {
+		test := tc
+		t.Run(test.name, func(t *testing.T) {
+			err := test.authArgs.validateAuthArgs()
+			if test.expected != nil {
+				g.Expect(err.Error()).To(Equal(test.expected.Error()))
+			} else {
+				g.Expect(err).To(BeNil())
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -304,6 +304,13 @@ func TestValidateAuthArgs(t *testing.T) {
 		expected error
 	}{
 		{
+			name: "AuthMethodIsRequired",
+			authArgs: authArgs{
+				AuthMethod: "",
+			},
+			expected: errors.New("--auth-method is a required parameter"),
+		},
+		{
 			name: "AlwaysExpectValidClientID",
 			authArgs: authArgs{
 				rawSubscriptionID:   validID,


### PR DESCRIPTION
**Reason for Change**:
CLI error message should indicate that the `--client-id` format is invalid instead of implying that the value may be missing.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
