### PR TITLE
chore: use Standard LoadBalancer as default

### DIFF
--- a/examples/dualstack/kubernetes.json
+++ b/examples/dualstack/kubernetes.json
@@ -8,8 +8,6 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.16",
             "kubernetesConfig": {
-                "loadBalancerSku": "Standard",
-                "excludeMasterFromStandardLB": true,
                 "clusterSubnet": "10.244.0.0/16,fc00::/8",
                 "serviceCidr": "10.0.0.0/16,fd00::/108",
                 "dnsServiceIP": "10.0.0.10",

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -40,9 +40,7 @@
             "name": "aad-pod-identity",
             "enabled": true
           }
-        ],
-        "loadBalancerSku": "Standard",
-        "excludeMasterFromStandardLB": true
+        ]
       }
     },
     "masterProfile": {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -176,8 +176,6 @@ const (
 	BasicLoadBalancerSku = "Basic"
 	// StandardLoadBalancerSku is the string const for Azure Standard Load Balancer
 	StandardLoadBalancerSku = "Standard"
-	// DefaultLoadBalancerSku determines the aks-engine provided default for enabling Azure cloudprovider load balancer SKU
-	DefaultLoadBalancerSku = BasicLoadBalancerSku
 	// DefaultExcludeMasterFromStandardLB determines the aks-engine provided default for excluding master nodes from standard load balancer.
 	DefaultExcludeMasterFromStandardLB = true
 	// DefaultSecureKubeletEnabled determines the aks-engine provided default for securing kubelet communications

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -371,11 +371,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			}
 			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = DefaultAzureStackLoadBalancerSku
 		} else if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
-			if a.HasAvailabilityZones() {
-				a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
-			} else {
-				a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = DefaultLoadBalancerSku
-			}
+			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 		}
 
 		if strings.ToLower(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku) == strings.ToLower(BasicLoadBalancerSku) {
@@ -417,9 +413,6 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		}
 
 		// Master-specific defaults that depend upon OrchestratorProfile defaults
-		if cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku {
-			cs.Properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = to.BoolPtr(DefaultExcludeMasterFromStandardLB)
-		}
 		if cs.Properties.MasterProfile != nil {
 			if !cs.Properties.MasterProfile.IsCustomVNET() {
 				if cs.Properties.OrchestratorProfile.IsAzureCNI() {
@@ -472,9 +465,6 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 
 		// Pool-specific defaults that depend upon OrchestratorProfile defaults
 		for _, profile := range cs.Properties.AgentPoolProfiles {
-			if cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku {
-				cs.Properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = to.BoolPtr(DefaultExcludeMasterFromStandardLB)
-			}
 			// configure the subnets if not in custom VNET
 			if cs.Properties.MasterProfile != nil && !cs.Properties.MasterProfile.IsCustomVNET() {
 				subnetCounter := 0

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2277,9 +2277,9 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 		t.Fatalf("MasterProfile.HasAvailabilityZones did not have the expected return, got %t, expected %t",
 			properties.MasterProfile.HasAvailabilityZones(), false)
 	}
-	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != DefaultLoadBalancerSku {
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != StandardLoadBalancerSku {
 		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
-			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, DefaultLoadBalancerSku)
+			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku)
 	}
 	// masters with VMSS and zones
 	mockCS = getMockBaseContainerService("1.12.0")
@@ -2324,9 +2324,9 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 		t.Fatalf("AgentPoolProfiles[0].HasAvailabilityZones did not have the expected return, got %t, expected %t",
 			properties.AgentPoolProfiles[0].HasAvailabilityZones(), false)
 	}
-	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != DefaultLoadBalancerSku {
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != StandardLoadBalancerSku {
 		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
-			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, DefaultLoadBalancerSku)
+			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku)
 	}
 	// agents with VMSS and zones
 	mockCS = getMockBaseContainerService("1.13.12")
@@ -3690,7 +3690,7 @@ func TestDefaultLoadBalancerSKU(t *testing.T) {
 					MasterProfile: &MasterProfile{},
 				},
 			},
-			expected: BasicLoadBalancerSku,
+			expected: StandardLoadBalancerSku,
 		},
 		{
 			name: "basic",
@@ -3709,7 +3709,7 @@ func TestDefaultLoadBalancerSKU(t *testing.T) {
 			expected: BasicLoadBalancerSku,
 		},
 		{
-			name: "default",
+			name: "basic using const",
 			cs: ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{
@@ -3725,7 +3725,7 @@ func TestDefaultLoadBalancerSKU(t *testing.T) {
 			expected: BasicLoadBalancerSku,
 		},
 		{
-			name: "default",
+			name: "standard",
 			cs: ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{
@@ -3741,7 +3741,7 @@ func TestDefaultLoadBalancerSKU(t *testing.T) {
 			expected: StandardLoadBalancerSku,
 		},
 		{
-			name: "default",
+			name: "standard using const",
 			cs: ContainerService{
 				Properties: &Properties{
 					OrchestratorProfile: &OrchestratorProfile{

--- a/pkg/api/mocks.go
+++ b/pkg/api/mocks.go
@@ -87,7 +87,7 @@ func CreateMockContainerService(containerServiceName, orchestratorVersion string
 		EtcdVersion:             DefaultEtcdVersion,
 		MobyVersion:             DefaultMobyVersion,
 		ContainerdVersion:       DefaultContainerdVersion,
-		LoadBalancerSku:         DefaultLoadBalancerSku,
+		LoadBalancerSku:         BasicLoadBalancerSku,
 		KubeletConfig:           make(map[string]string),
 		ControllerManagerConfig: make(map[string]string),
 		KubernetesImageBaseType: common.KubernetesImageBaseTypeGCR,

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -41,6 +41,9 @@ func TestK8sVars(t *testing.T) {
 			},
 			OrchestratorProfile: &api.OrchestratorProfile{
 				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{
+					LoadBalancerSku: api.BasicLoadBalancerSku,
+				},
 			},
 			LinuxProfile: &api.LinuxProfile{},
 			AgentPoolProfiles: []*api.AgentPoolProfile{

--- a/pkg/engine/testdata/mastersonly/mastersonly.json
+++ b/pkg/engine/testdata/mastersonly/mastersonly.json
@@ -3,11 +3,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.13",
-            "kubernetesConfig": {
-                "loadBalancerSku": "Standard",
-                "excludeMasterFromStandardLB": true
-            }
+            "orchestratorRelease": "1.13"
         },
         "masterProfile": {
             "count": 3,

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -429,7 +429,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 
 	// Now Test AgentVMSS with windows
 	// Restore LoadBalancerSku back to default and provide LoadBalancerBackendAddressPoolIDs
-	cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.DefaultLoadBalancerSku
+	cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.BasicLoadBalancerSku
 	cs.Properties.AgentPoolProfiles[0].LoadBalancerBackendAddressPoolIDs = []string{"/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"}
 	cs.Properties.AgentPoolProfiles[0].OSType = "Windows"
 	cs.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = to.BoolPtr(true)

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -58,9 +58,7 @@
 							"name": "rescheduler",
 							"enabled": true
 						}
-					],
-					"loadBalancerSku": "Standard",
-					"excludeMasterFromStandardLB": true
+					]
 				}
 			},
 			"masterProfile": {

--- a/test/e2e/test_cluster_configs/zones.json
+++ b/test/e2e/test_cluster_configs/zones.json
@@ -6,11 +6,7 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
-                "kubernetesConfig": {
-                    "loadBalancerSku": "Standard",
-					"excludeMasterFromStandardLB": true
-                }
+                "orchestratorType": "Kubernetes"
 			},
 			"masterProfile": {
 				"count": 3,


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR changes default cluster configuration enforcement so that Standard is the LoadBalancer SKU type if the user does not declare a `loadBalancerSku` value in the `kubernetesConfig` configuration object.

`"Basic"` LoadBalancer configuration is no longer appropriate as a default for cluster configurations, as it precludes running LoadBalancer-backed Kubernetes services behind multiple node pool-enabled clusters.

Folks who want to continue using the legacy `"Basic"` LoadBalancer type will have to explicitly declare so in their api model:

```
{
    "apiVersion": "vlabs",
    "properties": {
	"orchestratorProfile": {
		"orchestratorType": "Kubernetes",
			"kubernetesConfig": {
				"loadBalancerSku": "Basic",
...
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2952 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
