### PR TITLE
refactor: skip sgx driver installation if already exists in OS

### DIFF
--- a/docs/topics/sgx.md
+++ b/docs/topics/sgx.md
@@ -19,7 +19,7 @@ Refer to the [Quickstart Guide](../tutorials/quickstart.md) for details on how t
 
 | OS           | distro      | Notes |
 | ------------ | ----------- |-------|
-| Ubuntu 16.04 | `acc-16.04` | specially built image with UEFI BIOS support
+| Ubuntu 16.04 | `aks-ubuntu-16.04` | AKS-maintained Ubuntu 16.04 image with preinstalled components
 | Ubuntu 18.04 | `aks-ubuntu-18.04` | AKS-maintained Ubuntu 18.04 image with preinstalled components
 
 The following example is a fragment of a cluster definition (apimodel) file declaring two ACC agent pools, one running `Ubuntu 16.04` image on `2 vCPU` nodes, and another running `Ubuntu 18.04` image on `4 vCPU` nodes:
@@ -29,7 +29,7 @@ The following example is a fragment of a cluster definition (apimodel) file decl
     {
       "name": "agentpool1",
       "count": 3,
-      "distro": "acc-16.04",
+      "distro": "aks-ubuntu-16.04",
       "vmSize": "Standard_DC2s"
     },
     {

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -154,7 +154,7 @@ time_metric "EnsureRPC" ensureRPC
 time_metric "CreateKubeManifestDir" createKubeManifestDir
 
 {{- if HasDCSeriesSKU}}
-if [[ ${SGX_NODE} == true ]]; then
+if [[ ${SGX_NODE} == true && ! -e "/dev/sgx" ]]; then
   time_metric "InstallSGXDrivers" installSGXDrivers
 fi
 {{end}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -41186,7 +41186,7 @@ time_metric "EnsureRPC" ensureRPC
 time_metric "CreateKubeManifestDir" createKubeManifestDir
 
 {{- if HasDCSeriesSKU}}
-if [[ ${SGX_NODE} == true ]]; then
+if [[ ${SGX_NODE} == true && ! -e "/dev/sgx" ]]; then
   time_metric "InstallSGXDrivers" installSGXDrivers
 fi
 {{end}}

--- a/test/e2e/kubernetes/workloads/sgx-test.yaml
+++ b/test/e2e/kubernetes/workloads/sgx-test.yaml
@@ -18,6 +18,5 @@ spec:
       - name: dev-sgx
         hostPath:
           path: /dev/sgx
-          type: CharDevice
       restartPolicy: Never
   backoffLimit: 0


### PR DESCRIPTION
**Reason for Change**:

Azure Ubuntu images is now shipped with Intel SGX driver by default. We skip the driver installation if "/dev/sgx" is detected. We keep the installation code in case of a custom image is used.

**Issue Fixed**:

NA

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

None