### PR TITLE
chore: rev Linux VHDs to 2020.04.09

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -154,17 +154,17 @@ var (
 	// AKSUbuntu1604OSImageConfig is the AKS image based on Ubuntu 16.04-LTS.
 	AKSUbuntu1604OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
-		ImageSku:       "aks-engine-ubuntu-1604-202003",
+		ImageSku:       "aks-engine-ubuntu-1604-202004",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.03.19",
+		ImageVersion:   "2020.04.09",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
 	AKSUbuntu1804OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
-		ImageSku:       "aks-engine-ubuntu-1804-202003",
+		ImageSku:       "aks-engine-ubuntu-1804-202004",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.03.19",
+		ImageVersion:   "2020.04.09",
 	}
 
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019

--- a/test/e2e/test_cluster_configs/no_outbound.json
+++ b/test/e2e/test_cluster_configs/no_outbound.json
@@ -1,7 +1,7 @@
 {
 	"env": {},
 	"options": {
-		"allowedOrchestratorVersions": ["1.13", "1.14", "1.15", "1.16", "1.17"]
+		"allowedOrchestratorVersions": ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18"]
 	},
 	"apiModel": {
 		"apiVersion": "vlabs",
@@ -19,7 +19,15 @@
 					"name": "agentpool1",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
-					"availabilityProfile": "VirtualMachineScaleSets"
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"distro": "aks-ubuntu-16.04"
+				},
+				{
+					"name": "agentpool1",
+					"count": 1,
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"distro": "aks-ubuntu-18.04"
 				},
 				{
 					"name": "agentwin",

--- a/test/e2e/test_cluster_configs/no_outbound.json
+++ b/test/e2e/test_cluster_configs/no_outbound.json
@@ -16,21 +16,21 @@
 			},
 			"agentPoolProfiles": [
 				{
-					"name": "agentpool1",
+					"name": "pool1604vhd",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"availabilityProfile": "VirtualMachineScaleSets",
 					"distro": "aks-ubuntu-16.04"
 				},
 				{
-					"name": "agentpool1",
+					"name": "pool1804vhd",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"availabilityProfile": "VirtualMachineScaleSets",
 					"distro": "aks-ubuntu-18.04"
 				},
 				{
-					"name": "agentwin",
+					"name": "poolwinvhd",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"availabilityProfile": "VirtualMachineScaleSets",

--- a/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202004_2020.04.09.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202004_2020.04.09.txt
@@ -1,0 +1,153 @@
+Starting build on  Thu Apr 9 22:37:40 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dkms
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - gcc
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - linux-headers-4.15.0-1075-azure
+  - make
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - apmz v0.5.1
+  - bpftrace
+  - moby v3.0.11
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.19
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.0.33
+  - Azure CNI version 1.0.30
+  - Azure CNI version 1.0.29
+  - CNI plugin version 0.8.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - mcr.microsoft.com/oss/kubernetes/kubernetes-dashboard:v1.10.1
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v8.9.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.17.2
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.16.5
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.15.6
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.14.8
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.13.9
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - k8s.gcr.io/coredns:1.6.7
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.8
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.32
+  - nvidia/k8s-device-plugin:1.11
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.8
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.8
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.14.8
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.13.12
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.13.12
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.4.1
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.4.1
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar:v1.0.1
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - k8s.gcr.io/node-problem-detector:v0.8.1
+  - mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.3
+  - mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.9
+  - registry:2.7.1
+Using kernel:
+Linux version 4.15.0-1075-azure (buildd@lcy01-amd64-018) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)) #80-Ubuntu SMP Wed Mar 18 13:27:16 UTC 2020
+Install completed successfully on  Thu Apr 9 22:55:20 UTC 2020
+VSTS Build NUMBER: 20200409.13
+VSTS Build ID: 30147270
+Commit: d981027d449c1964e2105413ea10df150a9f41ab
+Feature flags:

--- a/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202004_2020.04.09.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202004_2020.04.09.txt
@@ -1,0 +1,155 @@
+Starting build on  Thu Apr 9 22:37:37 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dkms
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - gcc
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - linux-headers-5.0.0-1035-azure
+  - make
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - ntp
+  - ntpstat
+  - apmz v0.5.1
+  - bpftrace
+  - moby v3.0.11
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.19
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.0.33
+  - Azure CNI version 1.0.30
+  - Azure CNI version 1.0.29
+  - CNI plugin version 0.8.5
+  - img
+Docker images pre-pulled:
+  - k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+  - mcr.microsoft.com/oss/kubernetes/kubernetes-dashboard:v1.10.1
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
+  - k8s.gcr.io/kube-addon-manager-amd64:v8.9.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v8.9.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/k8s/core/pause:1.2.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.17.2
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.16.5
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.15.6
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.14.8
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.13.9
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - k8s.gcr.io/coredns:1.6.7
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.8
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.0.32
+  - nvidia/k8s-device-plugin:1.11
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.0
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.4
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.3
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.8
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.7-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.10-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.8
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.14.8
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.14.7
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.14.7-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.13.12
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.13.12
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.13.11
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.4.1
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.4.1
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar:v1.0.1
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - k8s.gcr.io/node-problem-detector:v0.8.1
+  - mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.3
+  - mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.9
+  - registry:2.7.1
+Using kernel:
+Linux version 5.0.0-1035-azure (buildd@lgw01-amd64-039) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #37-Ubuntu SMP Wed Mar 18 11:21:35 UTC 2020
+Install completed successfully on  Thu Apr 9 22:55:58 UTC 2020
+VSTS Build NUMBER: 20200409.14
+VSTS Build ID: 30147277
+Commit: d981027d449c1964e2105413ea10df150a9f41ab
+Feature flags:


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR brings in new Linux VHDs. Of especial import: these VHDs now explicitly back MCR image-originating (mcr.microsoft.com) cluster image references to support https://github.com/Azure/aks-engine/pull/3046.

Other changes:

Includes a new pre-installed etcd version:

- etcd v3.3.19

Includes new cluster-autoscaler versions:

- mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.1
- mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.17.2
- mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.16.5
- mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.15.6
- mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.14.8

New Azure CNI componentry:

- mcr.microsoft.com/containernetworking/networkmonitor:v0.0.8

Images supporting new Kubernetes versions:

- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.1
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.1
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.1
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.1
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.0
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.0
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.0
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.0

To support updated csi-secrets-store functionality:

- mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.3
- mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.9

Includes a new 16.04-LTS Linux kernel:

- `Linux version 4.15.0-1075-azure (buildd@lcy01-amd64-018) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)) #80-Ubuntu SMP Wed Mar 18 13:27:16 UTC 2020`

Includes a new 18.04-LTS Linux kernel:

- `Linux version 5.0.0-1035-azure (buildd@lgw01-amd64-039) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #37-Ubuntu SMP Wed Mar 18 11:21:35 UTC 2020`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
