### PR TITLE
test: use spot instance VMs in default e2e model

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -66,6 +66,7 @@
           128
         ],
         "availabilityProfile": "VirtualMachineScaleSets",
+        "scalesetPriority": "Spot",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityZones": ["1"]
       },
@@ -74,6 +75,7 @@
         "count": 1,
         "vmSize": "Standard_D2s_v3",
         "availabilityProfile": "VirtualMachineScaleSets",
+        "scalesetPriority": "Spot",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "osType": "Windows",
         "storageProfile": "Ephemeral",


### PR DESCRIPTION
**Reason for Change**:
Specifies spot instances in the agent pool VM scalesets used in e2e tests, to (hopefully) avoid allocation errors.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
