### PR TITLE
style: format CSE scripts consistently

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cis.sh
+++ b/parts/k8s/cloud-init/artifacts/cis.sh
@@ -12,7 +12,7 @@ assignRootPW() {
 }
 
 assignFilePermissions() {
-    FILES="
+  FILES="
     auth.log
     alternatives.log
     cloud-init.log
@@ -34,21 +34,21 @@ assignFilePermissions() {
     blobfuse-flexvol-installer.log
     landscape/sysinfo.log
     "
-    for FILE in ${FILES}; do
-        FILEPATH="/var/log/${FILE}"
-        DIR=$(dirname "${FILEPATH}")
-        mkdir -p ${DIR} || exit 112
-        touch ${FILEPATH} || exit 112
-        chmod 640 ${FILEPATH} || exit 112
-    done
-    find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
-    chmod 600 /etc/passwd- || exit 112
-    chmod 600 /etc/shadow- || exit 112
-    chmod 600 /etc/group- || exit 112
-    chmod 644 /etc/default/grub || exit 112
-    for filepath in /etc/crontab /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
-      chmod 0600 $filepath || exit 112
-    done
+  for FILE in ${FILES}; do
+    FILEPATH="/var/log/${FILE}"
+    DIR=$(dirname "${FILEPATH}")
+    mkdir -p ${DIR} || exit 112
+    touch ${FILEPATH} || exit 112
+    chmod 640 ${FILEPATH} || exit 112
+  done
+  find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
+  chmod 600 /etc/passwd- || exit 112
+  chmod 600 /etc/shadow- || exit 112
+  chmod 600 /etc/group- || exit 112
+  chmod 644 /etc/default/grub || exit 112
+  for filepath in /etc/crontab /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
+    chmod 0600 $filepath || exit 112
+  done
 }
 
 setPWExpiration() {
@@ -58,11 +58,11 @@ setPWExpiration() {
   grep 'PASS_MIN_DAYS' /etc/login.defs && exit 115
   sed -i "s|INACTIVE=||g" /etc/default/useradd || exit 115
   grep 'INACTIVE=' /etc/default/useradd && exit 115
-  echo 'PASS_MAX_DAYS 90' >> /etc/login.defs || exit 115
+  echo 'PASS_MAX_DAYS 90' >>/etc/login.defs || exit 115
   grep 'PASS_MAX_DAYS 90' /etc/login.defs || exit 115
-  echo 'PASS_MIN_DAYS 7' >> /etc/login.defs || exit 115
+  echo 'PASS_MIN_DAYS 7' >>/etc/login.defs || exit 115
   grep 'PASS_MIN_DAYS 7' /etc/login.defs || exit 115
-  echo 'INACTIVE=30' >> /etc/default/useradd || exit 115
+  echo 'INACTIVE=30' >>/etc/default/useradd || exit 115
   grep 'INACTIVE=30' /etc/default/useradd || exit 115
 }
 

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -6,150 +6,150 @@ ETCD_PEER_URL="https://${PRIVATE_IP}:2380"
 ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
 
 systemctlEnableAndStart() {
-    systemctl_restart 100 5 30 $1
-    RESTART_STATUS=$?
-    systemctl status $1 --no-pager -l > /var/log/azure/$1-status.log
-    if [ $RESTART_STATUS -ne 0 ]; then
-        return 1
-    fi
-    if ! retrycmd_if_failure 120 5 25 systemctl enable $1; then
-        return 1
-    fi
+  systemctl_restart 100 5 30 $1
+  RESTART_STATUS=$?
+  systemctl status $1 --no-pager -l >/var/log/azure/$1-status.log
+  if [ $RESTART_STATUS -ne 0 ]; then
+    return 1
+  fi
+  if ! retrycmd_if_failure 120 5 25 systemctl enable $1; then
+    return 1
+  fi
 }
-configureAdminUser(){
-    chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
-    chage -l "${ADMINUSER}"
+configureAdminUser() {
+  chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
+  chage -l "${ADMINUSER}"
 }
-configureEtcdUser(){
-    useradd -U etcd
-    chage -E -1 -I -1 -m 0 -M 99999 etcd
-    chage -l etcd
-    id etcd
+configureEtcdUser() {
+  useradd -U etcd
+  chage -E -1 -I -1 -m 0 -M 99999 etcd
+  chage -l etcd
+  id etcd
 }
-configureSecrets(){
-    APISERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/apiserver.key"
-    touch "${APISERVER_PRIVATE_KEY_PATH}"
-    CA_PRIVATE_KEY_PATH="/etc/kubernetes/certs/ca.key"
-    touch "${CA_PRIVATE_KEY_PATH}"
-    ETCD_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdserver.key"
-    touch "${ETCD_SERVER_PRIVATE_KEY_PATH}"
-    if [[ -z "${COSMOS_URI}" ]]; then
-      chown etcd:etcd "${ETCD_SERVER_PRIVATE_KEY_PATH}"
-    fi
-    ETCD_CLIENT_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdclient.key"
-    touch "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
-    ETCD_PEER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.key"
-    touch "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    if [[ -z "${COSMOS_URI}" ]]; then
-      chown etcd:etcd "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    fi
-    chmod 0600 "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_SERVER_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}" "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    chown root:root "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
-    ETCD_SERVER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdserver.crt"
-    touch "${ETCD_SERVER_CERTIFICATE_PATH}"
-    ETCD_CLIENT_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdclient.crt"
-    touch "${ETCD_CLIENT_CERTIFICATE_PATH}"
-    ETCD_PEER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.crt"
-    touch "${ETCD_PEER_CERTIFICATE_PATH}"
-    chmod 0644 "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
-    chown root:root "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
+configureSecrets() {
+  APISERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/apiserver.key"
+  touch "${APISERVER_PRIVATE_KEY_PATH}"
+  CA_PRIVATE_KEY_PATH="/etc/kubernetes/certs/ca.key"
+  touch "${CA_PRIVATE_KEY_PATH}"
+  ETCD_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdserver.key"
+  touch "${ETCD_SERVER_PRIVATE_KEY_PATH}"
+  if [[ -z ${COSMOS_URI} ]]; then
+    chown etcd:etcd "${ETCD_SERVER_PRIVATE_KEY_PATH}"
+  fi
+  ETCD_CLIENT_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdclient.key"
+  touch "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
+  ETCD_PEER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.key"
+  touch "${ETCD_PEER_PRIVATE_KEY_PATH}"
+  if [[ -z ${COSMOS_URI} ]]; then
+    chown etcd:etcd "${ETCD_PEER_PRIVATE_KEY_PATH}"
+  fi
+  chmod 0600 "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_SERVER_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}" "${ETCD_PEER_PRIVATE_KEY_PATH}"
+  chown root:root "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
+  ETCD_SERVER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdserver.crt"
+  touch "${ETCD_SERVER_CERTIFICATE_PATH}"
+  ETCD_CLIENT_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdclient.crt"
+  touch "${ETCD_CLIENT_CERTIFICATE_PATH}"
+  ETCD_PEER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.crt"
+  touch "${ETCD_PEER_CERTIFICATE_PATH}"
+  chmod 0644 "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
+  chown root:root "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
 
-    set +x
-    echo "${APISERVER_PRIVATE_KEY}" | base64 --decode > "${APISERVER_PRIVATE_KEY_PATH}"
-    echo "${CA_PRIVATE_KEY}" | base64 --decode > "${CA_PRIVATE_KEY_PATH}"
-    echo "${ETCD_SERVER_PRIVATE_KEY}" | base64 --decode > "${ETCD_SERVER_PRIVATE_KEY_PATH}"
-    echo "${ETCD_CLIENT_PRIVATE_KEY}" | base64 --decode > "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
-    echo "${ETCD_PEER_KEY}" | base64 --decode > "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    echo "${ETCD_SERVER_CERTIFICATE}" | base64 --decode > "${ETCD_SERVER_CERTIFICATE_PATH}"
-    echo "${ETCD_CLIENT_CERTIFICATE}" | base64 --decode > "${ETCD_CLIENT_CERTIFICATE_PATH}"
-    echo "${ETCD_PEER_CERT}" | base64 --decode > "${ETCD_PEER_CERTIFICATE_PATH}"
+  set +x
+  echo "${APISERVER_PRIVATE_KEY}" | base64 --decode >"${APISERVER_PRIVATE_KEY_PATH}"
+  echo "${CA_PRIVATE_KEY}" | base64 --decode >"${CA_PRIVATE_KEY_PATH}"
+  echo "${ETCD_SERVER_PRIVATE_KEY}" | base64 --decode >"${ETCD_SERVER_PRIVATE_KEY_PATH}"
+  echo "${ETCD_CLIENT_PRIVATE_KEY}" | base64 --decode >"${ETCD_CLIENT_PRIVATE_KEY_PATH}"
+  echo "${ETCD_PEER_KEY}" | base64 --decode >"${ETCD_PEER_PRIVATE_KEY_PATH}"
+  echo "${ETCD_SERVER_CERTIFICATE}" | base64 --decode >"${ETCD_SERVER_CERTIFICATE_PATH}"
+  echo "${ETCD_CLIENT_CERTIFICATE}" | base64 --decode >"${ETCD_CLIENT_CERTIFICATE_PATH}"
+  echo "${ETCD_PEER_CERT}" | base64 --decode >"${ETCD_PEER_CERTIFICATE_PATH}"
 }
 configureEtcd() {
-    set -x
+  set -x
 
-    ETCD_SETUP_FILE=/opt/azure/containers/setup-etcd.sh
-    wait_for_file 1200 1 $ETCD_SETUP_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
-    $ETCD_SETUP_FILE > /opt/azure/containers/setup-etcd.log 2>&1
-    RET=$?
-    if [ $RET -ne 0 ]; then
-        exit $RET
-    fi
+  ETCD_SETUP_FILE=/opt/azure/containers/setup-etcd.sh
+  wait_for_file 1200 1 $ETCD_SETUP_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
+  $ETCD_SETUP_FILE >/opt/azure/containers/setup-etcd.log 2>&1
+  RET=$?
+  if [ $RET -ne 0 ]; then
+    exit $RET
+  fi
 
-    if [[ -z "${ETCDCTL_ENDPOINTS}" ]]; then
-        {{/* Variables necessary for etcdctl are not present */}}
-        {{/* Must pull them from /etc/environment */}}
-        for entry in $(cat /etc/environment); do
-            export ${entry}
-        done
-    fi
-
-    MOUNT_ETCD_FILE=/opt/azure/containers/mountetcd.sh
-    wait_for_file 1200 1 $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
-    $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_VOL_MOUNT_FAIL"}}
-    systemctlEnableAndStart etcd || exit {{GetCSEErrorCode "ERR_ETCD_START_TIMEOUT"}}
-    for i in $(seq 1 600); do
-        MEMBER="$(sudo -E etcdctl member list | grep -E ${NODE_NAME} | cut -d':' -f 1)"
-        if [ "$MEMBER" != "" ]; then
-            break
-        else
-            sleep 1
-        fi
+  if [[ -z ${ETCDCTL_ENDPOINTS} ]]; then
+    {{/* Variables necessary for etcdctl are not present */}}
+    {{/* Must pull them from /etc/environment */}}
+    for entry in $(cat /etc/environment); do
+      export ${entry}
     done
-    retrycmd_if_failure 120 5 25 sudo -E etcdctl member update $MEMBER ${ETCD_PEER_URL} || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
+  fi
+
+  MOUNT_ETCD_FILE=/opt/azure/containers/mountetcd.sh
+  wait_for_file 1200 1 $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
+  $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_VOL_MOUNT_FAIL"}}
+  systemctlEnableAndStart etcd || exit {{GetCSEErrorCode "ERR_ETCD_START_TIMEOUT"}}
+  for i in $(seq 1 600); do
+    MEMBER="$(sudo -E etcdctl member list | grep -E ${NODE_NAME} | cut -d':' -f 1)"
+    if [ "$MEMBER" != "" ]; then
+      break
+    else
+      sleep 1
+    fi
+  done
+  retrycmd_if_failure 120 5 25 sudo -E etcdctl member update $MEMBER ${ETCD_PEER_URL} || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
 }
 ensureNTP() {
-    systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 ensureRPC() {
-    systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-    systemctlEnableAndStart rpc-statd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart rpc-statd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 ensureAuditD() {
-  if [[ "${AUDITD_ENABLED}" == true ]]; then
+  if [[ ${AUDITD_ENABLED} == true ]]; then
     systemctlEnableAndStart auditd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
   else
     apt_get_purge auditd mlocate &
   fi
 }
 generateAggregatedAPICerts() {
-    AGGREGATED_API_CERTS_SETUP_FILE=/etc/kubernetes/generate-proxy-certs.sh
-    wait_for_file 1200 1 $AGGREGATED_API_CERTS_SETUP_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    $AGGREGATED_API_CERTS_SETUP_FILE
+  AGGREGATED_API_CERTS_SETUP_FILE=/etc/kubernetes/generate-proxy-certs.sh
+  wait_for_file 1200 1 $AGGREGATED_API_CERTS_SETUP_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  $AGGREGATED_API_CERTS_SETUP_FILE
 }
 configureKubeletServerCert() {
-    KUBELET_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/kubeletserver.key"
-    KUBELET_SERVER_CERT_PATH="/etc/kubernetes/certs/kubeletserver.crt"
+  KUBELET_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/kubeletserver.key"
+  KUBELET_SERVER_CERT_PATH="/etc/kubernetes/certs/kubeletserver.crt"
 
-    openssl genrsa -out $KUBELET_SERVER_PRIVATE_KEY_PATH 2048
-    openssl req -new -x509 -days 7300 -key $KUBELET_SERVER_PRIVATE_KEY_PATH -out $KUBELET_SERVER_CERT_PATH -subj "/CN=${NODE_NAME}"
+  openssl genrsa -out $KUBELET_SERVER_PRIVATE_KEY_PATH 2048
+  openssl req -new -x509 -days 7300 -key $KUBELET_SERVER_PRIVATE_KEY_PATH -out $KUBELET_SERVER_CERT_PATH -subj "/CN=${NODE_NAME}"
 }
 configureK8s() {
-    KUBELET_PRIVATE_KEY_PATH="/etc/kubernetes/certs/client.key"
-    touch "${KUBELET_PRIVATE_KEY_PATH}"
-    APISERVER_PUBLIC_KEY_PATH="/etc/kubernetes/certs/apiserver.crt"
-    touch "${APISERVER_PUBLIC_KEY_PATH}"
-    chmod 0600 "${KUBELET_PRIVATE_KEY_PATH}"
-    chmod 0644 "${APISERVER_PUBLIC_KEY_PATH}"
-    chown root:root "${KUBELET_PRIVATE_KEY_PATH}" "${APISERVER_PUBLIC_KEY_PATH}"
+  KUBELET_PRIVATE_KEY_PATH="/etc/kubernetes/certs/client.key"
+  touch "${KUBELET_PRIVATE_KEY_PATH}"
+  APISERVER_PUBLIC_KEY_PATH="/etc/kubernetes/certs/apiserver.crt"
+  touch "${APISERVER_PUBLIC_KEY_PATH}"
+  chmod 0600 "${KUBELET_PRIVATE_KEY_PATH}"
+  chmod 0644 "${APISERVER_PUBLIC_KEY_PATH}"
+  chown root:root "${KUBELET_PRIVATE_KEY_PATH}" "${APISERVER_PUBLIC_KEY_PATH}"
 
-    set +x
-    echo "${KUBELET_PRIVATE_KEY}" | base64 --decode > "${KUBELET_PRIVATE_KEY_PATH}"
-    echo "${APISERVER_PUBLIC_KEY}" | base64 --decode > "${APISERVER_PUBLIC_KEY_PATH}"
-    configureKubeletServerCert
-    AZURE_JSON_PATH="/etc/kubernetes/azure.json"
-    if [[ -n "${MASTER_NODE}" ]]; then
-        if [[ "${ENABLE_AGGREGATED_APIS}" = True ]]; then
-            generateAggregatedAPICerts
-        fi
-    else
-        {{- /* If we are a node vm then we only proceed w/ local azure.json configuration if cloud-init has pre-paved that file */}}
-        wait_for_file 1 1 $AZURE_JSON_PATH || return
+  set +x
+  echo "${KUBELET_PRIVATE_KEY}" | base64 --decode >"${KUBELET_PRIVATE_KEY_PATH}"
+  echo "${APISERVER_PUBLIC_KEY}" | base64 --decode >"${APISERVER_PUBLIC_KEY_PATH}"
+  configureKubeletServerCert
+  AZURE_JSON_PATH="/etc/kubernetes/azure.json"
+  if [[ -n ${MASTER_NODE} ]]; then
+    if [[ ${ENABLE_AGGREGATED_APIS} == True ]]; then
+      generateAggregatedAPICerts
     fi
+  else
+    {{- /* If we are a node vm then we only proceed w/ local azure.json configuration if cloud-init has pre-paved that file */}}
+    wait_for_file 1 1 $AZURE_JSON_PATH || return
+  fi
 
-    {{/* Perform the required JSON escaping */}}
-    SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\\/\\\\}
-    SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\"/\\\"}
-    cat << EOF > "${AZURE_JSON_PATH}"
+  {{/* Perform the required JSON escaping */}}
+  SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\\/\\\\}
+  SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\"/\\\"}
+  cat <<EOF >"${AZURE_JSON_PATH}"
 {
     "cloud":"{{GetTargetEnvironment}}",
     "tenantId": "${TENANT_ID}",
@@ -189,230 +189,230 @@ configureK8s() {
     "providerKeyVersion": ""
 }
 EOF
-    set -x
-    if [[ "${CLOUDPROVIDER_BACKOFF_MODE}" = "v2" ]]; then
-        sed -i "/cloudProviderBackoffExponent/d" $AZURE_JSON_PATH
-        sed -i "/cloudProviderBackoffJitter/d" $AZURE_JSON_PATH
-    fi
+  set -x
+  if [[ ${CLOUDPROVIDER_BACKOFF_MODE} == "v2" ]]; then
+    sed -i "/cloudProviderBackoffExponent/d" $AZURE_JSON_PATH
+    sed -i "/cloudProviderBackoffJitter/d" $AZURE_JSON_PATH
+  fi
 }
 
 installNetworkPlugin() {
-{{- if IsAzureCNI}}
-    installAzureCNI
-{{end}}
-    installCNI
-    rm -rf $CNI_DOWNLOADS_DIR &
+  {{- if IsAzureCNI}}
+  installAzureCNI
+  {{end}}
+  installCNI
+  rm -rf $CNI_DOWNLOADS_DIR &
 }
 installCNI() {
-    CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
-    if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
-        downloadCNI
-    fi
-    mkdir -p $CNI_BIN_DIR
-    tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
-    chown -R root:root $CNI_BIN_DIR
-    chmod -R 755 $CNI_BIN_DIR
+  CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
+  if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
+    downloadCNI
+  fi
+  mkdir -p $CNI_BIN_DIR
+  tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
+  chown -R root:root $CNI_BIN_DIR
+  chmod -R 755 $CNI_BIN_DIR
 }
 {{- if IsAzureCNI}}
 installAzureCNI() {
-    CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
-    if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
-        downloadAzureCNI
-    fi
-    mkdir -p $CNI_CONFIG_DIR
-    chown -R root:root $CNI_CONFIG_DIR
-    chmod 755 $CNI_CONFIG_DIR
-    mkdir -p $CNI_BIN_DIR
-    tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
+  CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
+  if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
+    downloadAzureCNI
+  fi
+  mkdir -p $CNI_CONFIG_DIR
+  chown -R root:root $CNI_CONFIG_DIR
+  chmod 755 $CNI_CONFIG_DIR
+  mkdir -p $CNI_BIN_DIR
+  tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
 }
 {{end}}
 configureCNI() {
-    {{/* needed for the iptables rules to work on bridges */}}
-    retrycmd_if_failure 120 5 25 modprobe br_netfilter || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
-    echo -n "br_netfilter" > /etc/modules-load.d/br_netfilter.conf
-    configureCNIIPTables
-    {{if HasCiliumNetworkPlugin}}
-    systemctl enable sys-fs-bpf.mount
-    systemctl restart sys-fs-bpf.mount
-    REBOOTREQUIRED=true
-    {{end}}
-{{- if IsAzureStackCloud}}
-    if [[ "${NETWORK_PLUGIN}" = "azure" ]]; then
-        {{/* set environment to mas when using Azure CNI on Azure Stack */}}
-        {{/* shellcheck disable=SC2002,SC2005 */}}
-        echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipam.environment = "mas"') > "$CNI_CONFIG_DIR/10-azure.conflist"
-    fi
-{{end}}
+  {{/* needed for the iptables rules to work on bridges */}}
+  retrycmd_if_failure 120 5 25 modprobe br_netfilter || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  echo -n "br_netfilter" >/etc/modules-load.d/br_netfilter.conf
+  configureCNIIPTables
+  {{if HasCiliumNetworkPlugin}}
+  systemctl enable sys-fs-bpf.mount
+  systemctl restart sys-fs-bpf.mount
+  REBOOTREQUIRED=true
+  {{end}}
+  {{- if IsAzureStackCloud}}
+  if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
+    {{/* set environment to mas when using Azure CNI on Azure Stack */}}
+    {{/* shellcheck disable=SC2002,SC2005 */}}
+    echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipam.environment = "mas"') >"$CNI_CONFIG_DIR/10-azure.conflist"
+  fi
+  {{end}}
 }
 configureCNIIPTables() {
-    if [[ "${NETWORK_PLUGIN}" = "azure" ]]; then
-        mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
-        chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
-        if [[ "${NETWORK_POLICY}" == "calico" ]]; then
-          sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-        elif [[ "${NETWORK_POLICY}" == "" || "${NETWORK_POLICY}" == "none" ]] && [[ "${NETWORK_MODE}" == "transparent" ]]; then
-          sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-        fi
-        /sbin/ebtables -t nat --list
+  if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
+    mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
+    chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
+    if [[ ${NETWORK_POLICY} == "calico" ]]; then
+      sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
+    elif [[ ${NETWORK_POLICY} == "" || ${NETWORK_POLICY} == "none" ]] && [[ ${NETWORK_MODE} == "transparent" ]]; then
+      sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     fi
+    /sbin/ebtables -t nat --list
+  fi
 }
 {{- if NeedsContainerd}}
 installContainerd() {
-    removeMoby
-    CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||')
-    if [[ "$CURRENT_VERSION" != "${CONTAINERD_VERSION}" ]]; then
-        os_lower=$(echo ${OS} | tr '[:upper:]' '[:lower:]')
-        if [[ "${OS}" == "${UBUNTU_OS_NAME}" ]]; then
-            url_path="${os_lower}/${UBUNTU_RELEASE}/multiarch/prod"
-        elif [[ "${OS}" == "${DEBIAN_OS_NAME}" ]]; then
-            url_path="${os_lower}/${UBUNTU_RELEASE}/prod"
-        else
-            exit 25
-        fi
-        removeContainerd
-        echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/${url_path} testing main" > /tmp/microsoft-prod-testing.list
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod-testing.list /etc/apt/sources.list.d/ || exit 25
-        retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg || exit 26
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
-        apt_get_update || exit 99
-        apt_get_install 20 30 120 moby-containerd=${CONTAINERD_VERSION}* --allow-downgrades || exit 27
+  removeMoby
+  CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||')
+  if [[ $CURRENT_VERSION != "${CONTAINERD_VERSION}" ]]; then
+    os_lower=$(echo ${OS} | tr '[:upper:]' '[:lower:]')
+    if [[ ${OS} == "${UBUNTU_OS_NAME}" ]]; then
+      url_path="${os_lower}/${UBUNTU_RELEASE}/multiarch/prod"
+    elif [[ ${OS} == "${DEBIAN_OS_NAME}" ]]; then
+      url_path="${os_lower}/${UBUNTU_RELEASE}/prod"
+    else
+      exit 25
     fi
+    removeContainerd
+    echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/${url_path} testing main" >/tmp/microsoft-prod-testing.list
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod-testing.list /etc/apt/sources.list.d/ || exit 25
+    retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >/tmp/microsoft.gpg || exit 26
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
+    apt_get_update || exit 99
+    apt_get_install 20 30 120 moby-containerd=${CONTAINERD_VERSION}* --allow-downgrades || exit 27
+  fi
 }
 ensureContainerd() {
-    wait_for_file 1200 1 /etc/systemd/system/containerd.service.d/exec_start.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    wait_for_file 1200 1 /etc/containerd/config.toml || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart containerd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  wait_for_file 1200 1 /etc/systemd/system/containerd.service.d/exec_start.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  wait_for_file 1200 1 /etc/containerd/config.toml || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart containerd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 {{end}}
 {{- if IsDockerContainerRuntime}}
 ensureDocker() {
-    DOCKER_SERVICE_EXEC_START_FILE=/etc/systemd/system/docker.service.d/exec_start.conf
-    wait_for_file 1200 1 $DOCKER_SERVICE_EXEC_START_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    usermod -aG docker ${ADMINUSER}
-    DOCKER_MOUNT_FLAGS_SYSTEMD_FILE=/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf
-    DOCKER_JSON_FILE=/etc/docker/daemon.json
-    for i in $(seq 1 1200); do
-        if [ -s $DOCKER_JSON_FILE ]; then
-            jq '.' < $DOCKER_JSON_FILE && break
-        fi
-        if [ $i -eq 1200 ]; then
-            exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-        else
-            sleep 1
-        fi
-    done
-    systemctlEnableAndStart docker || exit {{GetCSEErrorCode "ERR_DOCKER_START_FAIL"}}
-    {{/* Delay start of docker-monitor for 30 mins after booting */}}
-    DOCKER_MONITOR_SYSTEMD_TIMER_FILE=/etc/systemd/system/docker-monitor.timer
-    wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_TIMER_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    DOCKER_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
-    wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart docker-monitor.timer || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  DOCKER_SERVICE_EXEC_START_FILE=/etc/systemd/system/docker.service.d/exec_start.conf
+  wait_for_file 1200 1 $DOCKER_SERVICE_EXEC_START_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  usermod -aG docker ${ADMINUSER}
+  DOCKER_MOUNT_FLAGS_SYSTEMD_FILE=/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf
+  DOCKER_JSON_FILE=/etc/docker/daemon.json
+  for i in $(seq 1 1200); do
+    if [ -s $DOCKER_JSON_FILE ]; then
+      jq '.' <$DOCKER_JSON_FILE && break
+    fi
+    if [ $i -eq 1200 ]; then
+      exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+    else
+      sleep 1
+    fi
+  done
+  systemctlEnableAndStart docker || exit {{GetCSEErrorCode "ERR_DOCKER_START_FAIL"}}
+  {{/* Delay start of docker-monitor for 30 mins after booting */}}
+  DOCKER_MONITOR_SYSTEMD_TIMER_FILE=/etc/systemd/system/docker-monitor.timer
+  wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_TIMER_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  DOCKER_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
+  wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart docker-monitor.timer || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 {{end}}
 {{- if EnableEncryptionWithExternalKms}}
 ensureKMS() {
-    systemctlEnableAndStart kms || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart kms || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 {{end}}
 {{- if IsIPv6Enabled}}
 ensureDHCPv6() {
-    wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-    retrycmd_if_failure 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  retrycmd_if_failure 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
 }
 {{end}}
 ensureKubelet() {
-    wait_for_file 1200 1 /etc/sysctl.d/11-aks-engine.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    sysctl_reload 10 5 120 || exit {{GetCSEErrorCode "ERR_SYSCTL_RELOAD"}}
-    KUBELET_DEFAULT_FILE=/etc/default/kubelet
-    wait_for_file 1200 1 $KUBELET_DEFAULT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    KUBECONFIG_FILE=/var/lib/kubelet/kubeconfig
-    wait_for_file 1200 1 $KUBECONFIG_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
-    wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
-    {{if HasCiliumNetworkPolicy}}
-    while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
-        sleep 3
-    done
-    {{end}}
-    {{if HasAntreaNetworkPolicy}}
-    while [ ! -f /etc/cni/net.d/10-antrea.conf ]; do
-        sleep 3
-    done
-    {{end}}
-    {{if HasFlannelNetworkPlugin}}
-    while [ ! -f /etc/cni/net.d/10-flannel.conf ]; do
-        sleep 3
-    done
-    {{end}}
+  wait_for_file 1200 1 /etc/sysctl.d/11-aks-engine.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sysctl_reload 10 5 120 || exit {{GetCSEErrorCode "ERR_SYSCTL_RELOAD"}}
+  KUBELET_DEFAULT_FILE=/etc/default/kubelet
+  wait_for_file 1200 1 $KUBELET_DEFAULT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  KUBECONFIG_FILE=/var/lib/kubelet/kubeconfig
+  wait_for_file 1200 1 $KUBECONFIG_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
+  wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+  {{if HasCiliumNetworkPolicy}}
+  while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
+    sleep 3
+  done
+  {{end}}
+  {{if HasAntreaNetworkPolicy}}
+  while [ ! -f /etc/cni/net.d/10-antrea.conf ]; do
+    sleep 3
+  done
+  {{end}}
+  {{if HasFlannelNetworkPlugin}}
+  while [ ! -f /etc/cni/net.d/10-flannel.conf ]; do
+    sleep 3
+  done
+  {{end}}
 }
 ensureLabelNodes() {
-    LABEL_NODES_SCRIPT_FILE=/opt/azure/containers/label-nodes.sh
-    wait_for_file 1200 1 $LABEL_NODES_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    LABEL_NODES_SYSTEMD_FILE=/etc/systemd/system/label-nodes.service
-    wait_for_file 1200 1 $LABEL_NODES_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart label-nodes || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  LABEL_NODES_SCRIPT_FILE=/opt/azure/containers/label-nodes.sh
+  wait_for_file 1200 1 $LABEL_NODES_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  LABEL_NODES_SYSTEMD_FILE=/etc/systemd/system/label-nodes.service
+  wait_for_file 1200 1 $LABEL_NODES_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart label-nodes || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 ensureJournal() {
-    {
-        echo "Storage=persistent"
-        echo "SystemMaxUse=1G"
-        echo "RuntimeMaxUse=1G"
-        echo "ForwardToSyslog=yes"
-    } >> /etc/systemd/journald.conf
-    systemctlEnableAndStart systemd-journald || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  {
+    echo "Storage=persistent"
+    echo "SystemMaxUse=1G"
+    echo "RuntimeMaxUse=1G"
+    echo "ForwardToSyslog=yes"
+  } >>/etc/systemd/journald.conf
+  systemctlEnableAndStart systemd-journald || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 installKubeletAndKubectl() {
-    if [[ ! -f "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" ]]; then
-        if version_gte ${KUBERNETES_VERSION} 1.17; then
-            extractKubeBinaries
-        else
-            if [[ "$CONTAINER_RUNTIME" == "docker" ]]; then
-                extractHyperkube "docker"
-            else
-                extractHyperkube "img"
-            fi
-        fi
+  if [[ ! -f "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" ]]; then
+    if version_gte ${KUBERNETES_VERSION} 1.17; then
+      extractKubeBinaries
+    else
+      if [[ $CONTAINER_RUNTIME == "docker" ]]; then
+        extractHyperkube "docker"
+      else
+        extractHyperkube "img"
+      fi
     fi
-    mv "/usr/local/bin/kubelet-${KUBERNETES_VERSION}" "/usr/local/bin/kubelet"
-    mv "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" "/usr/local/bin/kubectl"
-    chmod a+x /usr/local/bin/kubelet /usr/local/bin/kubectl
-    rm -rf /usr/local/bin/kubelet-* /usr/local/bin/kubectl-* /home/hyperkube-downloads &
+  fi
+  mv "/usr/local/bin/kubelet-${KUBERNETES_VERSION}" "/usr/local/bin/kubelet"
+  mv "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" "/usr/local/bin/kubectl"
+  chmod a+x /usr/local/bin/kubelet /usr/local/bin/kubectl
+  rm -rf /usr/local/bin/kubelet-* /usr/local/bin/kubectl-* /home/hyperkube-downloads &
 }
 ensureK8sControlPlane() {
-    if $REBOOTREQUIRED || [ "$NO_OUTBOUND" = "true" ]; then
-        return
-    fi
-    retrycmd_if_failure 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  if $REBOOTREQUIRED || [ "$NO_OUTBOUND" = "true" ]; then
+    return
+  fi
+  retrycmd_if_failure 120 5 25 $KUBECTL cluster-info 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{- if IsAzurePolicyAddonEnabled}}
 ensureLabelExclusionForAzurePolicyAddon() {
-    GATEKEEPER_NAMESPACE="gatekeeper-system"
-    retrycmd_if_failure 120 5 25 $KUBECTL create ns --save-config $GATEKEEPER_NAMESPACE 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  GATEKEEPER_NAMESPACE="gatekeeper-system"
+  retrycmd_if_failure 120 5 25 $KUBECTL create ns --save-config $GATEKEEPER_NAMESPACE 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 
-    retrycmd_if_failure 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  retrycmd_if_failure 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{end}}
 ensureEtcd() {
-    retrycmd_if_failure 120 5 25 curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key ${ETCD_CLIENT_URL}/v2/machines || exit {{GetCSEErrorCode "ERR_ETCD_RUNNING_TIMEOUT"}}
+  retrycmd_if_failure 120 5 25 curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key ${ETCD_CLIENT_URL}/v2/machines || exit {{GetCSEErrorCode "ERR_ETCD_RUNNING_TIMEOUT"}}
 }
 createKubeManifestDir() {
-    KUBEMANIFESTDIR=/etc/kubernetes/manifests
-    mkdir -p $KUBEMANIFESTDIR
+  KUBEMANIFESTDIR=/etc/kubernetes/manifests
+  mkdir -p $KUBEMANIFESTDIR
 }
 writeKubeConfig() {
-    local DIR=/home/$ADMINUSER/.kube
-    local FILE=$DIR/config
-    mkdir -p $DIR
-    touch $FILE
-    chown $ADMINUSER:$ADMINUSER $DIR $FILE
-    chmod 700 $DIR
-    chmod 600 $FILE
-    set +x
-    echo "
+  local DIR=/home/$ADMINUSER/.kube
+  local FILE=$DIR/config
+  mkdir -p $DIR
+  touch $FILE
+  chown $ADMINUSER:$ADMINUSER $DIR $FILE
+  chmod 700 $DIR
+  chmod 600 $FILE
+  set +x
+  echo "
 ---
 apiVersion: v1
 clusters:
@@ -432,159 +432,159 @@ users:
   user:
     client-certificate-data: \"$KUBECONFIG_CERTIFICATE\"
     client-key-data: \"$KUBECONFIG_KEY\"
-" > $FILE
-    set -x
-    KUBECTL="$KUBECTL --kubeconfig=$FILE"
+" >$FILE
+  set -x
+  KUBECTL="$KUBECTL --kubeconfig=$FILE"
 }
 {{- if IsClusterAutoscalerAddonEnabled}}
 configClusterAutoscalerAddon() {
-    CLUSTER_AUTOSCALER_ADDON_FILE=/etc/kubernetes/addons/cluster-autoscaler-deployment.yaml
-    wait_for_file 1200 1 $CLUSTER_AUTOSCALER_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    sed -i "s|<clientID>|$(echo $SERVICE_PRINCIPAL_CLIENT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<clientSec>|$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<subID>|$(echo $SUBSCRIPTION_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<tenantID>|$(echo $TENANT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<rg>|$(echo $RESOURCE_GROUP | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  CLUSTER_AUTOSCALER_ADDON_FILE=/etc/kubernetes/addons/cluster-autoscaler-deployment.yaml
+  wait_for_file 1200 1 $CLUSTER_AUTOSCALER_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sed -i "s|<clientID>|$(echo $SERVICE_PRINCIPAL_CLIENT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<clientSec>|$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<subID>|$(echo $SUBSCRIPTION_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<tenantID>|$(echo $TENANT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<rg>|$(echo $RESOURCE_GROUP | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
 }
 {{end}}
 {{- if IsACIConnectorAddonEnabled}}
 configACIConnectorAddon() {
-    ACI_CONNECTOR_CREDENTIALS=$(printf "{\"clientId\": \"%s\", \"clientSecret\": \"%s\", \"tenantId\": \"%s\", \"subscriptionId\": \"%s\", \"activeDirectoryEndpointUrl\": \"https://login.microsoftonline.com\",\"resourceManagerEndpointUrl\": \"https://management.azure.com/\", \"activeDirectoryGraphResourceId\": \"https://graph.windows.net/\", \"sqlManagementEndpointUrl\": \"https://management.core.windows.net:8443/\", \"galleryEndpointUrl\": \"https://gallery.azure.com/\", \"managementEndpointUrl\": \"https://management.core.windows.net/\"}" "$SERVICE_PRINCIPAL_CLIENT_ID" "$SERVICE_PRINCIPAL_CLIENT_SECRET" "$TENANT_ID" "$SUBSCRIPTION_ID" | base64 -w 0)
+  ACI_CONNECTOR_CREDENTIALS=$(printf '{"clientId": "%s", "clientSecret": "%s", "tenantId": "%s", "subscriptionId": "%s", "activeDirectoryEndpointUrl": "https://login.microsoftonline.com","resourceManagerEndpointUrl": "https://management.azure.com/", "activeDirectoryGraphResourceId": "https://graph.windows.net/", "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/", "galleryEndpointUrl": "https://gallery.azure.com/", "managementEndpointUrl": "https://management.core.windows.net/"}' "$SERVICE_PRINCIPAL_CLIENT_ID" "$SERVICE_PRINCIPAL_CLIENT_SECRET" "$TENANT_ID" "$SUBSCRIPTION_ID" | base64 -w 0)
 
-    openssl req -newkey rsa:4096 -new -nodes -x509 -days 3650 -keyout /etc/kubernetes/certs/aci-connector-key.pem -out /etc/kubernetes/certs/aci-connector-cert.pem -subj "/C=US/ST=CA/L=virtualkubelet/O=virtualkubelet/OU=virtualkubelet/CN=virtualkubelet"
-    ACI_CONNECTOR_KEY=$(base64 /etc/kubernetes/certs/aci-connector-key.pem -w0)
-    ACI_CONNECTOR_CERT=$(base64 /etc/kubernetes/certs/aci-connector-cert.pem -w0)
+  openssl req -newkey rsa:4096 -new -nodes -x509 -days 3650 -keyout /etc/kubernetes/certs/aci-connector-key.pem -out /etc/kubernetes/certs/aci-connector-cert.pem -subj "/C=US/ST=CA/L=virtualkubelet/O=virtualkubelet/OU=virtualkubelet/CN=virtualkubelet"
+  ACI_CONNECTOR_KEY=$(base64 /etc/kubernetes/certs/aci-connector-key.pem -w0)
+  ACI_CONNECTOR_CERT=$(base64 /etc/kubernetes/certs/aci-connector-cert.pem -w0)
 
-    ACI_CONNECTOR_ADDON_FILE=/etc/kubernetes/addons/aci-connector-deployment.yaml
-    wait_for_file 1200 1 $ACI_CONNECTOR_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    sed -i "s|<creds>|$ACI_CONNECTOR_CREDENTIALS|g" $ACI_CONNECTOR_ADDON_FILE
-    sed -i "s|<rgName>|$RESOURCE_GROUP|g" $ACI_CONNECTOR_ADDON_FILE
-    sed -i "s|<cert>|$ACI_CONNECTOR_CERT|g" $ACI_CONNECTOR_ADDON_FILE
-    sed -i "s|<key>|$ACI_CONNECTOR_KEY|g" $ACI_CONNECTOR_ADDON_FILE
+  ACI_CONNECTOR_ADDON_FILE=/etc/kubernetes/addons/aci-connector-deployment.yaml
+  wait_for_file 1200 1 $ACI_CONNECTOR_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sed -i "s|<creds>|$ACI_CONNECTOR_CREDENTIALS|g" $ACI_CONNECTOR_ADDON_FILE
+  sed -i "s|<rgName>|$RESOURCE_GROUP|g" $ACI_CONNECTOR_ADDON_FILE
+  sed -i "s|<cert>|$ACI_CONNECTOR_CERT|g" $ACI_CONNECTOR_ADDON_FILE
+  sed -i "s|<key>|$ACI_CONNECTOR_KEY|g" $ACI_CONNECTOR_ADDON_FILE
 }
 {{end}}
 {{- if IsAzurePolicyAddonEnabled}}
 configAzurePolicyAddon() {
-    AZURE_POLICY_ADDON_FILE=/etc/kubernetes/addons/azure-policy-deployment.yaml
-    sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $AZURE_POLICY_ADDON_FILE
+  AZURE_POLICY_ADDON_FILE=/etc/kubernetes/addons/azure-policy-deployment.yaml
+  sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $AZURE_POLICY_ADDON_FILE
 }
 {{end}}
 {{- if or IsClusterAutoscalerAddonEnabled IsACIConnectorAddonEnabled IsAzurePolicyAddonEnabled}}
 configAddons() {
-    {{if IsClusterAutoscalerAddonEnabled}}
-    if [[ "${CLUSTER_AUTOSCALER_ADDON}" = true ]]; then
-        configClusterAutoscalerAddon
-    fi
-    {{end}}
-    {{if IsACIConnectorAddonEnabled}}
-    if [[ "${ACI_CONNECTOR_ADDON}" = True ]]; then
-        configACIConnectorAddon
-    fi
-    {{end}}
-    {{if IsAzurePolicyAddonEnabled}}
-    configAzurePolicyAddon
-    {{end}}
+  {{if IsClusterAutoscalerAddonEnabled}}
+  if [[ ${CLUSTER_AUTOSCALER_ADDON} == true ]]; then
+    configClusterAutoscalerAddon
+  fi
+  {{end}}
+  {{if IsACIConnectorAddonEnabled}}
+  if [[ ${ACI_CONNECTOR_ADDON} == True ]]; then
+    configACIConnectorAddon
+  fi
+  {{end}}
+  {{if IsAzurePolicyAddonEnabled}}
+  configAzurePolicyAddon
+  {{end}}
 }
 {{end}}
 {{- if HasNSeriesSKU}}
 configGPUDrivers() {
-    {{/* only install the runtime since nvidia-docker2 has a hard dep on docker CE packages. */}}
-    {{/* we will manually install nvidia-docker2 */}}
-    rmmod nouveau
-    echo blacklist nouveau >> /etc/modprobe.d/blacklist.conf
-    retrycmd_if_failure_no_stats 120 5 25 update-initramfs -u || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  {{/* only install the runtime since nvidia-docker2 has a hard dep on docker CE packages. */}}
+  {{/* we will manually install nvidia-docker2 */}}
+  rmmod nouveau
+  echo blacklist nouveau >>/etc/modprobe.d/blacklist.conf
+  retrycmd_if_failure_no_stats 120 5 25 update-initramfs -u || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  wait_for_apt_locks
+  retrycmd_if_failure 30 5 3600 apt-get -o Dpkg::Options::="--force-confold" install -y nvidia-container-runtime="${NVIDIA_CONTAINER_RUNTIME_VERSION}+docker18.09.2-1" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  tmpDir=$GPU_DEST/tmp
+  (
+    set -e -o pipefail
+    cd "${tmpDir}"
     wait_for_apt_locks
-    retrycmd_if_failure 30 5 3600 apt-get -o Dpkg::Options::="--force-confold" install -y nvidia-container-runtime="${NVIDIA_CONTAINER_RUNTIME_VERSION}+docker18.09.2-1" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    tmpDir=$GPU_DEST/tmp
-    (
-      set -e -o pipefail
-      cd "${tmpDir}"
-      wait_for_apt_locks
-      dpkg-deb -R ./nvidia-docker2*.deb "${tmpDir}/pkg" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-      cp -r ${tmpDir}/pkg/usr/* /usr/ || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    )
-    rm -rf $GPU_DEST/tmp
-    retrycmd_if_failure 120 5 25 pkill -SIGHUP dockerd || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    mkdir -p $GPU_DEST/lib64 $GPU_DEST/overlay-workdir
-    retrycmd_if_failure 120 5 25 mount -t overlay -o lowerdir=/usr/lib/x86_64-linux-gnu,upperdir=${GPU_DEST}/lib64,workdir=${GPU_DEST}/overlay-workdir none /usr/lib/x86_64-linux-gnu || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    retrycmd_if_failure 3 1 600 sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    echo "${GPU_DEST}/lib64" > /etc/ld.so.conf.d/nvidia.conf
-    retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    umount -l /usr/lib/x86_64-linux-gnu
-    retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0 || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    retrycmd_if_failure 120 5 25 $GPU_DEST/bin/nvidia-smi || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+    dpkg-deb -R ./nvidia-docker2*.deb "${tmpDir}/pkg" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+    cp -r ${tmpDir}/pkg/usr/* /usr/ || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  )
+  rm -rf $GPU_DEST/tmp
+  retrycmd_if_failure 120 5 25 pkill -SIGHUP dockerd || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  mkdir -p $GPU_DEST/lib64 $GPU_DEST/overlay-workdir
+  retrycmd_if_failure 120 5 25 mount -t overlay -o lowerdir=/usr/lib/x86_64-linux-gnu,upperdir=${GPU_DEST}/lib64,workdir=${GPU_DEST}/overlay-workdir none /usr/lib/x86_64-linux-gnu || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  retrycmd_if_failure 3 1 600 sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  echo "${GPU_DEST}/lib64" >/etc/ld.so.conf.d/nvidia.conf
+  retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  umount -l /usr/lib/x86_64-linux-gnu
+  retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0 || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  retrycmd_if_failure 120 5 25 $GPU_DEST/bin/nvidia-smi || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
 }
 ensureGPUDrivers() {
-    configGPUDrivers
-    systemctlEnableAndStart nvidia-modprobe || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  configGPUDrivers
+  systemctlEnableAndStart nvidia-modprobe || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
 }
 {{end}}
 {{- if HasDCSeriesSKU}}
 installSGXDrivers() {
-    [[ "$UBUNTU_RELEASE" == "18.04" || "$UBUNTU_RELEASE" == "16.04" ]] || exit 92
+  [[ $UBUNTU_RELEASE == "18.04" || $UBUNTU_RELEASE == "16.04" ]] || exit 92
 
-    local packages="make gcc dkms"
-    wait_for_apt_locks
-    retrycmd_if_failure 30 5 3600 apt-get -y install "$packages" || exit 90
+  local packages="make gcc dkms"
+  wait_for_apt_locks
+  retrycmd_if_failure 30 5 3600 apt-get -y install "$packages" || exit 90
 
-    local oe_dir=/opt/azure/containers/oe
-    rm -rf ${oe_dir}
-    mkdir -p ${oe_dir}
-    pushd ${oe_dir} || exit
-    retrycmd_if_failure 10 10 120 curl -fsSL -O "https://download.01.org/intel-sgx/latest/version.xml" || exit 90
-    dcap_version="$(grep dcap version.xml | grep -o -E "[.0-9]+")"
-    sgx_driver_folder_url="https://download.01.org/intel-sgx/sgx-dcap/$dcap_version/linux"
-    retrycmd_if_failure 10 10 120 curl -fsSL -O "$sgx_driver_folder_url/SHA256SUM_dcap_$dcap_version" || exit 90
-    matched_line="$(grep "distro/ubuntuServer$UBUNTU_RELEASE/sgx_linux_x64_driver_.*bin" SHA256SUM_dcap_$dcap_version)"
-    read -ra tmp_array <<< "$matched_line"
-    sgx_driver_sha256sum_expected="${tmp_array[0]}"
-    sgx_driver_remote_path="${tmp_array[1]}"
-    sgx_driver_url="${sgx_driver_folder_url}/${sgx_driver_remote_path}"
-    sgx_driver=$(basename "$sgx_driver_url")
+  local oe_dir=/opt/azure/containers/oe
+  rm -rf ${oe_dir}
+  mkdir -p ${oe_dir}
+  pushd ${oe_dir} || exit
+  retrycmd_if_failure 10 10 120 curl -fsSL -O "https://download.01.org/intel-sgx/latest/version.xml" || exit 90
+  dcap_version="$(grep dcap version.xml | grep -o -E "[.0-9]+")"
+  sgx_driver_folder_url="https://download.01.org/intel-sgx/sgx-dcap/$dcap_version/linux"
+  retrycmd_if_failure 10 10 120 curl -fsSL -O "$sgx_driver_folder_url/SHA256SUM_dcap_$dcap_version" || exit 90
+  matched_line="$(grep "distro/ubuntuServer$UBUNTU_RELEASE/sgx_linux_x64_driver_.*bin" SHA256SUM_dcap_$dcap_version)"
+  read -ra tmp_array <<<"$matched_line"
+  sgx_driver_sha256sum_expected="${tmp_array[0]}"
+  sgx_driver_remote_path="${tmp_array[1]}"
+  sgx_driver_url="${sgx_driver_folder_url}/${sgx_driver_remote_path}"
+  sgx_driver=$(basename "$sgx_driver_url")
 
-    retrycmd_if_failure 10 10 120 curl -fsSL -O "${sgx_driver_url}" || exit 90
-    read -ra tmp_array <<< "$(sha256sum ./"$sgx_driver")"
-    sgx_driver_sha256sum_real="${tmp_array[0]}"
-    [[ "$sgx_driver_sha256sum_real" == "$sgx_driver_sha256sum_expected" ]] || exit 93
+  retrycmd_if_failure 10 10 120 curl -fsSL -O "${sgx_driver_url}" || exit 90
+  read -ra tmp_array <<<"$(sha256sum ./"$sgx_driver")"
+  sgx_driver_sha256sum_real="${tmp_array[0]}"
+  [[ $sgx_driver_sha256sum_real == "$sgx_driver_sha256sum_expected" ]] || exit 93
 
-    chmod a+x ./"${sgx_driver}"
-    if ! ./"${sgx_driver}"; then
-        popd || exit
-        exit 91
-    fi
+  chmod a+x ./"${sgx_driver}"
+  if ! ./"${sgx_driver}"; then
     popd || exit
-    rm -rf ${oe_dir}
+    exit 91
+  fi
+  popd || exit
+  rm -rf ${oe_dir}
 }
 {{end}}
 {{- if HasVHDDistroNodes}}
 cleanUpContainerImages() {
-    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'hyperkube') &
-    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'cloud-controller-manager') &
-    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${ETCD_VERSION}$|${ETCD_VERSION}-|${ETCD_VERSION}_" | grep 'etcd') &
-    if [ "$IS_HOSTED_MASTER" = "false" ]; then
-        docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'hcp-tunnel-front') &
-        docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'kube-svc-redirect') &
-        docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'nginx') &
-    fi
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'hyperkube') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'cloud-controller-manager') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${ETCD_VERSION}$|${ETCD_VERSION}-|${ETCD_VERSION}_" | grep 'etcd') &
+  if [ "$IS_HOSTED_MASTER" = "false" ]; then
+    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'hcp-tunnel-front') &
+    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'kube-svc-redirect') &
+    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'nginx') &
+  fi
 
-    docker rmi registry:2.7.1 &
+  docker rmi registry:2.7.1 &
 }
 cleanUpGPUDrivers() {
-    rm -Rf $GPU_DEST
-    rm -f /etc/apt/sources.list.d/nvidia-docker.list
+  rm -Rf $GPU_DEST
+  rm -f /etc/apt/sources.list.d/nvidia-docker.list
 }
 cleanUpContainerd() {
-    rm -Rf $CONTAINERD_DOWNLOADS_DIR
+  rm -Rf $CONTAINERD_DOWNLOADS_DIR
 }
 {{end}}
 removeEtcd() {
-    rm -rf /usr/bin/etcd
+  rm -rf /usr/bin/etcd
 }
 removeMoby() {
-    apt_get_purge moby-engine moby-cli || exit 27
+  apt_get_purge moby-engine moby-cli || exit 27
 }
 removeContainerd() {
-    apt_get_purge moby-containerd || exit 27
+  apt_get_purge moby-containerd || exit 27
 }
 #EOF

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -16,17 +16,17 @@ systemctlEnableAndStart() {
     return 1
   fi
 }
-configureAdminUser() {
+configureAdminUser(){
   chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
   chage -l "${ADMINUSER}"
 }
-configureEtcdUser() {
+configureEtcdUser(){
   useradd -U etcd
   chage -E -1 -I -1 -m 0 -M 99999 etcd
   chage -l etcd
   id etcd
 }
-configureSecrets() {
+configureSecrets(){
   APISERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/apiserver.key"
   touch "${APISERVER_PRIVATE_KEY_PATH}"
   CA_PRIVATE_KEY_PATH="/etc/kubernetes/certs/ca.key"
@@ -197,9 +197,9 @@ EOF
 }
 
 installNetworkPlugin() {
-  {{- if IsAzureCNI}}
+{{- if IsAzureCNI}}
   installAzureCNI
-  {{end}}
+{{end}}
   installCNI
   rm -rf $CNI_DOWNLOADS_DIR &
 }
@@ -236,13 +236,13 @@ configureCNI() {
   systemctl restart sys-fs-bpf.mount
   REBOOTREQUIRED=true
   {{end}}
-  {{- if IsAzureStackCloud}}
+{{- if IsAzureStackCloud}}
   if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
     {{/* set environment to mas when using Azure CNI on Azure Stack */}}
     {{/* shellcheck disable=SC2002,SC2005 */}}
     echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipam.environment = "mas"') >"$CNI_CONFIG_DIR/10-azure.conflist"
   fi
-  {{end}}
+{{end}}
 }
 configureCNIIPTables() {
   if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
@@ -386,7 +386,7 @@ ensureK8sControlPlane() {
   if $REBOOTREQUIRED || [ "$NO_OUTBOUND" = "true" ]; then
     return
   fi
-  retrycmd_if_failure 120 5 25 $KUBECTL cluster-info 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  retrycmd_if_failure 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{- if IsAzurePolicyAddonEnabled}}
 ensureLabelExclusionForAzurePolicyAddon() {

--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -1,177 +1,177 @@
 #!/bin/bash
 
 ensureCertificates() {
-    AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
-    AZURESTACK_RESOURCE_MANAGER_ENDPOINT=$(jq .resourceManagerEndpoint $AZURESTACK_ENVIRONMENT_JSON_PATH | tr -d "\"")
-    AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
-    curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
-    CURL_RETURNCODE=$?
-    KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
-    if [ $CURL_RETURNCODE != 0 ]; then
-        # Replace placeholder for ssl binding
-        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
-            sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
-            sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
-        fi
-
-        # Copying the AzureStack root certificate to the appropriate store to be updated.
-        AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH="/var/lib/waagent/Certificates.pem"
-        AZURESTACK_ROOT_CERTIFICATE__DEST_PATH="/usr/local/share/ca-certificates/azsCertificate.crt"
-        cp $AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH $AZURESTACK_ROOT_CERTIFICATE__DEST_PATH
-        update-ca-certificates
-    else
-        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
-            # the ARM resource manager endpoint binding certificate is trusted, remove the placeholder for ssl binding
-            sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
-            sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
-        fi
+  AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
+  AZURESTACK_RESOURCE_MANAGER_ENDPOINT=$(jq .resourceManagerEndpoint $AZURESTACK_ENVIRONMENT_JSON_PATH | tr -d '"')
+  AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
+  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
+  CURL_RETURNCODE=$?
+  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
+  if [ $CURL_RETURNCODE != 0 ]; then
+    # Replace placeholder for ssl binding
+    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+      sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
+      sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
     fi
 
-    # ensureCertificates will be retried if the exit code is not 0
-    curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
-    exit $?
+    # Copying the AzureStack root certificate to the appropriate store to be updated.
+    AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH="/var/lib/waagent/Certificates.pem"
+    AZURESTACK_ROOT_CERTIFICATE__DEST_PATH="/usr/local/share/ca-certificates/azsCertificate.crt"
+    cp $AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH $AZURESTACK_ROOT_CERTIFICATE__DEST_PATH
+    update-ca-certificates
+  else
+    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+      # the ARM resource manager endpoint binding certificate is trusted, remove the placeholder for ssl binding
+      sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+      sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+    fi
+  fi
+
+  # ensureCertificates will be retried if the exit code is not 0
+  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
+  exit $?
 }
 
 configureK8sCustomCloud() {
-    export -f ensureCertificates
-    retrycmd_if_failure 60 10 30 bash -c ensureCertificates
-    set +x
-    # When AUTHENTICATION_METHOD is client_certificate, the certificate is stored into key valut,
-    # And SERVICE_PRINCIPAL_CLIENT_SECRET will be the following json payload with based64 encode
-    #{
-    #    "data": "$pfxAsBase64EncodedString",
-    #    "dataType" :"pfx",
-    #    "password": "$password"
-    #}
-    if [[ "${AUTHENTICATION_METHOD,,}" == "client_certificate" ]]; then
-        SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED=$(echo ${SERVICE_PRINCIPAL_CLIENT_SECRET} | base64 --decode)
-        SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .data)
-        SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .password)
+  export -f ensureCertificates
+  retrycmd_if_failure 60 10 30 bash -c ensureCertificates
+  set +x
+  # When AUTHENTICATION_METHOD is client_certificate, the certificate is stored into key valut,
+  # And SERVICE_PRINCIPAL_CLIENT_SECRET will be the following json payload with based64 encode
+  #{
+  #    "data": "$pfxAsBase64EncodedString",
+  #    "dataType" :"pfx",
+  #    "password": "$password"
+  #}
+  if [[ ${AUTHENTICATION_METHOD,,} == "client_certificate" ]]; then
+    SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED=$(echo ${SERVICE_PRINCIPAL_CLIENT_SECRET} | base64 --decode)
+    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .data)
+    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .password)
 
-        # trim the starting and ending "
-        SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT#"\""}
-        SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT%"\""}
+    # trim the starting and ending "
+    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT#'"'}
+    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT%'"'}
 
-        SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD#"\""}
-        SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD%"\""}
+    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD#'"'}
+    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD%'"'}
 
-        KUBERNETES_FILE_DIR=$(dirname "${AZURE_JSON_PATH}")
-        K8S_CLIENT_CERT_PATH="${KUBERNETES_FILE_DIR}/k8s_auth_certificate.pfx"
-        echo $SERVICE_PRINCIPAL_CLIENT_SECRET_CERT | base64 --decode > $K8S_CLIENT_CERT_PATH
-        # shellcheck disable=SC2002,SC2005
-        echo $(cat "${AZURE_JSON_PATH}" | \
-            jq --arg K8S_CLIENT_CERT_PATH ${K8S_CLIENT_CERT_PATH} '. + {aadClientCertPath:($K8S_CLIENT_CERT_PATH)}' | \
-            jq --arg SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD ${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD} '. + {aadClientCertPassword:($SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD)}' |\
-            jq 'del(.aadClientSecret)') > ${AZURE_JSON_PATH}
-    fi
+    KUBERNETES_FILE_DIR=$(dirname "${AZURE_JSON_PATH}")
+    K8S_CLIENT_CERT_PATH="${KUBERNETES_FILE_DIR}/k8s_auth_certificate.pfx"
+    echo $SERVICE_PRINCIPAL_CLIENT_SECRET_CERT | base64 --decode >$K8S_CLIENT_CERT_PATH
+    # shellcheck disable=SC2002,SC2005
+    echo $(cat "${AZURE_JSON_PATH}" |
+      jq --arg K8S_CLIENT_CERT_PATH ${K8S_CLIENT_CERT_PATH} '. + {aadClientCertPath:($K8S_CLIENT_CERT_PATH)}' |
+      jq --arg SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD ${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD} '. + {aadClientCertPassword:($SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD)}' |
+      jq 'del(.aadClientSecret)') >${AZURE_JSON_PATH}
+  fi
 
-    if [[ "${IDENTITY_SYSTEM,,}" == "adfs"  ]]; then
-        # update the tenent id for ADFS environment.
-        # shellcheck disable=SC2002,SC2005
-        echo $(cat "${AZURE_JSON_PATH}" | jq '.tenantId = "adfs"') > ${AZURE_JSON_PATH}
-    fi
+  if [[ ${IDENTITY_SYSTEM,,} == "adfs" ]]; then
+    # update the tenent id for ADFS environment.
+    # shellcheck disable=SC2002,SC2005
+    echo $(cat "${AZURE_JSON_PATH}" | jq '.tenantId = "adfs"') >${AZURE_JSON_PATH}
+  fi
 
-    # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
-    echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
-    echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
+  # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
+  echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
+  echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
 
-    ifconfig eth0 mtu 1350
+  ifconfig eth0 mtu 1350
 
-    set -x
+  set -x
 }
 
 configureAzureStackInterfaces() {
-    set +x
+  set +x
 
-    NETWORK_INTERFACES_FILE="/etc/kubernetes/network_interfaces.json"
-    AZURE_CNI_CONFIG_FILE="/etc/kubernetes/interfaces.json"
-    AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
-    SERVICE_MANAGEMENT_ENDPOINT=$(jq -r '.serviceManagementEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
-    ACTIVE_DIRECTORY_ENDPOINT=$(jq -r '.activeDirectoryEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
-    RESOURCE_MANAGER_ENDPOINT=$(jq -r '.resourceManagerEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
+  NETWORK_INTERFACES_FILE="/etc/kubernetes/network_interfaces.json"
+  AZURE_CNI_CONFIG_FILE="/etc/kubernetes/interfaces.json"
+  AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
+  SERVICE_MANAGEMENT_ENDPOINT=$(jq -r '.serviceManagementEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
+  ACTIVE_DIRECTORY_ENDPOINT=$(jq -r '.activeDirectoryEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
+  RESOURCE_MANAGER_ENDPOINT=$(jq -r '.resourceManagerEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
 
-    if [[ "${IDENTITY_SYSTEM,,}" == "adfs"  ]]; then
-        TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}adfs/oauth2/token"
-    else
-        TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}${TENANT_ID}/oauth2/token"
+  if [[ ${IDENTITY_SYSTEM,,} == "adfs" ]]; then
+    TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}adfs/oauth2/token"
+  else
+    TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}${TENANT_ID}/oauth2/token"
+  fi
+
+  echo "Generating token for Azure Resource Manager"
+  echo "------------------------------------------------------------------------"
+  echo "Parameters"
+  echo "------------------------------------------------------------------------"
+  echo "SERVICE_PRINCIPAL_CLIENT_ID:     ..."
+  echo "SERVICE_PRINCIPAL_CLIENT_SECRET: ..."
+  echo "SERVICE_MANAGEMENT_ENDPOINT:     $SERVICE_MANAGEMENT_ENDPOINT"
+  echo "ACTIVE_DIRECTORY_ENDPOINT:       $ACTIVE_DIRECTORY_ENDPOINT"
+  echo "TENANT_ID:                       $TENANT_ID"
+  echo "IDENTITY_SYSTEM:                 $IDENTITY_SYSTEM"
+  echo "TOKEN_URL:                       $TOKEN_URL"
+  echo "------------------------------------------------------------------------"
+
+  TOKEN=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=$SERVICE_PRINCIPAL_CLIENT_ID" \
+    --data-urlencode "client_secret=$SERVICE_PRINCIPAL_CLIENT_SECRET" \
+    --data-urlencode "resource=$SERVICE_MANAGEMENT_ENDPOINT" \
+    ${TOKEN_URL} | jq '.access_token' | xargs)
+
+  if [[ -z $TOKEN ]]; then
+    echo "Error generating token for Azure Resource Manager"
+    exit 120
+  fi
+
+  echo "Fetching network interface configuration for node"
+  echo "------------------------------------------------------------------------"
+  echo "Parameters"
+  echo "------------------------------------------------------------------------"
+  echo "RESOURCE_MANAGER_ENDPOINT: $RESOURCE_MANAGER_ENDPOINT"
+  echo "SUBSCRIPTION_ID:           $SUBSCRIPTION_ID"
+  echo "RESOURCE_GROUP:            $RESOURCE_GROUP"
+  echo "NETWORK_API_VERSION:       $NETWORK_API_VERSION"
+  echo "------------------------------------------------------------------------"
+
+  curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "${RESOURCE_MANAGER_ENDPOINT}subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Network/networkInterfaces?api-version=$NETWORK_API_VERSION" >${NETWORK_INTERFACES_FILE}
+
+  if [[ ! -s ${NETWORK_INTERFACES_FILE} ]]; then
+    echo "Error fetching network interface configuration for node"
+    exit 121
+  fi
+
+  echo "Generating Azure CNI interface file"
+
+  mapfile -t local_interfaces < <(cat /sys/class/net/*/address | tr -d : | sed 's/.*/\U&/g')
+
+  SDN_INTERFACES=$(jq ".value | map(select(.properties.macAddress | inside(\"${local_interfaces[*]}\"))) | map(select((.properties.ipConfigurations | length) > 0))" ${NETWORK_INTERFACES_FILE})
+
+  AZURE_CNI_CONFIG=$(echo ${SDN_INTERFACES} | jq "{Interfaces: [.[] | {MacAddress: .properties.macAddress, IsPrimary: .properties.primary, IPSubnets: [{Prefix: .properties.ipConfigurations[0].properties.subnet.id, IPAddresses: .properties.ipConfigurations | [.[] | {Address: .properties.privateIPAddress, IsPrimary: .properties.primary}]}]}]}")
+
+  mapfile -t SUBNET_IDS < <(echo ${SDN_INTERFACES} | jq '[.[].properties.ipConfigurations[0].properties.subnet.id] | unique | .[]' -r)
+
+  for SUBNET_ID in "${SUBNET_IDS[@]}"; do
+    SUBNET_PREFIX=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      "${RESOURCE_MANAGER_ENDPOINT}${SUBNET_ID:1}?api-version=$NETWORK_API_VERSION" |
+      jq '.properties.addressPrefix' -r)
+
+    if [[ -z $SUBNET_PREFIX ]]; then
+      echo "Error fetching the subnet address prefix for a subnet ID"
+      exit 122
     fi
 
-    echo "Generating token for Azure Resource Manager"
-    echo "------------------------------------------------------------------------"
-    echo "Parameters"
-    echo "------------------------------------------------------------------------"
-    echo "SERVICE_PRINCIPAL_CLIENT_ID:     ..."
-    echo "SERVICE_PRINCIPAL_CLIENT_SECRET: ..."
-    echo "SERVICE_MANAGEMENT_ENDPOINT:     $SERVICE_MANAGEMENT_ENDPOINT"
-    echo "ACTIVE_DIRECTORY_ENDPOINT:       $ACTIVE_DIRECTORY_ENDPOINT"
-    echo "TENANT_ID:                       $TENANT_ID"
-    echo "IDENTITY_SYSTEM:                 $IDENTITY_SYSTEM"
-    echo "TOKEN_URL:                       $TOKEN_URL"
-    echo "------------------------------------------------------------------------"
+    # shellcheck disable=SC2001
+    AZURE_CNI_CONFIG=$(echo ${AZURE_CNI_CONFIG} | sed "s|$SUBNET_ID|$SUBNET_PREFIX|g")
+  done
 
-    TOKEN=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X POST \
-        -H "Content-Type: application/x-www-form-urlencoded" \
-        -d "grant_type=client_credentials" \
-        -d "client_id=$SERVICE_PRINCIPAL_CLIENT_ID" \
-        --data-urlencode "client_secret=$SERVICE_PRINCIPAL_CLIENT_SECRET" \
-        --data-urlencode "resource=$SERVICE_MANAGEMENT_ENDPOINT" \
-        ${TOKEN_URL} | jq '.access_token' | xargs)
+  echo ${AZURE_CNI_CONFIG} >${AZURE_CNI_CONFIG_FILE}
 
-    if [[ -z "$TOKEN" ]]; then
-        echo "Error generating token for Azure Resource Manager"
-        exit 120
-    fi
+  chmod 0444 ${AZURE_CNI_CONFIG_FILE}
 
-    echo "Fetching network interface configuration for node"
-    echo "------------------------------------------------------------------------"
-    echo "Parameters"
-    echo "------------------------------------------------------------------------"
-    echo "RESOURCE_MANAGER_ENDPOINT: $RESOURCE_MANAGER_ENDPOINT"
-    echo "SUBSCRIPTION_ID:           $SUBSCRIPTION_ID"
-    echo "RESOURCE_GROUP:            $RESOURCE_GROUP"
-    echo "NETWORK_API_VERSION:       $NETWORK_API_VERSION"
-    echo "------------------------------------------------------------------------"
-
-    curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
-        -H "Authorization: Bearer $TOKEN" \
-        -H "Content-Type: application/json" \
-        "${RESOURCE_MANAGER_ENDPOINT}subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Network/networkInterfaces?api-version=$NETWORK_API_VERSION" > ${NETWORK_INTERFACES_FILE}
-
-    if [[ ! -s ${NETWORK_INTERFACES_FILE} ]]; then
-        echo "Error fetching network interface configuration for node"
-        exit 121
-    fi
-
-    echo "Generating Azure CNI interface file"
-
-    mapfile -t local_interfaces < <(cat /sys/class/net/*/address | tr -d : | sed 's/.*/\U&/g')
-
-    SDN_INTERFACES=$(jq ".value | map(select(.properties.macAddress | inside(\"${local_interfaces[*]}\"))) | map(select((.properties.ipConfigurations | length) > 0))" ${NETWORK_INTERFACES_FILE})
-
-    AZURE_CNI_CONFIG=$(echo ${SDN_INTERFACES} | jq "{Interfaces: [.[] | {MacAddress: .properties.macAddress, IsPrimary: .properties.primary, IPSubnets: [{Prefix: .properties.ipConfigurations[0].properties.subnet.id, IPAddresses: .properties.ipConfigurations | [.[] | {Address: .properties.privateIPAddress, IsPrimary: .properties.primary}]}]}]}")
-
-    mapfile -t SUBNET_IDS < <(echo ${SDN_INTERFACES} | jq '[.[].properties.ipConfigurations[0].properties.subnet.id] | unique | .[]' -r)
-
-    for SUBNET_ID in "${SUBNET_IDS[@]}"; do
-        SUBNET_PREFIX=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            "${RESOURCE_MANAGER_ENDPOINT}${SUBNET_ID:1}?api-version=$NETWORK_API_VERSION" | \
-            jq '.properties.addressPrefix' -r)
-
-        if [[ -z "$SUBNET_PREFIX" ]]; then
-            echo "Error fetching the subnet address prefix for a subnet ID"
-            exit 122
-        fi
-
-        # shellcheck disable=SC2001
-        AZURE_CNI_CONFIG=$(echo ${AZURE_CNI_CONFIG} | sed "s|$SUBNET_ID|$SUBNET_PREFIX|g")
-    done
-
-    echo ${AZURE_CNI_CONFIG} > ${AZURE_CNI_CONFIG_FILE}
-
-    chmod 0444 ${AZURE_CNI_CONFIG_FILE}
-
-    set -x
+  set -x
 }
 #EOF

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -5,7 +5,7 @@ UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"
 DEBIAN_OS_NAME="DEBIAN"
 if ! echo "${UBUNTU_OS_NAME} ${RHEL_OS_NAME} ${DEBIAN_OS_NAME}" | grep -q "${OS}"; then
-    OS=$(sort -r /etc/*-release | gawk 'match($0, /^(ID_LIKE=(.*))$/, a) { print toupper(a[2] a[3]); exit }')
+  OS=$(sort -r /etc/*-release | gawk 'match($0, /^(ID_LIKE=(.*))$/, a) { print toupper(a[2] a[3]); exit }')
 fi
 KUBECTL=/usr/local/bin/kubectl
 DOCKER=/usr/bin/docker
@@ -16,154 +16,175 @@ DOCKER_VERSION=1.13.1-1
 NVIDIA_CONTAINER_RUNTIME_VERSION=2.0.0
 
 configure_prerequisites() {
-    ip_forward_path=/proc/sys/net/ipv4/ip_forward
-    ip_forward_setting="net.ipv4.ip_forward=0"
-    sysctl_conf=/etc/sysctl.conf
-    if ! grep -qE "^1$" ${ip_forward_path}; then
-        echo 1 > ${ip_forward_path}
-    fi
-    if grep -qE "${ip_forward_setting}" ${sysctl_conf}; then
-        sed -i '/^net.ipv4.ip_forward=0$/d' ${sysctl_conf}
-    fi
+  ip_forward_path=/proc/sys/net/ipv4/ip_forward
+  ip_forward_setting="net.ipv4.ip_forward=0"
+  sysctl_conf=/etc/sysctl.conf
+  if ! grep -qE "^1$" ${ip_forward_path}; then
+    echo 1 >${ip_forward_path}
+  fi
+  if grep -qE "${ip_forward_setting}" ${sysctl_conf}; then
+    sed -i '/^net.ipv4.ip_forward=0$/d' ${sysctl_conf}
+  fi
 }
 
 aptmarkWALinuxAgent() {
-    wait_for_apt_locks
-    retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || \
-    if [[ "$1" == "hold" ]]; then
-        exit 7
-    elif [[ "$1" == "unhold" ]]; then
-        exit 8
+  wait_for_apt_locks
+  retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent ||
+    if [[ $1 == "hold" ]]; then
+      exit 7
+    elif [[ $1 == "unhold" ]]; then
+      exit 8
     fi
 }
 
 retrycmd_if_failure() {
-    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
-    for i in $(seq 1 $retries); do
-        timeout $timeout ${@} && break || \
-        if [ $i -eq $retries ]; then
-            echo Executed \"$@\" $i times;
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
-    echo Executed \"$@\" $i times;
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  shift && shift && shift
+  for i in $(seq 1 $retries); do
+    timeout $timeout ${@} && break ||
+      if [ $i -eq $retries ]; then
+        echo Executed \"$@\" $i times
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
+  echo Executed \"$@\" $i times
 }
 retrycmd_if_failure_no_stats() {
-    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
-    for i in $(seq 1 $retries); do
-        timeout $timeout ${@} && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  shift && shift && shift
+  for i in $(seq 1 $retries); do
+    timeout $timeout ${@} && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 retrycmd_get_tarball() {
-    tar_retries=$1; wait_sleep=$2; tarball=$3; url=$4
-    echo "${tar_retries} retries"
-    for i in $(seq 1 $tar_retries); do
-        tar -tzf $tarball && break || \
-        if [ $i -eq $tar_retries ]; then
-            return 1
-        else
-            timeout 60 curl -fsSL $url -o $tarball
-            sleep $wait_sleep
-        fi
-    done
+  tar_retries=$1
+  wait_sleep=$2
+  tarball=$3
+  url=$4
+  echo "${tar_retries} retries"
+  for i in $(seq 1 $tar_retries); do
+    tar -tzf $tarball && break ||
+      if [ $i -eq $tar_retries ]; then
+        return 1
+      else
+        timeout 60 curl -fsSL $url -o $tarball
+        sleep $wait_sleep
+      fi
+  done
 }
 retrycmd_get_executable() {
-    retries=$1; wait_sleep=$2; filepath=$3; url=$4; validation_args=$5
-    echo "${retries} retries"
-    for i in $(seq 1 $retries); do
-        $filepath $validation_args && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            timeout 30 curl -fsSL $url -o $filepath
-            chmod +x $filepath
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  filepath=$3
+  url=$4
+  validation_args=$5
+  echo "${retries} retries"
+  for i in $(seq 1 $retries); do
+    $filepath $validation_args && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        timeout 30 curl -fsSL $url -o $filepath
+        chmod +x $filepath
+        sleep $wait_sleep
+      fi
+  done
 }
 wait_for_file() {
-    retries=$1; wait_sleep=$2; filepath=$3
-    paved=/opt/azure/cloud-init-files.paved
-    grep -Fq "${filepath}" $paved && return 0
-    for i in $(seq 1 $retries); do
-        grep -Fq '#EOF' $filepath && break
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
-    sed -i "/#EOF/d" $filepath
-    echo $filepath >> $paved
+  retries=$1
+  wait_sleep=$2
+  filepath=$3
+  paved=/opt/azure/cloud-init-files.paved
+  grep -Fq "${filepath}" $paved && return 0
+  for i in $(seq 1 $retries); do
+    grep -Fq '#EOF' $filepath && break
+    if [ $i -eq $retries ]; then
+      return 1
+    else
+      sleep $wait_sleep
+    fi
+  done
+  sed -i "/#EOF/d" $filepath
+  echo $filepath >>$paved
 }
 wait_for_apt_locks() {
-    while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
-        echo 'Waiting for release of apt locks'
-        sleep 3
-    done
+  while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+    echo 'Waiting for release of apt locks'
+    sleep 3
+  done
 }
 apt_get_update() {
-    retries=10
-    apt_update_output=/tmp/apt-get-update.out
-    for i in $(seq 1 $retries); do
-        wait_for_apt_locks
-        export DEBIAN_FRONTEND=noninteractive
-        dpkg --configure -a --force-confdef
-        apt-get -f -y install
-        ! (apt-get update 2>&1 | tee $apt_update_output | grep -E "^([WE]:.*)|([eE]rr.*)$") && \
-        cat $apt_update_output && break || \
-        cat $apt_update_output
-        if [ $i -eq $retries ]; then
-            return 1
-        else sleep 5
-        fi
-    done
-    echo Executed apt-get update $i times
+  retries=10
+  apt_update_output=/tmp/apt-get-update.out
+  for i in $(seq 1 $retries); do
     wait_for_apt_locks
+    export DEBIAN_FRONTEND=noninteractive
+    dpkg --configure -a --force-confdef
+    apt-get -f -y install
+    ! (apt-get update 2>&1 | tee $apt_update_output | grep -E "^([WE]:.*)|([eE]rr.*)$") &&
+      cat $apt_update_output && break ||
+      cat $apt_update_output
+    if [ $i -eq $retries ]; then
+      return 1
+    else
+      sleep 5
+    fi
+  done
+  echo Executed apt-get update $i times
+  wait_for_apt_locks
 }
 apt_get_install() {
-    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
-    for i in $(seq 1 $retries); do
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  shift && shift && shift
+  for i in $(seq 1 $retries); do
+    wait_for_apt_locks
+    export DEBIAN_FRONTEND=noninteractive
+    dpkg --configure -a --force-confdef
+    apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y ${@} && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+        apt_get_update
+      fi
+  done
+  echo Executed apt-get install --no-install-recommends -y \"$@\" $i times
+  wait_for_apt_locks
+}
+apt_get_purge() {
+  retries=20
+  wait_sleep=30
+  timeout=120
+  for package in $@; do
+    if apt list --installed | grep $package; then
+      for i in $(seq 1 $retries); do
         wait_for_apt_locks
         export DEBIAN_FRONTEND=noninteractive
         dpkg --configure -a --force-confdef
-        apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y ${@} && break || \
-        if [ $i -eq $retries ]; then
+        apt-get purge -o Dpkg::Options::="--force-confold" -y $package && break ||
+          if [ $i -eq $retries ]; then
             return 1
-        else
+          else
             sleep $wait_sleep
-            apt_get_update
-        fi
-    done
-    echo Executed apt-get install --no-install-recommends -y \"$@\" $i times;
-    wait_for_apt_locks
-}
-apt_get_purge() {
-    retries=20; wait_sleep=30; timeout=120
-    for package in $@; do
-        if apt list --installed | grep $package; then
-            for i in $(seq 1 $retries); do
-                wait_for_apt_locks
-                export DEBIAN_FRONTEND=noninteractive
-                dpkg --configure -a --force-confdef
-                apt-get purge -o Dpkg::Options::="--force-confold" -y $package && break || \
-                if [ $i -eq $retries ]; then
-                    return 1
-                else
-                    sleep $wait_sleep
-                fi
-            done
-        fi
-    done
-    echo Executed apt-get purge -y \"$package\" $i times;
-    wait_for_apt_locks
+          fi
+      done
+    fi
+  done
+  echo Executed apt-get purge -y \"$package\" $i times
+  wait_for_apt_locks
 }
 apt_get_dist_upgrade() {
   retries=10
@@ -174,51 +195,58 @@ apt_get_dist_upgrade() {
     dpkg --configure -a --force-confdef
     apt-get -f -y install
     apt-mark showhold
-    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") && \
-    cat $apt_dist_upgrade_output && break || \
-    cat $apt_dist_upgrade_output
+    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") &&
+      cat $apt_dist_upgrade_output && break ||
+      cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then
       return 1
-    else sleep 5
+    else
+      sleep 5
     fi
   done
   echo Executed apt-get dist-upgrade $i times
   wait_for_apt_locks
 }
 systemctl_restart() {
-    retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
-    for i in $(seq 1 $retries); do
-        timeout $timeout systemctl daemon-reload
-        timeout $timeout systemctl restart $svcname && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3 svcname=$4
+  for i in $(seq 1 $retries); do
+    timeout $timeout systemctl daemon-reload
+    timeout $timeout systemctl restart $svcname && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 systemctl_stop() {
-    retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
-    for i in $(seq 1 $retries); do
-        timeout $timeout systemctl daemon-reload
-        timeout $timeout systemctl stop $svcname && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3 svcname=$4
+  for i in $(seq 1 $retries); do
+    timeout $timeout systemctl daemon-reload
+    timeout $timeout systemctl stop $svcname && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 sysctl_reload() {
-    retries=$1; wait_sleep=$2; timeout=$3
-    for i in $(seq 1 $retries); do
-        timeout $timeout sysctl --system && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  for i in $(seq 1 $retries); do
+    timeout $timeout sysctl --system && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 version_gte() {
   test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1"

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -38,10 +38,7 @@ aptmarkWALinuxAgent() {
 }
 
 retrycmd_if_failure() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
-  shift && shift && shift
+  retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
   for i in $(seq 1 $retries); do
     timeout $timeout ${@} && break ||
       if [ $i -eq $retries ]; then
@@ -125,8 +122,7 @@ apt_get_update() {
       cat $apt_update_output
     if [ $i -eq $retries ]; then
       return 1
-    else
-      sleep 5
+    else sleep 5
     fi
   done
   echo Executed apt-get update $i times
@@ -183,8 +179,7 @@ apt_get_dist_upgrade() {
     cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then
       return 1
-    else
-      sleep 5
+    else sleep 5
     fi
   done
   echo Executed apt-get dist-upgrade $i times

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -54,10 +54,7 @@ retrycmd_if_failure() {
   echo Executed \"$@\" $i times
 }
 retrycmd_if_failure_no_stats() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
-  shift && shift && shift
+  retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
   for i in $(seq 1 $retries); do
     timeout $timeout ${@} && break ||
       if [ $i -eq $retries ]; then
@@ -68,10 +65,7 @@ retrycmd_if_failure_no_stats() {
   done
 }
 retrycmd_get_tarball() {
-  tar_retries=$1
-  wait_sleep=$2
-  tarball=$3
-  url=$4
+  tar_retries=$1; wait_sleep=$2; tarball=$3; url=$4
   echo "${tar_retries} retries"
   for i in $(seq 1 $tar_retries); do
     tar -tzf $tarball && break ||
@@ -84,11 +78,7 @@ retrycmd_get_tarball() {
   done
 }
 retrycmd_get_executable() {
-  retries=$1
-  wait_sleep=$2
-  filepath=$3
-  url=$4
-  validation_args=$5
+  retries=$1; wait_sleep=$2; filepath=$3; url=$4; validation_args=$5
   echo "${retries} retries"
   for i in $(seq 1 $retries); do
     $filepath $validation_args && break ||
@@ -102,9 +92,7 @@ retrycmd_get_executable() {
   done
 }
 wait_for_file() {
-  retries=$1
-  wait_sleep=$2
-  filepath=$3
+  retries=$1; wait_sleep=$2; filepath=$3
   paved=/opt/azure/cloud-init-files.paved
   grep -Fq "${filepath}" $paved && return 0
   for i in $(seq 1 $retries); do
@@ -145,10 +133,7 @@ apt_get_update() {
   wait_for_apt_locks
 }
 apt_get_install() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
-  shift && shift && shift
+  retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
   for i in $(seq 1 $retries); do
     wait_for_apt_locks
     export DEBIAN_FRONTEND=noninteractive
@@ -165,9 +150,7 @@ apt_get_install() {
   wait_for_apt_locks
 }
 apt_get_purge() {
-  retries=20
-  wait_sleep=30
-  timeout=120
+  retries=20; wait_sleep=30; timeout=120
   for package in $@; do
     if apt list --installed | grep $package; then
       for i in $(seq 1 $retries); do
@@ -195,9 +178,9 @@ apt_get_dist_upgrade() {
     dpkg --configure -a --force-confdef
     apt-get -f -y install
     apt-mark showhold
-    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") &&
-      cat $apt_dist_upgrade_output && break ||
-      cat $apt_dist_upgrade_output
+    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") && \
+    cat $apt_dist_upgrade_output && break || \
+    cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then
       return 1
     else
@@ -208,9 +191,7 @@ apt_get_dist_upgrade() {
   wait_for_apt_locks
 }
 systemctl_restart() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3 svcname=$4
+  retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
   for i in $(seq 1 $retries); do
     timeout $timeout systemctl daemon-reload
     timeout $timeout systemctl restart $svcname && break ||
@@ -222,9 +203,7 @@ systemctl_restart() {
   done
 }
 systemctl_stop() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3 svcname=$4
+  retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
   for i in $(seq 1 $retries); do
     timeout $timeout systemctl daemon-reload
     timeout $timeout systemctl stop $svcname && break ||
@@ -236,9 +215,7 @@ systemctl_stop() {
   done
 }
 sysctl_reload() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
+  retries=$1; wait_sleep=$2; timeout=$3
   for i in $(seq 1 $retries); do
     timeout $timeout sysctl --system && break ||
       if [ $i -eq $retries ]; then

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -13,206 +13,206 @@ UBUNTU_RELEASE=$(lsb_release -r -s)
 UBUNTU_CODENAME=$(lsb_release -c -s)
 
 disableTimeSyncd() {
-    systemctl_stop 20 5 10 systemd-timesyncd || exit 3
-    retrycmd_if_failure 120 5 25 systemctl disable systemd-timesyncd || exit 3
+  systemctl_stop 20 5 10 systemd-timesyncd || exit 3
+  retrycmd_if_failure 120 5 25 systemctl disable systemd-timesyncd || exit 3
 }
 installEtcd() {
-    CURRENT_VERSION=$(etcd --version | grep "etcd Version" | cut -d ":" -f 2 | tr -d '[:space:]')
-    if [[ "$CURRENT_VERSION" != "${ETCD_VERSION}" ]]; then
-        CLI_TOOL=$1
-        local path="/usr/bin"
-        CONTAINER_IMAGE=${ETCD_DOWNLOAD_URL}etcd:v${ETCD_VERSION}
-        pullContainerImage $CLI_TOOL ${CONTAINER_IMAGE}
-        removeEtcd
-        if [[ "$CLI_TOOL" == "docker" ]]; then
-            mkdir -p "$path"
-            docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcd > "$path/etcd"
-            docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcdctl > "$path/etcdctl"
-        else
-            tmpdir=/root/etcd${RANDOM}
-            img unpack -o ${tmpdir} ${CONTAINER_IMAGE}
-            mv ${tmpdir}/usr/local/bin/etcd ${tmpdir}/usr/local/bin/etcdctl ${path}
-            rm -rf ${tmpdir}
-        fi
-        chmod a+x "$path/etcd" "$path/etcdctl"
+  CURRENT_VERSION=$(etcd --version | grep "etcd Version" | cut -d ":" -f 2 | tr -d '[:space:]')
+  if [[ $CURRENT_VERSION != "${ETCD_VERSION}" ]]; then
+    CLI_TOOL=$1
+    local path="/usr/bin"
+    CONTAINER_IMAGE=${ETCD_DOWNLOAD_URL}etcd:v${ETCD_VERSION}
+    pullContainerImage $CLI_TOOL ${CONTAINER_IMAGE}
+    removeEtcd
+    if [[ $CLI_TOOL == "docker" ]]; then
+      mkdir -p "$path"
+      docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcd >"$path/etcd"
+      docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcdctl >"$path/etcdctl"
+    else
+      tmpdir=/root/etcd${RANDOM}
+      img unpack -o ${tmpdir} ${CONTAINER_IMAGE}
+      mv ${tmpdir}/usr/local/bin/etcd ${tmpdir}/usr/local/bin/etcdctl ${path}
+      rm -rf ${tmpdir}
     fi
+    chmod a+x "$path/etcd" "$path/etcdctl"
+  fi
 }
 installDeps() {
-    packages="apache2-utils apt-transport-https blobfuse ca-certificates cifs-utils conntrack cracklib-runtime dbus ebtables ethtool fuse git htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip"
-    if [[ "${OS}" == "${UBUNTU_OS_NAME}" ]]; then
-        retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb > /tmp/packages-microsoft-prod.deb || exit 42
-        retrycmd_if_failure 60 5 10 dpkg -i /tmp/packages-microsoft-prod.deb || exit 43
-        aptmarkWALinuxAgent hold
-        packages+=" cgroup-lite ceph-common glusterfs-client"
-        if [[ $UBUNTU_RELEASE == "18.04" ]]; then
-            disableTimeSyncd
-            packages+=" ntp ntpstat"
-        fi
-    elif [[ $OS == $DEBIAN_OS_NAME ]]; then
-        packages+=" gpg cgroup-bin"
+  packages="apache2-utils apt-transport-https blobfuse ca-certificates cifs-utils conntrack cracklib-runtime dbus ebtables ethtool fuse git htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip"
+  if [[ ${OS} == "${UBUNTU_OS_NAME}" ]]; then
+    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb >/tmp/packages-microsoft-prod.deb || exit 42
+    retrycmd_if_failure 60 5 10 dpkg -i /tmp/packages-microsoft-prod.deb || exit 43
+    aptmarkWALinuxAgent hold
+    packages+=" cgroup-lite ceph-common glusterfs-client"
+    if [[ $UBUNTU_RELEASE == "18.04" ]]; then
+      disableTimeSyncd
+      packages+=" ntp ntpstat"
     fi
+  elif [[ $OS == $DEBIAN_OS_NAME ]]; then
+    packages+=" gpg cgroup-bin"
+  fi
 
-    apt_get_update || exit 99
-    apt_get_dist_upgrade || exit 101
+  apt_get_update || exit 99
+  apt_get_dist_upgrade || exit 101
 
-    for apt_package in ${packages}; do
-      if ! apt_get_install 30 1 600 $apt_package; then
-        journalctl --no-pager -u $apt_package
-        exit 9
-      fi
-    done
-    if [[ "${AUDITD_ENABLED}" == true ]]; then
-      if ! apt_get_install 30 1 600 auditd; then
-        journalctl --no-pager -u auditd
-        exit 9
-      fi
+  for apt_package in ${packages}; do
+    if ! apt_get_install 30 1 600 $apt_package; then
+      journalctl --no-pager -u $apt_package
+      exit 9
     fi
+  done
+  if [[ ${AUDITD_ENABLED} == true ]]; then
+    if ! apt_get_install 30 1 600 auditd; then
+      journalctl --no-pager -u auditd
+      exit 9
+    fi
+  fi
 }
 installGPUDrivers() {
-    mkdir -p $GPU_DEST/tmp
-    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey > $GPU_DEST/tmp/aptnvidia.gpg || exit 85
-    wait_for_apt_locks
-    retrycmd_if_failure 120 5 25 apt-key add $GPU_DEST/tmp/aptnvidia.gpg || exit 85
-    wait_for_apt_locks
-    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/ubuntu${UBUNTU_RELEASE}/nvidia-docker.list > $GPU_DEST/tmp/nvidia-docker.list || exit  85
-    wait_for_apt_locks
-    retrycmd_if_failure_no_stats 120 5 25 cat $GPU_DEST/tmp/nvidia-docker.list > /etc/apt/sources.list.d/nvidia-docker.list || exit  85
-    apt_get_update
-    retrycmd_if_failure 30 5 3600 apt-get install -y linux-headers-$(uname -r) gcc make dkms || exit 85
-    retrycmd_if_failure 30 5 60 curl -fLS https://us.download.nvidia.com/tesla/$GPU_DV/NVIDIA-Linux-x86_64-${GPU_DV}.run -o ${GPU_DEST}/nvidia-drivers-${GPU_DV} || exit 85
-    tmpDir=$GPU_DEST/tmp
-    if ! (
-      set -e -o pipefail
-      cd "${tmpDir}"
-      retrycmd_if_failure 30 5 3600 apt-get download nvidia-docker2="${NVIDIA_DOCKER_VERSION}+docker18.09.2-1" || exit 85
-    ); then
-      exit 85
-    fi
+  mkdir -p $GPU_DEST/tmp
+  retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey >$GPU_DEST/tmp/aptnvidia.gpg || exit 85
+  wait_for_apt_locks
+  retrycmd_if_failure 120 5 25 apt-key add $GPU_DEST/tmp/aptnvidia.gpg || exit 85
+  wait_for_apt_locks
+  retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/ubuntu${UBUNTU_RELEASE}/nvidia-docker.list >$GPU_DEST/tmp/nvidia-docker.list || exit 85
+  wait_for_apt_locks
+  retrycmd_if_failure_no_stats 120 5 25 cat $GPU_DEST/tmp/nvidia-docker.list >/etc/apt/sources.list.d/nvidia-docker.list || exit 85
+  apt_get_update
+  retrycmd_if_failure 30 5 3600 apt-get install -y linux-headers-$(uname -r) gcc make dkms || exit 85
+  retrycmd_if_failure 30 5 60 curl -fLS https://us.download.nvidia.com/tesla/$GPU_DV/NVIDIA-Linux-x86_64-${GPU_DV}.run -o ${GPU_DEST}/nvidia-drivers-${GPU_DV} || exit 85
+  tmpDir=$GPU_DEST/tmp
+  if ! (
+    set -e -o pipefail
+    cd "${tmpDir}"
+    retrycmd_if_failure 30 5 3600 apt-get download nvidia-docker2="${NVIDIA_DOCKER_VERSION}+docker18.09.2-1" || exit 85
+  ); then
+    exit 85
+  fi
 }
 installMoby() {
-    removeContainerd
-    CURRENT_VERSION=$(dockerd --version | grep "Docker version" | cut -d "," -f 1 | cut -d " " -f 3 | cut -d "+" -f 1)
-    if [[ "$CURRENT_VERSION" != "${MOBY_VERSION}" ]]; then
-        removeMoby
-        retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list > /tmp/microsoft-prod.list || exit 25
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
-        retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg || exit 26
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
-        apt_get_update || exit 99
-        MOBY_CLI=${MOBY_VERSION}
-        if [[ "${MOBY_CLI}" == "3.0.4" ]]; then
-            MOBY_CLI="3.0.3"
-        fi
-        apt_get_install 20 30 120 moby-engine=${MOBY_VERSION}* moby-cli=${MOBY_CLI}* --allow-downgrades || exit 27
+  removeContainerd
+  CURRENT_VERSION=$(dockerd --version | grep "Docker version" | cut -d "," -f 1 | cut -d " " -f 3 | cut -d "+" -f 1)
+  if [[ $CURRENT_VERSION != "${MOBY_VERSION}" ]]; then
+    removeMoby
+    retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
+    retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >/tmp/microsoft.gpg || exit 26
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
+    apt_get_update || exit 99
+    MOBY_CLI=${MOBY_VERSION}
+    if [[ ${MOBY_CLI} == "3.0.4" ]]; then
+      MOBY_CLI="3.0.3"
     fi
+    apt_get_install 20 30 120 moby-engine=${MOBY_VERSION}* moby-cli=${MOBY_CLI}* --allow-downgrades || exit 27
+  fi
 }
 installBcc() {
-    IOVISOR_KEY_TMP=/tmp/iovisor-release.key
-    IOVISOR_URL=https://repo.iovisor.org/GPG-KEY
-    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL $IOVISOR_URL > $IOVISOR_KEY_TMP || exit 166
-    wait_for_apt_locks
-    retrycmd_if_failure 30 5 30 apt-key add $IOVISOR_KEY_TMP || exit 167
-    echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/iovisor.list
-    apt_get_update || exit 99
-    apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit 168
+  IOVISOR_KEY_TMP=/tmp/iovisor-release.key
+  IOVISOR_URL=https://repo.iovisor.org/GPG-KEY
+  retrycmd_if_failure_no_stats 120 5 25 curl -fsSL $IOVISOR_URL >$IOVISOR_KEY_TMP || exit 166
+  wait_for_apt_locks
+  retrycmd_if_failure 30 5 30 apt-key add $IOVISOR_KEY_TMP || exit 167
+  echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" >/etc/apt/sources.list.d/iovisor.list
+  apt_get_update || exit 99
+  apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit 168
 }
 downloadCNI() {
-    mkdir -p $CNI_DOWNLOADS_DIR
-    CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
-    retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${CNI_PLUGINS_URL} || exit 41
+  mkdir -p $CNI_DOWNLOADS_DIR
+  CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
+  retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${CNI_PLUGINS_URL} || exit 41
 }
 downloadAzureCNI() {
-    mkdir -p $CNI_DOWNLOADS_DIR
-    CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
-    retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${VNET_CNI_PLUGINS_URL} || exit 41
+  mkdir -p $CNI_DOWNLOADS_DIR
+  CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
+  retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${VNET_CNI_PLUGINS_URL} || exit 41
 }
 ensureAPMZ() {
-    local version=$1
-    local apmz_url="https://upstreamartifacts.azureedge.net/apmz/$version/binaries/apmz_linux_amd64.tar.gz" apmz_filepath="/usr/local/bin/apmz"
-    if [[ -f "$apmz_filepath" ]]; then
-        installed_version=$($apmz_filepath version)
-        if [[ "$version" == "$installed_version" ]]; then
-            return
-        fi
+  local version=$1
+  local apmz_url="https://upstreamartifacts.azureedge.net/apmz/$version/binaries/apmz_linux_amd64.tar.gz" apmz_filepath="/usr/local/bin/apmz"
+  if [[ -f $apmz_filepath ]]; then
+    installed_version=$($apmz_filepath version)
+    if [[ $version == "$installed_version" ]]; then
+      return
     fi
-    install_dir="$APMZ_DOWNLOADS_DIR/$version"
-    download_path="$install_dir/apmz.gz"
-    mkdir -p "$install_dir"
-    retrycmd_get_tarball 120 5 "$download_path" "${apmz_url}"
-    tar -xvf "$download_path" -C "$install_dir"
-    bin_path="$install_dir/apmz_linux_amd64"
-    chmod +x "$bin_path"
-    ln -Ffs "$bin_path" "$apmz_filepath"
+  fi
+  install_dir="$APMZ_DOWNLOADS_DIR/$version"
+  download_path="$install_dir/apmz.gz"
+  mkdir -p "$install_dir"
+  retrycmd_get_tarball 120 5 "$download_path" "${apmz_url}"
+  tar -xvf "$download_path" -C "$install_dir"
+  bin_path="$install_dir/apmz_linux_amd64"
+  chmod +x "$bin_path"
+  ln -Ffs "$bin_path" "$apmz_filepath"
 }
 installBpftrace() {
-    local version="v0.9.4"
-    local bpftrace_bin="bpftrace"
-    local bpftrace_tools="bpftrace-tools.tar"
-    local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
-    local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
-    local tools_filepath="/usr/local/share/$bpftrace_bin"
-    if [[ -f "$bpftrace_filepath" ]]; then
-        installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
-        if [[ "$version" == "$installed_version" ]]; then
-            return
-        fi
-        rm "$bpftrace_filepath"
-        if [[ -d "$tools_filepath" ]]; then
-            rm -r  "$tools_filepath"
-        fi
+  local version="v0.9.4"
+  local bpftrace_bin="bpftrace"
+  local bpftrace_tools="bpftrace-tools.tar"
+  local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
+  local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
+  local tools_filepath="/usr/local/share/$bpftrace_bin"
+  if [[ -f $bpftrace_filepath ]]; then
+    installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
+    if [[ $version == "$installed_version" ]]; then
+      return
     fi
-    mkdir -p "$tools_filepath"
-    install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
-    mkdir -p "$install_dir"
-    download_path="$install_dir/$bpftrace_tools"
-    retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit 169
-    retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit 170
-    tar -xvf "$download_path" -C "$tools_filepath"
-    chmod +x "$bpftrace_filepath"
-    chmod -R +x "$tools_filepath/tools"
+    rm "$bpftrace_filepath"
+    if [[ -d $tools_filepath ]]; then
+      rm -r "$tools_filepath"
+    fi
+  fi
+  mkdir -p "$tools_filepath"
+  install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
+  mkdir -p "$install_dir"
+  download_path="$install_dir/$bpftrace_tools"
+  retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit 169
+  retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit 170
+  tar -xvf "$download_path" -C "$tools_filepath"
+  chmod +x "$bpftrace_filepath"
+  chmod -R +x "$tools_filepath/tools"
 }
 installImg() {
-    img_filepath=/usr/local/bin/img
-    retrycmd_get_executable 120 5 $img_filepath "https://upstreamartifacts.azureedge.net/img/img-linux-amd64-v0.5.6" ls || exit 33
+  img_filepath=/usr/local/bin/img
+  retrycmd_get_executable 120 5 $img_filepath "https://upstreamartifacts.azureedge.net/img/img-linux-amd64-v0.5.6" ls || exit 33
 }
 extractHyperkube() {
-    CLI_TOOL=$1
-    path="/home/hyperkube-downloads/${KUBERNETES_VERSION}"
-    pullContainerImage $CLI_TOOL ${HYPERKUBE_URL}
-    if [[ "$CLI_TOOL" == "docker" ]]; then
-        mkdir -p "$path"
-        if docker run --rm --entrypoint "" -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /usr/local/bin/{kubelet,kubectl} $path"; then
-            mv "$path/kubelet" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
-            mv "$path/kubectl" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
-            return
-        else
-            docker run --rm -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /hyperkube $path"
-        fi
+  CLI_TOOL=$1
+  path="/home/hyperkube-downloads/${KUBERNETES_VERSION}"
+  pullContainerImage $CLI_TOOL ${HYPERKUBE_URL}
+  if [[ $CLI_TOOL == "docker" ]]; then
+    mkdir -p "$path"
+    if docker run --rm --entrypoint "" -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /usr/local/bin/{kubelet,kubectl} $path"; then
+      mv "$path/kubelet" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
+      mv "$path/kubectl" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
+      return
     else
-        img unpack -o "$path" ${HYPERKUBE_URL}
+      docker run --rm -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /hyperkube $path"
     fi
+  else
+    img unpack -o "$path" ${HYPERKUBE_URL}
+  fi
 
-    cp "$path/hyperkube" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
-    mv "$path/hyperkube" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
+  cp "$path/hyperkube" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
+  mv "$path/hyperkube" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
 }
 extractKubeBinaries() {
-    KUBE_BINARY_URL=${KUBE_BINARY_URL:-"https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"}
-    K8S_TGZ_TMP=${KUBE_BINARY_URL##*/}
-    mkdir -p "${K8S_DOWNLOADS_DIR}"
-    retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${KUBE_BINARY_URL} || exit 31
-    tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
-        --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
-    rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
+  KUBE_BINARY_URL=${KUBE_BINARY_URL:-"https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"}
+  K8S_TGZ_TMP=${KUBE_BINARY_URL##*/}
+  mkdir -p "${K8S_DOWNLOADS_DIR}"
+  retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${KUBE_BINARY_URL} || exit 31
+  tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
+    --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
+  rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
 }
 pullContainerImage() {
-    CLI_TOOL=$1
-    DOCKER_IMAGE_URL=$2
-    retrycmd_if_failure 60 1 1200 $CLI_TOOL pull $DOCKER_IMAGE_URL || exit 35
+  CLI_TOOL=$1
+  DOCKER_IMAGE_URL=$2
+  retrycmd_if_failure 60 1 1200 $CLI_TOOL pull $DOCKER_IMAGE_URL || exit 35
 }
 overrideNetworkConfig() {
-    CONFIG_FILEPATH="/etc/cloud/cloud.cfg.d/80_azure_net_config.cfg"
-    touch ${CONFIG_FILEPATH}
-    cat << EOF >> ${CONFIG_FILEPATH}
+  CONFIG_FILEPATH="/etc/cloud/cloud.cfg.d/80_azure_net_config.cfg"
+  touch ${CONFIG_FILEPATH}
+  cat <<EOF >>${CONFIG_FILEPATH}
 datasource:
     Azure:
         apply_network_config: false

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -56,16 +56,16 @@ fi
 time_metric "ConfigureAdminUser" configureAdminUser
 
 {{- if HasVHDDistroNodes}}
-{{- if not NeedsContainerd}}
+  {{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd
-{{end}}
-{{- if HasNSeriesSKU}}
+  {{end}}
+  {{- if HasNSeriesSKU}}
 if [[ ${GPU_NODE} != "true" ]]; then
   time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
 fi
-{{else}}
+  {{else}}
 time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
-{{end}}
+  {{end}}
 {{end}}
 
 {{- if HasVHDDistroNodes}}

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -3,21 +3,21 @@ ERR_FILE_WATCH_TIMEOUT=6 {{/* Timeout waiting for a file */}}
 
 set -x
 if [ -f /opt/azure/containers/provision.complete ]; then
-    echo "Already ran to success exiting..."
-    exit 0
+  echo "Already ran to success exiting..."
+  exit 0
 fi
 
-echo $(date),$(hostname), startcustomscript>>/opt/m
+echo $(date),$(hostname), startcustomscript >>/opt/m
 
 for i in $(seq 1 3600); do
-    if [ -s {{GetCSEHelpersScriptFilepath}} ]; then
-        grep -Fq '#HELPERSEOF' {{GetCSEHelpersScriptFilepath}} && break
-    fi
-    if [ $i -eq 3600 ]; then
-        exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    else
-        sleep 1
-    fi
+  if [ -s {{GetCSEHelpersScriptFilepath}} ]; then
+    grep -Fq '#HELPERSEOF' {{GetCSEHelpersScriptFilepath}} && break
+  fi
+  if [ $i -eq 3600 ]; then
+    exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  else
+    sleep 1
+  fi
 done
 sed -i "/#HELPERSEOF/d" {{GetCSEHelpersScriptFilepath}}
 source {{GetCSEHelpersScriptFilepath}}
@@ -42,79 +42,79 @@ source {{GetCustomCloudConfigCSEScriptFilepath }}
 {{end}}
 
 set +x
-ETCD_PEER_CERT=$(echo ${ETCD_PEER_CERTIFICATES} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((${NODE_INDEX}+1)))
-ETCD_PEER_KEY=$(echo ${ETCD_PEER_PRIVATE_KEYS} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((${NODE_INDEX}+1)))
+ETCD_PEER_CERT=$(echo ${ETCD_PEER_CERTIFICATES} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))
+ETCD_PEER_KEY=$(echo ${ETCD_PEER_PRIVATE_KEYS} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))
 set -x
 
 if [ -f /var/run/reboot-required ]; then
-    REBOOTREQUIRED=true
-    trace_info "RebootRequired" "reboot=true"
+  REBOOTREQUIRED=true
+  trace_info "RebootRequired" "reboot=true"
 else
-    REBOOTREQUIRED=false
+  REBOOTREQUIRED=false
 fi
 
 time_metric "ConfigureAdminUser" configureAdminUser
 
 {{- if HasVHDDistroNodes}}
-    {{- if not NeedsContainerd}}
+{{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd
-    {{end}}
-    {{- if HasNSeriesSKU}}
-if [[ "${GPU_NODE}" != "true" ]]; then
-    time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
+{{end}}
+{{- if HasNSeriesSKU}}
+if [[ ${GPU_NODE} != "true" ]]; then
+  time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
 fi
-    {{else}}
+{{else}}
 time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
-    {{end}}
+{{end}}
 {{end}}
 
 {{- if HasVHDDistroNodes}}
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
 if [ -f $VHD_LOGS_FILEPATH ]; then
-    echo "detected golden image pre-install"
-    time_metric "CleanUpContainerImages" cleanUpContainerImages
-    FULL_INSTALL_REQUIRED=false
+  echo "detected golden image pre-install"
+  time_metric "CleanUpContainerImages" cleanUpContainerImages
+  FULL_INSTALL_REQUIRED=false
 else
-    if [[ "${IS_VHD}" = true ]]; then
-        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
-        exit {{GetCSEErrorCode "ERR_VHD_FILE_NOT_FOUND"}}
-    fi
-    FULL_INSTALL_REQUIRED=true
+  if [[ ${IS_VHD} == true ]]; then
+    echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
+    exit {{GetCSEErrorCode "ERR_VHD_FILE_NOT_FOUND"}}
+  fi
+  FULL_INSTALL_REQUIRED=true
 fi
 {{else}}
 FULL_INSTALL_REQUIRED=true
 {{end}}
 
 {{- if not IsVHDDistroForAllNodes}}
-if [[ ( $OS == $UBUNTU_OS_NAME || $OS == $DEBIAN_OS_NAME ) ]] && [ "$FULL_INSTALL_REQUIRED" = "true" ]; then
-    time_metric "InstallDeps" installDeps
-    if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-        overrideNetworkConfig
-    fi
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        time_metric "InstallBcc" installBcc
-    fi
-    {{- if not IsDockerContainerRuntime}}
-    time_metric "InstallImg" installImg
-    {{end}}
+if [[ $OS == $UBUNTU_OS_NAME || $OS == $DEBIAN_OS_NAME ]] && [ "$FULL_INSTALL_REQUIRED" = "true" ]; then
+  time_metric "InstallDeps" installDeps
+  if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
+    overrideNetworkConfig
+  fi
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    time_metric "InstallBcc" installBcc
+  fi
+  {{- if not IsDockerContainerRuntime}}
+  time_metric "InstallImg" installImg
+  {{end}}
 else
-    echo "Golden image; skipping dependencies installation"
+  echo "Golden image; skipping dependencies installation"
 fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-    if apt list --installed | grep 'ntp'; then
-        time_metric "EnsureNTP" ensureNTP
-    fi
+  if apt list --installed | grep 'ntp'; then
+    time_metric "EnsureNTP" ensureNTP
+  fi
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    time_metric "EnsureAuditD" ensureAuditD
+  time_metric "EnsureAuditD" ensureAuditD
 fi
 
 {{- if not IsVHDDistroForAllNodes}}
-if [[ "$FULL_INSTALL_REQUIRED" = "true" ]]; then
-    time_metric "InstallBpftrace" installBpftrace
+if [[ $FULL_INSTALL_REQUIRED == "true" ]]; then
+  time_metric "InstallBpftrace" installBpftrace
 fi
 {{end}}
 
@@ -124,24 +124,24 @@ time_metric "InstallContainerd" installContainerd
 time_metric "installMoby" installMoby
 {{end}}
 
-if [[ -n "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
-    {{- if IsDockerContainerRuntime}}
-    CLI_TOOL="docker"
-    {{else}}
-    CLI_TOOL="img"
-    {{end}}
-    time_metric "InstallEtcd" installEtcd $CLI_TOOL
+if [[ -n ${MASTER_NODE} ]] && [[ -z ${COSMOS_URI} ]]; then
+  {{- if IsDockerContainerRuntime}}
+  CLI_TOOL="docker"
+  {{else}}
+  CLI_TOOL="img"
+  {{end}}
+  time_metric "InstallEtcd" installEtcd $CLI_TOOL
 fi
 
 {{/* this will capture the amount of time to install of the network plugin during cse */}}
 time_metric "InstallNetworkPlugin" installNetworkPlugin
 
 {{- if HasNSeriesSKU}}
-if [[ "${GPU_NODE}" = true ]]; then
-    if $FULL_INSTALL_REQUIRED; then
-        time_metric "InstallGPUDrivers" installGPUDrivers
-    fi
-    time_metric "EnsureGPUDrivers" ensureGPUDrivers
+if [[ ${GPU_NODE} == true ]]; then
+  if $FULL_INSTALL_REQUIRED; then
+    time_metric "InstallGPUDrivers" installGPUDrivers
+  fi
+  time_metric "EnsureGPUDrivers" ensureGPUDrivers
 fi
 {{end}}
 
@@ -154,32 +154,32 @@ time_metric "EnsureRPC" ensureRPC
 time_metric "CreateKubeManifestDir" createKubeManifestDir
 
 {{- if HasDCSeriesSKU}}
-if [[ "${SGX_NODE}" = true ]]; then
-    time_metric "InstallSGXDrivers" installSGXDrivers
+if [[ ${SGX_NODE} == true ]]; then
+  time_metric "InstallSGXDrivers" installSGXDrivers
 fi
 {{end}}
 
 {{/* create etcd user if we are configured for etcd */}}
-if [[ -n "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
-    time_metric "ConfigureEtcdUser" configureEtcdUser
+if [[ -n ${MASTER_NODE} ]] && [[ -z ${COSMOS_URI} ]]; then
+  time_metric "ConfigureEtcdUser" configureEtcdUser
 fi
 
-if [[ -n "${MASTER_NODE}" ]]; then
-    {{/* this step configures all certs */}}
-    {{/* both configs etcd/cosmos */}}
-    time_metric "ConfigureSecrets" configureSecrets
+if [[ -n ${MASTER_NODE} ]]; then
+  {{/* this step configures all certs */}}
+  {{/* both configs etcd/cosmos */}}
+  time_metric "ConfigureSecrets" configureSecrets
 fi
 
 {{/* configure etcd if we are configured for etcd */}}
-if [[ -n "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
-    time_metric "ConfigureEtcd" configureEtcd
+if [[ -n ${MASTER_NODE} ]] && [[ -z ${COSMOS_URI} ]]; then
+  time_metric "ConfigureEtcd" configureEtcd
 else
-    time_metric "RemoveEtcd" removeEtcd
+  time_metric "RemoveEtcd" removeEtcd
 fi
 
 {{- if HasCustomSearchDomain}}
 wait_for_file 3600 1 {{GetCustomSearchDomainsCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-{{GetCustomSearchDomainsCSEScriptFilepath}} > /opt/azure/containers/setup-custom-search-domain.log 2>&1 || exit {{GetCSEErrorCode "ERR_CUSTOM_SEARCH_DOMAINS_FAIL"}}
+{{GetCustomSearchDomainsCSEScriptFilepath}} >/opt/azure/containers/setup-custom-search-domain.log 2>&1 || exit {{GetCSEErrorCode "ERR_CUSTOM_SEARCH_DOMAINS_FAIL"}}
 {{end}}
 
 {{- if IsDockerContainerRuntime}}
@@ -190,16 +190,16 @@ time_metric "ConfigureK8s" configureK8s
 
 {{- if IsAzureStackCloud}}
 time_metric "ConfigureK8sCustomCloud" configureK8sCustomCloud
-    {{- if IsAzureCNI}}
-    time_metric "ConfigureAzureStackInterfaces" configureAzureStackInterfaces
-    {{end}}
+{{- if IsAzureCNI}}
+time_metric "ConfigureAzureStackInterfaces" configureAzureStackInterfaces
+{{end}}
 {{end}}
 
 time_metric "ConfigureCNI" configureCNI
 
 {{if or IsClusterAutoscalerAddonEnabled IsACIConnectorAddonEnabled IsAzurePolicyAddonEnabled}}
-if [[ -n "${MASTER_NODE}" ]]; then
-    time_metric "ConfigAddons" configAddons
+if [[ -n ${MASTER_NODE} ]]; then
+  time_metric "ConfigAddons" configAddons
 fi
 {{end}}
 
@@ -208,8 +208,8 @@ time_metric "EnsureContainerd" ensureContainerd
 {{end}}
 
 {{- if EnableEncryptionWithExternalKms}}
-if [[ -n "${MASTER_NODE}" && "${KMS_PROVIDER_VAULT_NAME}" != "" ]]; then
-    time_metric "EnsureKMS" ensureKMS
+if [[ -n ${MASTER_NODE} && ${KMS_PROVIDER_VAULT_NAME} != "" ]]; then
+  time_metric "EnsureKMS" ensureKMS
 fi
 {{end}}
 
@@ -221,35 +221,35 @@ time_metric "EnsureDHCPv6" ensureDHCPv6
 time_metric "EnsureKubelet" ensureKubelet
 time_metric "EnsureJournal" ensureJournal
 
-if [[ -n "${MASTER_NODE}" ]]; then
-    if version_gte ${KUBERNETES_VERSION} 1.16; then
-        time_metric "EnsureLabelNodes" ensureLabelNodes
+if [[ -n ${MASTER_NODE} ]]; then
+  if version_gte ${KUBERNETES_VERSION} 1.16; then
+    time_metric "EnsureLabelNodes" ensureLabelNodes
+  fi
+  time_metric "WriteKubeConfig" writeKubeConfig
+  if [[ -z ${COSMOS_URI} ]]; then
+    if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
+      time_metric "EnsureEtcd" ensureEtcd
     fi
-    time_metric "WriteKubeConfig" writeKubeConfig
-    if [[ -z "${COSMOS_URI}" ]]; then
-        if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
-            time_metric "EnsureEtcd" ensureEtcd
-        fi
-    fi
-    time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
-    {{if IsAzurePolicyAddonEnabled}}
-    time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
-    {{end}}
+  fi
+  time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
+  {{if IsAzurePolicyAddonEnabled}}
+  time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
+  {{end}}
 fi
 
 {{- if not IsVHDDistroForAllNodes}}
 if $FULL_INSTALL_REQUIRED; then
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        {{/* mitigation for bug https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1676635 */}}
-        echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind
-        sed -i "13i\echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind\n" /etc/rc.local
-    fi
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    {{/* mitigation for bug https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1676635 */}}
+    echo 2dd1ce17-079e-403c-b352-a1921ee207ee >/sys/bus/vmbus/drivers/hv_util/unbind
+    sed -i "13i\echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind\n" /etc/rc.local
+  fi
 fi
 {{end}}
 
 {{- if not IsAzureStackCloud}}
 if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    time_metric "PurgeApt" apt_get_purge apache2-utils &
+  time_metric "PurgeApt" apt_get_purge apache2-utils &
 fi
 {{end}}
 
@@ -257,31 +257,31 @@ fi
 RES=$(retrycmd_if_failure 20 1 3 nslookup ${API_SERVER_NAME})
 STS=$?
 if [[ $STS != 0 ]]; then
-    if [[ $RES == *"168.63.129.16"*  ]]; then
-        exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_AZURE_DNS_LOOKUP_FAIL"}}
-    else
-        exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_CONN_FAIL"}}
-    fi
+  if [[ $RES == *"168.63.129.16"* ]]; then
+    exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_AZURE_DNS_LOOKUP_FAIL"}}
+  else
+    exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_CONN_FAIL"}}
+  fi
 fi
 retrycmd_if_failure 50 1 3 nc -vz ${API_SERVER_NAME} 443 || exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_CONN_FAIL"}}
 {{end}}
 
 if $REBOOTREQUIRED; then
-    echo 'reboot required, rebooting node in 1 minute'
-    /bin/bash -c "shutdown -r 1 &"
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        aptmarkWALinuxAgent unhold &
-    fi
+  echo 'reboot required, rebooting node in 1 minute'
+  /bin/bash -c "shutdown -r 1 &"
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    aptmarkWALinuxAgent unhold &
+  fi
 else
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        /usr/lib/apt/apt.systemd.daily &
-        aptmarkWALinuxAgent unhold &
-    fi
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    /usr/lib/apt/apt.systemd.daily &
+    aptmarkWALinuxAgent unhold &
+  fi
 fi
 
 echo "Custom script finished successfully"
-echo $(date),$(hostname), endcustomscript>>/opt/m
+echo $(date),$(hostname), endcustomscript >>/opt/m
 mkdir -p /opt/azure/containers && touch /opt/azure/containers/provision.complete
-ps auxfww > /opt/azure/provision-ps.log &
+ps auxfww >/opt/azure/provision-ps.log &
 
 #EOF

--- a/parts/k8s/cloud-init/artifacts/enable-dhcpv6.sh
+++ b/parts/k8s/cloud-init/artifacts/enable-dhcpv6.sh
@@ -7,21 +7,21 @@ set -u
 DHCLIENT6_CONF_FILE=/etc/dhcp/dhclient6.conf
 CLOUD_INIT_CFG=/etc/network/interfaces.d/50-cloud-init.cfg
 
-read -r -d '' NETWORK_CONFIGURATION << EOC || true
+read -r -d '' NETWORK_CONFIGURATION <<EOC || true
 iface eth0 inet6 auto
     up sleep 5
     up dhclient -1 -6 -cf /etc/dhcp/dhclient6.conf -lf /var/lib/dhcp/dhclient6.eth0.leases -v eth0 || true
 EOC
 
 add_if_not_exists() {
-    grep -qxF "${1}" "${2}" || echo "${1}" >> "${2}"
+  grep -qxF "${1}" "${2}" || echo "${1}" >>"${2}"
 }
 
 echo "Configuring dhcpv6 ..."
 
-touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} && \
-    add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} && \
-    sudo ifdown eth0 && sudo ifup eth0
+touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} &&
+  add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} &&
+  sudo ifdown eth0 && sudo ifup eth0
 
 echo "Configuration complete"
 #EOF

--- a/parts/k8s/cloud-init/artifacts/enable-dhcpv6.sh
+++ b/parts/k8s/cloud-init/artifacts/enable-dhcpv6.sh
@@ -19,8 +19,8 @@ add_if_not_exists() {
 
 echo "Configuring dhcpv6 ..."
 
-touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} &&
-  add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} &&
+touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} && \
+  add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} && \
   sudo ifdown eth0 && sudo ifup eth0
 
 echo "Configuration complete"

--- a/parts/k8s/cloud-init/artifacts/health-monitor.sh
+++ b/parts/k8s/cloud-init/artifacts/health-monitor.sh
@@ -12,23 +12,23 @@ container_runtime_monitoring() {
   local -r crictl="${KUBE_HOME}/bin/crictl"
   local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
   local healthcheck_command="docker ps"
-  if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+  if [[ ${CONTAINER_RUNTIME:-docker} != "docker" ]]; then
     healthcheck_command="${crictl} pods"
   fi
 
-  until timeout 60 ${healthcheck_command} > /dev/null; do
-    if (( attempt == max_attempts )); then
+  until timeout 60 ${healthcheck_command} >/dev/null; do
+    if ((attempt == max_attempts)); then
       echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
       break
     fi
     echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
-    sleep "$(( 2 ** attempt++ ))"
+    sleep "$((2 ** attempt++))"
   done
   while true; do
-    if ! timeout 60 ${healthcheck_command} > /dev/null; then
+    if ! timeout 60 ${healthcheck_command} >/dev/null; then
       echo "Container runtime ${container_runtime_name} failed!"
-      if [[ "$container_runtime_name" == "docker" ]]; then
-          pkill -SIGUSR1 dockerd
+      if [[ $container_runtime_name == "docker" ]]; then
+        pkill -SIGUSR1 dockerd
       fi
       systemctl kill --kill-who=main "${container_runtime_name}"
       sleep 120
@@ -55,14 +55,14 @@ kubelet_monitoring() {
   done
 }
 
-if [[ "$#" -ne 1 ]]; then
+if [[ $# -ne 1 ]]; then
   echo "Usage: health-monitor.sh <container-runtime/kubelet>"
   exit 1
 fi
 
 KUBE_HOME="/usr/local/bin"
 KUBE_ENV="/etc/default/kube-env"
-if [[  -e "${KUBE_ENV}" ]]; then
+if [[ -e ${KUBE_ENV} ]]; then
   source "${KUBE_ENV}"
 fi
 
@@ -70,9 +70,9 @@ SLEEP_SECONDS=10
 component=$1
 echo "Start kubernetes health monitoring for ${component}"
 
-if [[ "${component}" == "container-runtime" ]]; then
+if [[ ${component} == "container-runtime" ]]; then
   container_runtime_monitoring
-elif [[ "${component}" == "kubelet" ]]; then
+elif [[ ${component} == "kubelet" ]]; then
   kubelet_monitoring
 else
   echo "Health monitoring for component ${component} is not supported!"

--- a/parts/k8s/cloud-init/artifacts/mountetcd.sh
+++ b/parts/k8s/cloud-init/artifacts/mountetcd.sh
@@ -7,19 +7,16 @@ PARTITION=${DISK}1
 MOUNTPOINT=/var/lib/etcddisk
 udevadm settle
 mkdir -p $MOUNTPOINT
-if mount | grep $MOUNTPOINT
-then
-    echo "disk is already mounted"
-    exit 0
+if mount | grep $MOUNTPOINT; then
+  echo "disk is already mounted"
+  exit 0
 fi
-if ! grep "/dev/sdc1" /etc/fstab
-then
-    echo "$PARTITION       $MOUNTPOINT       auto    defaults,nofail       0       2" >> /etc/fstab
+if ! grep "/dev/sdc1" /etc/fstab; then
+  echo "$PARTITION       $MOUNTPOINT       auto    defaults,nofail       0       2" >>/etc/fstab
 fi
-if ! ls $PARTITION
-then
-    /sbin/sgdisk --new 1 $DISK
-    /sbin/mkfs.ext4 $PARTITION -L etcd_disk -F -E lazy_itable_init=1,lazy_journal_init=1
+if ! ls $PARTITION; then
+  /sbin/sgdisk --new 1 $DISK
+  /sbin/mkfs.ext4 $PARTITION -L etcd_disk -F -E lazy_itable_init=1,lazy_journal_init=1
 fi
 mount $MOUNTPOINT
 /bin/chown -R etcd:etcd /var/lib/etcddisk

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39660,7 +39660,7 @@ assignRootPW() {
 }
 
 assignFilePermissions() {
-    FILES="
+  FILES="
     auth.log
     alternatives.log
     cloud-init.log
@@ -39682,21 +39682,21 @@ assignFilePermissions() {
     blobfuse-flexvol-installer.log
     landscape/sysinfo.log
     "
-    for FILE in ${FILES}; do
-        FILEPATH="/var/log/${FILE}"
-        DIR=$(dirname "${FILEPATH}")
-        mkdir -p ${DIR} || exit 112
-        touch ${FILEPATH} || exit 112
-        chmod 640 ${FILEPATH} || exit 112
-    done
-    find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
-    chmod 600 /etc/passwd- || exit 112
-    chmod 600 /etc/shadow- || exit 112
-    chmod 600 /etc/group- || exit 112
-    chmod 644 /etc/default/grub || exit 112
-    for filepath in /etc/crontab /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
-      chmod 0600 $filepath || exit 112
-    done
+  for FILE in ${FILES}; do
+    FILEPATH="/var/log/${FILE}"
+    DIR=$(dirname "${FILEPATH}")
+    mkdir -p ${DIR} || exit 112
+    touch ${FILEPATH} || exit 112
+    chmod 640 ${FILEPATH} || exit 112
+  done
+  find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
+  chmod 600 /etc/passwd- || exit 112
+  chmod 600 /etc/shadow- || exit 112
+  chmod 600 /etc/group- || exit 112
+  chmod 644 /etc/default/grub || exit 112
+  for filepath in /etc/crontab /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
+    chmod 0600 $filepath || exit 112
+  done
 }
 
 setPWExpiration() {
@@ -39706,11 +39706,11 @@ setPWExpiration() {
   grep 'PASS_MIN_DAYS' /etc/login.defs && exit 115
   sed -i "s|INACTIVE=||g" /etc/default/useradd || exit 115
   grep 'INACTIVE=' /etc/default/useradd && exit 115
-  echo 'PASS_MAX_DAYS 90' >> /etc/login.defs || exit 115
+  echo 'PASS_MAX_DAYS 90' >>/etc/login.defs || exit 115
   grep 'PASS_MAX_DAYS 90' /etc/login.defs || exit 115
-  echo 'PASS_MIN_DAYS 7' >> /etc/login.defs || exit 115
+  echo 'PASS_MIN_DAYS 7' >>/etc/login.defs || exit 115
   grep 'PASS_MIN_DAYS 7' /etc/login.defs || exit 115
-  echo 'INACTIVE=30' >> /etc/default/useradd || exit 115
+  echo 'INACTIVE=30' >>/etc/default/useradd || exit 115
   grep 'INACTIVE=30' /etc/default/useradd || exit 115
 }
 
@@ -39748,150 +39748,150 @@ ETCD_PEER_URL="https://${PRIVATE_IP}:2380"
 ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
 
 systemctlEnableAndStart() {
-    systemctl_restart 100 5 30 $1
-    RESTART_STATUS=$?
-    systemctl status $1 --no-pager -l > /var/log/azure/$1-status.log
-    if [ $RESTART_STATUS -ne 0 ]; then
-        return 1
-    fi
-    if ! retrycmd_if_failure 120 5 25 systemctl enable $1; then
-        return 1
-    fi
+  systemctl_restart 100 5 30 $1
+  RESTART_STATUS=$?
+  systemctl status $1 --no-pager -l >/var/log/azure/$1-status.log
+  if [ $RESTART_STATUS -ne 0 ]; then
+    return 1
+  fi
+  if ! retrycmd_if_failure 120 5 25 systemctl enable $1; then
+    return 1
+  fi
 }
-configureAdminUser(){
-    chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
-    chage -l "${ADMINUSER}"
+configureAdminUser() {
+  chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
+  chage -l "${ADMINUSER}"
 }
-configureEtcdUser(){
-    useradd -U etcd
-    chage -E -1 -I -1 -m 0 -M 99999 etcd
-    chage -l etcd
-    id etcd
+configureEtcdUser() {
+  useradd -U etcd
+  chage -E -1 -I -1 -m 0 -M 99999 etcd
+  chage -l etcd
+  id etcd
 }
-configureSecrets(){
-    APISERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/apiserver.key"
-    touch "${APISERVER_PRIVATE_KEY_PATH}"
-    CA_PRIVATE_KEY_PATH="/etc/kubernetes/certs/ca.key"
-    touch "${CA_PRIVATE_KEY_PATH}"
-    ETCD_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdserver.key"
-    touch "${ETCD_SERVER_PRIVATE_KEY_PATH}"
-    if [[ -z "${COSMOS_URI}" ]]; then
-      chown etcd:etcd "${ETCD_SERVER_PRIVATE_KEY_PATH}"
-    fi
-    ETCD_CLIENT_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdclient.key"
-    touch "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
-    ETCD_PEER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.key"
-    touch "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    if [[ -z "${COSMOS_URI}" ]]; then
-      chown etcd:etcd "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    fi
-    chmod 0600 "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_SERVER_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}" "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    chown root:root "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
-    ETCD_SERVER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdserver.crt"
-    touch "${ETCD_SERVER_CERTIFICATE_PATH}"
-    ETCD_CLIENT_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdclient.crt"
-    touch "${ETCD_CLIENT_CERTIFICATE_PATH}"
-    ETCD_PEER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.crt"
-    touch "${ETCD_PEER_CERTIFICATE_PATH}"
-    chmod 0644 "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
-    chown root:root "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
+configureSecrets() {
+  APISERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/apiserver.key"
+  touch "${APISERVER_PRIVATE_KEY_PATH}"
+  CA_PRIVATE_KEY_PATH="/etc/kubernetes/certs/ca.key"
+  touch "${CA_PRIVATE_KEY_PATH}"
+  ETCD_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdserver.key"
+  touch "${ETCD_SERVER_PRIVATE_KEY_PATH}"
+  if [[ -z ${COSMOS_URI} ]]; then
+    chown etcd:etcd "${ETCD_SERVER_PRIVATE_KEY_PATH}"
+  fi
+  ETCD_CLIENT_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdclient.key"
+  touch "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
+  ETCD_PEER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.key"
+  touch "${ETCD_PEER_PRIVATE_KEY_PATH}"
+  if [[ -z ${COSMOS_URI} ]]; then
+    chown etcd:etcd "${ETCD_PEER_PRIVATE_KEY_PATH}"
+  fi
+  chmod 0600 "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_SERVER_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}" "${ETCD_PEER_PRIVATE_KEY_PATH}"
+  chown root:root "${APISERVER_PRIVATE_KEY_PATH}" "${CA_PRIVATE_KEY_PATH}" "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
+  ETCD_SERVER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdserver.crt"
+  touch "${ETCD_SERVER_CERTIFICATE_PATH}"
+  ETCD_CLIENT_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdclient.crt"
+  touch "${ETCD_CLIENT_CERTIFICATE_PATH}"
+  ETCD_PEER_CERTIFICATE_PATH="/etc/kubernetes/certs/etcdpeer${NODE_INDEX}.crt"
+  touch "${ETCD_PEER_CERTIFICATE_PATH}"
+  chmod 0644 "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
+  chown root:root "${ETCD_SERVER_CERTIFICATE_PATH}" "${ETCD_CLIENT_CERTIFICATE_PATH}" "${ETCD_PEER_CERTIFICATE_PATH}"
 
-    set +x
-    echo "${APISERVER_PRIVATE_KEY}" | base64 --decode > "${APISERVER_PRIVATE_KEY_PATH}"
-    echo "${CA_PRIVATE_KEY}" | base64 --decode > "${CA_PRIVATE_KEY_PATH}"
-    echo "${ETCD_SERVER_PRIVATE_KEY}" | base64 --decode > "${ETCD_SERVER_PRIVATE_KEY_PATH}"
-    echo "${ETCD_CLIENT_PRIVATE_KEY}" | base64 --decode > "${ETCD_CLIENT_PRIVATE_KEY_PATH}"
-    echo "${ETCD_PEER_KEY}" | base64 --decode > "${ETCD_PEER_PRIVATE_KEY_PATH}"
-    echo "${ETCD_SERVER_CERTIFICATE}" | base64 --decode > "${ETCD_SERVER_CERTIFICATE_PATH}"
-    echo "${ETCD_CLIENT_CERTIFICATE}" | base64 --decode > "${ETCD_CLIENT_CERTIFICATE_PATH}"
-    echo "${ETCD_PEER_CERT}" | base64 --decode > "${ETCD_PEER_CERTIFICATE_PATH}"
+  set +x
+  echo "${APISERVER_PRIVATE_KEY}" | base64 --decode >"${APISERVER_PRIVATE_KEY_PATH}"
+  echo "${CA_PRIVATE_KEY}" | base64 --decode >"${CA_PRIVATE_KEY_PATH}"
+  echo "${ETCD_SERVER_PRIVATE_KEY}" | base64 --decode >"${ETCD_SERVER_PRIVATE_KEY_PATH}"
+  echo "${ETCD_CLIENT_PRIVATE_KEY}" | base64 --decode >"${ETCD_CLIENT_PRIVATE_KEY_PATH}"
+  echo "${ETCD_PEER_KEY}" | base64 --decode >"${ETCD_PEER_PRIVATE_KEY_PATH}"
+  echo "${ETCD_SERVER_CERTIFICATE}" | base64 --decode >"${ETCD_SERVER_CERTIFICATE_PATH}"
+  echo "${ETCD_CLIENT_CERTIFICATE}" | base64 --decode >"${ETCD_CLIENT_CERTIFICATE_PATH}"
+  echo "${ETCD_PEER_CERT}" | base64 --decode >"${ETCD_PEER_CERTIFICATE_PATH}"
 }
 configureEtcd() {
-    set -x
+  set -x
 
-    ETCD_SETUP_FILE=/opt/azure/containers/setup-etcd.sh
-    wait_for_file 1200 1 $ETCD_SETUP_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
-    $ETCD_SETUP_FILE > /opt/azure/containers/setup-etcd.log 2>&1
-    RET=$?
-    if [ $RET -ne 0 ]; then
-        exit $RET
-    fi
+  ETCD_SETUP_FILE=/opt/azure/containers/setup-etcd.sh
+  wait_for_file 1200 1 $ETCD_SETUP_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
+  $ETCD_SETUP_FILE >/opt/azure/containers/setup-etcd.log 2>&1
+  RET=$?
+  if [ $RET -ne 0 ]; then
+    exit $RET
+  fi
 
-    if [[ -z "${ETCDCTL_ENDPOINTS}" ]]; then
-        {{/* Variables necessary for etcdctl are not present */}}
-        {{/* Must pull them from /etc/environment */}}
-        for entry in $(cat /etc/environment); do
-            export ${entry}
-        done
-    fi
-
-    MOUNT_ETCD_FILE=/opt/azure/containers/mountetcd.sh
-    wait_for_file 1200 1 $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
-    $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_VOL_MOUNT_FAIL"}}
-    systemctlEnableAndStart etcd || exit {{GetCSEErrorCode "ERR_ETCD_START_TIMEOUT"}}
-    for i in $(seq 1 600); do
-        MEMBER="$(sudo -E etcdctl member list | grep -E ${NODE_NAME} | cut -d':' -f 1)"
-        if [ "$MEMBER" != "" ]; then
-            break
-        else
-            sleep 1
-        fi
+  if [[ -z ${ETCDCTL_ENDPOINTS} ]]; then
+    {{/* Variables necessary for etcdctl are not present */}}
+    {{/* Must pull them from /etc/environment */}}
+    for entry in $(cat /etc/environment); do
+      export ${entry}
     done
-    retrycmd_if_failure 120 5 25 sudo -E etcdctl member update $MEMBER ${ETCD_PEER_URL} || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
+  fi
+
+  MOUNT_ETCD_FILE=/opt/azure/containers/mountetcd.sh
+  wait_for_file 1200 1 $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
+  $MOUNT_ETCD_FILE || exit {{GetCSEErrorCode "ERR_ETCD_VOL_MOUNT_FAIL"}}
+  systemctlEnableAndStart etcd || exit {{GetCSEErrorCode "ERR_ETCD_START_TIMEOUT"}}
+  for i in $(seq 1 600); do
+    MEMBER="$(sudo -E etcdctl member list | grep -E ${NODE_NAME} | cut -d':' -f 1)"
+    if [ "$MEMBER" != "" ]; then
+      break
+    else
+      sleep 1
+    fi
+  done
+  retrycmd_if_failure 120 5 25 sudo -E etcdctl member update $MEMBER ${ETCD_PEER_URL} || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
 }
 ensureNTP() {
-    systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 ensureRPC() {
-    systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-    systemctlEnableAndStart rpc-statd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart rpc-statd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 ensureAuditD() {
-  if [[ "${AUDITD_ENABLED}" == true ]]; then
+  if [[ ${AUDITD_ENABLED} == true ]]; then
     systemctlEnableAndStart auditd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
   else
     apt_get_purge auditd mlocate &
   fi
 }
 generateAggregatedAPICerts() {
-    AGGREGATED_API_CERTS_SETUP_FILE=/etc/kubernetes/generate-proxy-certs.sh
-    wait_for_file 1200 1 $AGGREGATED_API_CERTS_SETUP_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    $AGGREGATED_API_CERTS_SETUP_FILE
+  AGGREGATED_API_CERTS_SETUP_FILE=/etc/kubernetes/generate-proxy-certs.sh
+  wait_for_file 1200 1 $AGGREGATED_API_CERTS_SETUP_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  $AGGREGATED_API_CERTS_SETUP_FILE
 }
 configureKubeletServerCert() {
-    KUBELET_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/kubeletserver.key"
-    KUBELET_SERVER_CERT_PATH="/etc/kubernetes/certs/kubeletserver.crt"
+  KUBELET_SERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/kubeletserver.key"
+  KUBELET_SERVER_CERT_PATH="/etc/kubernetes/certs/kubeletserver.crt"
 
-    openssl genrsa -out $KUBELET_SERVER_PRIVATE_KEY_PATH 2048
-    openssl req -new -x509 -days 7300 -key $KUBELET_SERVER_PRIVATE_KEY_PATH -out $KUBELET_SERVER_CERT_PATH -subj "/CN=${NODE_NAME}"
+  openssl genrsa -out $KUBELET_SERVER_PRIVATE_KEY_PATH 2048
+  openssl req -new -x509 -days 7300 -key $KUBELET_SERVER_PRIVATE_KEY_PATH -out $KUBELET_SERVER_CERT_PATH -subj "/CN=${NODE_NAME}"
 }
 configureK8s() {
-    KUBELET_PRIVATE_KEY_PATH="/etc/kubernetes/certs/client.key"
-    touch "${KUBELET_PRIVATE_KEY_PATH}"
-    APISERVER_PUBLIC_KEY_PATH="/etc/kubernetes/certs/apiserver.crt"
-    touch "${APISERVER_PUBLIC_KEY_PATH}"
-    chmod 0600 "${KUBELET_PRIVATE_KEY_PATH}"
-    chmod 0644 "${APISERVER_PUBLIC_KEY_PATH}"
-    chown root:root "${KUBELET_PRIVATE_KEY_PATH}" "${APISERVER_PUBLIC_KEY_PATH}"
+  KUBELET_PRIVATE_KEY_PATH="/etc/kubernetes/certs/client.key"
+  touch "${KUBELET_PRIVATE_KEY_PATH}"
+  APISERVER_PUBLIC_KEY_PATH="/etc/kubernetes/certs/apiserver.crt"
+  touch "${APISERVER_PUBLIC_KEY_PATH}"
+  chmod 0600 "${KUBELET_PRIVATE_KEY_PATH}"
+  chmod 0644 "${APISERVER_PUBLIC_KEY_PATH}"
+  chown root:root "${KUBELET_PRIVATE_KEY_PATH}" "${APISERVER_PUBLIC_KEY_PATH}"
 
-    set +x
-    echo "${KUBELET_PRIVATE_KEY}" | base64 --decode > "${KUBELET_PRIVATE_KEY_PATH}"
-    echo "${APISERVER_PUBLIC_KEY}" | base64 --decode > "${APISERVER_PUBLIC_KEY_PATH}"
-    configureKubeletServerCert
-    AZURE_JSON_PATH="/etc/kubernetes/azure.json"
-    if [[ -n "${MASTER_NODE}" ]]; then
-        if [[ "${ENABLE_AGGREGATED_APIS}" = True ]]; then
-            generateAggregatedAPICerts
-        fi
-    else
-        {{- /* If we are a node vm then we only proceed w/ local azure.json configuration if cloud-init has pre-paved that file */}}
-        wait_for_file 1 1 $AZURE_JSON_PATH || return
+  set +x
+  echo "${KUBELET_PRIVATE_KEY}" | base64 --decode >"${KUBELET_PRIVATE_KEY_PATH}"
+  echo "${APISERVER_PUBLIC_KEY}" | base64 --decode >"${APISERVER_PUBLIC_KEY_PATH}"
+  configureKubeletServerCert
+  AZURE_JSON_PATH="/etc/kubernetes/azure.json"
+  if [[ -n ${MASTER_NODE} ]]; then
+    if [[ ${ENABLE_AGGREGATED_APIS} == True ]]; then
+      generateAggregatedAPICerts
     fi
+  else
+    {{- /* If we are a node vm then we only proceed w/ local azure.json configuration if cloud-init has pre-paved that file */}}
+    wait_for_file 1 1 $AZURE_JSON_PATH || return
+  fi
 
-    {{/* Perform the required JSON escaping */}}
-    SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\\/\\\\}
-    SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\"/\\\"}
-    cat << EOF > "${AZURE_JSON_PATH}"
+  {{/* Perform the required JSON escaping */}}
+  SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\\/\\\\}
+  SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET//\"/\\\"}
+  cat <<EOF >"${AZURE_JSON_PATH}"
 {
     "cloud":"{{GetTargetEnvironment}}",
     "tenantId": "${TENANT_ID}",
@@ -39931,230 +39931,230 @@ configureK8s() {
     "providerKeyVersion": ""
 }
 EOF
-    set -x
-    if [[ "${CLOUDPROVIDER_BACKOFF_MODE}" = "v2" ]]; then
-        sed -i "/cloudProviderBackoffExponent/d" $AZURE_JSON_PATH
-        sed -i "/cloudProviderBackoffJitter/d" $AZURE_JSON_PATH
-    fi
+  set -x
+  if [[ ${CLOUDPROVIDER_BACKOFF_MODE} == "v2" ]]; then
+    sed -i "/cloudProviderBackoffExponent/d" $AZURE_JSON_PATH
+    sed -i "/cloudProviderBackoffJitter/d" $AZURE_JSON_PATH
+  fi
 }
 
 installNetworkPlugin() {
-{{- if IsAzureCNI}}
-    installAzureCNI
-{{end}}
-    installCNI
-    rm -rf $CNI_DOWNLOADS_DIR &
+  {{- if IsAzureCNI}}
+  installAzureCNI
+  {{end}}
+  installCNI
+  rm -rf $CNI_DOWNLOADS_DIR &
 }
 installCNI() {
-    CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
-    if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
-        downloadCNI
-    fi
-    mkdir -p $CNI_BIN_DIR
-    tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
-    chown -R root:root $CNI_BIN_DIR
-    chmod -R 755 $CNI_BIN_DIR
+  CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
+  if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
+    downloadCNI
+  fi
+  mkdir -p $CNI_BIN_DIR
+  tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
+  chown -R root:root $CNI_BIN_DIR
+  chmod -R 755 $CNI_BIN_DIR
 }
 {{- if IsAzureCNI}}
 installAzureCNI() {
-    CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
-    if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
-        downloadAzureCNI
-    fi
-    mkdir -p $CNI_CONFIG_DIR
-    chown -R root:root $CNI_CONFIG_DIR
-    chmod 755 $CNI_CONFIG_DIR
-    mkdir -p $CNI_BIN_DIR
-    tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
+  CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
+  if [[ ! -f "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ]]; then
+    downloadAzureCNI
+  fi
+  mkdir -p $CNI_CONFIG_DIR
+  chown -R root:root $CNI_CONFIG_DIR
+  chmod 755 $CNI_CONFIG_DIR
+  mkdir -p $CNI_BIN_DIR
+  tar -xzf "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" -C $CNI_BIN_DIR
 }
 {{end}}
 configureCNI() {
-    {{/* needed for the iptables rules to work on bridges */}}
-    retrycmd_if_failure 120 5 25 modprobe br_netfilter || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
-    echo -n "br_netfilter" > /etc/modules-load.d/br_netfilter.conf
-    configureCNIIPTables
-    {{if HasCiliumNetworkPlugin}}
-    systemctl enable sys-fs-bpf.mount
-    systemctl restart sys-fs-bpf.mount
-    REBOOTREQUIRED=true
-    {{end}}
-{{- if IsAzureStackCloud}}
-    if [[ "${NETWORK_PLUGIN}" = "azure" ]]; then
-        {{/* set environment to mas when using Azure CNI on Azure Stack */}}
-        {{/* shellcheck disable=SC2002,SC2005 */}}
-        echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipam.environment = "mas"') > "$CNI_CONFIG_DIR/10-azure.conflist"
-    fi
-{{end}}
+  {{/* needed for the iptables rules to work on bridges */}}
+  retrycmd_if_failure 120 5 25 modprobe br_netfilter || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  echo -n "br_netfilter" >/etc/modules-load.d/br_netfilter.conf
+  configureCNIIPTables
+  {{if HasCiliumNetworkPlugin}}
+  systemctl enable sys-fs-bpf.mount
+  systemctl restart sys-fs-bpf.mount
+  REBOOTREQUIRED=true
+  {{end}}
+  {{- if IsAzureStackCloud}}
+  if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
+    {{/* set environment to mas when using Azure CNI on Azure Stack */}}
+    {{/* shellcheck disable=SC2002,SC2005 */}}
+    echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipam.environment = "mas"') >"$CNI_CONFIG_DIR/10-azure.conflist"
+  fi
+  {{end}}
 }
 configureCNIIPTables() {
-    if [[ "${NETWORK_PLUGIN}" = "azure" ]]; then
-        mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
-        chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
-        if [[ "${NETWORK_POLICY}" == "calico" ]]; then
-          sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-        elif [[ "${NETWORK_POLICY}" == "" || "${NETWORK_POLICY}" == "none" ]] && [[ "${NETWORK_MODE}" == "transparent" ]]; then
-          sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-        fi
-        /sbin/ebtables -t nat --list
+  if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
+    mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
+    chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
+    if [[ ${NETWORK_POLICY} == "calico" ]]; then
+      sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
+    elif [[ ${NETWORK_POLICY} == "" || ${NETWORK_POLICY} == "none" ]] && [[ ${NETWORK_MODE} == "transparent" ]]; then
+      sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     fi
+    /sbin/ebtables -t nat --list
+  fi
 }
 {{- if NeedsContainerd}}
 installContainerd() {
-    removeMoby
-    CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||')
-    if [[ "$CURRENT_VERSION" != "${CONTAINERD_VERSION}" ]]; then
-        os_lower=$(echo ${OS} | tr '[:upper:]' '[:lower:]')
-        if [[ "${OS}" == "${UBUNTU_OS_NAME}" ]]; then
-            url_path="${os_lower}/${UBUNTU_RELEASE}/multiarch/prod"
-        elif [[ "${OS}" == "${DEBIAN_OS_NAME}" ]]; then
-            url_path="${os_lower}/${UBUNTU_RELEASE}/prod"
-        else
-            exit 25
-        fi
-        removeContainerd
-        echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/${url_path} testing main" > /tmp/microsoft-prod-testing.list
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod-testing.list /etc/apt/sources.list.d/ || exit 25
-        retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg || exit 26
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
-        apt_get_update || exit 99
-        apt_get_install 20 30 120 moby-containerd=${CONTAINERD_VERSION}* --allow-downgrades || exit 27
+  removeMoby
+  CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||')
+  if [[ $CURRENT_VERSION != "${CONTAINERD_VERSION}" ]]; then
+    os_lower=$(echo ${OS} | tr '[:upper:]' '[:lower:]')
+    if [[ ${OS} == "${UBUNTU_OS_NAME}" ]]; then
+      url_path="${os_lower}/${UBUNTU_RELEASE}/multiarch/prod"
+    elif [[ ${OS} == "${DEBIAN_OS_NAME}" ]]; then
+      url_path="${os_lower}/${UBUNTU_RELEASE}/prod"
+    else
+      exit 25
     fi
+    removeContainerd
+    echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/${url_path} testing main" >/tmp/microsoft-prod-testing.list
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod-testing.list /etc/apt/sources.list.d/ || exit 25
+    retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >/tmp/microsoft.gpg || exit 26
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
+    apt_get_update || exit 99
+    apt_get_install 20 30 120 moby-containerd=${CONTAINERD_VERSION}* --allow-downgrades || exit 27
+  fi
 }
 ensureContainerd() {
-    wait_for_file 1200 1 /etc/systemd/system/containerd.service.d/exec_start.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    wait_for_file 1200 1 /etc/containerd/config.toml || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart containerd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  wait_for_file 1200 1 /etc/systemd/system/containerd.service.d/exec_start.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  wait_for_file 1200 1 /etc/containerd/config.toml || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart containerd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 {{end}}
 {{- if IsDockerContainerRuntime}}
 ensureDocker() {
-    DOCKER_SERVICE_EXEC_START_FILE=/etc/systemd/system/docker.service.d/exec_start.conf
-    wait_for_file 1200 1 $DOCKER_SERVICE_EXEC_START_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    usermod -aG docker ${ADMINUSER}
-    DOCKER_MOUNT_FLAGS_SYSTEMD_FILE=/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf
-    DOCKER_JSON_FILE=/etc/docker/daemon.json
-    for i in $(seq 1 1200); do
-        if [ -s $DOCKER_JSON_FILE ]; then
-            jq '.' < $DOCKER_JSON_FILE && break
-        fi
-        if [ $i -eq 1200 ]; then
-            exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-        else
-            sleep 1
-        fi
-    done
-    systemctlEnableAndStart docker || exit {{GetCSEErrorCode "ERR_DOCKER_START_FAIL"}}
-    {{/* Delay start of docker-monitor for 30 mins after booting */}}
-    DOCKER_MONITOR_SYSTEMD_TIMER_FILE=/etc/systemd/system/docker-monitor.timer
-    wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_TIMER_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    DOCKER_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
-    wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart docker-monitor.timer || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  DOCKER_SERVICE_EXEC_START_FILE=/etc/systemd/system/docker.service.d/exec_start.conf
+  wait_for_file 1200 1 $DOCKER_SERVICE_EXEC_START_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  usermod -aG docker ${ADMINUSER}
+  DOCKER_MOUNT_FLAGS_SYSTEMD_FILE=/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf
+  DOCKER_JSON_FILE=/etc/docker/daemon.json
+  for i in $(seq 1 1200); do
+    if [ -s $DOCKER_JSON_FILE ]; then
+      jq '.' <$DOCKER_JSON_FILE && break
+    fi
+    if [ $i -eq 1200 ]; then
+      exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+    else
+      sleep 1
+    fi
+  done
+  systemctlEnableAndStart docker || exit {{GetCSEErrorCode "ERR_DOCKER_START_FAIL"}}
+  {{/* Delay start of docker-monitor for 30 mins after booting */}}
+  DOCKER_MONITOR_SYSTEMD_TIMER_FILE=/etc/systemd/system/docker-monitor.timer
+  wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_TIMER_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  DOCKER_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
+  wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart docker-monitor.timer || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 {{end}}
 {{- if EnableEncryptionWithExternalKms}}
 ensureKMS() {
-    systemctlEnableAndStart kms || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  systemctlEnableAndStart kms || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 {{end}}
 {{- if IsIPv6Enabled}}
 ensureDHCPv6() {
-    wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-    retrycmd_if_failure 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  retrycmd_if_failure 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
 }
 {{end}}
 ensureKubelet() {
-    wait_for_file 1200 1 /etc/sysctl.d/11-aks-engine.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    sysctl_reload 10 5 120 || exit {{GetCSEErrorCode "ERR_SYSCTL_RELOAD"}}
-    KUBELET_DEFAULT_FILE=/etc/default/kubelet
-    wait_for_file 1200 1 $KUBELET_DEFAULT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    KUBECONFIG_FILE=/var/lib/kubelet/kubeconfig
-    wait_for_file 1200 1 $KUBECONFIG_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
-    wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
-    {{if HasCiliumNetworkPolicy}}
-    while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
-        sleep 3
-    done
-    {{end}}
-    {{if HasAntreaNetworkPolicy}}
-    while [ ! -f /etc/cni/net.d/10-antrea.conf ]; do
-        sleep 3
-    done
-    {{end}}
-    {{if HasFlannelNetworkPlugin}}
-    while [ ! -f /etc/cni/net.d/10-flannel.conf ]; do
-        sleep 3
-    done
-    {{end}}
+  wait_for_file 1200 1 /etc/sysctl.d/11-aks-engine.conf || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sysctl_reload 10 5 120 || exit {{GetCSEErrorCode "ERR_SYSCTL_RELOAD"}}
+  KUBELET_DEFAULT_FILE=/etc/default/kubelet
+  wait_for_file 1200 1 $KUBELET_DEFAULT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  KUBECONFIG_FILE=/var/lib/kubelet/kubeconfig
+  wait_for_file 1200 1 $KUBECONFIG_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
+  wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+  {{if HasCiliumNetworkPolicy}}
+  while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
+    sleep 3
+  done
+  {{end}}
+  {{if HasAntreaNetworkPolicy}}
+  while [ ! -f /etc/cni/net.d/10-antrea.conf ]; do
+    sleep 3
+  done
+  {{end}}
+  {{if HasFlannelNetworkPlugin}}
+  while [ ! -f /etc/cni/net.d/10-flannel.conf ]; do
+    sleep 3
+  done
+  {{end}}
 }
 ensureLabelNodes() {
-    LABEL_NODES_SCRIPT_FILE=/opt/azure/containers/label-nodes.sh
-    wait_for_file 1200 1 $LABEL_NODES_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    LABEL_NODES_SYSTEMD_FILE=/etc/systemd/system/label-nodes.service
-    wait_for_file 1200 1 $LABEL_NODES_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    systemctlEnableAndStart label-nodes || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  LABEL_NODES_SCRIPT_FILE=/opt/azure/containers/label-nodes.sh
+  wait_for_file 1200 1 $LABEL_NODES_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  LABEL_NODES_SYSTEMD_FILE=/etc/systemd/system/label-nodes.service
+  wait_for_file 1200 1 $LABEL_NODES_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart label-nodes || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 ensureJournal() {
-    {
-        echo "Storage=persistent"
-        echo "SystemMaxUse=1G"
-        echo "RuntimeMaxUse=1G"
-        echo "ForwardToSyslog=yes"
-    } >> /etc/systemd/journald.conf
-    systemctlEnableAndStart systemd-journald || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+  {
+    echo "Storage=persistent"
+    echo "SystemMaxUse=1G"
+    echo "RuntimeMaxUse=1G"
+    echo "ForwardToSyslog=yes"
+  } >>/etc/systemd/journald.conf
+  systemctlEnableAndStart systemd-journald || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 installKubeletAndKubectl() {
-    if [[ ! -f "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" ]]; then
-        if version_gte ${KUBERNETES_VERSION} 1.17; then
-            extractKubeBinaries
-        else
-            if [[ "$CONTAINER_RUNTIME" == "docker" ]]; then
-                extractHyperkube "docker"
-            else
-                extractHyperkube "img"
-            fi
-        fi
+  if [[ ! -f "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" ]]; then
+    if version_gte ${KUBERNETES_VERSION} 1.17; then
+      extractKubeBinaries
+    else
+      if [[ $CONTAINER_RUNTIME == "docker" ]]; then
+        extractHyperkube "docker"
+      else
+        extractHyperkube "img"
+      fi
     fi
-    mv "/usr/local/bin/kubelet-${KUBERNETES_VERSION}" "/usr/local/bin/kubelet"
-    mv "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" "/usr/local/bin/kubectl"
-    chmod a+x /usr/local/bin/kubelet /usr/local/bin/kubectl
-    rm -rf /usr/local/bin/kubelet-* /usr/local/bin/kubectl-* /home/hyperkube-downloads &
+  fi
+  mv "/usr/local/bin/kubelet-${KUBERNETES_VERSION}" "/usr/local/bin/kubelet"
+  mv "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" "/usr/local/bin/kubectl"
+  chmod a+x /usr/local/bin/kubelet /usr/local/bin/kubectl
+  rm -rf /usr/local/bin/kubelet-* /usr/local/bin/kubectl-* /home/hyperkube-downloads &
 }
 ensureK8sControlPlane() {
-    if $REBOOTREQUIRED || [ "$NO_OUTBOUND" = "true" ]; then
-        return
-    fi
-    retrycmd_if_failure 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  if $REBOOTREQUIRED || [ "$NO_OUTBOUND" = "true" ]; then
+    return
+  fi
+  retrycmd_if_failure 120 5 25 $KUBECTL cluster-info 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{- if IsAzurePolicyAddonEnabled}}
 ensureLabelExclusionForAzurePolicyAddon() {
-    GATEKEEPER_NAMESPACE="gatekeeper-system"
-    retrycmd_if_failure 120 5 25 $KUBECTL create ns --save-config $GATEKEEPER_NAMESPACE 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  GATEKEEPER_NAMESPACE="gatekeeper-system"
+  retrycmd_if_failure 120 5 25 $KUBECTL create ns --save-config $GATEKEEPER_NAMESPACE 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 
-    retrycmd_if_failure 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  retrycmd_if_failure 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{end}}
 ensureEtcd() {
-    retrycmd_if_failure 120 5 25 curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key ${ETCD_CLIENT_URL}/v2/machines || exit {{GetCSEErrorCode "ERR_ETCD_RUNNING_TIMEOUT"}}
+  retrycmd_if_failure 120 5 25 curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key ${ETCD_CLIENT_URL}/v2/machines || exit {{GetCSEErrorCode "ERR_ETCD_RUNNING_TIMEOUT"}}
 }
 createKubeManifestDir() {
-    KUBEMANIFESTDIR=/etc/kubernetes/manifests
-    mkdir -p $KUBEMANIFESTDIR
+  KUBEMANIFESTDIR=/etc/kubernetes/manifests
+  mkdir -p $KUBEMANIFESTDIR
 }
 writeKubeConfig() {
-    local DIR=/home/$ADMINUSER/.kube
-    local FILE=$DIR/config
-    mkdir -p $DIR
-    touch $FILE
-    chown $ADMINUSER:$ADMINUSER $DIR $FILE
-    chmod 700 $DIR
-    chmod 600 $FILE
-    set +x
-    echo "
+  local DIR=/home/$ADMINUSER/.kube
+  local FILE=$DIR/config
+  mkdir -p $DIR
+  touch $FILE
+  chown $ADMINUSER:$ADMINUSER $DIR $FILE
+  chmod 700 $DIR
+  chmod 600 $FILE
+  set +x
+  echo "
 ---
 apiVersion: v1
 clusters:
@@ -40174,160 +40174,160 @@ users:
   user:
     client-certificate-data: \"$KUBECONFIG_CERTIFICATE\"
     client-key-data: \"$KUBECONFIG_KEY\"
-" > $FILE
-    set -x
-    KUBECTL="$KUBECTL --kubeconfig=$FILE"
+" >$FILE
+  set -x
+  KUBECTL="$KUBECTL --kubeconfig=$FILE"
 }
 {{- if IsClusterAutoscalerAddonEnabled}}
 configClusterAutoscalerAddon() {
-    CLUSTER_AUTOSCALER_ADDON_FILE=/etc/kubernetes/addons/cluster-autoscaler-deployment.yaml
-    wait_for_file 1200 1 $CLUSTER_AUTOSCALER_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    sed -i "s|<clientID>|$(echo $SERVICE_PRINCIPAL_CLIENT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<clientSec>|$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<subID>|$(echo $SUBSCRIPTION_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<tenantID>|$(echo $TENANT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
-    sed -i "s|<rg>|$(echo $RESOURCE_GROUP | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  CLUSTER_AUTOSCALER_ADDON_FILE=/etc/kubernetes/addons/cluster-autoscaler-deployment.yaml
+  wait_for_file 1200 1 $CLUSTER_AUTOSCALER_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sed -i "s|<clientID>|$(echo $SERVICE_PRINCIPAL_CLIENT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<clientSec>|$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<subID>|$(echo $SUBSCRIPTION_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<tenantID>|$(echo $TENANT_ID | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
+  sed -i "s|<rg>|$(echo $RESOURCE_GROUP | base64)|g" $CLUSTER_AUTOSCALER_ADDON_FILE
 }
 {{end}}
 {{- if IsACIConnectorAddonEnabled}}
 configACIConnectorAddon() {
-    ACI_CONNECTOR_CREDENTIALS=$(printf "{\"clientId\": \"%s\", \"clientSecret\": \"%s\", \"tenantId\": \"%s\", \"subscriptionId\": \"%s\", \"activeDirectoryEndpointUrl\": \"https://login.microsoftonline.com\",\"resourceManagerEndpointUrl\": \"https://management.azure.com/\", \"activeDirectoryGraphResourceId\": \"https://graph.windows.net/\", \"sqlManagementEndpointUrl\": \"https://management.core.windows.net:8443/\", \"galleryEndpointUrl\": \"https://gallery.azure.com/\", \"managementEndpointUrl\": \"https://management.core.windows.net/\"}" "$SERVICE_PRINCIPAL_CLIENT_ID" "$SERVICE_PRINCIPAL_CLIENT_SECRET" "$TENANT_ID" "$SUBSCRIPTION_ID" | base64 -w 0)
+  ACI_CONNECTOR_CREDENTIALS=$(printf '{"clientId": "%s", "clientSecret": "%s", "tenantId": "%s", "subscriptionId": "%s", "activeDirectoryEndpointUrl": "https://login.microsoftonline.com","resourceManagerEndpointUrl": "https://management.azure.com/", "activeDirectoryGraphResourceId": "https://graph.windows.net/", "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/", "galleryEndpointUrl": "https://gallery.azure.com/", "managementEndpointUrl": "https://management.core.windows.net/"}' "$SERVICE_PRINCIPAL_CLIENT_ID" "$SERVICE_PRINCIPAL_CLIENT_SECRET" "$TENANT_ID" "$SUBSCRIPTION_ID" | base64 -w 0)
 
-    openssl req -newkey rsa:4096 -new -nodes -x509 -days 3650 -keyout /etc/kubernetes/certs/aci-connector-key.pem -out /etc/kubernetes/certs/aci-connector-cert.pem -subj "/C=US/ST=CA/L=virtualkubelet/O=virtualkubelet/OU=virtualkubelet/CN=virtualkubelet"
-    ACI_CONNECTOR_KEY=$(base64 /etc/kubernetes/certs/aci-connector-key.pem -w0)
-    ACI_CONNECTOR_CERT=$(base64 /etc/kubernetes/certs/aci-connector-cert.pem -w0)
+  openssl req -newkey rsa:4096 -new -nodes -x509 -days 3650 -keyout /etc/kubernetes/certs/aci-connector-key.pem -out /etc/kubernetes/certs/aci-connector-cert.pem -subj "/C=US/ST=CA/L=virtualkubelet/O=virtualkubelet/OU=virtualkubelet/CN=virtualkubelet"
+  ACI_CONNECTOR_KEY=$(base64 /etc/kubernetes/certs/aci-connector-key.pem -w0)
+  ACI_CONNECTOR_CERT=$(base64 /etc/kubernetes/certs/aci-connector-cert.pem -w0)
 
-    ACI_CONNECTOR_ADDON_FILE=/etc/kubernetes/addons/aci-connector-deployment.yaml
-    wait_for_file 1200 1 $ACI_CONNECTOR_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    sed -i "s|<creds>|$ACI_CONNECTOR_CREDENTIALS|g" $ACI_CONNECTOR_ADDON_FILE
-    sed -i "s|<rgName>|$RESOURCE_GROUP|g" $ACI_CONNECTOR_ADDON_FILE
-    sed -i "s|<cert>|$ACI_CONNECTOR_CERT|g" $ACI_CONNECTOR_ADDON_FILE
-    sed -i "s|<key>|$ACI_CONNECTOR_KEY|g" $ACI_CONNECTOR_ADDON_FILE
+  ACI_CONNECTOR_ADDON_FILE=/etc/kubernetes/addons/aci-connector-deployment.yaml
+  wait_for_file 1200 1 $ACI_CONNECTOR_ADDON_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sed -i "s|<creds>|$ACI_CONNECTOR_CREDENTIALS|g" $ACI_CONNECTOR_ADDON_FILE
+  sed -i "s|<rgName>|$RESOURCE_GROUP|g" $ACI_CONNECTOR_ADDON_FILE
+  sed -i "s|<cert>|$ACI_CONNECTOR_CERT|g" $ACI_CONNECTOR_ADDON_FILE
+  sed -i "s|<key>|$ACI_CONNECTOR_KEY|g" $ACI_CONNECTOR_ADDON_FILE
 }
 {{end}}
 {{- if IsAzurePolicyAddonEnabled}}
 configAzurePolicyAddon() {
-    AZURE_POLICY_ADDON_FILE=/etc/kubernetes/addons/azure-policy-deployment.yaml
-    sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $AZURE_POLICY_ADDON_FILE
+  AZURE_POLICY_ADDON_FILE=/etc/kubernetes/addons/azure-policy-deployment.yaml
+  sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $AZURE_POLICY_ADDON_FILE
 }
 {{end}}
 {{- if or IsClusterAutoscalerAddonEnabled IsACIConnectorAddonEnabled IsAzurePolicyAddonEnabled}}
 configAddons() {
-    {{if IsClusterAutoscalerAddonEnabled}}
-    if [[ "${CLUSTER_AUTOSCALER_ADDON}" = true ]]; then
-        configClusterAutoscalerAddon
-    fi
-    {{end}}
-    {{if IsACIConnectorAddonEnabled}}
-    if [[ "${ACI_CONNECTOR_ADDON}" = True ]]; then
-        configACIConnectorAddon
-    fi
-    {{end}}
-    {{if IsAzurePolicyAddonEnabled}}
-    configAzurePolicyAddon
-    {{end}}
+  {{if IsClusterAutoscalerAddonEnabled}}
+  if [[ ${CLUSTER_AUTOSCALER_ADDON} == true ]]; then
+    configClusterAutoscalerAddon
+  fi
+  {{end}}
+  {{if IsACIConnectorAddonEnabled}}
+  if [[ ${ACI_CONNECTOR_ADDON} == True ]]; then
+    configACIConnectorAddon
+  fi
+  {{end}}
+  {{if IsAzurePolicyAddonEnabled}}
+  configAzurePolicyAddon
+  {{end}}
 }
 {{end}}
 {{- if HasNSeriesSKU}}
 configGPUDrivers() {
-    {{/* only install the runtime since nvidia-docker2 has a hard dep on docker CE packages. */}}
-    {{/* we will manually install nvidia-docker2 */}}
-    rmmod nouveau
-    echo blacklist nouveau >> /etc/modprobe.d/blacklist.conf
-    retrycmd_if_failure_no_stats 120 5 25 update-initramfs -u || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  {{/* only install the runtime since nvidia-docker2 has a hard dep on docker CE packages. */}}
+  {{/* we will manually install nvidia-docker2 */}}
+  rmmod nouveau
+  echo blacklist nouveau >>/etc/modprobe.d/blacklist.conf
+  retrycmd_if_failure_no_stats 120 5 25 update-initramfs -u || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  wait_for_apt_locks
+  retrycmd_if_failure 30 5 3600 apt-get -o Dpkg::Options::="--force-confold" install -y nvidia-container-runtime="${NVIDIA_CONTAINER_RUNTIME_VERSION}+docker18.09.2-1" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  tmpDir=$GPU_DEST/tmp
+  (
+    set -e -o pipefail
+    cd "${tmpDir}"
     wait_for_apt_locks
-    retrycmd_if_failure 30 5 3600 apt-get -o Dpkg::Options::="--force-confold" install -y nvidia-container-runtime="${NVIDIA_CONTAINER_RUNTIME_VERSION}+docker18.09.2-1" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    tmpDir=$GPU_DEST/tmp
-    (
-      set -e -o pipefail
-      cd "${tmpDir}"
-      wait_for_apt_locks
-      dpkg-deb -R ./nvidia-docker2*.deb "${tmpDir}/pkg" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-      cp -r ${tmpDir}/pkg/usr/* /usr/ || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    )
-    rm -rf $GPU_DEST/tmp
-    retrycmd_if_failure 120 5 25 pkill -SIGHUP dockerd || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    mkdir -p $GPU_DEST/lib64 $GPU_DEST/overlay-workdir
-    retrycmd_if_failure 120 5 25 mount -t overlay -o lowerdir=/usr/lib/x86_64-linux-gnu,upperdir=${GPU_DEST}/lib64,workdir=${GPU_DEST}/overlay-workdir none /usr/lib/x86_64-linux-gnu || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
-    retrycmd_if_failure 3 1 600 sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    echo "${GPU_DEST}/lib64" > /etc/ld.so.conf.d/nvidia.conf
-    retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    umount -l /usr/lib/x86_64-linux-gnu
-    retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0 || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    retrycmd_if_failure 120 5 25 $GPU_DEST/bin/nvidia-smi || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
-    retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+    dpkg-deb -R ./nvidia-docker2*.deb "${tmpDir}/pkg" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+    cp -r ${tmpDir}/pkg/usr/* /usr/ || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  )
+  rm -rf $GPU_DEST/tmp
+  retrycmd_if_failure 120 5 25 pkill -SIGHUP dockerd || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  mkdir -p $GPU_DEST/lib64 $GPU_DEST/overlay-workdir
+  retrycmd_if_failure 120 5 25 mount -t overlay -o lowerdir=/usr/lib/x86_64-linux-gnu,upperdir=${GPU_DEST}/lib64,workdir=${GPU_DEST}/overlay-workdir none /usr/lib/x86_64-linux-gnu || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_CONFIG"}}
+  retrycmd_if_failure 3 1 600 sh $GPU_DEST/nvidia-drivers-$GPU_DV --silent --accept-license --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}" || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  echo "${GPU_DEST}/lib64" >/etc/ld.so.conf.d/nvidia.conf
+  retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  umount -l /usr/lib/x86_64-linux-gnu
+  retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0 || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  retrycmd_if_failure 120 5 25 $GPU_DEST/bin/nvidia-smi || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  retrycmd_if_failure 120 5 25 ldconfig || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
 }
 ensureGPUDrivers() {
-    configGPUDrivers
-    systemctlEnableAndStart nvidia-modprobe || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
+  configGPUDrivers
+  systemctlEnableAndStart nvidia-modprobe || exit {{GetCSEErrorCode "ERR_GPU_DRIVERS_START_FAIL"}}
 }
 {{end}}
 {{- if HasDCSeriesSKU}}
 installSGXDrivers() {
-    [[ "$UBUNTU_RELEASE" == "18.04" || "$UBUNTU_RELEASE" == "16.04" ]] || exit 92
+  [[ $UBUNTU_RELEASE == "18.04" || $UBUNTU_RELEASE == "16.04" ]] || exit 92
 
-    local packages="make gcc dkms"
-    wait_for_apt_locks
-    retrycmd_if_failure 30 5 3600 apt-get -y install "$packages" || exit 90
+  local packages="make gcc dkms"
+  wait_for_apt_locks
+  retrycmd_if_failure 30 5 3600 apt-get -y install "$packages" || exit 90
 
-    local oe_dir=/opt/azure/containers/oe
-    rm -rf ${oe_dir}
-    mkdir -p ${oe_dir}
-    pushd ${oe_dir} || exit
-    retrycmd_if_failure 10 10 120 curl -fsSL -O "https://download.01.org/intel-sgx/latest/version.xml" || exit 90
-    dcap_version="$(grep dcap version.xml | grep -o -E "[.0-9]+")"
-    sgx_driver_folder_url="https://download.01.org/intel-sgx/sgx-dcap/$dcap_version/linux"
-    retrycmd_if_failure 10 10 120 curl -fsSL -O "$sgx_driver_folder_url/SHA256SUM_dcap_$dcap_version" || exit 90
-    matched_line="$(grep "distro/ubuntuServer$UBUNTU_RELEASE/sgx_linux_x64_driver_.*bin" SHA256SUM_dcap_$dcap_version)"
-    read -ra tmp_array <<< "$matched_line"
-    sgx_driver_sha256sum_expected="${tmp_array[0]}"
-    sgx_driver_remote_path="${tmp_array[1]}"
-    sgx_driver_url="${sgx_driver_folder_url}/${sgx_driver_remote_path}"
-    sgx_driver=$(basename "$sgx_driver_url")
+  local oe_dir=/opt/azure/containers/oe
+  rm -rf ${oe_dir}
+  mkdir -p ${oe_dir}
+  pushd ${oe_dir} || exit
+  retrycmd_if_failure 10 10 120 curl -fsSL -O "https://download.01.org/intel-sgx/latest/version.xml" || exit 90
+  dcap_version="$(grep dcap version.xml | grep -o -E "[.0-9]+")"
+  sgx_driver_folder_url="https://download.01.org/intel-sgx/sgx-dcap/$dcap_version/linux"
+  retrycmd_if_failure 10 10 120 curl -fsSL -O "$sgx_driver_folder_url/SHA256SUM_dcap_$dcap_version" || exit 90
+  matched_line="$(grep "distro/ubuntuServer$UBUNTU_RELEASE/sgx_linux_x64_driver_.*bin" SHA256SUM_dcap_$dcap_version)"
+  read -ra tmp_array <<<"$matched_line"
+  sgx_driver_sha256sum_expected="${tmp_array[0]}"
+  sgx_driver_remote_path="${tmp_array[1]}"
+  sgx_driver_url="${sgx_driver_folder_url}/${sgx_driver_remote_path}"
+  sgx_driver=$(basename "$sgx_driver_url")
 
-    retrycmd_if_failure 10 10 120 curl -fsSL -O "${sgx_driver_url}" || exit 90
-    read -ra tmp_array <<< "$(sha256sum ./"$sgx_driver")"
-    sgx_driver_sha256sum_real="${tmp_array[0]}"
-    [[ "$sgx_driver_sha256sum_real" == "$sgx_driver_sha256sum_expected" ]] || exit 93
+  retrycmd_if_failure 10 10 120 curl -fsSL -O "${sgx_driver_url}" || exit 90
+  read -ra tmp_array <<<"$(sha256sum ./"$sgx_driver")"
+  sgx_driver_sha256sum_real="${tmp_array[0]}"
+  [[ $sgx_driver_sha256sum_real == "$sgx_driver_sha256sum_expected" ]] || exit 93
 
-    chmod a+x ./"${sgx_driver}"
-    if ! ./"${sgx_driver}"; then
-        popd || exit
-        exit 91
-    fi
+  chmod a+x ./"${sgx_driver}"
+  if ! ./"${sgx_driver}"; then
     popd || exit
-    rm -rf ${oe_dir}
+    exit 91
+  fi
+  popd || exit
+  rm -rf ${oe_dir}
 }
 {{end}}
 {{- if HasVHDDistroNodes}}
 cleanUpContainerImages() {
-    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'hyperkube') &
-    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'cloud-controller-manager') &
-    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${ETCD_VERSION}$|${ETCD_VERSION}-|${ETCD_VERSION}_" | grep 'etcd') &
-    if [ "$IS_HOSTED_MASTER" = "false" ]; then
-        docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'hcp-tunnel-front') &
-        docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'kube-svc-redirect') &
-        docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'nginx') &
-    fi
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'hyperkube') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'cloud-controller-manager') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${ETCD_VERSION}$|${ETCD_VERSION}-|${ETCD_VERSION}_" | grep 'etcd') &
+  if [ "$IS_HOSTED_MASTER" = "false" ]; then
+    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'hcp-tunnel-front') &
+    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'kube-svc-redirect') &
+    docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'nginx') &
+  fi
 
-    docker rmi registry:2.7.1 &
+  docker rmi registry:2.7.1 &
 }
 cleanUpGPUDrivers() {
-    rm -Rf $GPU_DEST
-    rm -f /etc/apt/sources.list.d/nvidia-docker.list
+  rm -Rf $GPU_DEST
+  rm -f /etc/apt/sources.list.d/nvidia-docker.list
 }
 cleanUpContainerd() {
-    rm -Rf $CONTAINERD_DOWNLOADS_DIR
+  rm -Rf $CONTAINERD_DOWNLOADS_DIR
 }
 {{end}}
 removeEtcd() {
-    rm -rf /usr/bin/etcd
+  rm -rf /usr/bin/etcd
 }
 removeMoby() {
-    apt_get_purge moby-engine moby-cli || exit 27
+  apt_get_purge moby-engine moby-cli || exit 27
 }
 removeContainerd() {
-    apt_get_purge moby-containerd || exit 27
+  apt_get_purge moby-containerd || exit 27
 }
 #EOF
 `)
@@ -40350,178 +40350,178 @@ func k8sCloudInitArtifactsCse_configSh() (*asset, error) {
 var _k8sCloudInitArtifactsCse_customcloudSh = []byte(`#!/bin/bash
 
 ensureCertificates() {
-    AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
-    AZURESTACK_RESOURCE_MANAGER_ENDPOINT=$(jq .resourceManagerEndpoint $AZURESTACK_ENVIRONMENT_JSON_PATH | tr -d "\"")
-    AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
-    curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
-    CURL_RETURNCODE=$?
-    KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
-    if [ $CURL_RETURNCODE != 0 ]; then
-        # Replace placeholder for ssl binding
-        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
-            sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
-            sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
-        fi
-
-        # Copying the AzureStack root certificate to the appropriate store to be updated.
-        AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH="/var/lib/waagent/Certificates.pem"
-        AZURESTACK_ROOT_CERTIFICATE__DEST_PATH="/usr/local/share/ca-certificates/azsCertificate.crt"
-        cp $AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH $AZURESTACK_ROOT_CERTIFICATE__DEST_PATH
-        update-ca-certificates
-    else
-        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
-            # the ARM resource manager endpoint binding certificate is trusted, remove the placeholder for ssl binding
-            sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
-            sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
-        fi
+  AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
+  AZURESTACK_RESOURCE_MANAGER_ENDPOINT=$(jq .resourceManagerEndpoint $AZURESTACK_ENVIRONMENT_JSON_PATH | tr -d '"')
+  AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
+  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
+  CURL_RETURNCODE=$?
+  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
+  if [ $CURL_RETURNCODE != 0 ]; then
+    # Replace placeholder for ssl binding
+    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+      sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
+      sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
     fi
 
-    # ensureCertificates will be retried if the exit code is not 0
-    curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
-    exit $?
+    # Copying the AzureStack root certificate to the appropriate store to be updated.
+    AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH="/var/lib/waagent/Certificates.pem"
+    AZURESTACK_ROOT_CERTIFICATE__DEST_PATH="/usr/local/share/ca-certificates/azsCertificate.crt"
+    cp $AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH $AZURESTACK_ROOT_CERTIFICATE__DEST_PATH
+    update-ca-certificates
+  else
+    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+      # the ARM resource manager endpoint binding certificate is trusted, remove the placeholder for ssl binding
+      sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+      sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+    fi
+  fi
+
+  # ensureCertificates will be retried if the exit code is not 0
+  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
+  exit $?
 }
 
 configureK8sCustomCloud() {
-    export -f ensureCertificates
-    retrycmd_if_failure 60 10 30 bash -c ensureCertificates
-    set +x
-    # When AUTHENTICATION_METHOD is client_certificate, the certificate is stored into key valut,
-    # And SERVICE_PRINCIPAL_CLIENT_SECRET will be the following json payload with based64 encode
-    #{
-    #    "data": "$pfxAsBase64EncodedString",
-    #    "dataType" :"pfx",
-    #    "password": "$password"
-    #}
-    if [[ "${AUTHENTICATION_METHOD,,}" == "client_certificate" ]]; then
-        SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED=$(echo ${SERVICE_PRINCIPAL_CLIENT_SECRET} | base64 --decode)
-        SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .data)
-        SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .password)
+  export -f ensureCertificates
+  retrycmd_if_failure 60 10 30 bash -c ensureCertificates
+  set +x
+  # When AUTHENTICATION_METHOD is client_certificate, the certificate is stored into key valut,
+  # And SERVICE_PRINCIPAL_CLIENT_SECRET will be the following json payload with based64 encode
+  #{
+  #    "data": "$pfxAsBase64EncodedString",
+  #    "dataType" :"pfx",
+  #    "password": "$password"
+  #}
+  if [[ ${AUTHENTICATION_METHOD,,} == "client_certificate" ]]; then
+    SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED=$(echo ${SERVICE_PRINCIPAL_CLIENT_SECRET} | base64 --decode)
+    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .data)
+    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .password)
 
-        # trim the starting and ending "
-        SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT#"\""}
-        SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT%"\""}
+    # trim the starting and ending "
+    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT#'"'}
+    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT%'"'}
 
-        SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD#"\""}
-        SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD%"\""}
+    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD#'"'}
+    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD%'"'}
 
-        KUBERNETES_FILE_DIR=$(dirname "${AZURE_JSON_PATH}")
-        K8S_CLIENT_CERT_PATH="${KUBERNETES_FILE_DIR}/k8s_auth_certificate.pfx"
-        echo $SERVICE_PRINCIPAL_CLIENT_SECRET_CERT | base64 --decode > $K8S_CLIENT_CERT_PATH
-        # shellcheck disable=SC2002,SC2005
-        echo $(cat "${AZURE_JSON_PATH}" | \
-            jq --arg K8S_CLIENT_CERT_PATH ${K8S_CLIENT_CERT_PATH} '. + {aadClientCertPath:($K8S_CLIENT_CERT_PATH)}' | \
-            jq --arg SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD ${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD} '. + {aadClientCertPassword:($SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD)}' |\
-            jq 'del(.aadClientSecret)') > ${AZURE_JSON_PATH}
-    fi
+    KUBERNETES_FILE_DIR=$(dirname "${AZURE_JSON_PATH}")
+    K8S_CLIENT_CERT_PATH="${KUBERNETES_FILE_DIR}/k8s_auth_certificate.pfx"
+    echo $SERVICE_PRINCIPAL_CLIENT_SECRET_CERT | base64 --decode >$K8S_CLIENT_CERT_PATH
+    # shellcheck disable=SC2002,SC2005
+    echo $(cat "${AZURE_JSON_PATH}" |
+      jq --arg K8S_CLIENT_CERT_PATH ${K8S_CLIENT_CERT_PATH} '. + {aadClientCertPath:($K8S_CLIENT_CERT_PATH)}' |
+      jq --arg SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD ${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD} '. + {aadClientCertPassword:($SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD)}' |
+      jq 'del(.aadClientSecret)') >${AZURE_JSON_PATH}
+  fi
 
-    if [[ "${IDENTITY_SYSTEM,,}" == "adfs"  ]]; then
-        # update the tenent id for ADFS environment.
-        # shellcheck disable=SC2002,SC2005
-        echo $(cat "${AZURE_JSON_PATH}" | jq '.tenantId = "adfs"') > ${AZURE_JSON_PATH}
-    fi
+  if [[ ${IDENTITY_SYSTEM,,} == "adfs" ]]; then
+    # update the tenent id for ADFS environment.
+    # shellcheck disable=SC2002,SC2005
+    echo $(cat "${AZURE_JSON_PATH}" | jq '.tenantId = "adfs"') >${AZURE_JSON_PATH}
+  fi
 
-    # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
-    echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
-    echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
+  # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
+  echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
+  echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
 
-    ifconfig eth0 mtu 1350
+  ifconfig eth0 mtu 1350
 
-    set -x
+  set -x
 }
 
 configureAzureStackInterfaces() {
-    set +x
+  set +x
 
-    NETWORK_INTERFACES_FILE="/etc/kubernetes/network_interfaces.json"
-    AZURE_CNI_CONFIG_FILE="/etc/kubernetes/interfaces.json"
-    AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
-    SERVICE_MANAGEMENT_ENDPOINT=$(jq -r '.serviceManagementEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
-    ACTIVE_DIRECTORY_ENDPOINT=$(jq -r '.activeDirectoryEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
-    RESOURCE_MANAGER_ENDPOINT=$(jq -r '.resourceManagerEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
+  NETWORK_INTERFACES_FILE="/etc/kubernetes/network_interfaces.json"
+  AZURE_CNI_CONFIG_FILE="/etc/kubernetes/interfaces.json"
+  AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
+  SERVICE_MANAGEMENT_ENDPOINT=$(jq -r '.serviceManagementEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
+  ACTIVE_DIRECTORY_ENDPOINT=$(jq -r '.activeDirectoryEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
+  RESOURCE_MANAGER_ENDPOINT=$(jq -r '.resourceManagerEndpoint' ${AZURESTACK_ENVIRONMENT_JSON_PATH})
 
-    if [[ "${IDENTITY_SYSTEM,,}" == "adfs"  ]]; then
-        TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}adfs/oauth2/token"
-    else
-        TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}${TENANT_ID}/oauth2/token"
+  if [[ ${IDENTITY_SYSTEM,,} == "adfs" ]]; then
+    TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}adfs/oauth2/token"
+  else
+    TOKEN_URL="${ACTIVE_DIRECTORY_ENDPOINT}${TENANT_ID}/oauth2/token"
+  fi
+
+  echo "Generating token for Azure Resource Manager"
+  echo "------------------------------------------------------------------------"
+  echo "Parameters"
+  echo "------------------------------------------------------------------------"
+  echo "SERVICE_PRINCIPAL_CLIENT_ID:     ..."
+  echo "SERVICE_PRINCIPAL_CLIENT_SECRET: ..."
+  echo "SERVICE_MANAGEMENT_ENDPOINT:     $SERVICE_MANAGEMENT_ENDPOINT"
+  echo "ACTIVE_DIRECTORY_ENDPOINT:       $ACTIVE_DIRECTORY_ENDPOINT"
+  echo "TENANT_ID:                       $TENANT_ID"
+  echo "IDENTITY_SYSTEM:                 $IDENTITY_SYSTEM"
+  echo "TOKEN_URL:                       $TOKEN_URL"
+  echo "------------------------------------------------------------------------"
+
+  TOKEN=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=$SERVICE_PRINCIPAL_CLIENT_ID" \
+    --data-urlencode "client_secret=$SERVICE_PRINCIPAL_CLIENT_SECRET" \
+    --data-urlencode "resource=$SERVICE_MANAGEMENT_ENDPOINT" \
+    ${TOKEN_URL} | jq '.access_token' | xargs)
+
+  if [[ -z $TOKEN ]]; then
+    echo "Error generating token for Azure Resource Manager"
+    exit 120
+  fi
+
+  echo "Fetching network interface configuration for node"
+  echo "------------------------------------------------------------------------"
+  echo "Parameters"
+  echo "------------------------------------------------------------------------"
+  echo "RESOURCE_MANAGER_ENDPOINT: $RESOURCE_MANAGER_ENDPOINT"
+  echo "SUBSCRIPTION_ID:           $SUBSCRIPTION_ID"
+  echo "RESOURCE_GROUP:            $RESOURCE_GROUP"
+  echo "NETWORK_API_VERSION:       $NETWORK_API_VERSION"
+  echo "------------------------------------------------------------------------"
+
+  curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "${RESOURCE_MANAGER_ENDPOINT}subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Network/networkInterfaces?api-version=$NETWORK_API_VERSION" >${NETWORK_INTERFACES_FILE}
+
+  if [[ ! -s ${NETWORK_INTERFACES_FILE} ]]; then
+    echo "Error fetching network interface configuration for node"
+    exit 121
+  fi
+
+  echo "Generating Azure CNI interface file"
+
+  mapfile -t local_interfaces < <(cat /sys/class/net/*/address | tr -d : | sed 's/.*/\U&/g')
+
+  SDN_INTERFACES=$(jq ".value | map(select(.properties.macAddress | inside(\"${local_interfaces[*]}\"))) | map(select((.properties.ipConfigurations | length) > 0))" ${NETWORK_INTERFACES_FILE})
+
+  AZURE_CNI_CONFIG=$(echo ${SDN_INTERFACES} | jq "{Interfaces: [.[] | {MacAddress: .properties.macAddress, IsPrimary: .properties.primary, IPSubnets: [{Prefix: .properties.ipConfigurations[0].properties.subnet.id, IPAddresses: .properties.ipConfigurations | [.[] | {Address: .properties.privateIPAddress, IsPrimary: .properties.primary}]}]}]}")
+
+  mapfile -t SUBNET_IDS < <(echo ${SDN_INTERFACES} | jq '[.[].properties.ipConfigurations[0].properties.subnet.id] | unique | .[]' -r)
+
+  for SUBNET_ID in "${SUBNET_IDS[@]}"; do
+    SUBNET_PREFIX=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      "${RESOURCE_MANAGER_ENDPOINT}${SUBNET_ID:1}?api-version=$NETWORK_API_VERSION" |
+      jq '.properties.addressPrefix' -r)
+
+    if [[ -z $SUBNET_PREFIX ]]; then
+      echo "Error fetching the subnet address prefix for a subnet ID"
+      exit 122
     fi
 
-    echo "Generating token for Azure Resource Manager"
-    echo "------------------------------------------------------------------------"
-    echo "Parameters"
-    echo "------------------------------------------------------------------------"
-    echo "SERVICE_PRINCIPAL_CLIENT_ID:     ..."
-    echo "SERVICE_PRINCIPAL_CLIENT_SECRET: ..."
-    echo "SERVICE_MANAGEMENT_ENDPOINT:     $SERVICE_MANAGEMENT_ENDPOINT"
-    echo "ACTIVE_DIRECTORY_ENDPOINT:       $ACTIVE_DIRECTORY_ENDPOINT"
-    echo "TENANT_ID:                       $TENANT_ID"
-    echo "IDENTITY_SYSTEM:                 $IDENTITY_SYSTEM"
-    echo "TOKEN_URL:                       $TOKEN_URL"
-    echo "------------------------------------------------------------------------"
+    # shellcheck disable=SC2001
+    AZURE_CNI_CONFIG=$(echo ${AZURE_CNI_CONFIG} | sed "s|$SUBNET_ID|$SUBNET_PREFIX|g")
+  done
 
-    TOKEN=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X POST \
-        -H "Content-Type: application/x-www-form-urlencoded" \
-        -d "grant_type=client_credentials" \
-        -d "client_id=$SERVICE_PRINCIPAL_CLIENT_ID" \
-        --data-urlencode "client_secret=$SERVICE_PRINCIPAL_CLIENT_SECRET" \
-        --data-urlencode "resource=$SERVICE_MANAGEMENT_ENDPOINT" \
-        ${TOKEN_URL} | jq '.access_token' | xargs)
+  echo ${AZURE_CNI_CONFIG} >${AZURE_CNI_CONFIG_FILE}
 
-    if [[ -z "$TOKEN" ]]; then
-        echo "Error generating token for Azure Resource Manager"
-        exit 120
-    fi
+  chmod 0444 ${AZURE_CNI_CONFIG_FILE}
 
-    echo "Fetching network interface configuration for node"
-    echo "------------------------------------------------------------------------"
-    echo "Parameters"
-    echo "------------------------------------------------------------------------"
-    echo "RESOURCE_MANAGER_ENDPOINT: $RESOURCE_MANAGER_ENDPOINT"
-    echo "SUBSCRIPTION_ID:           $SUBSCRIPTION_ID"
-    echo "RESOURCE_GROUP:            $RESOURCE_GROUP"
-    echo "NETWORK_API_VERSION:       $NETWORK_API_VERSION"
-    echo "------------------------------------------------------------------------"
-
-    curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
-        -H "Authorization: Bearer $TOKEN" \
-        -H "Content-Type: application/json" \
-        "${RESOURCE_MANAGER_ENDPOINT}subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Network/networkInterfaces?api-version=$NETWORK_API_VERSION" > ${NETWORK_INTERFACES_FILE}
-
-    if [[ ! -s ${NETWORK_INTERFACES_FILE} ]]; then
-        echo "Error fetching network interface configuration for node"
-        exit 121
-    fi
-
-    echo "Generating Azure CNI interface file"
-
-    mapfile -t local_interfaces < <(cat /sys/class/net/*/address | tr -d : | sed 's/.*/\U&/g')
-
-    SDN_INTERFACES=$(jq ".value | map(select(.properties.macAddress | inside(\"${local_interfaces[*]}\"))) | map(select((.properties.ipConfigurations | length) > 0))" ${NETWORK_INTERFACES_FILE})
-
-    AZURE_CNI_CONFIG=$(echo ${SDN_INTERFACES} | jq "{Interfaces: [.[] | {MacAddress: .properties.macAddress, IsPrimary: .properties.primary, IPSubnets: [{Prefix: .properties.ipConfigurations[0].properties.subnet.id, IPAddresses: .properties.ipConfigurations | [.[] | {Address: .properties.privateIPAddress, IsPrimary: .properties.primary}]}]}]}")
-
-    mapfile -t SUBNET_IDS < <(echo ${SDN_INTERFACES} | jq '[.[].properties.ipConfigurations[0].properties.subnet.id] | unique | .[]' -r)
-
-    for SUBNET_ID in "${SUBNET_IDS[@]}"; do
-        SUBNET_PREFIX=$(curl -s --retry 5 --retry-delay 10 --max-time 60 -f -X GET \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            "${RESOURCE_MANAGER_ENDPOINT}${SUBNET_ID:1}?api-version=$NETWORK_API_VERSION" | \
-            jq '.properties.addressPrefix' -r)
-
-        if [[ -z "$SUBNET_PREFIX" ]]; then
-            echo "Error fetching the subnet address prefix for a subnet ID"
-            exit 122
-        fi
-
-        # shellcheck disable=SC2001
-        AZURE_CNI_CONFIG=$(echo ${AZURE_CNI_CONFIG} | sed "s|$SUBNET_ID|$SUBNET_PREFIX|g")
-    done
-
-    echo ${AZURE_CNI_CONFIG} > ${AZURE_CNI_CONFIG_FILE}
-
-    chmod 0444 ${AZURE_CNI_CONFIG_FILE}
-
-    set -x
+  set -x
 }
 #EOF
 `)
@@ -40548,7 +40548,7 @@ UBUNTU_OS_NAME="UBUNTU"
 RHEL_OS_NAME="RHEL"
 DEBIAN_OS_NAME="DEBIAN"
 if ! echo "${UBUNTU_OS_NAME} ${RHEL_OS_NAME} ${DEBIAN_OS_NAME}" | grep -q "${OS}"; then
-    OS=$(sort -r /etc/*-release | gawk 'match($0, /^(ID_LIKE=(.*))$/, a) { print toupper(a[2] a[3]); exit }')
+  OS=$(sort -r /etc/*-release | gawk 'match($0, /^(ID_LIKE=(.*))$/, a) { print toupper(a[2] a[3]); exit }')
 fi
 KUBECTL=/usr/local/bin/kubectl
 DOCKER=/usr/bin/docker
@@ -40559,154 +40559,175 @@ DOCKER_VERSION=1.13.1-1
 NVIDIA_CONTAINER_RUNTIME_VERSION=2.0.0
 
 configure_prerequisites() {
-    ip_forward_path=/proc/sys/net/ipv4/ip_forward
-    ip_forward_setting="net.ipv4.ip_forward=0"
-    sysctl_conf=/etc/sysctl.conf
-    if ! grep -qE "^1$" ${ip_forward_path}; then
-        echo 1 > ${ip_forward_path}
-    fi
-    if grep -qE "${ip_forward_setting}" ${sysctl_conf}; then
-        sed -i '/^net.ipv4.ip_forward=0$/d' ${sysctl_conf}
-    fi
+  ip_forward_path=/proc/sys/net/ipv4/ip_forward
+  ip_forward_setting="net.ipv4.ip_forward=0"
+  sysctl_conf=/etc/sysctl.conf
+  if ! grep -qE "^1$" ${ip_forward_path}; then
+    echo 1 >${ip_forward_path}
+  fi
+  if grep -qE "${ip_forward_setting}" ${sysctl_conf}; then
+    sed -i '/^net.ipv4.ip_forward=0$/d' ${sysctl_conf}
+  fi
 }
 
 aptmarkWALinuxAgent() {
-    wait_for_apt_locks
-    retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent || \
-    if [[ "$1" == "hold" ]]; then
-        exit 7
-    elif [[ "$1" == "unhold" ]]; then
-        exit 8
+  wait_for_apt_locks
+  retrycmd_if_failure 120 5 25 apt-mark $1 walinuxagent ||
+    if [[ $1 == "hold" ]]; then
+      exit 7
+    elif [[ $1 == "unhold" ]]; then
+      exit 8
     fi
 }
 
 retrycmd_if_failure() {
-    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
-    for i in $(seq 1 $retries); do
-        timeout $timeout ${@} && break || \
-        if [ $i -eq $retries ]; then
-            echo Executed \"$@\" $i times;
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
-    echo Executed \"$@\" $i times;
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  shift && shift && shift
+  for i in $(seq 1 $retries); do
+    timeout $timeout ${@} && break ||
+      if [ $i -eq $retries ]; then
+        echo Executed \"$@\" $i times
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
+  echo Executed \"$@\" $i times
 }
 retrycmd_if_failure_no_stats() {
-    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
-    for i in $(seq 1 $retries); do
-        timeout $timeout ${@} && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  shift && shift && shift
+  for i in $(seq 1 $retries); do
+    timeout $timeout ${@} && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 retrycmd_get_tarball() {
-    tar_retries=$1; wait_sleep=$2; tarball=$3; url=$4
-    echo "${tar_retries} retries"
-    for i in $(seq 1 $tar_retries); do
-        tar -tzf $tarball && break || \
-        if [ $i -eq $tar_retries ]; then
-            return 1
-        else
-            timeout 60 curl -fsSL $url -o $tarball
-            sleep $wait_sleep
-        fi
-    done
+  tar_retries=$1
+  wait_sleep=$2
+  tarball=$3
+  url=$4
+  echo "${tar_retries} retries"
+  for i in $(seq 1 $tar_retries); do
+    tar -tzf $tarball && break ||
+      if [ $i -eq $tar_retries ]; then
+        return 1
+      else
+        timeout 60 curl -fsSL $url -o $tarball
+        sleep $wait_sleep
+      fi
+  done
 }
 retrycmd_get_executable() {
-    retries=$1; wait_sleep=$2; filepath=$3; url=$4; validation_args=$5
-    echo "${retries} retries"
-    for i in $(seq 1 $retries); do
-        $filepath $validation_args && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            timeout 30 curl -fsSL $url -o $filepath
-            chmod +x $filepath
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  filepath=$3
+  url=$4
+  validation_args=$5
+  echo "${retries} retries"
+  for i in $(seq 1 $retries); do
+    $filepath $validation_args && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        timeout 30 curl -fsSL $url -o $filepath
+        chmod +x $filepath
+        sleep $wait_sleep
+      fi
+  done
 }
 wait_for_file() {
-    retries=$1; wait_sleep=$2; filepath=$3
-    paved=/opt/azure/cloud-init-files.paved
-    grep -Fq "${filepath}" $paved && return 0
-    for i in $(seq 1 $retries); do
-        grep -Fq '#EOF' $filepath && break
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
-    sed -i "/#EOF/d" $filepath
-    echo $filepath >> $paved
+  retries=$1
+  wait_sleep=$2
+  filepath=$3
+  paved=/opt/azure/cloud-init-files.paved
+  grep -Fq "${filepath}" $paved && return 0
+  for i in $(seq 1 $retries); do
+    grep -Fq '#EOF' $filepath && break
+    if [ $i -eq $retries ]; then
+      return 1
+    else
+      sleep $wait_sleep
+    fi
+  done
+  sed -i "/#EOF/d" $filepath
+  echo $filepath >>$paved
 }
 wait_for_apt_locks() {
-    while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
-        echo 'Waiting for release of apt locks'
-        sleep 3
-    done
+  while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+    echo 'Waiting for release of apt locks'
+    sleep 3
+  done
 }
 apt_get_update() {
-    retries=10
-    apt_update_output=/tmp/apt-get-update.out
-    for i in $(seq 1 $retries); do
-        wait_for_apt_locks
-        export DEBIAN_FRONTEND=noninteractive
-        dpkg --configure -a --force-confdef
-        apt-get -f -y install
-        ! (apt-get update 2>&1 | tee $apt_update_output | grep -E "^([WE]:.*)|([eE]rr.*)$") && \
-        cat $apt_update_output && break || \
-        cat $apt_update_output
-        if [ $i -eq $retries ]; then
-            return 1
-        else sleep 5
-        fi
-    done
-    echo Executed apt-get update $i times
+  retries=10
+  apt_update_output=/tmp/apt-get-update.out
+  for i in $(seq 1 $retries); do
     wait_for_apt_locks
+    export DEBIAN_FRONTEND=noninteractive
+    dpkg --configure -a --force-confdef
+    apt-get -f -y install
+    ! (apt-get update 2>&1 | tee $apt_update_output | grep -E "^([WE]:.*)|([eE]rr.*)$") &&
+      cat $apt_update_output && break ||
+      cat $apt_update_output
+    if [ $i -eq $retries ]; then
+      return 1
+    else
+      sleep 5
+    fi
+  done
+  echo Executed apt-get update $i times
+  wait_for_apt_locks
 }
 apt_get_install() {
-    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
-    for i in $(seq 1 $retries); do
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  shift && shift && shift
+  for i in $(seq 1 $retries); do
+    wait_for_apt_locks
+    export DEBIAN_FRONTEND=noninteractive
+    dpkg --configure -a --force-confdef
+    apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y ${@} && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+        apt_get_update
+      fi
+  done
+  echo Executed apt-get install --no-install-recommends -y \"$@\" $i times
+  wait_for_apt_locks
+}
+apt_get_purge() {
+  retries=20
+  wait_sleep=30
+  timeout=120
+  for package in $@; do
+    if apt list --installed | grep $package; then
+      for i in $(seq 1 $retries); do
         wait_for_apt_locks
         export DEBIAN_FRONTEND=noninteractive
         dpkg --configure -a --force-confdef
-        apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y ${@} && break || \
-        if [ $i -eq $retries ]; then
+        apt-get purge -o Dpkg::Options::="--force-confold" -y $package && break ||
+          if [ $i -eq $retries ]; then
             return 1
-        else
+          else
             sleep $wait_sleep
-            apt_get_update
-        fi
-    done
-    echo Executed apt-get install --no-install-recommends -y \"$@\" $i times;
-    wait_for_apt_locks
-}
-apt_get_purge() {
-    retries=20; wait_sleep=30; timeout=120
-    for package in $@; do
-        if apt list --installed | grep $package; then
-            for i in $(seq 1 $retries); do
-                wait_for_apt_locks
-                export DEBIAN_FRONTEND=noninteractive
-                dpkg --configure -a --force-confdef
-                apt-get purge -o Dpkg::Options::="--force-confold" -y $package && break || \
-                if [ $i -eq $retries ]; then
-                    return 1
-                else
-                    sleep $wait_sleep
-                fi
-            done
-        fi
-    done
-    echo Executed apt-get purge -y \"$package\" $i times;
-    wait_for_apt_locks
+          fi
+      done
+    fi
+  done
+  echo Executed apt-get purge -y \"$package\" $i times
+  wait_for_apt_locks
 }
 apt_get_dist_upgrade() {
   retries=10
@@ -40717,51 +40738,58 @@ apt_get_dist_upgrade() {
     dpkg --configure -a --force-confdef
     apt-get -f -y install
     apt-mark showhold
-    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") && \
-    cat $apt_dist_upgrade_output && break || \
-    cat $apt_dist_upgrade_output
+    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") &&
+      cat $apt_dist_upgrade_output && break ||
+      cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then
       return 1
-    else sleep 5
+    else
+      sleep 5
     fi
   done
   echo Executed apt-get dist-upgrade $i times
   wait_for_apt_locks
 }
 systemctl_restart() {
-    retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
-    for i in $(seq 1 $retries); do
-        timeout $timeout systemctl daemon-reload
-        timeout $timeout systemctl restart $svcname && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3 svcname=$4
+  for i in $(seq 1 $retries); do
+    timeout $timeout systemctl daemon-reload
+    timeout $timeout systemctl restart $svcname && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 systemctl_stop() {
-    retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
-    for i in $(seq 1 $retries); do
-        timeout $timeout systemctl daemon-reload
-        timeout $timeout systemctl stop $svcname && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3 svcname=$4
+  for i in $(seq 1 $retries); do
+    timeout $timeout systemctl daemon-reload
+    timeout $timeout systemctl stop $svcname && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 sysctl_reload() {
-    retries=$1; wait_sleep=$2; timeout=$3
-    for i in $(seq 1 $retries); do
-        timeout $timeout sysctl --system && break || \
-        if [ $i -eq $retries ]; then
-            return 1
-        else
-            sleep $wait_sleep
-        fi
-    done
+  retries=$1
+  wait_sleep=$2
+  timeout=$3
+  for i in $(seq 1 $retries); do
+    timeout $timeout sysctl --system && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
 }
 version_gte() {
   test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1"
@@ -40800,206 +40828,206 @@ UBUNTU_RELEASE=$(lsb_release -r -s)
 UBUNTU_CODENAME=$(lsb_release -c -s)
 
 disableTimeSyncd() {
-    systemctl_stop 20 5 10 systemd-timesyncd || exit 3
-    retrycmd_if_failure 120 5 25 systemctl disable systemd-timesyncd || exit 3
+  systemctl_stop 20 5 10 systemd-timesyncd || exit 3
+  retrycmd_if_failure 120 5 25 systemctl disable systemd-timesyncd || exit 3
 }
 installEtcd() {
-    CURRENT_VERSION=$(etcd --version | grep "etcd Version" | cut -d ":" -f 2 | tr -d '[:space:]')
-    if [[ "$CURRENT_VERSION" != "${ETCD_VERSION}" ]]; then
-        CLI_TOOL=$1
-        local path="/usr/bin"
-        CONTAINER_IMAGE=${ETCD_DOWNLOAD_URL}etcd:v${ETCD_VERSION}
-        pullContainerImage $CLI_TOOL ${CONTAINER_IMAGE}
-        removeEtcd
-        if [[ "$CLI_TOOL" == "docker" ]]; then
-            mkdir -p "$path"
-            docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcd > "$path/etcd"
-            docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcdctl > "$path/etcdctl"
-        else
-            tmpdir=/root/etcd${RANDOM}
-            img unpack -o ${tmpdir} ${CONTAINER_IMAGE}
-            mv ${tmpdir}/usr/local/bin/etcd ${tmpdir}/usr/local/bin/etcdctl ${path}
-            rm -rf ${tmpdir}
-        fi
-        chmod a+x "$path/etcd" "$path/etcdctl"
+  CURRENT_VERSION=$(etcd --version | grep "etcd Version" | cut -d ":" -f 2 | tr -d '[:space:]')
+  if [[ $CURRENT_VERSION != "${ETCD_VERSION}" ]]; then
+    CLI_TOOL=$1
+    local path="/usr/bin"
+    CONTAINER_IMAGE=${ETCD_DOWNLOAD_URL}etcd:v${ETCD_VERSION}
+    pullContainerImage $CLI_TOOL ${CONTAINER_IMAGE}
+    removeEtcd
+    if [[ $CLI_TOOL == "docker" ]]; then
+      mkdir -p "$path"
+      docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcd >"$path/etcd"
+      docker run --rm --entrypoint cat ${CONTAINER_IMAGE} /usr/local/bin/etcdctl >"$path/etcdctl"
+    else
+      tmpdir=/root/etcd${RANDOM}
+      img unpack -o ${tmpdir} ${CONTAINER_IMAGE}
+      mv ${tmpdir}/usr/local/bin/etcd ${tmpdir}/usr/local/bin/etcdctl ${path}
+      rm -rf ${tmpdir}
     fi
+    chmod a+x "$path/etcd" "$path/etcdctl"
+  fi
 }
 installDeps() {
-    packages="apache2-utils apt-transport-https blobfuse ca-certificates cifs-utils conntrack cracklib-runtime dbus ebtables ethtool fuse git htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip"
-    if [[ "${OS}" == "${UBUNTU_OS_NAME}" ]]; then
-        retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb > /tmp/packages-microsoft-prod.deb || exit 42
-        retrycmd_if_failure 60 5 10 dpkg -i /tmp/packages-microsoft-prod.deb || exit 43
-        aptmarkWALinuxAgent hold
-        packages+=" cgroup-lite ceph-common glusterfs-client"
-        if [[ $UBUNTU_RELEASE == "18.04" ]]; then
-            disableTimeSyncd
-            packages+=" ntp ntpstat"
-        fi
-    elif [[ $OS == $DEBIAN_OS_NAME ]]; then
-        packages+=" gpg cgroup-bin"
+  packages="apache2-utils apt-transport-https blobfuse ca-certificates cifs-utils conntrack cracklib-runtime dbus ebtables ethtool fuse git htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysstat traceroute util-linux xz-utils zip"
+  if [[ ${OS} == "${UBUNTU_OS_NAME}" ]]; then
+    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb >/tmp/packages-microsoft-prod.deb || exit 42
+    retrycmd_if_failure 60 5 10 dpkg -i /tmp/packages-microsoft-prod.deb || exit 43
+    aptmarkWALinuxAgent hold
+    packages+=" cgroup-lite ceph-common glusterfs-client"
+    if [[ $UBUNTU_RELEASE == "18.04" ]]; then
+      disableTimeSyncd
+      packages+=" ntp ntpstat"
     fi
+  elif [[ $OS == $DEBIAN_OS_NAME ]]; then
+    packages+=" gpg cgroup-bin"
+  fi
 
-    apt_get_update || exit 99
-    apt_get_dist_upgrade || exit 101
+  apt_get_update || exit 99
+  apt_get_dist_upgrade || exit 101
 
-    for apt_package in ${packages}; do
-      if ! apt_get_install 30 1 600 $apt_package; then
-        journalctl --no-pager -u $apt_package
-        exit 9
-      fi
-    done
-    if [[ "${AUDITD_ENABLED}" == true ]]; then
-      if ! apt_get_install 30 1 600 auditd; then
-        journalctl --no-pager -u auditd
-        exit 9
-      fi
+  for apt_package in ${packages}; do
+    if ! apt_get_install 30 1 600 $apt_package; then
+      journalctl --no-pager -u $apt_package
+      exit 9
     fi
+  done
+  if [[ ${AUDITD_ENABLED} == true ]]; then
+    if ! apt_get_install 30 1 600 auditd; then
+      journalctl --no-pager -u auditd
+      exit 9
+    fi
+  fi
 }
 installGPUDrivers() {
-    mkdir -p $GPU_DEST/tmp
-    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey > $GPU_DEST/tmp/aptnvidia.gpg || exit 85
-    wait_for_apt_locks
-    retrycmd_if_failure 120 5 25 apt-key add $GPU_DEST/tmp/aptnvidia.gpg || exit 85
-    wait_for_apt_locks
-    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/ubuntu${UBUNTU_RELEASE}/nvidia-docker.list > $GPU_DEST/tmp/nvidia-docker.list || exit  85
-    wait_for_apt_locks
-    retrycmd_if_failure_no_stats 120 5 25 cat $GPU_DEST/tmp/nvidia-docker.list > /etc/apt/sources.list.d/nvidia-docker.list || exit  85
-    apt_get_update
-    retrycmd_if_failure 30 5 3600 apt-get install -y linux-headers-$(uname -r) gcc make dkms || exit 85
-    retrycmd_if_failure 30 5 60 curl -fLS https://us.download.nvidia.com/tesla/$GPU_DV/NVIDIA-Linux-x86_64-${GPU_DV}.run -o ${GPU_DEST}/nvidia-drivers-${GPU_DV} || exit 85
-    tmpDir=$GPU_DEST/tmp
-    if ! (
-      set -e -o pipefail
-      cd "${tmpDir}"
-      retrycmd_if_failure 30 5 3600 apt-get download nvidia-docker2="${NVIDIA_DOCKER_VERSION}+docker18.09.2-1" || exit 85
-    ); then
-      exit 85
-    fi
+  mkdir -p $GPU_DEST/tmp
+  retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey >$GPU_DEST/tmp/aptnvidia.gpg || exit 85
+  wait_for_apt_locks
+  retrycmd_if_failure 120 5 25 apt-key add $GPU_DEST/tmp/aptnvidia.gpg || exit 85
+  wait_for_apt_locks
+  retrycmd_if_failure_no_stats 120 5 25 curl -fsSL https://nvidia.github.io/nvidia-docker/ubuntu${UBUNTU_RELEASE}/nvidia-docker.list >$GPU_DEST/tmp/nvidia-docker.list || exit 85
+  wait_for_apt_locks
+  retrycmd_if_failure_no_stats 120 5 25 cat $GPU_DEST/tmp/nvidia-docker.list >/etc/apt/sources.list.d/nvidia-docker.list || exit 85
+  apt_get_update
+  retrycmd_if_failure 30 5 3600 apt-get install -y linux-headers-$(uname -r) gcc make dkms || exit 85
+  retrycmd_if_failure 30 5 60 curl -fLS https://us.download.nvidia.com/tesla/$GPU_DV/NVIDIA-Linux-x86_64-${GPU_DV}.run -o ${GPU_DEST}/nvidia-drivers-${GPU_DV} || exit 85
+  tmpDir=$GPU_DEST/tmp
+  if ! (
+    set -e -o pipefail
+    cd "${tmpDir}"
+    retrycmd_if_failure 30 5 3600 apt-get download nvidia-docker2="${NVIDIA_DOCKER_VERSION}+docker18.09.2-1" || exit 85
+  ); then
+    exit 85
+  fi
 }
 installMoby() {
-    removeContainerd
-    CURRENT_VERSION=$(dockerd --version | grep "Docker version" | cut -d "," -f 1 | cut -d " " -f 3 | cut -d "+" -f 1)
-    if [[ "$CURRENT_VERSION" != "${MOBY_VERSION}" ]]; then
-        removeMoby
-        retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list > /tmp/microsoft-prod.list || exit 25
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
-        retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg || exit 26
-        retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
-        apt_get_update || exit 99
-        MOBY_CLI=${MOBY_VERSION}
-        if [[ "${MOBY_CLI}" == "3.0.4" ]]; then
-            MOBY_CLI="3.0.3"
-        fi
-        apt_get_install 20 30 120 moby-engine=${MOBY_VERSION}* moby-cli=${MOBY_CLI}* --allow-downgrades || exit 27
+  removeContainerd
+  CURRENT_VERSION=$(dockerd --version | grep "Docker version" | cut -d "," -f 1 | cut -d " " -f 3 | cut -d "+" -f 1)
+  if [[ $CURRENT_VERSION != "${MOBY_VERSION}" ]]; then
+    removeMoby
+    retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
+    retrycmd_if_failure_no_stats 120 5 25 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >/tmp/microsoft.gpg || exit 26
+    retrycmd_if_failure 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
+    apt_get_update || exit 99
+    MOBY_CLI=${MOBY_VERSION}
+    if [[ ${MOBY_CLI} == "3.0.4" ]]; then
+      MOBY_CLI="3.0.3"
     fi
+    apt_get_install 20 30 120 moby-engine=${MOBY_VERSION}* moby-cli=${MOBY_CLI}* --allow-downgrades || exit 27
+  fi
 }
 installBcc() {
-    IOVISOR_KEY_TMP=/tmp/iovisor-release.key
-    IOVISOR_URL=https://repo.iovisor.org/GPG-KEY
-    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL $IOVISOR_URL > $IOVISOR_KEY_TMP || exit 166
-    wait_for_apt_locks
-    retrycmd_if_failure 30 5 30 apt-key add $IOVISOR_KEY_TMP || exit 167
-    echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/iovisor.list
-    apt_get_update || exit 99
-    apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit 168
+  IOVISOR_KEY_TMP=/tmp/iovisor-release.key
+  IOVISOR_URL=https://repo.iovisor.org/GPG-KEY
+  retrycmd_if_failure_no_stats 120 5 25 curl -fsSL $IOVISOR_URL >$IOVISOR_KEY_TMP || exit 166
+  wait_for_apt_locks
+  retrycmd_if_failure 30 5 30 apt-key add $IOVISOR_KEY_TMP || exit 167
+  echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" >/etc/apt/sources.list.d/iovisor.list
+  apt_get_update || exit 99
+  apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit 168
 }
 downloadCNI() {
-    mkdir -p $CNI_DOWNLOADS_DIR
-    CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
-    retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${CNI_PLUGINS_URL} || exit 41
+  mkdir -p $CNI_DOWNLOADS_DIR
+  CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
+  retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${CNI_PLUGINS_URL} || exit 41
 }
 downloadAzureCNI() {
-    mkdir -p $CNI_DOWNLOADS_DIR
-    CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
-    retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${VNET_CNI_PLUGINS_URL} || exit 41
+  mkdir -p $CNI_DOWNLOADS_DIR
+  CNI_TGZ_TMP=${VNET_CNI_PLUGINS_URL##*/}
+  retrycmd_get_tarball 120 5 "$CNI_DOWNLOADS_DIR/${CNI_TGZ_TMP}" ${VNET_CNI_PLUGINS_URL} || exit 41
 }
 ensureAPMZ() {
-    local version=$1
-    local apmz_url="https://upstreamartifacts.azureedge.net/apmz/$version/binaries/apmz_linux_amd64.tar.gz" apmz_filepath="/usr/local/bin/apmz"
-    if [[ -f "$apmz_filepath" ]]; then
-        installed_version=$($apmz_filepath version)
-        if [[ "$version" == "$installed_version" ]]; then
-            return
-        fi
+  local version=$1
+  local apmz_url="https://upstreamartifacts.azureedge.net/apmz/$version/binaries/apmz_linux_amd64.tar.gz" apmz_filepath="/usr/local/bin/apmz"
+  if [[ -f $apmz_filepath ]]; then
+    installed_version=$($apmz_filepath version)
+    if [[ $version == "$installed_version" ]]; then
+      return
     fi
-    install_dir="$APMZ_DOWNLOADS_DIR/$version"
-    download_path="$install_dir/apmz.gz"
-    mkdir -p "$install_dir"
-    retrycmd_get_tarball 120 5 "$download_path" "${apmz_url}"
-    tar -xvf "$download_path" -C "$install_dir"
-    bin_path="$install_dir/apmz_linux_amd64"
-    chmod +x "$bin_path"
-    ln -Ffs "$bin_path" "$apmz_filepath"
+  fi
+  install_dir="$APMZ_DOWNLOADS_DIR/$version"
+  download_path="$install_dir/apmz.gz"
+  mkdir -p "$install_dir"
+  retrycmd_get_tarball 120 5 "$download_path" "${apmz_url}"
+  tar -xvf "$download_path" -C "$install_dir"
+  bin_path="$install_dir/apmz_linux_amd64"
+  chmod +x "$bin_path"
+  ln -Ffs "$bin_path" "$apmz_filepath"
 }
 installBpftrace() {
-    local version="v0.9.4"
-    local bpftrace_bin="bpftrace"
-    local bpftrace_tools="bpftrace-tools.tar"
-    local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
-    local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
-    local tools_filepath="/usr/local/share/$bpftrace_bin"
-    if [[ -f "$bpftrace_filepath" ]]; then
-        installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
-        if [[ "$version" == "$installed_version" ]]; then
-            return
-        fi
-        rm "$bpftrace_filepath"
-        if [[ -d "$tools_filepath" ]]; then
-            rm -r  "$tools_filepath"
-        fi
+  local version="v0.9.4"
+  local bpftrace_bin="bpftrace"
+  local bpftrace_tools="bpftrace-tools.tar"
+  local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
+  local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
+  local tools_filepath="/usr/local/share/$bpftrace_bin"
+  if [[ -f $bpftrace_filepath ]]; then
+    installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
+    if [[ $version == "$installed_version" ]]; then
+      return
     fi
-    mkdir -p "$tools_filepath"
-    install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
-    mkdir -p "$install_dir"
-    download_path="$install_dir/$bpftrace_tools"
-    retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit 169
-    retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit 170
-    tar -xvf "$download_path" -C "$tools_filepath"
-    chmod +x "$bpftrace_filepath"
-    chmod -R +x "$tools_filepath/tools"
+    rm "$bpftrace_filepath"
+    if [[ -d $tools_filepath ]]; then
+      rm -r "$tools_filepath"
+    fi
+  fi
+  mkdir -p "$tools_filepath"
+  install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
+  mkdir -p "$install_dir"
+  download_path="$install_dir/$bpftrace_tools"
+  retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit 169
+  retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit 170
+  tar -xvf "$download_path" -C "$tools_filepath"
+  chmod +x "$bpftrace_filepath"
+  chmod -R +x "$tools_filepath/tools"
 }
 installImg() {
-    img_filepath=/usr/local/bin/img
-    retrycmd_get_executable 120 5 $img_filepath "https://upstreamartifacts.azureedge.net/img/img-linux-amd64-v0.5.6" ls || exit 33
+  img_filepath=/usr/local/bin/img
+  retrycmd_get_executable 120 5 $img_filepath "https://upstreamartifacts.azureedge.net/img/img-linux-amd64-v0.5.6" ls || exit 33
 }
 extractHyperkube() {
-    CLI_TOOL=$1
-    path="/home/hyperkube-downloads/${KUBERNETES_VERSION}"
-    pullContainerImage $CLI_TOOL ${HYPERKUBE_URL}
-    if [[ "$CLI_TOOL" == "docker" ]]; then
-        mkdir -p "$path"
-        if docker run --rm --entrypoint "" -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /usr/local/bin/{kubelet,kubectl} $path"; then
-            mv "$path/kubelet" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
-            mv "$path/kubectl" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
-            return
-        else
-            docker run --rm -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /hyperkube $path"
-        fi
+  CLI_TOOL=$1
+  path="/home/hyperkube-downloads/${KUBERNETES_VERSION}"
+  pullContainerImage $CLI_TOOL ${HYPERKUBE_URL}
+  if [[ $CLI_TOOL == "docker" ]]; then
+    mkdir -p "$path"
+    if docker run --rm --entrypoint "" -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /usr/local/bin/{kubelet,kubectl} $path"; then
+      mv "$path/kubelet" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
+      mv "$path/kubectl" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
+      return
     else
-        img unpack -o "$path" ${HYPERKUBE_URL}
+      docker run --rm -v $path:$path ${HYPERKUBE_URL} /bin/bash -c "cp /hyperkube $path"
     fi
+  else
+    img unpack -o "$path" ${HYPERKUBE_URL}
+  fi
 
-    cp "$path/hyperkube" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
-    mv "$path/hyperkube" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
+  cp "$path/hyperkube" "/usr/local/bin/kubelet-${KUBERNETES_VERSION}"
+  mv "$path/hyperkube" "/usr/local/bin/kubectl-${KUBERNETES_VERSION}"
 }
 extractKubeBinaries() {
-    KUBE_BINARY_URL=${KUBE_BINARY_URL:-"https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"}
-    K8S_TGZ_TMP=${KUBE_BINARY_URL##*/}
-    mkdir -p "${K8S_DOWNLOADS_DIR}"
-    retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${KUBE_BINARY_URL} || exit 31
-    tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
-        --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
-    rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
+  KUBE_BINARY_URL=${KUBE_BINARY_URL:-"https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-node-linux-amd64.tar.gz"}
+  K8S_TGZ_TMP=${KUBE_BINARY_URL##*/}
+  mkdir -p "${K8S_DOWNLOADS_DIR}"
+  retrycmd_get_tarball 120 5 "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" ${KUBE_BINARY_URL} || exit 31
+  tar --transform="s|.*|&-${KUBERNETES_VERSION}|" --show-transformed-names -xzvf "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}" \
+    --strip-components=3 -C /usr/local/bin kubernetes/node/bin/kubelet kubernetes/node/bin/kubectl
+  rm -f "$K8S_DOWNLOADS_DIR/${K8S_TGZ_TMP}"
 }
 pullContainerImage() {
-    CLI_TOOL=$1
-    DOCKER_IMAGE_URL=$2
-    retrycmd_if_failure 60 1 1200 $CLI_TOOL pull $DOCKER_IMAGE_URL || exit 35
+  CLI_TOOL=$1
+  DOCKER_IMAGE_URL=$2
+  retrycmd_if_failure 60 1 1200 $CLI_TOOL pull $DOCKER_IMAGE_URL || exit 35
 }
 overrideNetworkConfig() {
-    CONFIG_FILEPATH="/etc/cloud/cloud.cfg.d/80_azure_net_config.cfg"
-    touch ${CONFIG_FILEPATH}
-    cat << EOF >> ${CONFIG_FILEPATH}
+  CONFIG_FILEPATH="/etc/cloud/cloud.cfg.d/80_azure_net_config.cfg"
+  touch ${CONFIG_FILEPATH}
+  cat <<EOF >>${CONFIG_FILEPATH}
 datasource:
     Azure:
         apply_network_config: false
@@ -41028,21 +41056,21 @@ ERR_FILE_WATCH_TIMEOUT=6 {{/* Timeout waiting for a file */}}
 
 set -x
 if [ -f /opt/azure/containers/provision.complete ]; then
-    echo "Already ran to success exiting..."
-    exit 0
+  echo "Already ran to success exiting..."
+  exit 0
 fi
 
-echo $(date),$(hostname), startcustomscript>>/opt/m
+echo $(date),$(hostname), startcustomscript >>/opt/m
 
 for i in $(seq 1 3600); do
-    if [ -s {{GetCSEHelpersScriptFilepath}} ]; then
-        grep -Fq '#HELPERSEOF' {{GetCSEHelpersScriptFilepath}} && break
-    fi
-    if [ $i -eq 3600 ]; then
-        exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-    else
-        sleep 1
-    fi
+  if [ -s {{GetCSEHelpersScriptFilepath}} ]; then
+    grep -Fq '#HELPERSEOF' {{GetCSEHelpersScriptFilepath}} && break
+  fi
+  if [ $i -eq 3600 ]; then
+    exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  else
+    sleep 1
+  fi
 done
 sed -i "/#HELPERSEOF/d" {{GetCSEHelpersScriptFilepath}}
 source {{GetCSEHelpersScriptFilepath}}
@@ -41067,79 +41095,79 @@ source {{GetCustomCloudConfigCSEScriptFilepath }}
 {{end}}
 
 set +x
-ETCD_PEER_CERT=$(echo ${ETCD_PEER_CERTIFICATES} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((${NODE_INDEX}+1)))
-ETCD_PEER_KEY=$(echo ${ETCD_PEER_PRIVATE_KEYS} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((${NODE_INDEX}+1)))
+ETCD_PEER_CERT=$(echo ${ETCD_PEER_CERTIFICATES} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))
+ETCD_PEER_KEY=$(echo ${ETCD_PEER_PRIVATE_KEYS} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))
 set -x
 
 if [ -f /var/run/reboot-required ]; then
-    REBOOTREQUIRED=true
-    trace_info "RebootRequired" "reboot=true"
+  REBOOTREQUIRED=true
+  trace_info "RebootRequired" "reboot=true"
 else
-    REBOOTREQUIRED=false
+  REBOOTREQUIRED=false
 fi
 
 time_metric "ConfigureAdminUser" configureAdminUser
 
 {{- if HasVHDDistroNodes}}
-    {{- if not NeedsContainerd}}
+{{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd
-    {{end}}
-    {{- if HasNSeriesSKU}}
-if [[ "${GPU_NODE}" != "true" ]]; then
-    time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
+{{end}}
+{{- if HasNSeriesSKU}}
+if [[ ${GPU_NODE} != "true" ]]; then
+  time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
 fi
-    {{else}}
+{{else}}
 time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
-    {{end}}
+{{end}}
 {{end}}
 
 {{- if HasVHDDistroNodes}}
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
 if [ -f $VHD_LOGS_FILEPATH ]; then
-    echo "detected golden image pre-install"
-    time_metric "CleanUpContainerImages" cleanUpContainerImages
-    FULL_INSTALL_REQUIRED=false
+  echo "detected golden image pre-install"
+  time_metric "CleanUpContainerImages" cleanUpContainerImages
+  FULL_INSTALL_REQUIRED=false
 else
-    if [[ "${IS_VHD}" = true ]]; then
-        echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
-        exit {{GetCSEErrorCode "ERR_VHD_FILE_NOT_FOUND"}}
-    fi
-    FULL_INSTALL_REQUIRED=true
+  if [[ ${IS_VHD} == true ]]; then
+    echo "Using VHD distro but file $VHD_LOGS_FILEPATH not found"
+    exit {{GetCSEErrorCode "ERR_VHD_FILE_NOT_FOUND"}}
+  fi
+  FULL_INSTALL_REQUIRED=true
 fi
 {{else}}
 FULL_INSTALL_REQUIRED=true
 {{end}}
 
 {{- if not IsVHDDistroForAllNodes}}
-if [[ ( $OS == $UBUNTU_OS_NAME || $OS == $DEBIAN_OS_NAME ) ]] && [ "$FULL_INSTALL_REQUIRED" = "true" ]; then
-    time_metric "InstallDeps" installDeps
-    if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-        overrideNetworkConfig
-    fi
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        time_metric "InstallBcc" installBcc
-    fi
-    {{- if not IsDockerContainerRuntime}}
-    time_metric "InstallImg" installImg
-    {{end}}
+if [[ $OS == $UBUNTU_OS_NAME || $OS == $DEBIAN_OS_NAME ]] && [ "$FULL_INSTALL_REQUIRED" = "true" ]; then
+  time_metric "InstallDeps" installDeps
+  if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
+    overrideNetworkConfig
+  fi
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    time_metric "InstallBcc" installBcc
+  fi
+  {{- if not IsDockerContainerRuntime}}
+  time_metric "InstallImg" installImg
+  {{end}}
 else
-    echo "Golden image; skipping dependencies installation"
+  echo "Golden image; skipping dependencies installation"
 fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-    if apt list --installed | grep 'ntp'; then
-        time_metric "EnsureNTP" ensureNTP
-    fi
+  if apt list --installed | grep 'ntp'; then
+    time_metric "EnsureNTP" ensureNTP
+  fi
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    time_metric "EnsureAuditD" ensureAuditD
+  time_metric "EnsureAuditD" ensureAuditD
 fi
 
 {{- if not IsVHDDistroForAllNodes}}
-if [[ "$FULL_INSTALL_REQUIRED" = "true" ]]; then
-    time_metric "InstallBpftrace" installBpftrace
+if [[ $FULL_INSTALL_REQUIRED == "true" ]]; then
+  time_metric "InstallBpftrace" installBpftrace
 fi
 {{end}}
 
@@ -41149,24 +41177,24 @@ time_metric "InstallContainerd" installContainerd
 time_metric "installMoby" installMoby
 {{end}}
 
-if [[ -n "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
-    {{- if IsDockerContainerRuntime}}
-    CLI_TOOL="docker"
-    {{else}}
-    CLI_TOOL="img"
-    {{end}}
-    time_metric "InstallEtcd" installEtcd $CLI_TOOL
+if [[ -n ${MASTER_NODE} ]] && [[ -z ${COSMOS_URI} ]]; then
+  {{- if IsDockerContainerRuntime}}
+  CLI_TOOL="docker"
+  {{else}}
+  CLI_TOOL="img"
+  {{end}}
+  time_metric "InstallEtcd" installEtcd $CLI_TOOL
 fi
 
 {{/* this will capture the amount of time to install of the network plugin during cse */}}
 time_metric "InstallNetworkPlugin" installNetworkPlugin
 
 {{- if HasNSeriesSKU}}
-if [[ "${GPU_NODE}" = true ]]; then
-    if $FULL_INSTALL_REQUIRED; then
-        time_metric "InstallGPUDrivers" installGPUDrivers
-    fi
-    time_metric "EnsureGPUDrivers" ensureGPUDrivers
+if [[ ${GPU_NODE} == true ]]; then
+  if $FULL_INSTALL_REQUIRED; then
+    time_metric "InstallGPUDrivers" installGPUDrivers
+  fi
+  time_metric "EnsureGPUDrivers" ensureGPUDrivers
 fi
 {{end}}
 
@@ -41179,32 +41207,32 @@ time_metric "EnsureRPC" ensureRPC
 time_metric "CreateKubeManifestDir" createKubeManifestDir
 
 {{- if HasDCSeriesSKU}}
-if [[ "${SGX_NODE}" = true ]]; then
-    time_metric "InstallSGXDrivers" installSGXDrivers
+if [[ ${SGX_NODE} == true ]]; then
+  time_metric "InstallSGXDrivers" installSGXDrivers
 fi
 {{end}}
 
 {{/* create etcd user if we are configured for etcd */}}
-if [[ -n "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
-    time_metric "ConfigureEtcdUser" configureEtcdUser
+if [[ -n ${MASTER_NODE} ]] && [[ -z ${COSMOS_URI} ]]; then
+  time_metric "ConfigureEtcdUser" configureEtcdUser
 fi
 
-if [[ -n "${MASTER_NODE}" ]]; then
-    {{/* this step configures all certs */}}
-    {{/* both configs etcd/cosmos */}}
-    time_metric "ConfigureSecrets" configureSecrets
+if [[ -n ${MASTER_NODE} ]]; then
+  {{/* this step configures all certs */}}
+  {{/* both configs etcd/cosmos */}}
+  time_metric "ConfigureSecrets" configureSecrets
 fi
 
 {{/* configure etcd if we are configured for etcd */}}
-if [[ -n "${MASTER_NODE}" ]] && [[ -z "${COSMOS_URI}" ]]; then
-    time_metric "ConfigureEtcd" configureEtcd
+if [[ -n ${MASTER_NODE} ]] && [[ -z ${COSMOS_URI} ]]; then
+  time_metric "ConfigureEtcd" configureEtcd
 else
-    time_metric "RemoveEtcd" removeEtcd
+  time_metric "RemoveEtcd" removeEtcd
 fi
 
 {{- if HasCustomSearchDomain}}
 wait_for_file 3600 1 {{GetCustomSearchDomainsCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-{{GetCustomSearchDomainsCSEScriptFilepath}} > /opt/azure/containers/setup-custom-search-domain.log 2>&1 || exit {{GetCSEErrorCode "ERR_CUSTOM_SEARCH_DOMAINS_FAIL"}}
+{{GetCustomSearchDomainsCSEScriptFilepath}} >/opt/azure/containers/setup-custom-search-domain.log 2>&1 || exit {{GetCSEErrorCode "ERR_CUSTOM_SEARCH_DOMAINS_FAIL"}}
 {{end}}
 
 {{- if IsDockerContainerRuntime}}
@@ -41215,16 +41243,16 @@ time_metric "ConfigureK8s" configureK8s
 
 {{- if IsAzureStackCloud}}
 time_metric "ConfigureK8sCustomCloud" configureK8sCustomCloud
-    {{- if IsAzureCNI}}
-    time_metric "ConfigureAzureStackInterfaces" configureAzureStackInterfaces
-    {{end}}
+{{- if IsAzureCNI}}
+time_metric "ConfigureAzureStackInterfaces" configureAzureStackInterfaces
+{{end}}
 {{end}}
 
 time_metric "ConfigureCNI" configureCNI
 
 {{if or IsClusterAutoscalerAddonEnabled IsACIConnectorAddonEnabled IsAzurePolicyAddonEnabled}}
-if [[ -n "${MASTER_NODE}" ]]; then
-    time_metric "ConfigAddons" configAddons
+if [[ -n ${MASTER_NODE} ]]; then
+  time_metric "ConfigAddons" configAddons
 fi
 {{end}}
 
@@ -41233,8 +41261,8 @@ time_metric "EnsureContainerd" ensureContainerd
 {{end}}
 
 {{- if EnableEncryptionWithExternalKms}}
-if [[ -n "${MASTER_NODE}" && "${KMS_PROVIDER_VAULT_NAME}" != "" ]]; then
-    time_metric "EnsureKMS" ensureKMS
+if [[ -n ${MASTER_NODE} && ${KMS_PROVIDER_VAULT_NAME} != "" ]]; then
+  time_metric "EnsureKMS" ensureKMS
 fi
 {{end}}
 
@@ -41246,35 +41274,35 @@ time_metric "EnsureDHCPv6" ensureDHCPv6
 time_metric "EnsureKubelet" ensureKubelet
 time_metric "EnsureJournal" ensureJournal
 
-if [[ -n "${MASTER_NODE}" ]]; then
-    if version_gte ${KUBERNETES_VERSION} 1.16; then
-        time_metric "EnsureLabelNodes" ensureLabelNodes
+if [[ -n ${MASTER_NODE} ]]; then
+  if version_gte ${KUBERNETES_VERSION} 1.16; then
+    time_metric "EnsureLabelNodes" ensureLabelNodes
+  fi
+  time_metric "WriteKubeConfig" writeKubeConfig
+  if [[ -z ${COSMOS_URI} ]]; then
+    if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
+      time_metric "EnsureEtcd" ensureEtcd
     fi
-    time_metric "WriteKubeConfig" writeKubeConfig
-    if [[ -z "${COSMOS_URI}" ]]; then
-        if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
-            time_metric "EnsureEtcd" ensureEtcd
-        fi
-    fi
-    time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
-    {{if IsAzurePolicyAddonEnabled}}
-    time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
-    {{end}}
+  fi
+  time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
+  {{if IsAzurePolicyAddonEnabled}}
+  time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
+  {{end}}
 fi
 
 {{- if not IsVHDDistroForAllNodes}}
 if $FULL_INSTALL_REQUIRED; then
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        {{/* mitigation for bug https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1676635 */}}
-        echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind
-        sed -i "13i\echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind\n" /etc/rc.local
-    fi
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    {{/* mitigation for bug https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1676635 */}}
+    echo 2dd1ce17-079e-403c-b352-a1921ee207ee >/sys/bus/vmbus/drivers/hv_util/unbind
+    sed -i "13i\echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind\n" /etc/rc.local
+  fi
 fi
 {{end}}
 
 {{- if not IsAzureStackCloud}}
 if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    time_metric "PurgeApt" apt_get_purge apache2-utils &
+  time_metric "PurgeApt" apt_get_purge apache2-utils &
 fi
 {{end}}
 
@@ -41282,32 +41310,32 @@ fi
 RES=$(retrycmd_if_failure 20 1 3 nslookup ${API_SERVER_NAME})
 STS=$?
 if [[ $STS != 0 ]]; then
-    if [[ $RES == *"168.63.129.16"*  ]]; then
-        exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_AZURE_DNS_LOOKUP_FAIL"}}
-    else
-        exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_CONN_FAIL"}}
-    fi
+  if [[ $RES == *"168.63.129.16"* ]]; then
+    exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_AZURE_DNS_LOOKUP_FAIL"}}
+  else
+    exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_CONN_FAIL"}}
+  fi
 fi
 retrycmd_if_failure 50 1 3 nc -vz ${API_SERVER_NAME} 443 || exit {{GetCSEErrorCode "ERR_K8S_API_SERVER_CONN_FAIL"}}
 {{end}}
 
 if $REBOOTREQUIRED; then
-    echo 'reboot required, rebooting node in 1 minute'
-    /bin/bash -c "shutdown -r 1 &"
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        aptmarkWALinuxAgent unhold &
-    fi
+  echo 'reboot required, rebooting node in 1 minute'
+  /bin/bash -c "shutdown -r 1 &"
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    aptmarkWALinuxAgent unhold &
+  fi
 else
-    if [[ $OS == $UBUNTU_OS_NAME ]]; then
-        /usr/lib/apt/apt.systemd.daily &
-        aptmarkWALinuxAgent unhold &
-    fi
+  if [[ $OS == $UBUNTU_OS_NAME ]]; then
+    /usr/lib/apt/apt.systemd.daily &
+    aptmarkWALinuxAgent unhold &
+  fi
 fi
 
 echo "Custom script finished successfully"
-echo $(date),$(hostname), endcustomscript>>/opt/m
+echo $(date),$(hostname), endcustomscript >>/opt/m
 mkdir -p /opt/azure/containers && touch /opt/azure/containers/provision.complete
-ps auxfww > /opt/azure/provision-ps.log &
+ps auxfww >/opt/azure/provision-ps.log &
 
 #EOF
 `)
@@ -41464,21 +41492,21 @@ set -u
 DHCLIENT6_CONF_FILE=/etc/dhcp/dhclient6.conf
 CLOUD_INIT_CFG=/etc/network/interfaces.d/50-cloud-init.cfg
 
-read -r -d '' NETWORK_CONFIGURATION << EOC || true
+read -r -d '' NETWORK_CONFIGURATION <<EOC || true
 iface eth0 inet6 auto
     up sleep 5
     up dhclient -1 -6 -cf /etc/dhcp/dhclient6.conf -lf /var/lib/dhcp/dhclient6.eth0.leases -v eth0 || true
 EOC
 
 add_if_not_exists() {
-    grep -qxF "${1}" "${2}" || echo "${1}" >> "${2}"
+  grep -qxF "${1}" "${2}" || echo "${1}" >>"${2}"
 }
 
 echo "Configuring dhcpv6 ..."
 
-touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} && \
-    add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} && \
-    sudo ifdown eth0 && sudo ifup eth0
+touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} &&
+  add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} &&
+  sudo ifdown eth0 && sudo ifup eth0
 
 echo "Configuration complete"
 #EOF
@@ -41591,7 +41619,7 @@ K8S_PROXY_CRT_FILEPATH="${K8S_PROXY_CRT_FILEPATH:=/etc/kubernetes/certs/proxy.cr
 PROXY_CERTS_LOCK_NAME="master_proxy_cert_lock"
 PROXY_CERT_LOCK_FILE="/tmp/create_cert.fifl"
 
-if [[ -z "${COSMOS_URI}" ]]; then
+if [[ -z ${COSMOS_URI} ]]; then
   ETCDCTL_ENDPOINTS="${ETCDCTL_ENDPOINTS:=https://127.0.0.1:2379}"
   ETCDCTL_CA_FILE="${ETCDCTL_CA_FILE:=/etc/kubernetes/certs/ca.crt}"
   ETCD_CA_PARAM="--cacert=${ETCDCTL_CA_FILE}"
@@ -41613,41 +41641,41 @@ openssl req -new -key $PROXY_CLIENT_KEY -out $PROXY_CLIENT_CSR -subj '/CN=aggreg
 openssl x509 -req -days 730 -in $PROXY_CLIENT_CSR -CA $PROXY_CRT -CAkey $PROXY_CA_KEY -set_serial 02 -out $PROXY_CLIENT_CRT
 
 write_certs_to_disk() {
-    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only > $K8S_PROXY_CA_CRT_FILEPATH
-    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only > $K8S_PROXY_KEY_FILEPATH
-    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only > $K8S_PROXY_CRT_FILEPATH
-    {{- /* Remove whitespace padding at beginning of 1st line */}}
-    sed -i '1s/\s//' $K8S_PROXY_CA_CRT_FILEPATH $K8S_PROXY_CRT_FILEPATH $K8S_PROXY_KEY_FILEPATH
-    chmod 600 $K8S_PROXY_KEY_FILEPATH
+  ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only >$K8S_PROXY_CA_CRT_FILEPATH
+  ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only >$K8S_PROXY_KEY_FILEPATH
+  ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only >$K8S_PROXY_CRT_FILEPATH
+  {{- /* Remove whitespace padding at beginning of 1st line */}}
+  sed -i '1s/\s//' $K8S_PROXY_CA_CRT_FILEPATH $K8S_PROXY_CRT_FILEPATH $K8S_PROXY_KEY_FILEPATH
+  chmod 600 $K8S_PROXY_KEY_FILEPATH
 }
 
 write_certs_to_disk_with_retry() {
-    for i in $(seq 1 12); do
-        write_certs_to_disk && break || sleep 5
-    done
+  for i in $(seq 1 12); do
+    write_certs_to_disk && break || sleep 5
+  done
 }
-is_etcd_healthy(){
-    for i in $(seq 1 100); do
-        ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} endpoint health && break || sleep 5
-    done
+is_etcd_healthy() {
+  for i in $(seq 1 100); do
+    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} endpoint health && break || sleep 5
+  done
 }
 is_etcd_healthy
 {{- /* lock file to enable "only 1 master generates certs" */}}
 rm -f "${PROXY_CERT_LOCK_FILE}"
 mkfifo "${PROXY_CERT_LOCK_FILE}"
 
-ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} lock ${PROXY_CERTS_LOCK_NAME}  > "${PROXY_CERT_LOCK_FILE}" &
+ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} lock ${PROXY_CERTS_LOCK_NAME} >"${PROXY_CERT_LOCK_FILE}" &
 
 pid=$!
-if read -r lockthis < "${PROXY_CERT_LOCK_FILE}"; then
+if read -r lockthis <"${PROXY_CERT_LOCK_FILE}"; then
   if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
-    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_REQUESTHEADER_CLIENT_CA " $(cat ${PROXY_CRT})" >/dev/null 2>&1;
+    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_REQUESTHEADER_CLIENT_CA " $(cat ${PROXY_CRT})" >/dev/null 2>&1
   fi
   if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
-    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_KEY " $(cat ${PROXY_CLIENT_KEY})" >/dev/null 2>&1;
+    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_KEY " $(cat ${PROXY_CLIENT_KEY})" >/dev/null 2>&1
   fi
   if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
-    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_CERT " $(cat ${PROXY_CLIENT_CRT})" >/dev/null 2>&1;
+    ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_CERT " $(cat ${PROXY_CLIENT_CRT})" >/dev/null 2>&1
   fi
 fi
 kill $pid
@@ -41687,23 +41715,23 @@ container_runtime_monitoring() {
   local -r crictl="${KUBE_HOME}/bin/crictl"
   local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
   local healthcheck_command="docker ps"
-  if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+  if [[ ${CONTAINER_RUNTIME:-docker} != "docker" ]]; then
     healthcheck_command="${crictl} pods"
   fi
 
-  until timeout 60 ${healthcheck_command} > /dev/null; do
-    if (( attempt == max_attempts )); then
+  until timeout 60 ${healthcheck_command} >/dev/null; do
+    if ((attempt == max_attempts)); then
       echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
       break
     fi
     echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
-    sleep "$(( 2 ** attempt++ ))"
+    sleep "$((2 ** attempt++))"
   done
   while true; do
-    if ! timeout 60 ${healthcheck_command} > /dev/null; then
+    if ! timeout 60 ${healthcheck_command} >/dev/null; then
       echo "Container runtime ${container_runtime_name} failed!"
-      if [[ "$container_runtime_name" == "docker" ]]; then
-          pkill -SIGUSR1 dockerd
+      if [[ $container_runtime_name == "docker" ]]; then
+        pkill -SIGUSR1 dockerd
       fi
       systemctl kill --kill-who=main "${container_runtime_name}"
       sleep 120
@@ -41730,14 +41758,14 @@ kubelet_monitoring() {
   done
 }
 
-if [[ "$#" -ne 1 ]]; then
+if [[ $# -ne 1 ]]; then
   echo "Usage: health-monitor.sh <container-runtime/kubelet>"
   exit 1
 fi
 
 KUBE_HOME="/usr/local/bin"
 KUBE_ENV="/etc/default/kube-env"
-if [[  -e "${KUBE_ENV}" ]]; then
+if [[ -e ${KUBE_ENV} ]]; then
   source "${KUBE_ENV}"
 fi
 
@@ -41745,9 +41773,9 @@ SLEEP_SECONDS=10
 component=$1
 echo "Start kubernetes health monitoring for ${component}"
 
-if [[ "${component}" == "container-runtime" ]]; then
+if [[ ${component} == "container-runtime" ]]; then
   container_runtime_monitoring
-elif [[ "${component}" == "kubelet" ]]; then
+elif [[ ${component} == "kubelet" ]]; then
   kubelet_monitoring
 else
   echo "Health monitoring for component ${component} is not supported!"
@@ -42007,19 +42035,16 @@ PARTITION=${DISK}1
 MOUNTPOINT=/var/lib/etcddisk
 udevadm settle
 mkdir -p $MOUNTPOINT
-if mount | grep $MOUNTPOINT
-then
-    echo "disk is already mounted"
-    exit 0
+if mount | grep $MOUNTPOINT; then
+  echo "disk is already mounted"
+  exit 0
 fi
-if ! grep "/dev/sdc1" /etc/fstab
-then
-    echo "$PARTITION       $MOUNTPOINT       auto    defaults,nofail       0       2" >> /etc/fstab
+if ! grep "/dev/sdc1" /etc/fstab; then
+  echo "$PARTITION       $MOUNTPOINT       auto    defaults,nofail       0       2" >>/etc/fstab
 fi
-if ! ls $PARTITION
-then
-    /sbin/sgdisk --new 1 $DISK
-    /sbin/mkfs.ext4 $PARTITION -L etcd_disk -F -E lazy_itable_init=1,lazy_journal_init=1
+if ! ls $PARTITION; then
+  /sbin/sgdisk --new 1 $DISK
+  /sbin/mkfs.ext4 $PARTITION -L etcd_disk -F -E lazy_itable_init=1,lazy_journal_init=1
 fi
 mount $MOUNTPOINT
 /bin/chown -R etcd:etcd /var/lib/etcddisk

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40581,10 +40581,7 @@ aptmarkWALinuxAgent() {
 }
 
 retrycmd_if_failure() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
-  shift && shift && shift
+  retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
   for i in $(seq 1 $retries); do
     timeout $timeout ${@} && break ||
       if [ $i -eq $retries ]; then
@@ -40668,8 +40665,7 @@ apt_get_update() {
       cat $apt_update_output
     if [ $i -eq $retries ]; then
       return 1
-    else
-      sleep 5
+    else sleep 5
     fi
   done
   echo Executed apt-get update $i times
@@ -40726,8 +40722,7 @@ apt_get_dist_upgrade() {
     cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then
       return 1
-    else
-      sleep 5
+    else sleep 5
     fi
   done
   echo Executed apt-get dist-upgrade $i times
@@ -41086,16 +41081,16 @@ fi
 time_metric "ConfigureAdminUser" configureAdminUser
 
 {{- if HasVHDDistroNodes}}
-{{- if not NeedsContainerd}}
+  {{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd
-{{end}}
-{{- if HasNSeriesSKU}}
+  {{end}}
+  {{- if HasNSeriesSKU}}
 if [[ ${GPU_NODE} != "true" ]]; then
   time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
 fi
-{{else}}
+  {{else}}
 time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
-{{end}}
+  {{end}}
 {{end}}
 
 {{- if HasVHDDistroNodes}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39758,17 +39758,17 @@ systemctlEnableAndStart() {
     return 1
   fi
 }
-configureAdminUser() {
+configureAdminUser(){
   chage -E -1 -I -1 -m 0 -M 99999 "${ADMINUSER}"
   chage -l "${ADMINUSER}"
 }
-configureEtcdUser() {
+configureEtcdUser(){
   useradd -U etcd
   chage -E -1 -I -1 -m 0 -M 99999 etcd
   chage -l etcd
   id etcd
 }
-configureSecrets() {
+configureSecrets(){
   APISERVER_PRIVATE_KEY_PATH="/etc/kubernetes/certs/apiserver.key"
   touch "${APISERVER_PRIVATE_KEY_PATH}"
   CA_PRIVATE_KEY_PATH="/etc/kubernetes/certs/ca.key"
@@ -39939,9 +39939,9 @@ EOF
 }
 
 installNetworkPlugin() {
-  {{- if IsAzureCNI}}
+{{- if IsAzureCNI}}
   installAzureCNI
-  {{end}}
+{{end}}
   installCNI
   rm -rf $CNI_DOWNLOADS_DIR &
 }
@@ -39978,13 +39978,13 @@ configureCNI() {
   systemctl restart sys-fs-bpf.mount
   REBOOTREQUIRED=true
   {{end}}
-  {{- if IsAzureStackCloud}}
+{{- if IsAzureStackCloud}}
   if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
     {{/* set environment to mas when using Azure CNI on Azure Stack */}}
     {{/* shellcheck disable=SC2002,SC2005 */}}
     echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipam.environment = "mas"') >"$CNI_CONFIG_DIR/10-azure.conflist"
   fi
-  {{end}}
+{{end}}
 }
 configureCNIIPTables() {
   if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
@@ -40128,7 +40128,7 @@ ensureK8sControlPlane() {
   if $REBOOTREQUIRED || [ "$NO_OUTBOUND" = "true" ]; then
     return
   fi
-  retrycmd_if_failure 120 5 25 $KUBECTL cluster-info 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  retrycmd_if_failure 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{- if IsAzurePolicyAddonEnabled}}
 ensureLabelExclusionForAzurePolicyAddon() {
@@ -40597,10 +40597,7 @@ retrycmd_if_failure() {
   echo Executed \"$@\" $i times
 }
 retrycmd_if_failure_no_stats() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
-  shift && shift && shift
+  retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
   for i in $(seq 1 $retries); do
     timeout $timeout ${@} && break ||
       if [ $i -eq $retries ]; then
@@ -40611,10 +40608,7 @@ retrycmd_if_failure_no_stats() {
   done
 }
 retrycmd_get_tarball() {
-  tar_retries=$1
-  wait_sleep=$2
-  tarball=$3
-  url=$4
+  tar_retries=$1; wait_sleep=$2; tarball=$3; url=$4
   echo "${tar_retries} retries"
   for i in $(seq 1 $tar_retries); do
     tar -tzf $tarball && break ||
@@ -40627,11 +40621,7 @@ retrycmd_get_tarball() {
   done
 }
 retrycmd_get_executable() {
-  retries=$1
-  wait_sleep=$2
-  filepath=$3
-  url=$4
-  validation_args=$5
+  retries=$1; wait_sleep=$2; filepath=$3; url=$4; validation_args=$5
   echo "${retries} retries"
   for i in $(seq 1 $retries); do
     $filepath $validation_args && break ||
@@ -40645,9 +40635,7 @@ retrycmd_get_executable() {
   done
 }
 wait_for_file() {
-  retries=$1
-  wait_sleep=$2
-  filepath=$3
+  retries=$1; wait_sleep=$2; filepath=$3
   paved=/opt/azure/cloud-init-files.paved
   grep -Fq "${filepath}" $paved && return 0
   for i in $(seq 1 $retries); do
@@ -40688,10 +40676,7 @@ apt_get_update() {
   wait_for_apt_locks
 }
 apt_get_install() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
-  shift && shift && shift
+  retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
   for i in $(seq 1 $retries); do
     wait_for_apt_locks
     export DEBIAN_FRONTEND=noninteractive
@@ -40708,9 +40693,7 @@ apt_get_install() {
   wait_for_apt_locks
 }
 apt_get_purge() {
-  retries=20
-  wait_sleep=30
-  timeout=120
+  retries=20; wait_sleep=30; timeout=120
   for package in $@; do
     if apt list --installed | grep $package; then
       for i in $(seq 1 $retries); do
@@ -40738,9 +40721,9 @@ apt_get_dist_upgrade() {
     dpkg --configure -a --force-confdef
     apt-get -f -y install
     apt-mark showhold
-    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") &&
-      cat $apt_dist_upgrade_output && break ||
-      cat $apt_dist_upgrade_output
+    ! (apt-get dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|([eE]rr.*)$") && \
+    cat $apt_dist_upgrade_output && break || \
+    cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then
       return 1
     else
@@ -40751,9 +40734,7 @@ apt_get_dist_upgrade() {
   wait_for_apt_locks
 }
 systemctl_restart() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3 svcname=$4
+  retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
   for i in $(seq 1 $retries); do
     timeout $timeout systemctl daemon-reload
     timeout $timeout systemctl restart $svcname && break ||
@@ -40765,9 +40746,7 @@ systemctl_restart() {
   done
 }
 systemctl_stop() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3 svcname=$4
+  retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
   for i in $(seq 1 $retries); do
     timeout $timeout systemctl daemon-reload
     timeout $timeout systemctl stop $svcname && break ||
@@ -40779,9 +40758,7 @@ systemctl_stop() {
   done
 }
 sysctl_reload() {
-  retries=$1
-  wait_sleep=$2
-  timeout=$3
+  retries=$1; wait_sleep=$2; timeout=$3
   for i in $(seq 1 $retries); do
     timeout $timeout sysctl --system && break ||
       if [ $i -eq $retries ]; then
@@ -41504,8 +41481,8 @@ add_if_not_exists() {
 
 echo "Configuring dhcpv6 ..."
 
-touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} &&
-  add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} &&
+touch /etc/dhcp/dhclient6.conf && add_if_not_exists "timeout 10;" ${DHCLIENT6_CONF_FILE} && \
+  add_if_not_exists "${NETWORK_CONFIGURATION}" ${CLOUD_INIT_CFG} && \
   sudo ifdown eth0 && sudo ifup eth0
 
 echo "Configuration complete"


### PR DESCRIPTION
**Reason for Change**:
Formats shell scripts under ./parts/k8s to use 2-space indentation and to simplify some `bash` syntax. This should save some valuable bytes in AKS Engine's CSE payload.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I ran `shfmt -s -i 2 -w` and then reverted any changes that looked risky or controversial. (It would be easy to enforce this format style in `make test-style` in the future if we revisit those changes.)