### PR TITLE
chore: rev Linux VHDs to 2020.03.19

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -68,7 +68,6 @@ jobs:
   parameters:
     name: 'ubuntu_18_04_linux_e2e'
     apimodel: 'examples/ubuntu-1804/kubernetes.json'
-    skipTests: 'should have healthy time synchronization'
     stabilityIterations: '10'
     enableKMSEncryption: false
 

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -164,7 +164,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-engine-ubuntu-1604-202003",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.03.16",
+		ImageVersion:   "2020.03.19",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
@@ -172,7 +172,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-engine-ubuntu-1804-202003",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.03.16",
+		ImageVersion:   "2020.03.19",
 	}
 
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019

--- a/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202003_2020.03.19.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202003_2020.03.19.txt
@@ -1,0 +1,143 @@
+Starting build on  Thu Mar 19 20:58:29 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - apmz v0.5.1
+  - bpftrace
+  - moby v3.0.11
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.18
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.0.33
+  - Azure CNI version 1.0.30
+  - Azure CNI version 1.0.29
+  - CNI plugin version 0.8.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - mcr.microsoft.com/oss/kubernetes/kubernetes-dashboard:v1.10.1
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v8.9.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.18.0
+  - k8s.gcr.io/cluster-autoscaler:v1.17.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.4
+  - k8s.gcr.io/cluster-autoscaler:v1.15.5
+  - k8s.gcr.io/cluster-autoscaler:v1.14.7
+  - k8s.gcr.io/cluster-autoscaler:v1.13.9
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - k8s.gcr.io/coredns:1.6.7
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.32
+  - nvidia/k8s-device-plugin:1.11
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/kube-apiserver:v1.18.0-beta.1
+  - k8s.gcr.io/kube-controller-manager:v1.18.0-beta.1
+  - k8s.gcr.io/kube-proxy:v1.18.0-beta.1
+  - k8s.gcr.io/kube-scheduler:v1.18.0-beta.1
+  - k8s.gcr.io/kube-apiserver:v1.17.4
+  - k8s.gcr.io/kube-controller-manager:v1.17.4
+  - k8s.gcr.io/kube-proxy:v1.17.4
+  - k8s.gcr.io/kube-scheduler:v1.17.4
+  - k8s.gcr.io/kube-apiserver:v1.17.3
+  - k8s.gcr.io/kube-controller-manager:v1.17.3
+  - k8s.gcr.io/kube-proxy:v1.17.3
+  - k8s.gcr.io/kube-scheduler:v1.17.3
+  - k8s.gcr.io/hyperkube-amd64:v1.16.8
+  - k8s.gcr.io/hyperkube-amd64:v1.16.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.15.11
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.11
+  - k8s.gcr.io/hyperkube-amd64:v1.15.10
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.14.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+  - k8s.gcr.io/hyperkube-amd64:v1.14.7
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.13.12
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+  - k8s.gcr.io/hyperkube-amd64:v1.13.11
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.4.1
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.4.1
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar:v1.0.1
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - k8s.gcr.io/node-problem-detector:v0.8.1
+  - registry:2.7.1
+Using kernel:
+Linux version 4.15.0-1071-azure (buildd@lgw01-amd64-031) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)) #76-Ubuntu SMP Wed Feb 12 03:02:44 UTC 2020
+Install completed successfully on  Thu Mar 19 21:14:54 UTC 2020
+VSTS Build NUMBER: 20200319.13
+VSTS Build ID: 29594162
+Commit: 4b562e6a093bcdb9772972484568ccff69cf4791
+Feature flags:

--- a/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202003_2020.03.19.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202003_2020.03.19.txt
@@ -1,0 +1,145 @@
+Starting build on  Thu Mar 19 20:59:00 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - ntp
+  - ntpstat
+  - apmz v0.5.1
+  - bpftrace
+  - moby v3.0.11
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.18
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.0.33
+  - Azure CNI version 1.0.30
+  - Azure CNI version 1.0.29
+  - CNI plugin version 0.8.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - mcr.microsoft.com/oss/kubernetes/kubernetes-dashboard:v1.10.1
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v8.9.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - k8s.gcr.io/cluster-autoscaler:v1.18.0
+  - k8s.gcr.io/cluster-autoscaler:v1.17.1
+  - k8s.gcr.io/cluster-autoscaler:v1.16.4
+  - k8s.gcr.io/cluster-autoscaler:v1.15.5
+  - k8s.gcr.io/cluster-autoscaler:v1.14.7
+  - k8s.gcr.io/cluster-autoscaler:v1.13.9
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - k8s.gcr.io/coredns:1.6.7
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.6
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.32
+  - nvidia/k8s-device-plugin:1.11
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - k8s.gcr.io/kube-apiserver:v1.18.0-beta.1
+  - k8s.gcr.io/kube-controller-manager:v1.18.0-beta.1
+  - k8s.gcr.io/kube-proxy:v1.18.0-beta.1
+  - k8s.gcr.io/kube-scheduler:v1.18.0-beta.1
+  - k8s.gcr.io/kube-apiserver:v1.17.4
+  - k8s.gcr.io/kube-controller-manager:v1.17.4
+  - k8s.gcr.io/kube-proxy:v1.17.4
+  - k8s.gcr.io/kube-scheduler:v1.17.4
+  - k8s.gcr.io/kube-apiserver:v1.17.3
+  - k8s.gcr.io/kube-controller-manager:v1.17.3
+  - k8s.gcr.io/kube-proxy:v1.17.3
+  - k8s.gcr.io/kube-scheduler:v1.17.3
+  - k8s.gcr.io/hyperkube-amd64:v1.16.8
+  - k8s.gcr.io/hyperkube-amd64:v1.16.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.15.11
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.11
+  - k8s.gcr.io/hyperkube-amd64:v1.15.10
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.14.8
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.8
+  - k8s.gcr.io/hyperkube-amd64:v1.14.7
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7-azs
+  - k8s.gcr.io/hyperkube-amd64:v1.13.12
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.12
+  - k8s.gcr.io/hyperkube-amd64:v1.13.11
+  - k8s.gcr.io/cloud-controller-manager-amd64:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.4.1
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.4.1
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar:v1.0.1
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - k8s.gcr.io/node-problem-detector:v0.8.1
+  - registry:2.7.1
+Using kernel:
+Linux version 5.0.0-1032-azure (buildd@lcy01-amd64-016) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #34-Ubuntu SMP Mon Feb 10 19:37:25 UTC 2020
+Install completed successfully on  Thu Mar 19 21:17:58 UTC 2020
+VSTS Build NUMBER: 20200319.14
+VSTS Build ID: 29594176
+Commit: 4b562e6a093bcdb9772972484568ccff69cf4791
+Feature flags:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR revs Linux VHDs to 2020.03.19. This VHD includes these fixes to the label-nodes systemd job:

https://github.com/Azure/aks-engine/pull/2915
https://github.com/Azure/aks-engine/pull/2929

In addition, we are pre-installing the following packages for 18.04-LTS:

- ntp
- ntpstat

Going forward, 18.04-LTS will use ntp for time synchronization instead of systemd-timesync.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
