### PR TITLE
fix: remove unnecessary apt lock waits

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -127,7 +127,6 @@ apt_get_update() {
     fi
   done
   echo Executed apt-get update $i times
-  wait_for_apt_locks
 }
 apt_get_install() {
   retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
@@ -144,7 +143,6 @@ apt_get_install() {
       fi
   done
   echo Executed apt-get install --no-install-recommends -y \"$@\" $i times
-  wait_for_apt_locks
 }
 apt_get_purge() {
   retries=20; wait_sleep=30; timeout=120
@@ -164,7 +162,6 @@ apt_get_purge() {
     fi
   done
   echo Executed apt-get purge -y \"$package\" $i times
-  wait_for_apt_locks
 }
 apt_get_dist_upgrade() {
   retries=10
@@ -184,7 +181,6 @@ apt_get_dist_upgrade() {
     fi
   done
   echo Executed apt-get dist-upgrade $i times
-  wait_for_apt_locks
 }
 systemctl_restart() {
   retries=$1; wait_sleep=$2; timeout=$3 svcname=$4

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40682,7 +40682,6 @@ apt_get_update() {
     fi
   done
   echo Executed apt-get update $i times
-  wait_for_apt_locks
 }
 apt_get_install() {
   retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
@@ -40699,7 +40698,6 @@ apt_get_install() {
       fi
   done
   echo Executed apt-get install --no-install-recommends -y \"$@\" $i times
-  wait_for_apt_locks
 }
 apt_get_purge() {
   retries=20; wait_sleep=30; timeout=120
@@ -40719,7 +40717,6 @@ apt_get_purge() {
     fi
   done
   echo Executed apt-get purge -y \"$package\" $i times
-  wait_for_apt_locks
 }
 apt_get_dist_upgrade() {
   retries=10
@@ -40739,7 +40736,6 @@ apt_get_dist_upgrade() {
     fi
   done
   echo Executed apt-get dist-upgrade $i times
-  wait_for_apt_locks
 }
 systemctl_restart() {
   retries=$1; wait_sleep=$2; timeout=$3 svcname=$4


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR removes superfluous "wait for no held apt locks" *after* apt operations have already completed. Instead we are waiting only *before* attempting an apt operation. This configuration in concert will promote good apt race condition avoidance without unnecessarily blocking CSE progression (for example, the next operation after an apt operation is probably not _another_ apt operation, and so waiting for apt locks to be released means we're delaying that next operation unnecessarily).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
