### PR TITLE
fix: use same cluster-autoscaler version in MCR

### DIFF
--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -208,7 +208,7 @@ var kubernetesImageBaseVersionedImages = map[string]map[string]map[string]string
 			common.AddonResizerComponentName:  "oss/kubernetes/autoscaler/addon-resizer:1.8.7",
 			common.MetricsServerAddonName:     "oss/kubernetes/metrics-server:v0.3.5",
 			common.AddonManagerComponentName:  "oss/kubernetes/kube-addon-manager:v9.0.2",
-			common.ClusterAutoscalerAddonName: "oss/kubernetes/autoscaler/cluster-autoscaler:v1.17.0",
+			common.ClusterAutoscalerAddonName: "oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.0",
 		},
 		"1.17": {
 			common.AddonResizerComponentName:  "oss/kubernetes/autoscaler/addon-resizer:1.8.7",


### PR DESCRIPTION
**Reason for Change**:
For Kubernetes 1.18, cluster-autoscaler was using the v1.17.0 tag in MCR, but the v1.18.0 in GCR. This looks like just an oversight.

```console
% docker pull mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.0
v1.18.0: Pulling from oss/kubernetes/autoscaler/cluster-autoscaler
9ff2acc3204b: Pull complete 
2beb2eb0dad4: Pull complete 
Digest: sha256:bb4d5b62e4716f736c2c5376498dd763dc2e12648416b34d6760c4c2ca8c1250
Status: Downloaded newer image for mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.0
mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.0
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
