### PR TITLE
feat: add support for Kubernetes 1.18.0

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -178,11 +178,12 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.17.2":         false,
 	"1.17.3":         true,
 	"1.17.4":         true,
-	"1.18.0-alpha.1": true,
-	"1.18.0-alpha.2": true,
-	"1.18.0-alpha.3": true,
-	"1.18.0-alpha.5": true,
-	"1.18.0-beta.1":  true,
+	"1.18.0-alpha.1": false,
+	"1.18.0-alpha.2": false,
+	"1.18.0-alpha.3": false,
+	"1.18.0-alpha.5": false,
+	"1.18.0-beta.1":  false,
+	"1.18.0":         true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/api/components_test.go
+++ b/pkg/api/components_test.go
@@ -1604,7 +1604,7 @@ func getContainerServicesMap() map[string]*ContainerService {
 		"1.18": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
-					OrchestratorVersion: "1.18.0-alpha.1",
+					OrchestratorVersion: "1.18.0",
 					KubernetesConfig: &KubernetesConfig{
 						KubernetesImageBase:     specConfig.KubernetesImageBase,
 						KubernetesImageBaseType: common.KubernetesImageBaseTypeGCR,
@@ -1616,7 +1616,7 @@ func getContainerServicesMap() map[string]*ContainerService {
 		"1.18 user-configured": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
-					OrchestratorVersion: "1.18.0-alpha.1",
+					OrchestratorVersion: "1.18.0",
 					KubernetesConfig: &KubernetesConfig{
 						KubernetesImageBase:     specConfig.KubernetesImageBase,
 						KubernetesImageBaseType: common.KubernetesImageBaseTypeGCR,
@@ -1635,7 +1635,7 @@ func getContainerServicesMap() map[string]*ContainerService {
 		"1.18 + customCcmImage + customKubeAPIServerImage + customKubeControllerManagerImage + customKubeSchedulerImage": {
 			Properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
-					OrchestratorVersion: "1.18.0-alpha.1",
+					OrchestratorVersion: "1.18.0",
 					KubernetesConfig: &KubernetesConfig{
 						CustomCcmImage:                   customCcmImage,
 						CustomKubeAPIServerImage:         customKubeAPIServerImage,

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1548,7 +1548,7 @@ func TestMasterProfileDefaults(t *testing.T) {
 	}
 
 	// this validates cluster subnet default configuration for single stack IPv6 only cluster
-	mockCS = getMockBaseContainerService("1.18.0-alpha.1")
+	mockCS = getMockBaseContainerService("1.18.0")
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6Only: true}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1292,7 +1292,7 @@ func (k *KubernetesConfig) Validate(k8sVersion string, hasWindows, ipv6DualStack
 	}
 
 	if isIPv6 {
-		minVersion, err := semver.Make("1.18.0-alpha.4")
+		minVersion, err := semver.Make("1.18.0")
 		if err != nil {
 			return errors.New("could not validate version")
 		}
@@ -1454,7 +1454,7 @@ func (k *KubernetesConfig) Validate(k8sVersion string, hasWindows, ipv6DualStack
 	// dualstack IPVS mode supported from 1.16+
 	// dualstack IPtables mode supported from 1.18+
 	if ipv6DualStackEnabled && k.ProxyMode == KubeProxyModeIPTables {
-		minVersion, err := semver.Make("1.18.0-alpha.2")
+		minVersion, err := semver.Make("1.18.0")
 		if err != nil {
 			return errors.New("could not validate version")
 		}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -598,7 +598,7 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 			ProxyMode:     "iptables",
 		}
 
-		if err := c.Validate(k8sVersion, false, true, false); err == nil && !common.IsKubernetesVersionGe(k8sVersion, "1.18.0-alpha.2") {
+		if err := c.Validate(k8sVersion, false, true, false); err == nil && !common.IsKubernetesVersionGe(k8sVersion, "1.18.0") {
 			t.Errorf("should error with ipv6 dual stack feature enabled as iptables mode not supported in %s", k8sVersion)
 		}
 
@@ -648,7 +648,7 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 	}
 
 	// Tests that apply to single stack IPv6 with 1.18 and later releases
-	for _, k8sVersion := range common.GetVersionsGt(common.GetAllSupportedKubernetesVersions(false, false), "1.18.0-alpha.4", true, true) {
+	for _, k8sVersion := range common.GetVersionsGt(common.GetAllSupportedKubernetesVersions(false, false), "1.18.0", true, true) {
 		c := KubernetesConfig{
 			NetworkPlugin: "azure",
 		}

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -84,8 +84,7 @@ function Get-FilesToCacheOnVHD
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.17.2/windowszip/v1.17.2-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.17.3/windowszip/v1.17.3-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.17.4/windowszip/v1.17.4-1int.zip",
-            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.0-beta.1/windowszip/v1.18.0-beta.1-1int.zip",
-            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.0-beta.2/windowszip/v1.18.0-beta.2-1int.zip"
+            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.0/windowszip/v1.18.0-1int.zip"
 
         );
         "c:\akse-cache\win-vnet-cni\" = @(

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -338,7 +338,7 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="
-1.18.0-beta.1
+1.18.0
 1.17.4
 1.17.3
 1.16.8


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.18.md

**Issue Fixed**:
Closes #2923

**Requirements**:

- [ ] Kubernetes artifacts built and pushed by Azure Pipelines
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
This will fail until Kubernetes 1.18.0 is actually released ~today~ *tomorrow* and our pipeline does its thing.