### PR TITLE
feat: Allow specifying Distro and ImageRef at the same time to support air-gapped cloud

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -444,22 +444,24 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			}
 
 			// Distro assignment for masterProfile
-			if cs.Properties.MasterProfile.Distro == "" && cs.Properties.MasterProfile.ImageRef == nil {
-				if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
-					cs.Properties.MasterProfile.Distro = AKSUbuntu1604
-				} else {
+			if cs.Properties.MasterProfile.ImageRef == nil {
+				if cs.Properties.MasterProfile.Distro == "" {
+					if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
+						cs.Properties.MasterProfile.Distro = AKSUbuntu1604
+					} else {
+						cs.Properties.MasterProfile.Distro = Ubuntu
+					}
+				} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
+					if cs.Properties.MasterProfile.Distro == AKSDockerEngine || cs.Properties.MasterProfile.Distro == AKS1604Deprecated {
+						cs.Properties.MasterProfile.Distro = AKSUbuntu1604
+					} else if cs.Properties.MasterProfile.Distro == AKS1804Deprecated {
+						cs.Properties.MasterProfile.Distro = AKSUbuntu1804
+					}
+				}
+				// The AKS Distro is not available in Azure German Cloud.
+				if cloudSpecConfig.CloudName == AzureGermanCloud {
 					cs.Properties.MasterProfile.Distro = Ubuntu
 				}
-			} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
-				if cs.Properties.MasterProfile.Distro == AKSDockerEngine || cs.Properties.MasterProfile.Distro == AKS1604Deprecated {
-					cs.Properties.MasterProfile.Distro = AKSUbuntu1604
-				} else if cs.Properties.MasterProfile.Distro == AKS1804Deprecated {
-					cs.Properties.MasterProfile.Distro = AKSUbuntu1804
-				}
-			}
-			// The AKS Distro is not available in Azure German Cloud.
-			if cloudSpecConfig.CloudName == AzureGermanCloud {
-				cs.Properties.MasterProfile.Distro = Ubuntu
 			}
 		}
 
@@ -484,29 +486,31 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			}
 			// Distro assignment for pools
 			if profile.OSType != Windows {
-				if profile.Distro == "" && profile.ImageRef == nil {
-					if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
-						if profile.OSDiskSizeGB != 0 && profile.OSDiskSizeGB < VHDDiskSizeAKS {
-							profile.Distro = Ubuntu
+				if profile.ImageRef == nil {
+					if profile.Distro == "" {
+						if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
+							if profile.OSDiskSizeGB != 0 && profile.OSDiskSizeGB < VHDDiskSizeAKS {
+								profile.Distro = Ubuntu
+							} else {
+								profile.Distro = AKSUbuntu1604
+							}
 						} else {
-							profile.Distro = AKSUbuntu1604
+							profile.Distro = Ubuntu
 						}
-					} else {
+						// Ensure deprecated distros are overridden
+						// Previous versions of aks-engine required the docker-engine distro for N series vms,
+						// so we need to hard override it in order to produce a working cluster in upgrade/scale contexts.
+					} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
+						if profile.Distro == AKSDockerEngine || profile.Distro == AKS1604Deprecated {
+							profile.Distro = AKSUbuntu1604
+						} else if profile.Distro == AKS1804Deprecated {
+							profile.Distro = AKSUbuntu1804
+						}
+					}
+					// The AKS Distro is not available in Azure German Cloud.
+					if cloudSpecConfig.CloudName == AzureGermanCloud {
 						profile.Distro = Ubuntu
 					}
-					// Ensure deprecated distros are overridden
-					// Previous versions of aks-engine required the docker-engine distro for N series vms,
-					// so we need to hard override it in order to produce a working cluster in upgrade/scale contexts.
-				} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
-					if profile.Distro == AKSDockerEngine || profile.Distro == AKS1604Deprecated {
-						profile.Distro = AKSUbuntu1604
-					} else if profile.Distro == AKS1804Deprecated {
-						profile.Distro = AKSUbuntu1804
-					}
-				}
-				// The AKS Distro is not available in Azure German Cloud.
-				if cloudSpecConfig.CloudName == AzureGermanCloud {
-					profile.Distro = Ubuntu
 				}
 			}
 		}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -393,9 +393,6 @@ func (a *Properties) validateMasterProfile(isUpdate bool) error {
 	}
 
 	if m.ImageRef != nil {
-		if m.Distro != "" {
-			return errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously")
-		}
 		if err := m.ImageRef.validateImageNameAndGroup(); err != nil {
 			return err
 		}
@@ -501,9 +498,6 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 		}
 
 		if agentPoolProfile.ImageRef != nil {
-			if agentPoolProfile.Distro != "" {
-				return errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously", agentPoolProfile.Name)
-			}
 			return agentPoolProfile.ImageRef.validateImageNameAndGroup()
 		}
 

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -4311,7 +4311,7 @@ func TestValidateMasterProfileImageRef(t *testing.T) {
 		isUpdate      bool
 		expectedError error
 	}{
-		"should error when masterProfile includes both an ImageRef and a Distro configuration": {
+		"should not error when masterProfile includes both an ImageRef and a Distro configuration": {
 			properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: Kubernetes,
@@ -4329,9 +4329,9 @@ func TestValidateMasterProfileImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      false,
-			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously"),
+			expectedError: nil,
 		},
-		"should error when masterProfile includes both an ImageRef and a Distro configuration in update context": {
+		"should not error when masterProfile includes both an ImageRef and a Distro configuration in update context": {
 			properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: Kubernetes,
@@ -4349,7 +4349,7 @@ func TestValidateMasterProfileImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      true,
-			expectedError: errors.New("masterProfile includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously"),
+			expectedError: nil,
 		},
 		"should not error when masterProfile includes an ImageRef configuration only": {
 			properties: &Properties{
@@ -4459,7 +4459,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 		isUpdate      bool
 		expectedError error
 	}{
-		"should error when AgentPoolProfile includes both an ImageRef and a Distro configuration": {
+		"should not error when AgentPoolProfile includes both an ImageRef and a Distro configuration": {
 			properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: Kubernetes,
@@ -4479,9 +4479,9 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      false,
-			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously", "foo"),
+			expectedError: nil,
 		},
-		"should error when AgentPoolProfile includes both an ImageRef and a Distro configuration in update context": {
+		"should not error when AgentPoolProfile includes both an ImageRef and a Distro configuration in update context": {
 			properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: Kubernetes,
@@ -4501,7 +4501,7 @@ func TestValidateAgentPoolProfilesImageRef(t *testing.T) {
 				},
 			},
 			isUpdate:      true,
-			expectedError: errors.Errorf("agentPoolProfile %s includes a custom image configuration (imageRef) and an explicit distro configuration, you may use one of these but not both simultaneously", "foo"),
+			expectedError: nil,
 		},
 		"should not error when AgentPoolProfile includes an ImageRef configuration only": {
 			properties: &Properties{


### PR DESCRIPTION
**Reason for Change**:
To support a scenario in air-gapped cloud where you need to manually upload an "official" distro image and refer it as ImageRef but STILL be treated as an official distro in aks-engine.

This change is required for treating these manually uploaded "official" distro images exactly same as official Distros VHDs in aks-engine flow, especially passing "{{- if HasVHDDistroNodes}}" variant checks in cse_main.sh to be treated as a "golden image":

https://github.com/Azure/aks-engine/blob/51bde0dbbec2bf90a18ad3fda5bdf3b127c94c3a/parts/k8s/cloud-init/artifacts/cse_main.sh#L71

Also, the semantic makes sense. When you specify Distro and ImageRef at the same time, Distro value is only used as a "hint" in various places. It still outputs ImageRef as an os image in the ARM template.

I believe this change is very safe because it does not affect existing behavior at all (all existing test cases pass).

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
