### PR TITLE
feat: EncryptionAtHost support

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -523,6 +523,7 @@ func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterP
 	vlabsProfile.CosmosEtcd = api.CosmosEtcd
 	vlabsProfile.AuditDEnabled = api.AuditDEnabled
 	vlabsProfile.UltraSSDEnabled = api.UltraSSDEnabled
+	vlabsProfile.EncryptionAtHost = api.EncryptionAtHost
 	convertCustomFilesToVlabs(api, vlabsProfile)
 	vlabsProfile.SysctlDConfig = map[string]string{}
 	for key, val := range api.SysctlDConfig {
@@ -574,6 +575,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	p.AuditDEnabled = api.AuditDEnabled
 	p.UltraSSDEnabled = api.UltraSSDEnabled
 	p.DiskEncryptionSetID = api.DiskEncryptionSetID
+	p.EncryptionAtHost = api.EncryptionAtHost
 
 	for k, v := range api.CustomNodeLabels {
 		p.CustomNodeLabels[k] = v

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -579,6 +579,7 @@ func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 	api.SinglePlacementGroup = vlabs.SinglePlacementGroup
 	api.CosmosEtcd = vlabs.CosmosEtcd
 	api.UltraSSDEnabled = vlabs.UltraSSDEnabled
+	api.EncryptionAtHost = vlabs.EncryptionAtHost
 	api.AuditDEnabled = vlabs.AuditDEnabled
 	convertCustomFilesToAPI(vlabs, api)
 	api.SysctlDConfig = map[string]string{}
@@ -620,6 +621,7 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 	api.AuditDEnabled = vlabs.AuditDEnabled
 	api.DiskEncryptionSetID = vlabs.DiskEncryptionSetID
 	api.UltraSSDEnabled = vlabs.UltraSSDEnabled
+	api.EncryptionAtHost = vlabs.EncryptionAtHost
 
 	api.CustomNodeLabels = map[string]string{}
 	for k, v := range vlabs.CustomNodeLabels {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -572,6 +572,7 @@ type MasterProfile struct {
 	SinglePlacementGroup      *bool             `json:"singlePlacementGroup,omitempty"`
 	AuditDEnabled             *bool             `json:"auditDEnabled,omitempty"`
 	UltraSSDEnabled           *bool             `json:"ultraSSDEnabled,omitempty"`
+	EncryptionAtHost          *bool             `json:"encryptionAtHost,omitempty"`
 	CustomVMTags              map[string]string `json:"customVMTags,omitempty"`
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376
@@ -658,6 +659,7 @@ type AgentPoolProfile struct {
 	DiskEncryptionSetID                 string               `json:"diskEncryptionSetID,omitempty"`
 	SysctlDConfig                       map[string]string    `json:"sysctldConfig,omitempty"`
 	UltraSSDEnabled                     *bool                `json:"ultraSSDEnabled,omitempty"`
+	EncryptionAtHost                    *bool                `json:"encryptionAtHost,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -684,17 +684,18 @@ func TestMasterProfileGetCosmosEndPointURI(t *testing.T) {
 
 func TestHasStorageProfile(t *testing.T) {
 	cases := []struct {
-		name                    string
-		p                       Properties
-		expectedHasMD           bool
-		expectedHasSA           bool
-		expectedMasterMD        bool
-		expectedAgent0E         bool
-		expectedAgent0MD        bool
-		expectedPrivateJB       bool
-		expectedHasDisks        bool
-		expectedDesID           string
-		expectedUltraSSDEnabled bool
+		name                     string
+		p                        Properties
+		expectedHasMD            bool
+		expectedHasSA            bool
+		expectedMasterMD         bool
+		expectedAgent0E          bool
+		expectedAgent0MD         bool
+		expectedPrivateJB        bool
+		expectedHasDisks         bool
+		expectedDesID            string
+		expectedUltraSSDEnabled  bool
+		expectedEncryptionAtHost bool
 	}{
 		{
 			name: "Storage Account",
@@ -925,6 +926,35 @@ func TestHasStorageProfile(t *testing.T) {
 			expectedPrivateJB:       false,
 			expectedUltraSSDEnabled: true,
 		},
+		{
+			name: "EncryptionAtHost setting",
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					StorageProfile:   ManagedDisks,
+					EncryptionAtHost: to.BoolPtr(true),
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						StorageProfile:   ManagedDisks,
+						EncryptionAtHost: to.BoolPtr(true),
+					},
+					{
+						StorageProfile:   ManagedDisks,
+						EncryptionAtHost: to.BoolPtr(true),
+					},
+				},
+			},
+			expectedHasMD:            true,
+			expectedHasSA:            false,
+			expectedMasterMD:         true,
+			expectedAgent0MD:         true,
+			expectedAgent0E:          false,
+			expectedPrivateJB:        false,
+			expectedEncryptionAtHost: true,
+		},
 	}
 
 	for _, c := range cases {
@@ -945,6 +975,9 @@ func TestHasStorageProfile(t *testing.T) {
 			}
 			if to.Bool(c.p.MasterProfile.UltraSSDEnabled) != c.expectedUltraSSDEnabled {
 				t.Fatalf("expected UltraSSDEnabled to return %v but instead returned %v", c.expectedUltraSSDEnabled, to.Bool(c.p.MasterProfile.UltraSSDEnabled))
+			}
+			if to.Bool(c.p.MasterProfile.EncryptionAtHost) != c.expectedEncryptionAtHost {
+				t.Fatalf("expected EncryptionAtHost to return %v but instead returned %v", c.expectedEncryptionAtHost, to.Bool(c.p.MasterProfile.EncryptionAtHost))
 			}
 			if c.p.AgentPoolProfiles[0].IsManagedDisks() != c.expectedAgent0MD {
 				t.Fatalf("expected IsManagedDisks() to return %t but instead returned %t", c.expectedAgent0MD, c.p.AgentPoolProfiles[0].IsManagedDisks())
@@ -967,6 +1000,9 @@ func TestHasStorageProfile(t *testing.T) {
 			}
 			if to.Bool(c.p.AgentPoolProfiles[0].UltraSSDEnabled) != c.expectedUltraSSDEnabled {
 				t.Fatalf("expected UltraSSDEnabled to return %v but instead returned %v", c.expectedUltraSSDEnabled, to.Bool(c.p.AgentPoolProfiles[0].UltraSSDEnabled))
+			}
+			if to.Bool(c.p.AgentPoolProfiles[0].EncryptionAtHost) != c.expectedEncryptionAtHost {
+				t.Fatalf("expected EncryptionAtHost to return %v but instead returned %v", c.expectedUltraSSDEnabled, to.Bool(c.p.AgentPoolProfiles[0].UltraSSDEnabled))
 			}
 		})
 	}

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -438,6 +438,7 @@ type MasterProfile struct {
 	CustomVMTags              map[string]string `json:"customVMTags,omitempty"`
 	SysctlDConfig             map[string]string `json:"sysctldConfig,omitempty"`
 	UltraSSDEnabled           *bool             `json:"ultraSSDEnabled,omitempty"`
+	EncryptionAtHost          *bool             `json:"encryptionAtHost,omitempty"`
 
 	// subnet is internal
 	subnet string
@@ -509,6 +510,7 @@ type AgentPoolProfile struct {
 	CustomVMTags                        map[string]string    `json:"customVMTags,omitempty"`
 	DiskEncryptionSetID                 string               `json:"diskEncryptionSetID,omitempty"`
 	UltraSSDEnabled                     *bool                `json:"ultraSSDEnabled,omitempty"`
+	EncryptionAtHost                    *bool                `json:"encryptionAtHost,omitempty"`
 	// subnet is internal
 	subnet string
 

--- a/pkg/api/vlabs/types_test.go
+++ b/pkg/api/vlabs/types_test.go
@@ -145,6 +145,10 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("AgentPoolProfile.UltraSSDEnabled should be false by default")
 	}
 
+	if to.Bool(ap.EncryptionAtHost) {
+		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be false by default")
+	}
+
 	// With osType Windows
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Windows", "count": 1, "vmSize": "Standard_D2_v2",
 "availabilityProfile": "AvailabilitySet", "storageProfile" : "ManagedDisks", "vnetSubnetID" : "12345" }`
@@ -167,7 +171,7 @@ func TestAgentPoolProfile(t *testing.T) {
 
 	// With osType Windows and Ephemeral disks
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Windows", "count": 1, "vmSize": "Standard_D2_v2",
-"availabilityProfile": "AvailabilitySet", "storageProfile" : "Ephemeral", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID", "ultraSSDEnabled": true }`
+"availabilityProfile": "AvailabilitySet", "storageProfile" : "Ephemeral", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID", "ultraSSDEnabled": true, "encryptionAtHost": true }`
 	ap = &AgentPoolProfile{}
 	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
 		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
@@ -197,6 +201,9 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("AgentPoolProfile.UltraSSDEnabled should be true after unmarshal")
 	}
 
+	if !to.Bool(ap.EncryptionAtHost) {
+		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be true after unmarshal")
+	}
 	// With osType Linux and RHEL distro
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Linux", "distro" : "rhel", "count": 1, "vmSize": "Standard_D2_v2",
 "availabilityProfile": "AvailabilitySet", "storageProfile" : "ManagedDisks", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID" }`
@@ -231,7 +238,7 @@ func TestAgentPoolProfile(t *testing.T) {
 
 	// With VMSS and Spot VMs
 	AgentPoolProfileText = `{"name":"linuxpool1","osType":"Linux","distro":"rhel","count":1,"vmSize":"Standard_D2_v2",
-"availabilityProfile":"VirtualMachineScaleSets","scaleSetPriority":"Spot","ScaleSetEvictionPolicy":"Delete","SpotMaxPrice":88, "ultraSSDEnabled": true}`
+"availabilityProfile":"VirtualMachineScaleSets","scaleSetPriority":"Spot","ScaleSetEvictionPolicy":"Delete","SpotMaxPrice":88, "ultraSSDEnabled": true, "encryptionAtHost": true}`
 	ap = &AgentPoolProfile{}
 	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
 		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
@@ -253,6 +260,9 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("AgentPoolProfile.UltraSSDEnabled should be true after unmarshal")
 	}
 
+	if !to.Bool(ap.EncryptionAtHost) {
+		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be true after unmarshal")
+	}
 	// With osType Linux and coreos distro
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Linux", "distro" : "coreos", "count": 1, "vmSize": "Standard_D2_v2",
 "availabilityProfile": "VirtualMachineScaleSets", "storageProfile" : "ManagedDisks", "diskSizesGB" : [750, 250, 600, 1000], "diskEncryptionSetID": "diskEncryptionSetID" }`


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This PR is actually a place holder, it's mainly for AKS to support  EncryptionAtHost(Enable Encryption at Host support for VM/VMSS) (JEDI requirement) which is going to be in private preview late this month.

EncryptionAtHost functionality actually does not work by this PR since it depends on
 - go sdk ready and upgrade to supported go sdk version
 - EncryptionAtHost feature on public regions ready
 - subs whitelist

Will make it work when the above 3 requirements are fullfilled.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
