### PR TITLE
chore: force Basic LB SKU on Azure Stack

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -267,6 +267,8 @@ const (
 	MaxAzureStackManagedDiskSize = "1023"
 	// AzureStackSuffix is appended to kubernetes version on Azure Stack instances
 	AzureStackSuffix = "-azs"
+	// DefaultAzureStackLoadBalancerSku determines the aks-engine provided default for enabling Azure cloudprovider load balancer SKU on Azure Stack
+	DefaultAzureStackLoadBalancerSku = BasicLoadBalancerSku
 )
 
 const (

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -365,7 +365,12 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			}
 		}
 
-		if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
+		if a.IsAzureStackCloud() && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != DefaultAzureStackLoadBalancerSku {
+			if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "" {
+				log.Warnf("apimodel: orchestratorProfile.kubernetesConfig.LoadBalancerSku forced to \"%s\"\n", DefaultAzureStackLoadBalancerSku)
+			}
+			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = DefaultAzureStackLoadBalancerSku
+		} else if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
 			if a.HasAvailabilityZones() {
 				a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 			} else {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -952,20 +952,26 @@ func TestKubernetesImageBaseAppendSlash(t *testing.T) {
 	}
 }
 
-func TestKubernetesImageBaseAzureStack(t *testing.T) {
+func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.15.7")
 	properties := mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/k8s/azurestack/core/"
-	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = "gcr"
+	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
+	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 	properties.CustomCloudProfile = &CustomCloudProfile{}
 	properties.CustomCloudProfile.Environment = &azure.Environment{}
 	mockCS.setOrchestratorDefaults(true, true)
-	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != "mcr.microsoft.com/" {
-		t.Fatalf("defaults flow did not set Azure Stack's KubernetesImageBase")
+
+	expectedImageBase := "mcr.microsoft.com/"
+	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != expectedImageBase {
+		t.Fatalf("setOrchestratorDefaults did not set KubernetesImageBase to its expect value (%s) for Azure Stack clouds", expectedImageBase)
 	}
-	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType != "mcr" {
-		t.Fatalf("defaults flow did not set Azure Stack's KubernetesImageBaseType")
+	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType != common.KubernetesImageBaseTypeMCR {
+		t.Fatalf("setOrchestratorDefaults did not set KubernetesImageBaseType to its expect value (%s) for Azure Stack clouds", common.KubernetesImageBaseTypeMCR)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != DefaultAzureStackLoadBalancerSku {
+		t.Fatalf("setOrchestratorDefaults did not set LoadBalancerSku to its expect value (%s) for Azure Stack clouds", DefaultAzureStackLoadBalancerSku)
 	}
 }
 


### PR DESCRIPTION
**Reason for Change**:
Default to Basic LB SKU on Azure Stack even if the default for Azure is the Standard SKU.

**Issue Fixed**:
Fixes #2972
Related to #2952


**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
