### PR TITLE
test: promote --failFast to an e2e flag, defaulting to false

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	UseDeployCommand    bool   `envconfig:"USE_DEPLOY_COMMAND"`
 	GinkgoFocus         string `envconfig:"GINKGO_FOCUS"`
 	GinkgoSkip          string `envconfig:"GINKGO_SKIP"`
+	GinkgoFailFast      bool   `envconfig:"GINKGO_FAIL_FAST" default:"false"`
 	DebugAfterSuite     bool   `envconfig:"DEBUG_AFTERSUITE" default:"false"`
 	BlockSSHPort        bool   `envconfig:"BLOCK_SSH" default:"false"`
 	AddNodePoolInput    string `envconfig:"ADD_NODE_POOL_INPUT" default:""`

--- a/test/e2e/runner/ginkgo.go
+++ b/test/e2e/runner/ginkgo.go
@@ -39,7 +39,11 @@ func (g *Ginkgo) Run() error {
 	g.Point.SetTestStart()
 	// use the test bin rather than compile the directory b/c the compile will happen in a sub dir which is another module
 	testFile := fmt.Sprintf("test/e2e/%s/%s.test", g.Config.Orchestrator, g.Config.Orchestrator)
-	var cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", "--focus", g.Config.GinkgoFocus, "--skip", g.Config.GinkgoSkip, testFile)
+	failFastFlag := ""
+	if g.Config.GinkgoFailFast {
+		failFastFlag = "--failFast"
+	}
+	var cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", failFastFlag, "-r", "-v", "--focus", g.Config.GinkgoFocus, "--skip", g.Config.GinkgoSkip, testFile)
 	util.PrintCommand(cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
**Reason for Change**:
Runs all e2e test specs to completion by default, instead of ending tests after the first failure. The behavior can be overridden by adding `GINKGO_FAIL_FAST=[1|true]` to the environment.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
