### PR TITLE
fix: do some clean up before retry to install the gpu driver.

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -507,10 +507,10 @@ installGPUDriversRun() {
     fi
     {{- /* we need to append the date to the end of the file because the retry will override the log file */}}
     local log_file_name="/var/log/nvidia-installer-$(date +%s).log"
-    sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent \
-        --kernel-name=${KERNEL_NAME} \
+    sh $GPU_DEST/nvidia-drivers-$GPU_DV -s \
+        -k=${KERNEL_NAME} \
         --log-file-name=${log_file_name} \
-        --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
+        -a --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
     exit $?
 }
 

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -487,6 +487,25 @@ configAddons() {
 }
 {{end}}
 {{- if HasNSeriesSKU}}
+
+installGPUDriversRun() {
+    # if there's no file under the module folder, means the installation not succeeds
+    # so need to do some cleanup here.
+    NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
+    NVIDIA_DKMS_MODULE_DIR="${NVIDIA_DKMS_DIR}/*azure/x86_64/module"
+    if [ -d "${NVIDIA_DKMS_DIR}" ]; then
+        if [ -z "$(ls -A ${NVIDIA_DKMS_MODULE_DIR})" ]; then
+            echo "the dkms folder exists, but the module does not exists, we need to do the clean up first before retry to install."
+            # we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the 
+            # nvidia-uninstall itself may not exists either in this case
+            rm -rf "${NVIDIA_DKMS_DIR}"
+        fi
+    fi
+    
+    sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
+    exit $?
+}
+
 configGPUDrivers() {
   {{/* only install the runtime since nvidia-docker2 has a hard dep on docker CE packages. */}}
   {{/* we will manually install nvidia-docker2 */}}
@@ -507,7 +526,9 @@ configGPUDrivers() {
   retrycmd_if_failure 120 5 25 pkill -SIGHUP dockerd || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
   mkdir -p $GPU_DEST/lib64 $GPU_DEST/overlay-workdir
   retrycmd_if_failure 120 5 25 mount -t overlay -o lowerdir=/usr/lib/x86_64-linux-gnu,upperdir=${GPU_DEST}/lib64,workdir=${GPU_DEST}/overlay-workdir none /usr/lib/x86_64-linux-gnu || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-  retrycmd_if_failure 3 1 600 sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  export -f installGPUDriversRun
+  export GPU_DEST GPU_DV
+  retrycmd_if_failure 3 1 600 bash -c installGPUDriversRun || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
   echo "${GPU_DEST}/lib64" >/etc/ld.so.conf.d/nvidia.conf
   retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
   umount -l /usr/lib/x86_64-linux-gnu

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -493,19 +493,22 @@ installGPUDriversRun() {
     when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
     if yes please help remove the clean up logic here too */}}
     set -x
-    NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
-    NVIDIA_DKMS_MODULE_DIR="${NVIDIA_DKMS_DIR}/*azure/x86_64/module"
+    MODULE_NAME="nvidia"
+    NVIDIA_DKMS_DIR="/var/lib/dkms/${MODULE_NAME}/${GPU_DV}"
+    KERNEL_NAME=$(uname -r)
     if [ -d "${NVIDIA_DKMS_DIR}" ]; then
-        if [ -z "$(ls -A ${NVIDIA_DKMS_MODULE_DIR})" ]; then
-            echo "the dkms folder exists, but the module does not exists, we need to do the clean up first before retry to install."
-            {{- /* we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
-            rm -rf "${NVIDIA_DKMS_DIR}"
+        echo "the dkms module folder exists, we need to do the clean up first before retry to install."
+        if [ -x "$(command -v dkms)" ]; then
+          dkms remove -m ${MODULE_NAME} -v ${GPU_DV} -k ${KERNEL_NAME}
+        else
+          echo "the dkms tool is not found, so we just remove the directory to have a try"
+          rm -rf "${NVIDIA_DKMS_DIR}"
         fi
     fi
     {{- /* we need to append the date to the end of the file because the retry will override the log file */}}
     local log_file_name="/var/log/nvidia-installer-$(date +%s).log"
     sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent \
-        --kernel-name=$(uname -r) \
+        --kernel-name=${KERNEL_NAME} \
         --log-file-name=${log_file_name} \
         --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
     exit $?

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -489,15 +489,15 @@ configAddons() {
 {{- if HasNSeriesSKU}}
 
 installGPUDriversRun() {
-    # if there's no file under the module folder, means the installation not succeeds
-    # so need to do some cleanup here.
+    {{- /* there is no file under the module folder, the installation failed, so clean up the dirty directory
+     when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
+     if yes please help remove the clean up logic here too */}}
     NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
     NVIDIA_DKMS_MODULE_DIR="${NVIDIA_DKMS_DIR}/*azure/x86_64/module"
     if [ -d "${NVIDIA_DKMS_DIR}" ]; then
         if [ -z "$(ls -A ${NVIDIA_DKMS_MODULE_DIR})" ]; then
             echo "the dkms folder exists, but the module does not exists, we need to do the clean up first before retry to install."
-            # we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the 
-            # nvidia-uninstall itself may not exists either in this case
+            {{- /*  we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
             rm -rf "${NVIDIA_DKMS_DIR}"
         fi
     fi

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -490,19 +490,24 @@ configAddons() {
 
 installGPUDriversRun() {
     {{- /* there is no file under the module folder, the installation failed, so clean up the dirty directory
-     when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
-     if yes please help remove the clean up logic here too */}}
+    when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
+    if yes please help remove the clean up logic here too */}}
+    set -x
     NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
     NVIDIA_DKMS_MODULE_DIR="${NVIDIA_DKMS_DIR}/*azure/x86_64/module"
     if [ -d "${NVIDIA_DKMS_DIR}" ]; then
         if [ -z "$(ls -A ${NVIDIA_DKMS_MODULE_DIR})" ]; then
             echo "the dkms folder exists, but the module does not exists, we need to do the clean up first before retry to install."
-            {{- /*  we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
+            {{- /* we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
             rm -rf "${NVIDIA_DKMS_DIR}"
         fi
     fi
-    
-    sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
+    {{- /* we need to append the date to the end of the file because the retry will override the log file */}}
+    local log_file_name="/var/log/nvidia-installer-$(date +%s).log"
+    sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent \
+        --kernel-name=$(uname -r) \
+        --log-file-name=${log_file_name} \
+        --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
     exit $?
 }
 

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -9,6 +9,8 @@ if ! echo "${UBUNTU_OS_NAME} ${RHEL_OS_NAME} ${DEBIAN_OS_NAME}" | grep -q "${OS}
 fi
 KUBECTL=/usr/local/bin/kubectl
 DOCKER=/usr/bin/docker
+# when you upgrade the GPU driver version, please help check whether the retry installation is gone
+# if yes, please help remove the clean up logic in the installGPUDriversRun (cse_config.sh)
 GPU_DV=418.40.04
 GPU_DEST=/usr/local/nvidia
 NVIDIA_DOCKER_VERSION=2.0.3

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -9,8 +9,6 @@ if ! echo "${UBUNTU_OS_NAME} ${RHEL_OS_NAME} ${DEBIAN_OS_NAME}" | grep -q "${OS}
 fi
 KUBECTL=/usr/local/bin/kubectl
 DOCKER=/usr/bin/docker
-# when you upgrade the GPU driver version, please help check whether the retry installation is gone
-# if yes, please help remove the clean up logic in the installGPUDriversRun (cse_config.sh)
 GPU_DV=418.40.04
 GPU_DEST=/usr/local/nvidia
 NVIDIA_DOCKER_VERSION=2.0.3

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40249,10 +40249,10 @@ installGPUDriversRun() {
     fi
     {{- /* we need to append the date to the end of the file because the retry will override the log file */}}
     local log_file_name="/var/log/nvidia-installer-$(date +%s).log"
-    sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent \
-        --kernel-name=${KERNEL_NAME} \
+    sh $GPU_DEST/nvidia-drivers-$GPU_DV -s \
+        -k=${KERNEL_NAME} \
         --log-file-name=${log_file_name} \
-        --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
+        -a --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
     exit $?
 }
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40573,6 +40573,8 @@ if ! echo "${UBUNTU_OS_NAME} ${RHEL_OS_NAME} ${DEBIAN_OS_NAME}" | grep -q "${OS}
 fi
 KUBECTL=/usr/local/bin/kubectl
 DOCKER=/usr/bin/docker
+# when you upgrade the GPU driver version, please help check whether the retry installation is gone
+# if yes, please help remove the clean up logic in the installGPUDriversRun (cse_config.sh)
 GPU_DV=418.40.04
 GPU_DEST=/usr/local/nvidia
 NVIDIA_DOCKER_VERSION=2.0.3

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40235,19 +40235,22 @@ installGPUDriversRun() {
     when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
     if yes please help remove the clean up logic here too */}}
     set -x
-    NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
-    NVIDIA_DKMS_MODULE_DIR="${NVIDIA_DKMS_DIR}/*azure/x86_64/module"
+    MODULE_NAME="nvidia"
+    NVIDIA_DKMS_DIR="/var/lib/dkms/${MODULE_NAME}/${GPU_DV}"
+    KERNEL_NAME=$(uname -r)
     if [ -d "${NVIDIA_DKMS_DIR}" ]; then
-        if [ -z "$(ls -A ${NVIDIA_DKMS_MODULE_DIR})" ]; then
-            echo "the dkms folder exists, but the module does not exists, we need to do the clean up first before retry to install."
-            {{- /* we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
-            rm -rf "${NVIDIA_DKMS_DIR}"
+        echo "the dkms module folder exists, we need to do the clean up first before retry to install."
+        if [ -x "$(command -v dkms)" ]; then
+          dkms remove -m ${MODULE_NAME} -v ${GPU_DV} -k ${KERNEL_NAME}
+        else
+          echo "the dkms tool is not found, so we just remove the directory to have a try"
+          rm -rf "${NVIDIA_DKMS_DIR}"
         fi
     fi
     {{- /* we need to append the date to the end of the file because the retry will override the log file */}}
     local log_file_name="/var/log/nvidia-installer-$(date +%s).log"
     sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent \
-        --kernel-name=$(uname -r) \
+        --kernel-name=${KERNEL_NAME} \
         --log-file-name=${log_file_name} \
         --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
     exit $?

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40232,19 +40232,24 @@ configAddons() {
 
 installGPUDriversRun() {
     {{- /* there is no file under the module folder, the installation failed, so clean up the dirty directory
-     when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
-     if yes please help remove the clean up logic here too */}}
+    when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
+    if yes please help remove the clean up logic here too */}}
+    set -x
     NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
     NVIDIA_DKMS_MODULE_DIR="${NVIDIA_DKMS_DIR}/*azure/x86_64/module"
     if [ -d "${NVIDIA_DKMS_DIR}" ]; then
         if [ -z "$(ls -A ${NVIDIA_DKMS_MODULE_DIR})" ]; then
             echo "the dkms folder exists, but the module does not exists, we need to do the clean up first before retry to install."
-            {{- /*  we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
+            {{- /* we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
             rm -rf "${NVIDIA_DKMS_DIR}"
         fi
     fi
-    
-    sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
+    {{- /* we need to append the date to the end of the file because the retry will override the log file */}}
+    local log_file_name="/var/log/nvidia-installer-$(date +%s).log"
+    sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent \
+        --kernel-name=$(uname -r) \
+        --log-file-name=${log_file_name} \
+        --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
     exit $?
 }
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40231,15 +40231,15 @@ configAddons() {
 {{- if HasNSeriesSKU}}
 
 installGPUDriversRun() {
-    # if there's no file under the module folder, means the installation not succeeds
-    # so need to do some cleanup here.
+    {{- /* there is no file under the module folder, the installation failed, so clean up the dirty directory
+     when you upgrade the GPU driver version, please help check whether the retry installation issue is gone,
+     if yes please help remove the clean up logic here too */}}
     NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
     NVIDIA_DKMS_MODULE_DIR="${NVIDIA_DKMS_DIR}/*azure/x86_64/module"
     if [ -d "${NVIDIA_DKMS_DIR}" ]; then
         if [ -z "$(ls -A ${NVIDIA_DKMS_MODULE_DIR})" ]; then
             echo "the dkms folder exists, but the module does not exists, we need to do the clean up first before retry to install."
-            # we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the 
-            # nvidia-uninstall itself may not exists either in this case
+            {{- /*  we do not use the /usr/local/nvidia/bin/nvidia-uninstall directly, because the nvidia-uninstall itself may not exists too */}}
             rm -rf "${NVIDIA_DKMS_DIR}"
         fi
     fi
@@ -40573,8 +40573,6 @@ if ! echo "${UBUNTU_OS_NAME} ${RHEL_OS_NAME} ${DEBIAN_OS_NAME}" | grep -q "${OS}
 fi
 KUBECTL=/usr/local/bin/kubectl
 DOCKER=/usr/bin/docker
-# when you upgrade the GPU driver version, please help check whether the retry installation is gone
-# if yes, please help remove the clean up logic in the installGPUDriversRun (cse_config.sh)
 GPU_DV=418.40.04
 GPU_DEST=/usr/local/nvidia
 NVIDIA_DOCKER_VERSION=2.0.3


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
when we doing stress test for the scaling of the GPU nodes.
we found in some cases, we will meet this error:
the module already there, and the retry will not succeed if we do not do some clean up.

so the fix is to do some clean up before the reinstallation.

tests done:
1. ran the scripts snip in the box, and the retry works.
2. did the private change in the RP, and run the stress GPU nodes scaling test, and it passed.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
