### PR TITLE
feat: Enable Antrea in NetworkPolicyOnly mode with Azure CNI

### DIFF
--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -102,7 +102,7 @@ For the latest documentation on Cilium (including BPF and XDP reference guides),
 
 ## Antrea
 
-The kubernetes-antrea deployment template enables Antrea networking and policies for the AKS Engine cluster via `"networkPolicy": "antrea"` or `"networkPlugin": "antrea"` being present inside the `kubernetesConfig`.
+The kubernetes-antrea deployment template enables Antrea networking and policies for the AKS Engine cluster via `"networkPolicy": "antrea"` and `"networkPlugin": "antrea"` being present inside the `kubernetesConfig`.
 
 
 ```json
@@ -110,11 +110,12 @@ The kubernetes-antrea deployment template enables Antrea networking and policies
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "networkPolicy": "antrea"
+        "networkPolicy": "antrea",
+        "networkPlugin": "antrea"
       }
 ```
 
-Antrea also supports `NetworkPolicyOnly` mode with Azure CNI. In this mode, Antrea will enforce Network Policies using OVS and Azure CNI will take care of Networking. The kubernetes-antrea deployment template enables Azure Networking and Antrea Network Policies for the AKS Engine via `"networkPolicy": "antrea"` and `"networkPlugin": "azure"` being present inside the `kubernetesConfig`. For more details regarding Antrea NetworkPolicyOnly mode, please refer to [this]() (Link TODO).
+Antrea also supports `NetworkPolicyOnly` mode with Azure CNI. In this mode, Antrea will enforce Network Policies using OVS and Azure CNI will take care of Networking. The kubernetes-antrea deployment template enables Azure Networking and Antrea Network Policies for the AKS Engine via `"networkPolicy": "antrea"` and optional `"networkPlugin": "azure"` being present inside the `kubernetesConfig`. For more details regarding Antrea NetworkPolicyOnly mode, please refer to [this]() (Link TODO).
 
 
 ```json
@@ -123,7 +124,6 @@ Antrea also supports `NetworkPolicyOnly` mode with Azure CNI. In this mode, Antr
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "networkPlugin": "azure",
         "networkPolicy": "antrea"
       }
 ```

--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -124,16 +124,7 @@ Antrea also supports `NetworkPolicyOnly` mode with Azure CNI. In this mode, Antr
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "azure",
-        "networkPolicy": "antrea",
-        "addons": [
-          {
-            "name": "antrea",
-            "enabled": true,
-            "config": {
-              "trafficEncapMode": "networkPolicyOnly"
-            }
-          }
-        ]
+        "networkPolicy": "antrea"
       }
 ```
 

--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -99,9 +99,11 @@ Once the template has been successfully deployed, following the [deploy the demo
 
 For the latest documentation on Cilium (including BPF and XDP reference guides), please refer to [this](http://cilium.readthedocs.io/en/latest/)
 
+
 ## Antrea
 
 The kubernetes-antrea deployment template enables Antrea networking and policies for the AKS Engine cluster via `"networkPolicy": "antrea"` or `"networkPlugin": "antrea"` being present inside the `kubernetesConfig`.
+
 
 ```json
   "properties": {
@@ -109,6 +111,29 @@ The kubernetes-antrea deployment template enables Antrea networking and policies
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "antrea"
+      }
+```
+
+Antrea also supports `NetworkPolicyOnly` mode with Azure CNI. In this mode, Antrea will enforce Network Policies using OVS and Azure CNI will take care of Networking. The kubernetes-antrea deployment template enables Azure Networking and Antrea Network Policies for the AKS Engine via `"networkPolicy": "antrea"` and `"networkPlugin": "azure"` being present inside the `kubernetesConfig`. For more details regarding Antrea NetworkPolicyOnly mode, please refer to [this]() (Link TODO).
+
+
+```json
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPlugin": "azure",
+        "networkPolicy": "antrea",
+        "addons": [
+          {
+            "name": "antrea",
+            "enabled": true,
+            "config": {
+              "trafficEncapMode": "networkPolicyOnly"
+            }
+          }
+        ]
       }
 ```
 

--- a/parts/k8s/addons/antrea.yaml
+++ b/parts/k8s/addons/antrea.yaml
@@ -275,7 +275,7 @@ data:
     # - geneve
     # - gre
     # - stt
-    tunnelType: {{ContainerConfig "tunnelType"}}
+    #tunnelType: vxlan
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate

--- a/parts/k8s/addons/antrea.yaml
+++ b/parts/k8s/addons/antrea.yaml
@@ -275,7 +275,7 @@ data:
     # - geneve
     # - gre
     # - stt
-    #tunnelType: vxlan
+    tunnelType: {{ContainerConfig "tunnelType"}}
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
@@ -296,7 +296,7 @@ data:
     # hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
     # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
     #
-    #trafficEncapMode: encap
+    trafficEncapMode: {{ContainerConfig "trafficEncapMode"}}
   antrea-cni.conf: |
     {
         "cniVersion":"0.3.0",
@@ -561,6 +561,7 @@ spec:
         - install_cni
         image: {{ContainerImage "install-cni"}}
         name: install-cni
+        command: [{{ContainerConfig "installCniCmd"}}]
         securityContext:
           capabilities:
             add:

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -260,7 +260,6 @@ configureAzureCNI() {
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     elif [[ "${NETWORK_POLICY}" == "antrea" ]]; then
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-      echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins += [{"type": "antrea"}]') > "$CNI_CONFIG_DIR/10-azure.conflist"
     elif [[ "${NETWORK_POLICY}" == "" || "${NETWORK_POLICY}" == "none" ]] && [[ "${NETWORK_MODE}" == "transparent" ]]; then
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     fi

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -246,23 +246,26 @@ configureCNI() {
 {{end}}
 }
 configureAzureCNI() {
-    if [[ "${NETWORK_PLUGIN}" == "azure" ]]; then
-        mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
-        chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
-        if [[ "${IS_IPV6_DUALSTACK_FEATURE_ENABLED}" == "true" ]]; then
-            echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipv6Mode="ipv6nat"') > "$CNI_CONFIG_DIR/10-azure.conflist"
-        fi
+  if [[ "${NETWORK_PLUGIN}" == "azure" ]]; then
+    mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
+    chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
+    if [[ "${IS_IPV6_DUALSTACK_FEATURE_ENABLED}" == "true" ]]; then
+      echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipv6Mode="ipv6nat"') > "$CNI_CONFIG_DIR/10-azure.conflist"
+    fi
     if [[ {{GetKubeProxyMode}} == "ipvs" ]]; then
-        serviceCidrs={{GetServiceCidr}}
-        echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq  --arg serviceCidrs $serviceCidrs '.plugins[0]+={serviceCidrs: $serviceCidrs}') > /etc/cni/net.d/10-azure.conflist
+      serviceCidrs={{GetServiceCidr}}
+      echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq  --arg serviceCidrs $serviceCidrs '.plugins[0]+={serviceCidrs: $serviceCidrs}') > /etc/cni/net.d/10-azure.conflist
     fi
     if [[ "${NETWORK_POLICY}" == "calico" ]]; then
-        sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
+      sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
+    elif [[ "${NETWORK_POLICY}" == "antrea" ]]; then
+      sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
+      echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins += [{"type": "antrea"}]') > "$CNI_CONFIG_DIR/10-azure.conflist"
     elif [[ "${NETWORK_POLICY}" == "" || "${NETWORK_POLICY}" == "none" ]] && [[ "${NETWORK_MODE}" == "transparent" ]]; then
-        sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
+      sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     fi
     /sbin/ebtables -t nat --list
-    fi
+  fi
 }
 {{- if NeedsContainerd}}
 installContainerd() {
@@ -347,9 +350,15 @@ ensureKubelet() {
   done
   {{end}}
   {{if HasAntreaNetworkPolicy}}
-  while [ ! -f /etc/cni/net.d/10-antrea.conf ]; do
-    sleep 3
-  done
+  if [[ "${NETWORK_PLUGIN}" = "azure" ]]; then
+    while ! $(grep -sq "antrea" $CNI_CONFIG_DIR/10-azure.conflist); do
+      sleep 3
+    done
+  else
+    while [ ! -f $CNI_CONFIG_DIR/10-antrea.conf ]; do
+      sleep 3
+    done
+  fi
   {{end}}
   {{if HasFlannelNetworkPlugin}}
   while [ ! -f /etc/cni/net.d/10-flannel.conf ]; do

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -402,7 +402,6 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		Enabled: to.BoolPtr(o.KubernetesConfig.NetworkPolicy == NetworkPolicyAntrea),
 		Config: map[string]string{
 			"serviceCidr":      o.KubernetesConfig.ServiceCIDR,
-			"tunnelType":       common.AntreaDefaultTunnelType,
 			"trafficEncapMode": common.AntreaDefaultTrafficEncapMode,
 			"installCniCmd":    common.AntreaDefaultInstallCniCmd,
 		},
@@ -426,11 +425,10 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		},
 	}
 
-	if getAddonsIndexByName(o.KubernetesConfig.Addons, common.AntreaAddonName) != -1 {
-		// Update cni install command when network plugin is set to azure cni
-		if o.KubernetesConfig.IsAddonEnabled(common.AntreaAddonName) && o.IsAzureCNI() {
-			defaultsAntreaDaemonSetAddonsConfig.Config["installCniCmd"] = common.AntreaInstallCniChainCmd
-		}
+	// Set NetworkPolicyOnly mode when azure cni is enabled
+	if o.KubernetesConfig.NetworkPolicy == NetworkPolicyAntrea && o.IsAzureCNI() {
+		defaultsAntreaDaemonSetAddonsConfig.Config["trafficEncapMode"] = common.AntreaNetworkPolicyOnlyMode
+		defaultsAntreaDaemonSetAddonsConfig.Config["installCniCmd"] = common.AntreaInstallCniChainCmd
 	}
 
 	defaultsAADPodIdentityAddonsConfig := KubernetesAddon{

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -4028,21 +4028,81 @@ func TestSetAddonsConfig(t *testing.T) {
 							},
 							ClusterSubnet: DefaultKubernetesSubnet,
 							ProxyMode:     KubeProxyModeIPTables,
-							NetworkPlugin: NetworkPluginAzure,
+							NetworkPlugin: NetworkPluginAntrea,
+							Addons: []KubernetesAddon{
+								{
+									Name:    common.AntreaAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"serviceCidr":      DefaultKubernetesServiceCIDR,
+										"tunnelType":       common.AntreaDefaultTunnelType,
+										"trafficEncapMode": common.AntreaDefaultTrafficEncapMode,
+										"installCniCmd":    common.AntreaDefaultInstallCniCmd,
+									},
+								},
+							},
 						},
 					},
 				},
 			},
 			isUpgrade: false,
-			expectedAddons: concatenateDefaultAddons([]KubernetesAddon{
+			expectedAddons: omitFromAddons([]string{common.IPMASQAgentAddonName, common.AzureCNINetworkMonitorAddonName}, concatenateDefaultAddons([]KubernetesAddon{
 				{
 					Name:    common.AntreaAddonName,
 					Enabled: to.BoolPtr(true),
 					Config: map[string]string{
-						"serviceCidr": DefaultKubernetesServiceCIDR,
+						"serviceCidr":      DefaultKubernetesServiceCIDR,
+						"tunnelType":       common.AntreaDefaultTunnelType,
+						"trafficEncapMode": common.AntreaDefaultTrafficEncapMode,
+						"installCniCmd":    common.AntreaDefaultInstallCniCmd,
 					},
 				},
-			}, "1.15.4"),
+			}, "1.15.4")),
+		},
+		{
+			name: "antrea addon enabled with azure",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &KubernetesConfig{
+							KubernetesImageBaseType: common.KubernetesImageBaseTypeGCR,
+							DNSServiceIP:            DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: DefaultKubernetesSubnet,
+							ProxyMode:     KubeProxyModeIPTables,
+							NetworkPolicy: NetworkPolicyAntrea,
+							NetworkPlugin: NetworkPluginAzure,
+							Addons: []KubernetesAddon{
+								{
+									Name:    common.AntreaAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"serviceCidr":      DefaultKubernetesServiceCIDR,
+										"tunnelType":       common.AntreaDefaultTunnelType,
+										"trafficEncapMode": common.AntreaNetworkPolicyOnlyMode,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: omitFromAddons([]string{common.AzureCNINetworkMonitorAddonName}, concatenateDefaultAddons([]KubernetesAddon{
+				{
+					Name:    common.AntreaAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"tunnelType":       common.AntreaDefaultTunnelType,
+						"trafficEncapMode": common.AntreaNetworkPolicyOnlyMode,
+						"installCniCmd":    common.AntreaInstallCniChainCmd,
+						"serviceCidr":      DefaultKubernetesServiceCIDR,
+					},
+				},
+			}, "1.15.4")),
 		},
 		{
 			name: "addons with IPv6 single stack",
@@ -4438,6 +4498,7 @@ func TestSetAddonsConfig(t *testing.T) {
 				common.PodSecurityPolicyAddonName,
 				common.AADAdminGroupAddonName,
 				common.SecretsStoreCSIDriverAddonName,
+				common.AntreaAddonName,
 			} {
 				addon := test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons[getAddonsIndexByName(test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons, addonName)]
 				if addon.IsEnabled() {

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -4078,7 +4078,7 @@ func TestSetAddonsConfig(t *testing.T) {
 									Name:    common.AntreaAddonName,
 									Enabled: to.BoolPtr(true),
 									Config: map[string]string{
-										"serviceCidr":      DefaultKubernetesServiceCIDR,
+										"serviceCidr": DefaultKubernetesServiceCIDR,
 									},
 								},
 							},

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -4064,7 +4064,7 @@ func TestSetAddonsConfig(t *testing.T) {
 					OrchestratorProfile: &OrchestratorProfile{
 						OrchestratorVersion: "1.15.4",
 						KubernetesConfig: &KubernetesConfig{
-							KubernetesImageBaseType: common.KubernetesImageBaseTypeGCR,
+							KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR,
 							DNSServiceIP:            DefaultKubernetesDNSServiceIP,
 							KubeletConfig: map[string]string{
 								"--cluster-domain": "cluster.local",

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -4035,7 +4035,6 @@ func TestSetAddonsConfig(t *testing.T) {
 									Enabled: to.BoolPtr(true),
 									Config: map[string]string{
 										"serviceCidr":      DefaultKubernetesServiceCIDR,
-										"tunnelType":       common.AntreaDefaultTunnelType,
 										"trafficEncapMode": common.AntreaDefaultTrafficEncapMode,
 										"installCniCmd":    common.AntreaDefaultInstallCniCmd,
 									},
@@ -4052,7 +4051,6 @@ func TestSetAddonsConfig(t *testing.T) {
 					Enabled: to.BoolPtr(true),
 					Config: map[string]string{
 						"serviceCidr":      DefaultKubernetesServiceCIDR,
-						"tunnelType":       common.AntreaDefaultTunnelType,
 						"trafficEncapMode": common.AntreaDefaultTrafficEncapMode,
 						"installCniCmd":    common.AntreaDefaultInstallCniCmd,
 					},
@@ -4081,8 +4079,6 @@ func TestSetAddonsConfig(t *testing.T) {
 									Enabled: to.BoolPtr(true),
 									Config: map[string]string{
 										"serviceCidr":      DefaultKubernetesServiceCIDR,
-										"tunnelType":       common.AntreaDefaultTunnelType,
-										"trafficEncapMode": common.AntreaNetworkPolicyOnlyMode,
 									},
 								},
 							},
@@ -4096,7 +4092,6 @@ func TestSetAddonsConfig(t *testing.T) {
 					Name:    common.AntreaAddonName,
 					Enabled: to.BoolPtr(true),
 					Config: map[string]string{
-						"tunnelType":       common.AntreaDefaultTunnelType,
 						"trafficEncapMode": common.AntreaNetworkPolicyOnlyMode,
 						"installCniCmd":    common.AntreaInstallCniChainCmd,
 						"serviceCidr":      DefaultKubernetesServiceCIDR,

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -363,3 +363,11 @@ func GetDefaultContainerdConfig() ContainerdConfig {
 const (
 	ContainerDataDirKey = "dataDir"
 )
+
+// Antrea Plugin Const
+const (
+	AntreaDefaultTrafficEncapMode = "Encap"
+	AntreaDefaultInstallCniCmd    = "install_cni"
+	AntreaInstallCniChainCmd      = "install_cni_chaining"
+	AntreaNetworkPolicyOnlyMode   = "networkPolicyOnly"
+)

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -122,7 +122,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			o.KubernetesConfig.NetworkPlugin = NetworkPluginCilium
 		case NetworkPolicyAntrea:
 			if o.KubernetesConfig.NetworkPlugin == "" {
-				o.KubernetesConfig.NetworkPlugin = NetworkPluginAntrea
+				o.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
 			}
 		}
 

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -121,7 +121,9 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		case NetworkPolicyCilium:
 			o.KubernetesConfig.NetworkPlugin = NetworkPluginCilium
 		case NetworkPolicyAntrea:
-			o.KubernetesConfig.NetworkPlugin = NetworkPluginAntrea
+			if o.KubernetesConfig.NetworkPlugin == "" {
+				o.KubernetesConfig.NetworkPlugin = NetworkPluginAntrea
+			}
 		}
 
 		if a.IsAzureStackCloud() {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -880,9 +880,9 @@ func TestNetworkPolicyDefaults(t *testing.T) {
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyAntrea
 	mockCS.setOrchestratorDefaults(true, true)
-	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != NetworkPluginAntrea {
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != NetworkPluginAzure {
 		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
-			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, NetworkPluginAntrea)
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, NetworkPluginAzure)
 	}
 
 	mockCS = getMockBaseContainerService("1.8.10")

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -84,6 +84,10 @@ var (
 			networkPolicy: NetworkPolicyAntrea,
 		},
 		{
+			networkPlugin: "azure",
+			networkPolicy: NetworkPolicyAntrea,
+		},
+		{
 			networkPlugin: "",
 			networkPolicy: NetworkPolicyAntrea,
 		},

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37247,7 +37247,6 @@ configureAzureCNI() {
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     elif [[ "${NETWORK_POLICY}" == "antrea" ]]; then
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-      echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins += [{"type": "antrea"}]') > "$CNI_CONFIG_DIR/10-azure.conflist"
     elif [[ "${NETWORK_POLICY}" == "" || "${NETWORK_POLICY}" == "none" ]] && [[ "${NETWORK_MODE}" == "transparent" ]]; then
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     fi

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27100,7 +27100,7 @@ data:
     # - geneve
     # - gre
     # - stt
-    tunnelType: {{ContainerConfig "tunnelType"}}
+    #tunnelType: vxlan
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
@@ -37232,38 +37232,27 @@ configureCNI() {
   fi
 {{end}}
 }
-<<<<<<< HEAD
 configureAzureCNI() {
-    if [[ "${NETWORK_PLUGIN}" == "azure" ]]; then
-        mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
-        chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
-        if [[ "${IS_IPV6_DUALSTACK_FEATURE_ENABLED}" == "true" ]]; then
-            echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipv6Mode="ipv6nat"') > "$CNI_CONFIG_DIR/10-azure.conflist"
-        fi
-    if [[ {{GetKubeProxyMode}} == "ipvs" ]]; then
-        serviceCidrs={{GetServiceCidr}}
-        echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq  --arg serviceCidrs $serviceCidrs '.plugins[0]+={serviceCidrs: $serviceCidrs}') > /etc/cni/net.d/10-azure.conflist
-    fi
-    if [[ "${NETWORK_POLICY}" == "calico" ]]; then
-        sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-    elif [[ "${NETWORK_POLICY}" == "" || "${NETWORK_POLICY}" == "none" ]] && [[ "${NETWORK_MODE}" == "transparent" ]]; then
-        sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
-=======
-configureCNIIPTables() {
-  if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
+  if [[ "${NETWORK_PLUGIN}" == "azure" ]]; then
     mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
     chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
-    if [[ ${NETWORK_POLICY} == "calico" ]]; then
+    if [[ "${IS_IPV6_DUALSTACK_FEATURE_ENABLED}" ]]; then
+      echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipv6Mode="ipv6nat"') > "$CNI_CONFIG_DIR/10-azure.conflist"
+    fi
+    if [[ {{GetKubeProxyMode}} == "ipvs" ]]; then
+      serviceCidrs={{GetServiceCidr}}
+      echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq  --arg serviceCidrs $serviceCidrs '.plugins[0]+={serviceCidrs: $serviceCidrs}') > /etc/cni/net.d/10-azure.conflist
+    fi
+    if [[ "${NETWORK_POLICY}" == "calico" ]]; then
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
     elif [[ "${NETWORK_POLICY}" == "antrea" ]]; then
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
       echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins += [{"type": "antrea"}]') > "$CNI_CONFIG_DIR/10-azure.conflist"
-    elif [[ ${NETWORK_POLICY} == "" || ${NETWORK_POLICY} == "none" ]] && [[ ${NETWORK_MODE} == "transparent" ]]; then
+    elif [[ "${NETWORK_POLICY}" == "" || "${NETWORK_POLICY}" == "none" ]] && [[ "${NETWORK_MODE}" == "transparent" ]]; then
       sed -i 's#"mode":"bridge"#"mode":"transparent"#g' $CNI_CONFIG_DIR/10-azure.conflist
->>>>>>> Enable Antrea in NetworkPolicyOnly mode with Azure CNI
     fi
     /sbin/ebtables -t nat --list
-    fi
+  fi
 }
 {{- if NeedsContainerd}}
 installContainerd() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37236,7 +37236,7 @@ configureAzureCNI() {
   if [[ "${NETWORK_PLUGIN}" == "azure" ]]; then
     mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
     chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
-    if [[ "${IS_IPV6_DUALSTACK_FEATURE_ENABLED}" ]]; then
+    if [[ "${IS_IPV6_DUALSTACK_FEATURE_ENABLED}" == "true" ]]; then
       echo $(cat "$CNI_CONFIG_DIR/10-azure.conflist" | jq '.plugins[0].ipv6Mode="ipv6nat"') > "$CNI_CONFIG_DIR/10-azure.conflist"
     fi
     if [[ {{GetKubeProxyMode}} == "ipvs" ]]; then

--- a/test/e2e/test_cluster_configs/network_policy/antrea_azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/antrea_azure.json
@@ -1,0 +1,55 @@
+{
+	"env": {},
+	"options": {
+		"allowedOrchestratorVersions": ["1.13", "1.14", "1.15", "1.16"]
+	},
+	"apiModel": {
+		"apiVersion": "vlabs",
+		"properties": {
+			"orchestratorProfile": {
+				"orchestratorType": "Kubernetes",
+				"kubernetesConfig": {
+					"networkPolicy": "antrea",
+					"networkPlugin": "azure",
+					"addons": [
+						{
+							"name": "antrea",
+							"enabled": true,
+							"config": {
+								"trafficEncapMode": "networkPolicyOnly"
+							}
+						}
+					]
+				}
+			},
+			"masterProfile": {
+				"count": 1,
+				"dnsPrefix": "",
+				"vmSize": "Standard_D2_v3"
+			},
+			"agentPoolProfiles": [
+				{
+					"name": "agent1",
+					"count": 1,
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Spot"
+				}
+			],
+			"linuxProfile": {
+				"adminUsername": "azureuser",
+				"ssh": {
+					"publicKeys": [
+						{
+							"keyData": ""
+						}
+					]
+				}
+			},
+			"servicePrincipalProfile": {
+				"clientId": "",
+				"secret": ""
+			}
+		}
+	}
+}

--- a/test/e2e/test_cluster_configs/network_policy/antrea_azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/antrea_azure.json
@@ -10,16 +10,7 @@
 				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPolicy": "antrea",
-					"networkPlugin": "azure",
-					"addons": [
-						{
-							"name": "antrea",
-							"enabled": true,
-							"config": {
-								"trafficEncapMode": "networkPolicyOnly"
-							}
-						}
-					]
+					"networkPlugin": "azure"
 				}
 			},
 			"masterProfile": {


### PR DESCRIPTION
In this mode antrea will enforce network policies using OVS and azure cni will take care of networking.

Azure CNI will be deployed in transparent mode in which veth pair will be created for each POD. Antrea will move veth pair host namespace leg to OVS and update host route table accordingly.
