### PR TITLE
feat: Support Non-Azure Stack Custom Clouds with custom endpoints/root certs/sources.list

### DIFF
--- a/cmd/addpool.go
+++ b/cmd/addpool.go
@@ -143,9 +143,9 @@ func (apc *addPoolCmd) load() error {
 		return errors.Wrap(err, "error parsing the agent pool")
 	}
 
-	if apc.containerService.Properties.IsAzureStackCloud() {
+	if apc.containerService.Properties.IsCustomCloudProfile() {
 		writeCustomCloudProfile(apc.containerService)
-		if err = apc.containerService.Properties.SetAzureStackCloudSpec(api.AzureStackCloudSpecParams{IsUpgrade: false, IsScale: true}); err != nil {
+		if err = apc.containerService.Properties.SetCustomCloudSpec(api.AzureCustomCloudSpecParams{IsUpgrade: false, IsScale: true}); err != nil {
 			return errors.Wrap(err, "error parsing the api model")
 		}
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -220,7 +220,7 @@ func (dc *deployCmd) loadAPIModel() error {
 		return errors.New("--location does not match api model location")
 	}
 
-	if dc.containerService.Properties.IsAzureStackCloud() {
+	if dc.containerService.Properties.IsCustomCloudProfile() {
 		err = dc.containerService.SetCustomCloudProfileEnvironment()
 		if err != nil {
 			return errors.Wrap(err, "error parsing the api model")
@@ -365,7 +365,7 @@ func autofillApimodel(dc *deployCmd) error {
 	if k8sConfig != nil && k8sConfig.Addons != nil && k8sConfig.IsContainerMonitoringAddonEnabled() {
 		log.Infoln("container monitoring addon enabled")
 		cloudOrDependenciesLocation := dc.containerService.GetCloudSpecConfig().CloudName
-		if dc.containerService.Properties.IsAzureStackCloud() {
+		if dc.containerService.Properties.IsCustomCloudProfile() {
 			cloudOrDependenciesLocation = string(dc.containerService.Properties.CustomCloudProfile.DependenciesLocation)
 		}
 		workspaceDomain := helpers.GetLogAnalyticsWorkspaceDomain(cloudOrDependenciesLocation)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -669,6 +669,47 @@ func TestDeployCmdRun(t *testing.T) {
 	}
 }
 
+func TestLoadApiModelOnCustomCloud(t *testing.T) {
+	t.Parallel()
+
+	outdir, del := makeTmpDir(t)
+	defer del()
+
+	d := &deployCmd{
+		client: &armhelpers.MockAKSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs:      &authArgs{},
+			getClientMock: &armhelpers.MockAKSEngineClient{},
+		},
+		apimodelPath:    "../pkg/engine/testdata/customcloud/kubernetes.json",
+		outputDirectory: outdir,
+		forceOverwrite:  true,
+		location:        "westus",
+	}
+
+	r := &cobra.Command{}
+	f := r.Flags()
+
+	addAuthFlags(d.getAuthArgs(), f)
+
+	fakeRawSubscriptionID := "6dc93fae-9a76-421f-bbe5-cc6460ea81cb"
+	fakeSubscriptionID, err := uuid.Parse(fakeRawSubscriptionID)
+	fakeClientID := "b829b379-ca1f-4f1d-91a2-0d26b244680d"
+	fakeClientSecret := "0se43bie-3zs5-303e-aav5-dcf231vb82ds"
+	if err != nil {
+		t.Fatalf("Invalid SubscriptionId in Test: %s", err)
+	}
+
+	d.getAuthArgs().SubscriptionID = fakeSubscriptionID
+	d.getAuthArgs().rawSubscriptionID = fakeRawSubscriptionID
+	d.getAuthArgs().rawClientID = fakeClientID
+	d.getAuthArgs().ClientSecret = fakeClientSecret
+	err = d.loadAPIModel()
+	if err != nil {
+		t.Fatalf("Failed to call LoadAPIModel: %s", err)
+	}
+}
+
 func TestLoadApiModelOnAzureStack(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -159,10 +159,10 @@ func (sc *scaleCmd) load() error {
 		return errors.Wrap(err, "error parsing the api model")
 	}
 
-	if sc.containerService.Properties.IsAzureStackCloud() {
+	if sc.containerService.Properties.IsCustomCloudProfile() {
 		writeCustomCloudProfile(sc.containerService)
 
-		if err = sc.containerService.Properties.SetAzureStackCloudSpec(api.AzureStackCloudSpecParams{IsUpgrade: false, IsScale: true}); err != nil {
+		if err = sc.containerService.Properties.SetCustomCloudSpec(api.AzureCustomCloudSpecParams{IsUpgrade: false, IsScale: true}); err != nil {
 			return errors.Wrap(err, "error parsing the api model")
 		}
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -172,9 +172,9 @@ func (uc *upgradeCmd) loadCluster() error {
 		}
 	}
 
-	if uc.containerService.Properties.IsAzureStackCloud() {
+	if uc.containerService.Properties.IsCustomCloudProfile() {
 		writeCustomCloudProfile(uc.containerService)
-		if err = uc.containerService.Properties.SetAzureStackCloudSpec(api.AzureStackCloudSpecParams{
+		if err = uc.containerService.Properties.SetCustomCloudSpec(api.AzureCustomCloudSpecParams{
 			IsUpgrade: true,
 			IsScale:   false,
 		}); err != nil {

--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 {{- if IsCustomCloudProfile}}
-{{- if not IsAzureStackCloud}}
+  {{- if not IsAzureStackCloud}}
 ensureCustomCloudRootCertificates() {
     CUSTOM_CLOUD_ROOT_CERTIFICATES="{{GetCustomCloudRootCertificates}}"
 
@@ -38,7 +38,7 @@ ensureCustomCloudSourcesList() {
         echo $CUSTOM_CLOUD_SOURCES_LIST | base64 -d > /etc/apt/sources.list
     fi
 }
-{{end}}
+  {{end}}
 
 configureK8sCustomCloud() {
   KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml

--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -4,6 +4,7 @@
   {{- if not IsAzureStackCloud}}
 ensureCustomCloudRootCertificates() {
     CUSTOM_CLOUD_ROOT_CERTIFICATES="{{GetCustomCloudRootCertificates}}"
+    KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
 
     if [ ! -z $CUSTOM_CLOUD_ROOT_CERTIFICATES ]; then
         # Replace placeholder for ssl binding
@@ -41,8 +42,6 @@ ensureCustomCloudSourcesList() {
   {{end}}
 
 configureK8sCustomCloud() {
-  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
-
   {{- if IsAzureStackCloud}}
   export -f ensureAzureStackCertificates
   retrycmd 60 10 30 bash -c ensureAzureStackCertificates
@@ -103,7 +102,7 @@ ensureAzureStackCertificates() {
   AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
   curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
   CURL_RETURNCODE=$?
-
+  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
   if [ $CURL_RETURNCODE != 0 ]; then
     # Replace placeholder for ssl binding
     if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then

--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 {{- if IsCustomCloudProfile}}
+{{- if not IsAzureStackCloud}}
 ensureCustomCloudRootCertificates() {
     CUSTOM_CLOUD_ROOT_CERTIFICATES="{{GetCustomCloudRootCertificates}}"
 
@@ -37,6 +38,7 @@ ensureCustomCloudSourcesList() {
         echo $CUSTOM_CLOUD_SOURCES_LIST | base64 -d > /etc/apt/sources.list
     fi
 }
+{{end}}
 
 configureK8sCustomCloud() {
   KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -36,7 +36,7 @@ eval "$(apmz bash -d)"
 wait_for_file 3600 1 {{GetCSEConfigScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
 source {{GetCSEConfigScriptFilepath}}
 
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
 wait_for_file 3600 1 {{GetCustomCloudConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
 source {{GetCustomCloudConfigCSEScriptFilepath }}
 {{end}}
@@ -188,9 +188,9 @@ time_metric "EnsureDocker" ensureDocker
 
 time_metric "ConfigureK8s" configureK8s
 
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
 time_metric "ConfigureK8sCustomCloud" configureK8sCustomCloud
-{{- if IsAzureCNI}}
+{{- if and IsAzureStackCloud IsAzureCNI}}
 time_metric "ConfigureAzureStackInterfaces" configureAzureStackInterfaces
 {{end}}
 {{end}}

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -59,7 +59,7 @@ write_files:
   {{end}}
 {{end}}
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: {{GetCustomCloudConfigCSEScriptFilepath}}
   permissions: "0744"
   encoding: gzip
@@ -383,7 +383,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
 {{else}}
     KUBELET_NODE_LABELS={{GetMasterKubernetesLabelsDeprecated "',variables('labelResourceGroup'),'"}}
 {{end}}
-{{if IsAzureStackCloud }}
+{{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
 {{if AnyAgentIsLinux}}
@@ -498,7 +498,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
 {{end}}
     #EOF
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: "/etc/kubernetes/azurestackcloud.json"
   permissions: "0600"
   owner: "root"

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -67,7 +67,7 @@ write_files:
   {{end}}
 {{end}}
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: {{GetCustomCloudConfigCSEScriptFilepath}}
   permissions: "0744"
   encoding: gzip
@@ -347,7 +347,7 @@ write_files:
 {{else}}
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabelsDeprecated . "',variables('labelResourceGroup'),'"}}
 {{end}}
-{{if IsAzureStackCloud }}
+{{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
     #EOF
@@ -364,7 +364,7 @@ write_files:
 {{end}}
     #EOF
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: "/etc/kubernetes/azurestackcloud.json"
   permissions: "0600"
   owner: "root"

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -293,7 +293,7 @@ try
             -ExcludeMasterFromStandardLB $global:ExcludeMasterFromStandardLB `
             -TargetEnvironment $TargetEnvironment
 
-        {{if IsAzureStackCloud}}
+        {{if IsCustomCloudProfile}}
         $azureStackConfigFile = [io.path]::Combine($global:KubeDir, "azurestackcloud.json")
         $envJSON = "{{ GetBase64EncodedEnvironmentJSON }}"
         [io.file]::WriteAllBytes($azureStackConfigFile, [System.Convert]::FromBase64String($envJSON))

--- a/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
@@ -15,7 +15,7 @@ spec:
       imagePullPolicy: IfNotPresent
       command: [{{ContainerConfig "command"}}]
       args: [{{GetControllerManagerArgs}}]
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
       env:
       - name: AZURE_ENVIRONMENT_FILEPATH
         value: "/etc/kubernetes/azurestackcloud.json"
@@ -33,7 +33,7 @@ spec:
         - name: msi
           mountPath: /var/lib/waagent/ManagedIdentity-Settings
           readOnly: true
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
         <volumeMountssl>
 {{end}}
   volumes:
@@ -51,6 +51,6 @@ spec:
     - name: msi
       hostPath:
         path: /var/lib/waagent/ManagedIdentity-Settings
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
     <volumessl>
 {{end}}

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -30,7 +30,7 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 	k8sComponents := GetK8sComponentsByVersionMap(o.KubernetesConfig)[o.OrchestratorVersion]
 	omsagentImage := "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod03022020"
 	var workspaceDomain string
-	if cs.Properties.IsAzureStackCloud() {
+	if cs.Properties.IsCustomCloudProfile() {
 		dependenciesLocation := string(cs.Properties.CustomCloudProfile.DependenciesLocation)
 		workspaceDomain = helpers.GetLogAnalyticsWorkspaceDomain(dependenciesLocation)
 		if strings.EqualFold(dependenciesLocation, "china") {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -513,14 +513,14 @@ const (
 )
 
 const (
-	// AzureStackDependenciesLocationPublic indicates to get dependencies from in AzurePublic cloud
-	AzureStackDependenciesLocationPublic = "public"
-	// AzureStackDependenciesLocationChina indicates to get dependencies from AzureChina cloud
-	AzureStackDependenciesLocationChina = "china"
-	// AzureStackDependenciesLocationGerman indicates to get dependencies from AzureGerman cloud
-	AzureStackDependenciesLocationGerman = "german"
-	// AzureStackDependenciesLocationUSGovernment indicates to get dependencies from AzureUSGovernment cloud
-	AzureStackDependenciesLocationUSGovernment = "usgovernment"
+	// AzureCustomCloudDependenciesLocationPublic indicates to get dependencies from in AzurePublic cloud
+	AzureCustomCloudDependenciesLocationPublic = "public"
+	// AzureCustomCloudDependenciesLocationChina indicates to get dependencies from AzureChina cloud
+	AzureCustomCloudDependenciesLocationChina = "china"
+	// AzureCustomCloudDependenciesLocationGerman indicates to get dependencies from AzureGerman cloud
+	AzureCustomCloudDependenciesLocationGerman = "german"
+	// AzureCustomCloudDependenciesLocationUSGovernment indicates to get dependencies from AzureUSGovernment cloud
+	AzureCustomCloudDependenciesLocationUSGovernment = "usgovernment"
 )
 
 const (

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -693,6 +693,8 @@ func convertCloudProfileToVLabs(api *CustomCloudProfile, vlabsccp *vlabs.CustomC
 	vlabsccp.AuthenticationMethod = api.AuthenticationMethod
 	vlabsccp.DependenciesLocation = vlabs.DependenciesLocation(api.DependenciesLocation)
 	vlabsccp.PortalURL = api.PortalURL
+	vlabsccp.CustomCloudRootCertificates = api.CustomCloudRootCertificates
+	vlabsccp.CustomCloudSourcesList = api.CustomCloudSourcesList
 }
 
 func convertTelemetryProfileToVLabs(api *TelemetryProfile, vlabstp *vlabs.TelemetryProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -768,6 +768,8 @@ func convertVLabsCustomCloudProfile(vlabs *vlabs.CustomCloudProfile, api *Custom
 	api.AuthenticationMethod = vlabs.AuthenticationMethod
 	api.DependenciesLocation = DependenciesLocation(vlabs.DependenciesLocation)
 	api.PortalURL = vlabs.PortalURL
+	api.CustomCloudRootCertificates = vlabs.CustomCloudRootCertificates
+	api.CustomCloudSourcesList = vlabs.CustomCloudSourcesList
 }
 
 func convertVLabsTelemetryProfile(vlabs *vlabs.TelemetryProfile, api *TelemetryProfile) {

--- a/pkg/api/defaults-custom-cloud-profile.go
+++ b/pkg/api/defaults-custom-cloud-profile.go
@@ -22,8 +22,8 @@ type CustomCloudProfileDefaultsParams struct {
 	IsScale   bool
 }
 
-func getAzureStackFQDNSuffix(portalUrl, location string) string {
-	azsFQDNSuffix := strings.Replace(portalUrl, fmt.Sprintf("https://portal.%s.", location), "", -1)
+func getAzureStackFQDNSuffix(portalURL, location string) string {
+	azsFQDNSuffix := strings.Replace(portalURL, fmt.Sprintf("https://portal.%s.", location), "", -1)
 	azsFQDNSuffix = strings.TrimSuffix(azsFQDNSuffix, "/")
 
 	return azsFQDNSuffix

--- a/pkg/api/defaults-custom-cloud-profile.go
+++ b/pkg/api/defaults-custom-cloud-profile.go
@@ -22,17 +22,24 @@ type CustomCloudProfileDefaultsParams struct {
 	IsScale   bool
 }
 
+func getAzureStackFQDNSuffix(portalUrl, location string) string {
+	azsFQDNSuffix := strings.Replace(portalUrl, fmt.Sprintf("https://portal.%s.", location), "", -1)
+	azsFQDNSuffix = strings.TrimSuffix(azsFQDNSuffix, "/")
+
+	return azsFQDNSuffix
+}
+
 func (cs *ContainerService) setCustomCloudProfileDefaults(params CustomCloudProfileDefaultsParams) error {
 	p := cs.Properties
-	if p.IsAzureStackCloud() {
+	if p.IsCustomCloudProfile() {
 		p.CustomCloudProfile.AuthenticationMethod = helpers.EnsureString(p.CustomCloudProfile.AuthenticationMethod, ClientSecretAuthMethod)
 		p.CustomCloudProfile.IdentitySystem = helpers.EnsureString(p.CustomCloudProfile.IdentitySystem, AzureADIdentitySystem)
-		p.CustomCloudProfile.DependenciesLocation = DependenciesLocation(helpers.EnsureString(string(p.CustomCloudProfile.DependenciesLocation), AzureStackDependenciesLocationPublic))
+		p.CustomCloudProfile.DependenciesLocation = DependenciesLocation(helpers.EnsureString(string(p.CustomCloudProfile.DependenciesLocation), AzureCustomCloudDependenciesLocationPublic))
 		err := cs.SetCustomCloudProfileEnvironment()
 		if err != nil {
 			return fmt.Errorf("Failed to set environment - %s", err)
 		}
-		err = p.SetAzureStackCloudSpec(AzureStackCloudSpecParams(params))
+		err = p.SetCustomCloudSpec(AzureCustomCloudSpecParams(params))
 		if err != nil {
 			return fmt.Errorf("Failed to set cloud spec - %s", err)
 		}
@@ -40,23 +47,31 @@ func (cs *ContainerService) setCustomCloudProfileDefaults(params CustomCloudProf
 	return nil
 }
 
-// SetCustomCloudProfileEnvironment retrieves the endpoints from Azure Stack metadata endpoint and sets the values for azure.Environment
+// SetCustomCloudProfileEnvironment retrieves the endpoints from metadata endpoint (when required) and sets the values for azure.Environment
 func (cs *ContainerService) SetCustomCloudProfileEnvironment() error {
 	p := cs.Properties
-	if p.IsAzureStackCloud() {
+	if p.IsCustomCloudProfile() {
 		if p.CustomCloudProfile.Environment == nil {
 			p.CustomCloudProfile.Environment = &azure.Environment{}
 		}
 
 		env := p.CustomCloudProfile.Environment
-		if env.Name == "" || env.ResourceManagerEndpoint == "" || env.ServiceManagementEndpoint == "" || env.ActiveDirectoryEndpoint == "" || env.GraphEndpoint == "" || env.ResourceManagerVMDNSSuffix == "" {
-			env.Name = AzureStackCloud
-			if !strings.HasPrefix(p.CustomCloudProfile.PortalURL, fmt.Sprintf("https://portal.%s.", cs.Location)) {
-				return fmt.Errorf("portalURL needs to start with https://portal.%s. ", cs.Location)
+		if env.Name == "" || env.ServiceManagementEndpoint == "" || env.ActiveDirectoryEndpoint == "" || env.GraphEndpoint == "" || env.ResourceManagerVMDNSSuffix == "" {
+			if env.Name == "" {
+				env.Name = AzureStackCloud
 			}
-			azsFQDNSuffix := strings.Replace(p.CustomCloudProfile.PortalURL, fmt.Sprintf("https://portal.%s.", cs.Location), "", -1)
-			azsFQDNSuffix = strings.TrimSuffix(azsFQDNSuffix, "/")
-			env.ResourceManagerEndpoint = fmt.Sprintf("https://management.%s.%s/", cs.Location, azsFQDNSuffix)
+
+			if p.IsAzureStackCloud() {
+				if !strings.HasPrefix(p.CustomCloudProfile.PortalURL, fmt.Sprintf("https://portal.%s.", cs.Location)) {
+					return fmt.Errorf("portalURL needs to start with https://portal.%s. ", cs.Location)
+				}
+
+				azsFQDNSuffix := getAzureStackFQDNSuffix(p.CustomCloudProfile.PortalURL, cs.Location)
+				env.ResourceManagerEndpoint = fmt.Sprintf("https://management.%s.%s/", cs.Location, azsFQDNSuffix)
+			} else if env.ResourceManagerEndpoint == "" {
+				return fmt.Errorf("Non-AzureStack CustomCloudProfile MUST provide ResourceManagerEndpoint")
+			}
+
 			metadataURL := fmt.Sprintf("%s/metadata/endpoints?api-version=1.0", strings.TrimSuffix(env.ResourceManagerEndpoint, "/"))
 
 			// Retrieve the metadata
@@ -65,18 +80,18 @@ func (cs *ContainerService) SetCustomCloudProfileEnvironment() error {
 			}
 			endpointsresp, err := httpClient.Get(metadataURL)
 			if err != nil || endpointsresp.StatusCode != 200 {
-				return fmt.Errorf("%s . apimodel invalid: failed to retrieve Azure Stack endpoints from %s", err, metadataURL)
+				return fmt.Errorf("%s . apimodel invalid: failed to retrieve custom endpoints from metadataURL %s", err, metadataURL)
 			}
 
 			body, err := ioutil.ReadAll(endpointsresp.Body)
 			if err != nil {
-				return fmt.Errorf("%s . apimodel invalid: failed to read the response from %s", err, metadataURL)
+				return fmt.Errorf("%s . apimodel invalid: failed to read the response from metadataURL %s", err, metadataURL)
 			}
 
 			endpoints := AzureStackMetadataEndpoints{}
 			err = json.Unmarshal(body, &endpoints)
 			if err != nil {
-				return fmt.Errorf("%s . apimodel invalid: failed to parse the response from %s", err, metadataURL)
+				return fmt.Errorf("%s . apimodel invalid: failed to parse the response from metadataURL %s", err, metadataURL)
 			}
 
 			if endpoints.GraphEndpoint == "" || endpoints.Authentication == nil || endpoints.Authentication.LoginEndpoint == "" || len(endpoints.Authentication.Audiences) == 0 || endpoints.Authentication.Audiences[0] == "" {
@@ -93,100 +108,115 @@ func (cs *ContainerService) SetCustomCloudProfileEnvironment() error {
 			}
 
 			env.ManagementPortalURL = endpoints.PortalEndpoint
-			env.ResourceManagerVMDNSSuffix = fmt.Sprintf("cloudapp.%s", azsFQDNSuffix)
-			env.StorageEndpointSuffix = fmt.Sprintf("%s.%s", cs.Location, azsFQDNSuffix)
-			env.KeyVaultDNSSuffix = fmt.Sprintf("vault.%s.%s", cs.Location, azsFQDNSuffix)
+
+			if p.IsAzureStackCloud() {
+				azsFQDNSuffix := getAzureStackFQDNSuffix(p.CustomCloudProfile.PortalURL, cs.Location)
+				env.ResourceManagerVMDNSSuffix = fmt.Sprintf("cloudapp.%s", azsFQDNSuffix)
+				env.StorageEndpointSuffix = fmt.Sprintf("%s.%s", cs.Location, azsFQDNSuffix)
+				env.KeyVaultDNSSuffix = fmt.Sprintf("vault.%s.%s", cs.Location, azsFQDNSuffix)
+			} else if env.ResourceManagerVMDNSSuffix == "" || env.StorageEndpointSuffix == "" || env.KeyVaultDNSSuffix == "" {
+				// Non-AzureStack CustomCloud MUST provide suffixes
+				return fmt.Errorf("Non-AzureStack CustomCloudProfile MUST provide ResourceManagerVMDNSSuffix, StorageEndpointSuffix, KeyVaultDNSSuffix")
+			}
 		}
 	}
+
 	return nil
 }
 
-// AzureStackCloudSpecParams is the parameters when we set the azure stack cloud spec defaults for ContainerService.
-type AzureStackCloudSpecParams struct {
+// AzureCustomCloudSpecParams is the parameters when we set the azure stack cloud spec defaults for ContainerService.
+type AzureCustomCloudSpecParams struct {
 	IsUpgrade bool
 	IsScale   bool
 }
 
-// SetAzureStackCloudSpec sets the cloud spec for Azure Stack .
-func (p *Properties) SetAzureStackCloudSpec(params AzureStackCloudSpecParams) error {
-	if p.IsAzureStackCloud() {
-		var azureStackCloudSpec AzureEnvironmentSpecConfig
+// SetAzureCustomCloudSpec sets the cloud spec for Custom Cloud .
+func (p *Properties) SetCustomCloudSpec(params AzureCustomCloudSpecParams) error {
+	if p.IsCustomCloudProfile() {
+		var azureCustomCloudSpec AzureEnvironmentSpecConfig
 		switch p.CustomCloudProfile.DependenciesLocation {
-		case AzureStackDependenciesLocationPublic:
-			azureStackCloudSpec = AzureCloudSpecEnvMap[AzurePublicCloud]
-		case AzureStackDependenciesLocationChina:
-			azureStackCloudSpec = AzureCloudSpecEnvMap[AzureChinaCloud]
-		case AzureStackDependenciesLocationGerman:
-			azureStackCloudSpec = AzureCloudSpecEnvMap[AzureGermanCloud]
-		case AzureStackDependenciesLocationUSGovernment:
-			azureStackCloudSpec = AzureCloudSpecEnvMap[AzureUSGovernmentCloud]
+		case AzureCustomCloudDependenciesLocationPublic:
+			azureCustomCloudSpec = AzureCloudSpecEnvMap[AzurePublicCloud]
+		case AzureCustomCloudDependenciesLocationChina:
+			azureCustomCloudSpec = AzureCloudSpecEnvMap[AzureChinaCloud]
+		case AzureCustomCloudDependenciesLocationGerman:
+			azureCustomCloudSpec = AzureCloudSpecEnvMap[AzureGermanCloud]
+		case AzureCustomCloudDependenciesLocationUSGovernment:
+			azureCustomCloudSpec = AzureCloudSpecEnvMap[AzureUSGovernmentCloud]
 		default:
-			azureStackCloudSpec = AzureCloudSpecEnvMap[AzurePublicCloud]
+			azureCustomCloudSpec = AzureCloudSpecEnvMap[AzurePublicCloud]
 		}
 		if p.CustomCloudProfile.Environment == nil || p.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix == "" {
 			return errors.New("Failed to set Cloud Spec for Azure Stack due to invalid environment")
 		}
 
-		azureStackCloudSpec.EndpointConfig.ResourceManagerVMDNSSuffix = p.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
-		azureStackCloudSpec.CloudName = AzureStackCloud
+		azureCustomCloudSpec.EndpointConfig.ResourceManagerVMDNSSuffix = p.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
+
+		if p.CustomCloudProfile.Environment.Name == "" || p.IsAzureStackCloud() {
+			azureCustomCloudSpec.CloudName = AzureStackCloud
+		} else {
+			azureCustomCloudSpec.CloudName = p.CustomCloudProfile.Environment.Name
+		}
 
 		//Sets default values for telemetry PID where none is set
 		if p.CustomCloudProfile.AzureEnvironmentSpecConfig == nil {
 			switch {
 			case params.IsScale:
-				azureStackCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = DefaultAzureStackScaleTelemetryPID
+				azureCustomCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = DefaultAzureStackScaleTelemetryPID
 			case params.IsUpgrade:
-				azureStackCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = DefaultAzureStackUpgradeTelemetryPID
+				azureCustomCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = DefaultAzureStackUpgradeTelemetryPID
 			default:
-				azureStackCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = DefaultAzureStackDeployTelemetryPID
+				azureCustomCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = DefaultAzureStackDeployTelemetryPID
 			}
 
 		}
 
-		// Use the custom input to overwrite the default values in AzureStackCloudSpec
+		// Use the custom input to overwrite the default values in azureCustomCloudSpec
 		if p.CustomCloudProfile.AzureEnvironmentSpecConfig != nil {
 			ascc := p.CustomCloudProfile.AzureEnvironmentSpecConfig
-			azureStackCloudSpec.CloudName = helpers.EnsureString(ascc.CloudName, azureStackCloudSpec.CloudName)
+			azureCustomCloudSpec.CloudName = helpers.EnsureString(ascc.CloudName, azureCustomCloudSpec.CloudName)
 
 			// DockerSpecConfig
 			asccDockerSpecConfig := ascc.DockerSpecConfig
-			azsDockerSpecConfig := azureStackCloudSpec.DockerSpecConfig
-			azureStackCloudSpec.DockerSpecConfig.DockerComposeDownloadURL = helpers.EnsureString(asccDockerSpecConfig.DockerComposeDownloadURL, azsDockerSpecConfig.DockerComposeDownloadURL)
-			azureStackCloudSpec.DockerSpecConfig.DockerEngineRepo = helpers.EnsureString(asccDockerSpecConfig.DockerEngineRepo, azsDockerSpecConfig.DockerComposeDownloadURL)
+			azsDockerSpecConfig := azureCustomCloudSpec.DockerSpecConfig
+			azureCustomCloudSpec.DockerSpecConfig.DockerComposeDownloadURL = helpers.EnsureString(asccDockerSpecConfig.DockerComposeDownloadURL, azsDockerSpecConfig.DockerComposeDownloadURL)
+			azureCustomCloudSpec.DockerSpecConfig.DockerEngineRepo = helpers.EnsureString(asccDockerSpecConfig.DockerEngineRepo, azsDockerSpecConfig.DockerComposeDownloadURL)
 
 			//KubernetesSpecConfig
 			asccKubernetesSpecConfig := ascc.KubernetesSpecConfig
-			azsKubernetesSpecConfig := azureStackCloudSpec.KubernetesSpecConfig
+			azsKubernetesSpecConfig := azureCustomCloudSpec.KubernetesSpecConfig
 
-			azureStackCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = helpers.EnsureString(asccKubernetesSpecConfig.AzureTelemetryPID, DefaultAzureStackDeployTelemetryPID)
-			azureStackCloudSpec.KubernetesSpecConfig.ACIConnectorImageBase = helpers.EnsureString(asccKubernetesSpecConfig.ACIConnectorImageBase, azsKubernetesSpecConfig.ACIConnectorImageBase)
-			azureStackCloudSpec.KubernetesSpecConfig.AzureCNIImageBase = helpers.EnsureString(asccKubernetesSpecConfig.AzureCNIImageBase, azsKubernetesSpecConfig.AzureCNIImageBase)
-			azureStackCloudSpec.KubernetesSpecConfig.CalicoImageBase = helpers.EnsureString(asccKubernetesSpecConfig.CalicoImageBase, azsKubernetesSpecConfig.CalicoImageBase)
-			azureStackCloudSpec.KubernetesSpecConfig.CNIPluginsDownloadURL = helpers.EnsureString(asccKubernetesSpecConfig.CNIPluginsDownloadURL, azsKubernetesSpecConfig.CNIPluginsDownloadURL)
-			azureStackCloudSpec.KubernetesSpecConfig.ContainerdDownloadURLBase = helpers.EnsureString(asccKubernetesSpecConfig.ContainerdDownloadURLBase, azsKubernetesSpecConfig.ContainerdDownloadURLBase)
-			azureStackCloudSpec.KubernetesSpecConfig.EtcdDownloadURLBase = helpers.EnsureString(asccKubernetesSpecConfig.EtcdDownloadURLBase, azsKubernetesSpecConfig.EtcdDownloadURLBase)
-			azureStackCloudSpec.KubernetesSpecConfig.KubeBinariesSASURLBase = helpers.EnsureString(asccKubernetesSpecConfig.KubeBinariesSASURLBase, azsKubernetesSpecConfig.KubeBinariesSASURLBase)
-			azureStackCloudSpec.KubernetesSpecConfig.KubernetesImageBase = helpers.EnsureString(asccKubernetesSpecConfig.KubernetesImageBase, azsKubernetesSpecConfig.KubernetesImageBase)
-			azureStackCloudSpec.KubernetesSpecConfig.MCRKubernetesImageBase = helpers.EnsureString(asccKubernetesSpecConfig.MCRKubernetesImageBase, azsKubernetesSpecConfig.MCRKubernetesImageBase)
-			azureStackCloudSpec.KubernetesSpecConfig.NVIDIAImageBase = helpers.EnsureString(asccKubernetesSpecConfig.NVIDIAImageBase, azsKubernetesSpecConfig.NVIDIAImageBase)
-			azureStackCloudSpec.KubernetesSpecConfig.TillerImageBase = helpers.EnsureString(asccKubernetesSpecConfig.TillerImageBase, azsKubernetesSpecConfig.TillerImageBase)
-			azureStackCloudSpec.KubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL = helpers.EnsureString(asccKubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL, azsKubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL)
-			azureStackCloudSpec.KubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL = helpers.EnsureString(asccKubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL, azsKubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL)
-			azureStackCloudSpec.KubernetesSpecConfig.WindowsTelemetryGUID = helpers.EnsureString(asccKubernetesSpecConfig.WindowsTelemetryGUID, azsKubernetesSpecConfig.WindowsTelemetryGUID)
+			azureCustomCloudSpec.KubernetesSpecConfig.AzureTelemetryPID = helpers.EnsureString(asccKubernetesSpecConfig.AzureTelemetryPID, DefaultAzureStackDeployTelemetryPID)
+			azureCustomCloudSpec.KubernetesSpecConfig.ACIConnectorImageBase = helpers.EnsureString(asccKubernetesSpecConfig.ACIConnectorImageBase, azsKubernetesSpecConfig.ACIConnectorImageBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.AzureCNIImageBase = helpers.EnsureString(asccKubernetesSpecConfig.AzureCNIImageBase, azsKubernetesSpecConfig.AzureCNIImageBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.CalicoImageBase = helpers.EnsureString(asccKubernetesSpecConfig.CalicoImageBase, azsKubernetesSpecConfig.CalicoImageBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.CNIPluginsDownloadURL = helpers.EnsureString(asccKubernetesSpecConfig.CNIPluginsDownloadURL, azsKubernetesSpecConfig.CNIPluginsDownloadURL)
+			azureCustomCloudSpec.KubernetesSpecConfig.ContainerdDownloadURLBase = helpers.EnsureString(asccKubernetesSpecConfig.ContainerdDownloadURLBase, azsKubernetesSpecConfig.ContainerdDownloadURLBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.EtcdDownloadURLBase = helpers.EnsureString(asccKubernetesSpecConfig.EtcdDownloadURLBase, azsKubernetesSpecConfig.EtcdDownloadURLBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.KubeBinariesSASURLBase = helpers.EnsureString(asccKubernetesSpecConfig.KubeBinariesSASURLBase, azsKubernetesSpecConfig.KubeBinariesSASURLBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.KubernetesImageBase = helpers.EnsureString(asccKubernetesSpecConfig.KubernetesImageBase, azsKubernetesSpecConfig.KubernetesImageBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.MCRKubernetesImageBase = helpers.EnsureString(asccKubernetesSpecConfig.MCRKubernetesImageBase, azsKubernetesSpecConfig.MCRKubernetesImageBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.NVIDIAImageBase = helpers.EnsureString(asccKubernetesSpecConfig.NVIDIAImageBase, azsKubernetesSpecConfig.NVIDIAImageBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.TillerImageBase = helpers.EnsureString(asccKubernetesSpecConfig.TillerImageBase, azsKubernetesSpecConfig.TillerImageBase)
+			azureCustomCloudSpec.KubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL = helpers.EnsureString(asccKubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL, azsKubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL)
+			azureCustomCloudSpec.KubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL = helpers.EnsureString(asccKubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL, azsKubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL)
+			azureCustomCloudSpec.KubernetesSpecConfig.WindowsTelemetryGUID = helpers.EnsureString(asccKubernetesSpecConfig.WindowsTelemetryGUID, azsKubernetesSpecConfig.WindowsTelemetryGUID)
 
 			//EndpointConfig
 			asccEndpointConfig := ascc.EndpointConfig
-			azsEndpointConfig := azureStackCloudSpec.EndpointConfig
-			azureStackCloudSpec.EndpointConfig.ResourceManagerVMDNSSuffix = helpers.EnsureString(asccEndpointConfig.ResourceManagerVMDNSSuffix, azsEndpointConfig.ResourceManagerVMDNSSuffix)
+			azsEndpointConfig := azureCustomCloudSpec.EndpointConfig
+			azureCustomCloudSpec.EndpointConfig.ResourceManagerVMDNSSuffix = helpers.EnsureString(asccEndpointConfig.ResourceManagerVMDNSSuffix, azsEndpointConfig.ResourceManagerVMDNSSuffix)
 
 			//OSImageConfig
-			azureStackCloudSpec.OSImageConfig = make(map[Distro]AzureOSImageConfig)
+			azureCustomCloudSpec.OSImageConfig = make(map[Distro]AzureOSImageConfig)
 			for k, v := range ascc.OSImageConfig {
-				azureStackCloudSpec.OSImageConfig[k] = v
+				azureCustomCloudSpec.OSImageConfig[k] = v
 			}
-			p.CustomCloudProfile.AzureEnvironmentSpecConfig = &azureStackCloudSpec
+			p.CustomCloudProfile.AzureEnvironmentSpecConfig = &azureCustomCloudSpec
 		}
-		AzureCloudSpecEnvMap[AzureStackCloud] = azureStackCloudSpec
+
+		// Kubernetes only understand AzureStackCloud environment (AzureCloudSpecEnvMap is only accessed using AzureStackCloud for custom clouds)
+		AzureCloudSpecEnvMap[AzureStackCloud] = azureCustomCloudSpec
 	}
 	return nil
 }

--- a/pkg/api/defaults-custom-cloud-profile.go
+++ b/pkg/api/defaults-custom-cloud-profile.go
@@ -124,7 +124,7 @@ func (cs *ContainerService) SetCustomCloudProfileEnvironment() error {
 	return nil
 }
 
-// AzureCustomCloudSpecParams is the parameters when we set the azure stack cloud spec defaults for ContainerService.
+// AzureCustomCloudSpecParams is the parameters when we set the custom cloud spec defaults for ContainerService.
 type AzureCustomCloudSpecParams struct {
 	IsUpgrade bool
 	IsScale   bool

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -39,7 +39,7 @@ func (cs *ContainerService) SetPropertiesDefaults(params PropertiesDefaultsParam
 	properties := cs.Properties
 
 	// Set custom cloud profile defaults if this cluster configuration has custom cloud profile
-	if cs.Properties.CustomCloudProfile != nil {
+	if cs.Properties.IsCustomCloudProfile() {
 		err := cs.setCustomCloudProfileDefaults(CustomCloudProfileDefaultsParams{
 			IsUpgrade: params.IsUpgrade,
 			IsScale:   params.IsScale,

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2972,7 +2972,7 @@ func TestSetCustomCloudProfileDefaults(t *testing.T) {
 	mockCSEmptyResourceManagerVMDNSSuffix.Properties.CustomCloudProfile = mockCSPEmptyResourceManagerVMDNSSuffix.CustomCloudProfile
 	mockCSEmptyResourceManagerVMDNSSuffix.Properties.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix = ""
 
-	acutalerr := mockCSEmptyResourceManagerVMDNSSuffix.Properties.SetAzureStackCloudSpec(AzureStackCloudSpecParams{
+	acutalerr := mockCSEmptyResourceManagerVMDNSSuffix.Properties.SetCustomCloudSpec(AzureCustomCloudSpecParams{
 		IsUpgrade: false,
 		IsScale:   false,
 	})
@@ -2986,7 +2986,7 @@ func TestSetCustomCloudProfileDefaults(t *testing.T) {
 	mockCSPNilEnvironment := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
 	mockCSNilEnvironment.Properties.CustomCloudProfile = mockCSPNilEnvironment.CustomCloudProfile
 	mockCSNilEnvironment.Properties.CustomCloudProfile.Environment = nil
-	acutalerr = mockCSEmptyResourceManagerVMDNSSuffix.Properties.SetAzureStackCloudSpec(AzureStackCloudSpecParams{
+	acutalerr = mockCSEmptyResourceManagerVMDNSSuffix.Properties.SetCustomCloudSpec(AzureCustomCloudSpecParams{
 		IsUpgrade: false,
 		IsScale:   false,
 	})

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2082,7 +2082,7 @@ func (p *Properties) IsCustomCloudProfile() bool {
 
 // GetCustomCloudRootCertificates returns comma-separated list of base64-encoded custom root certificates
 func (p *Properties) GetCustomCloudRootCertificates() string {
-	if p.CustomCloudProfile != nil {
+	if p.IsCustomCloudProfile() {
 		return p.CustomCloudProfile.CustomCloudRootCertificates
 	}
 	return ""
@@ -2090,7 +2090,7 @@ func (p *Properties) GetCustomCloudRootCertificates() string {
 
 // GetCustomCloudSourcesList returns a base64-encoded custom sources.list file
 func (p *Properties) GetCustomCloudSourcesList() string {
-	if p.CustomCloudProfile != nil {
+	if p.IsCustomCloudProfile() {
 		return p.CustomCloudProfile.CustomCloudSourcesList
 	}
 	return ""
@@ -2121,7 +2121,7 @@ func (p *Properties) GetKubernetesHyperkubeSpec() string {
 // IsAzureStackCloud return true if the cloud is AzureStack
 func (p *Properties) IsAzureStackCloud() bool {
 	// For backward compatibility, treat nil Environment and empty Environment name as AzureStackCloud as well
-	return p.CustomCloudProfile != nil && (p.CustomCloudProfile.Environment == nil || p.CustomCloudProfile.Environment.Name == "" || strings.EqualFold(p.CustomCloudProfile.Environment.Name, "AzureStackCloud"))
+	return p.IsCustomCloudProfile() && (p.CustomCloudProfile.Environment == nil || p.CustomCloudProfile.Environment.Name == "" || strings.EqualFold(p.CustomCloudProfile.Environment.Name, "AzureStackCloud"))
 }
 
 // GetCustomEnvironmentJSON return the JSON format string for custom environment

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -824,12 +824,14 @@ type DependenciesLocation string
 
 // CustomCloudProfile represents the custom cloud profile
 type CustomCloudProfile struct {
-	Environment                *azure.Environment          `json:"environment,omitempty"`
-	AzureEnvironmentSpecConfig *AzureEnvironmentSpecConfig `json:"azureEnvironmentSpecConfig,omitempty"`
-	IdentitySystem             string                      `json:"identitySystem,omitempty"`
-	AuthenticationMethod       string                      `json:"authenticationMethod,omitempty"`
-	DependenciesLocation       DependenciesLocation        `json:"dependenciesLocation,omitempty"`
-	PortalURL                  string                      `json:"portalURL,omitempty"`
+	Environment                 *azure.Environment          `json:"environment,omitempty"`
+	AzureEnvironmentSpecConfig  *AzureEnvironmentSpecConfig `json:"azureEnvironmentSpecConfig,omitempty"`
+	IdentitySystem              string                      `json:"identitySystem,omitempty"`
+	AuthenticationMethod        string                      `json:"authenticationMethod,omitempty"`
+	DependenciesLocation        DependenciesLocation        `json:"dependenciesLocation,omitempty"`
+	PortalURL                   string                      `json:"portalURL,omitempty"`
+	CustomCloudRootCertificates string                      `json:"customCloudRootCertificates,omitempty"`
+	CustomCloudSourcesList      string                      `json:"customCloudSourcesList,omitempty"`
 }
 
 // TelemetryProfile contains settings for collecting telemtry.
@@ -2073,6 +2075,27 @@ func (p *Properties) IsNVIDIADevicePluginEnabled() bool {
 	return p.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.NVIDIADevicePluginAddonName)
 }
 
+// IsCustomCloudProfile returns true if user has provided a custom cloud profile
+func (p *Properties) IsCustomCloudProfile() bool {
+	return p.CustomCloudProfile != nil
+}
+
+// GetCustomCloudRootCertificates returns comma-separated list of base64-encoded custom root certificates
+func (p *Properties) GetCustomCloudRootCertificates() string {
+	if p.CustomCloudProfile != nil {
+		return p.CustomCloudProfile.CustomCloudRootCertificates
+	}
+	return ""
+}
+
+// GetCustomCloudSourcesList returns a base64-encoded custom sources.list file
+func (p *Properties) GetCustomCloudSourcesList() string {
+	if p.CustomCloudProfile != nil {
+		return p.CustomCloudProfile.CustomCloudSourcesList
+	}
+	return ""
+}
+
 // GetKubernetesVersion returns the cluster Kubernetes version, with the Azure Stack suffix if Azure Stack Cloud.
 func (p *Properties) GetKubernetesVersion() string {
 	if p.IsAzureStackCloud() {
@@ -2097,13 +2120,14 @@ func (p *Properties) GetKubernetesHyperkubeSpec() string {
 
 // IsAzureStackCloud return true if the cloud is AzureStack
 func (p *Properties) IsAzureStackCloud() bool {
-	return p.CustomCloudProfile != nil
+	// For backward compatibility, treat nil Environment and empty Environment name as AzureStackCloud as well
+	return p.CustomCloudProfile != nil && (p.CustomCloudProfile.Environment == nil || p.CustomCloudProfile.Environment.Name == "" || strings.EqualFold(p.CustomCloudProfile.Environment.Name, "AzureStackCloud"))
 }
 
 // GetCustomEnvironmentJSON return the JSON format string for custom environment
 func (p *Properties) GetCustomEnvironmentJSON(escape bool) (string, error) {
 	var environmentJSON string
-	if p.IsAzureStackCloud() {
+	if p.IsCustomCloudProfile() {
 		bytes, err := json.Marshal(p.CustomCloudProfile.Environment)
 		if err != nil {
 			return "", fmt.Errorf("Could not serialize Environment object - %s", err.Error())
@@ -2121,7 +2145,7 @@ func (p *Properties) GetCustomEnvironmentJSON(escape bool) (string, error) {
 // the return value will be empty string for those clouds
 func (p *Properties) GetCustomCloudName() string {
 	var cloudProfileName string
-	if p.IsAzureStackCloud() {
+	if p.IsCustomCloudProfile() {
 		cloudProfileName = p.CustomCloudProfile.Environment.Name
 	}
 	return cloudProfileName
@@ -2132,7 +2156,7 @@ func (p *Properties) GetCustomCloudName() string {
 // If AzurePublicCloud, AzureChinaCloud,AzureGermanCloud or AzureUSGovernmentCloud, GetLocations provides all azure regions in prod.
 func (cs *ContainerService) GetLocations() []string {
 	var allLocations []string
-	if cs.Properties.IsAzureStackCloud() {
+	if cs.Properties.IsCustomCloudProfile() {
 		allLocations = []string{cs.Location}
 	} else {
 		allLocations = helpers.GetAzureLocations()
@@ -2144,7 +2168,7 @@ func (cs *ContainerService) GetLocations() []string {
 // For AzurePublicCloud,AzureChinaCloud,azureGermanCloud,AzureUSGovernmentCloud, it will be always be client_secret
 // For AzureStackCloud, if it is specified in configuration, the value will be used, if not ,the default value is client_secret.
 func (p *Properties) GetCustomCloudAuthenticationMethod() string {
-	if p.IsAzureStackCloud() {
+	if p.IsCustomCloudProfile() {
 		return p.CustomCloudProfile.AuthenticationMethod
 	}
 	return ClientSecretAuthMethod
@@ -2154,7 +2178,7 @@ func (p *Properties) GetCustomCloudAuthenticationMethod() string {
 // For AzurePublicCloud,AzureChinaCloud,azureGermanCloud,AzureUSGovernmentCloud, it will be always be AzureAD
 // For AzureStackCloud, if it is specified in configuration, the value will be used, if not ,the default value is AzureAD.
 func (p *Properties) GetCustomCloudIdentitySystem() string {
-	if p.IsAzureStackCloud() {
+	if p.IsCustomCloudProfile() {
 		return p.CustomCloudProfile.IdentitySystem
 	}
 	return AzureADIdentitySystem

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -103,7 +103,7 @@ var (
 	DistroValues = []Distro{"", Ubuntu, Ubuntu1804, Ubuntu1804Gen2, RHEL, AKSUbuntu1604, AKSUbuntu1804, ACC1604}
 
 	// DependenciesLocationValues holds the valid values for dependencies location
-	DependenciesLocationValues = []DependenciesLocation{"", AzureStackDependenciesLocationPublic, AzureStackDependenciesLocationChina, AzureStackDependenciesLocationGerman, AzureStackDependenciesLocationUSGovernment}
+	DependenciesLocationValues = []DependenciesLocation{"", AzureCustomCloudDependenciesLocationPublic, AzureCustomCloudDependenciesLocationChina, AzureCustomCloudDependenciesLocationGerman, AzureCustomCloudDependenciesLocationUSGovernment}
 
 	// NetworkModeValues holds the valid values for network mode implementation for cni
 	NetworkModeValues = [...]string{"", NetworkModeBridge, NetworkModeTransparent}
@@ -161,14 +161,14 @@ const (
 )
 
 const (
-	// AzureStackDependenciesLocationPublic indicates to get dependencies from in AzurePublic cloud
-	AzureStackDependenciesLocationPublic = "public"
-	// AzureStackDependenciesLocationChina indicates to get dependencies from AzureChina cloud
-	AzureStackDependenciesLocationChina = "china"
-	// AzureStackDependenciesLocationGerman indicates to get dependencies from AzureGerman cloud
-	AzureStackDependenciesLocationGerman = "german"
-	// AzureStackDependenciesLocationUSGovernment indicates to get dependencies from AzureUSGovernment cloud
-	AzureStackDependenciesLocationUSGovernment = "usgovernment"
+	// AzureCustomCloudDependenciesLocationPublic indicates to get dependencies from in AzurePublic cloud
+	AzureCustomCloudDependenciesLocationPublic = "public"
+	// AzureCustomCloudDependenciesLocationChina indicates to get dependencies from AzureChina cloud
+	AzureCustomCloudDependenciesLocationChina = "china"
+	// AzureCustomCloudDependenciesLocationGerman indicates to get dependencies from AzureGerman cloud
+	AzureCustomCloudDependenciesLocationGerman = "german"
+	// AzureCustomCloudDependenciesLocationUSGovernment indicates to get dependencies from AzureUSGovernment cloud
+	AzureCustomCloudDependenciesLocationUSGovernment = "usgovernment"
 )
 
 const (

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -629,7 +629,7 @@ func (p *Properties) IsCustomCloudProfile() bool {
 
 // GetCustomCloudRootCertificates returns comma-separated list of base64-encoded custom root certificates
 func (p *Properties) GetCustomCloudRootCertificates() string {
-	if p.CustomCloudProfile != nil {
+	if p.IsCustomCloudProfile() {
 		return p.CustomCloudProfile.CustomCloudRootCertificates
 	}
 	return ""
@@ -637,7 +637,7 @@ func (p *Properties) GetCustomCloudRootCertificates() string {
 
 // GetCustomCloudSourcesList returns a base64-encoded custom sources.list file
 func (p *Properties) GetCustomCloudSourcesList() string {
-	if p.CustomCloudProfile != nil {
+	if p.IsCustomCloudProfile() {
 		return p.CustomCloudProfile.CustomCloudSourcesList
 	}
 	return ""
@@ -646,7 +646,7 @@ func (p *Properties) GetCustomCloudSourcesList() string {
 // IsAzureStackCloud return true if the cloud is AzureStack
 func (p *Properties) IsAzureStackCloud() bool {
 	// For backward compatibility, treat nil Environment and empty Environment name as AzureStackCloud as well
-	return p.CustomCloudProfile != nil && (p.CustomCloudProfile.Environment == nil || p.CustomCloudProfile.Environment.Name == "" || strings.EqualFold(p.CustomCloudProfile.Environment.Name, "AzureStackCloud"))
+	return p.IsCustomCloudProfile() && (p.CustomCloudProfile.Environment == nil || p.CustomCloudProfile.Environment.Name == "" || strings.EqualFold(p.CustomCloudProfile.Environment.Name, "AzureStackCloud"))
 }
 
 // HasAADAdminGroupID returns true if the cluster has an AADProfile w/ a valid AdminGroupID

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -582,12 +582,14 @@ type DependenciesLocation string
 
 // CustomCloudProfile represents the custom cloud profile
 type CustomCloudProfile struct {
-	Environment                *azure.Environment          `json:"environment,omitempty"`
-	AzureEnvironmentSpecConfig *AzureEnvironmentSpecConfig `json:"azureEnvironmentSpecConfig,omitempty"`
-	IdentitySystem             string                      `json:"identitySystem,omitempty"`
-	AuthenticationMethod       string                      `json:"authenticationMethod,omitempty"`
-	DependenciesLocation       DependenciesLocation        `json:"dependenciesLocation,omitempty"`
-	PortalURL                  string                      `json:"portalURL,omitempty"`
+	Environment                 *azure.Environment          `json:"environment,omitempty"`
+	AzureEnvironmentSpecConfig  *AzureEnvironmentSpecConfig `json:"azureEnvironmentSpecConfig,omitempty"`
+	IdentitySystem              string                      `json:"identitySystem,omitempty"`
+	AuthenticationMethod        string                      `json:"authenticationMethod,omitempty"`
+	DependenciesLocation        DependenciesLocation        `json:"dependenciesLocation,omitempty"`
+	PortalURL                   string                      `json:"portalURL,omitempty"`
+	CustomCloudRootCertificates string                      `json:"customCloudRootCertificates,omitempty"`
+	CustomCloudSourcesList      string                      `json:"customCloudSourcesList,omitempty"`
 }
 
 // TelemetryProfile contains settings for collecting telemtry.
@@ -620,9 +622,31 @@ func (p *Properties) HasAvailabilityZones() bool {
 	return hasZones
 }
 
+// IsCustomCloudProfile return true if user has provided a custom cloud profile
+func (p *Properties) IsCustomCloudProfile() bool {
+	return p.CustomCloudProfile != nil
+}
+
+// GetCustomCloudRootCertificates returns comma-separated list of base64-encoded custom root certificates
+func (p *Properties) GetCustomCloudRootCertificates() string {
+	if p.CustomCloudProfile != nil {
+		return p.CustomCloudProfile.CustomCloudRootCertificates
+	}
+	return ""
+}
+
+// GetCustomCloudSourcesList returns a base64-encoded custom sources.list file
+func (p *Properties) GetCustomCloudSourcesList() string {
+	if p.CustomCloudProfile != nil {
+		return p.CustomCloudProfile.CustomCloudSourcesList
+	}
+	return ""
+}
+
 // IsAzureStackCloud return true if the cloud is AzureStack
 func (p *Properties) IsAzureStackCloud() bool {
-	return p.CustomCloudProfile != nil
+	// For backward compatibility, treat nil Environment and empty Environment name as AzureStackCloud as well
+	return p.CustomCloudProfile != nil && (p.CustomCloudProfile.Environment == nil || p.CustomCloudProfile.Environment.Name == "" || strings.EqualFold(p.CustomCloudProfile.Environment.Name, "AzureStackCloud"))
 }
 
 // HasAADAdminGroupID returns true if the cluster has an AADProfile w/ a valid AdminGroupID

--- a/pkg/api/vlabs/types_test.go
+++ b/pkg/api/vlabs/types_test.go
@@ -369,7 +369,7 @@ func TestAgentPoolIsNSeriesSKU(t *testing.T) {
 	}
 }
 
-func TestIsAzureStackCloud(t *testing.T) {
+func TestIsCustomCloudProfile(t *testing.T) {
 	testcases := []struct {
 		name       string
 		properties Properties
@@ -407,6 +407,56 @@ func TestIsAzureStackCloud(t *testing.T) {
 		},
 		{
 			"empty environment ",
+			GetMockPropertiesWithCustomCloudProfile("AzureStackCloud", true, false, true),
+			true,
+		},
+	}
+	for _, testcase := range testcases {
+		actual := testcase.properties.IsCustomCloudProfile()
+		if testcase.expected != actual {
+			t.Errorf("Test \"%s\": expected IsCustomCloudProfile() to return %t, but got %t . ", testcase.name, testcase.expected, actual)
+		}
+	}
+}
+
+func TestIsAzureStackCloud(t *testing.T) {
+	testcases := []struct {
+		name       string
+		properties Properties
+		expected   bool
+	}{
+		{
+			"Empty environment name should be treated as AzureStackCloud",
+			GetMockPropertiesWithCustomCloudProfile("", true, true, false),
+			true,
+		},
+		{
+			"Empty environment name (with AzureEnvironmentSpecConfig) should be treated as AzureStackCloud",
+			GetMockPropertiesWithCustomCloudProfile("", true, true, true),
+			true,
+		},
+		{
+			"lower case AzureStackCloud name",
+			GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, true),
+			true,
+		},
+		{
+			"cammel case AzureStackCloud name",
+			GetMockPropertiesWithCustomCloudProfile("AzureStackCloud", true, true, true),
+			true,
+		},
+		{
+			"incorrect AzureStackCloud name",
+			GetMockPropertiesWithCustomCloudProfile("NotAzureStackCloud", true, true, true),
+			false,
+		},
+		{
+			"empty cloud profile",
+			GetMockPropertiesWithCustomCloudProfile("AzureStackCloud", false, false, false),
+			false,
+		},
+		{
+			"empty environment should be treated as AzureStackCloud",
 			GetMockPropertiesWithCustomCloudProfile("AzureStackCloud", true, false, true),
 			true,
 		},

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1852,18 +1852,24 @@ func (i *ImageReference) validateImageNameAndGroup() error {
 
 func (cs *ContainerService) validateCustomCloudProfile() error {
 	a := cs.Properties
-	if a.CustomCloudProfile != nil {
-		if a.CustomCloudProfile.PortalURL == "" {
-			return errors.New("portalURL needs to be specified when CustomCloudProfile is provided")
-		}
-		if !strings.HasPrefix(a.CustomCloudProfile.PortalURL, fmt.Sprintf("https://portal.%s.", cs.Location)) {
-			return errors.Errorf("portalURL needs to start with https://portal.%s. ", cs.Location)
-		}
-		if a.CustomCloudProfile.AuthenticationMethod != "" && !(a.CustomCloudProfile.AuthenticationMethod == ClientSecretAuthMethod || a.CustomCloudProfile.AuthenticationMethod == ClientCertificateAuthMethod) {
-			return errors.Errorf("authenticationMethod allowed values are '%s' and '%s'", ClientCertificateAuthMethod, ClientSecretAuthMethod)
-		}
-		if a.CustomCloudProfile.IdentitySystem != "" && !(a.CustomCloudProfile.IdentitySystem == AzureADIdentitySystem || a.CustomCloudProfile.IdentitySystem == ADFSIdentitySystem) {
-			return errors.Errorf("identitySystem allowed values are '%s' and '%s'", AzureADIdentitySystem, ADFSIdentitySystem)
+
+	if a.IsCustomCloudProfile() {
+		if a.IsAzureStackCloud() {
+			if a.CustomCloudProfile.PortalURL == "" {
+				return errors.New("portalURL needs to be specified when AzureStackCloud CustomCloudProfile is provided")
+			}
+
+			if !strings.HasPrefix(a.CustomCloudProfile.PortalURL, fmt.Sprintf("https://portal.%s.", cs.Location)) {
+				return errors.Errorf("portalURL needs to start with https://portal.%s. ", cs.Location)
+			}
+
+			if a.CustomCloudProfile.AuthenticationMethod != "" && !(a.CustomCloudProfile.AuthenticationMethod == ClientSecretAuthMethod || a.CustomCloudProfile.AuthenticationMethod == ClientCertificateAuthMethod) {
+				return errors.Errorf("authenticationMethod allowed values are '%s' and '%s'", ClientCertificateAuthMethod, ClientSecretAuthMethod)
+			}
+
+			if a.CustomCloudProfile.IdentitySystem != "" && !(a.CustomCloudProfile.IdentitySystem == AzureADIdentitySystem || a.CustomCloudProfile.IdentitySystem == ADFSIdentitySystem) {
+				return errors.Errorf("identitySystem allowed values are '%s' and '%s'", AzureADIdentitySystem, ADFSIdentitySystem)
+			}
 		}
 
 		dependenciesLocationValues := DependenciesLocationValues
@@ -1892,7 +1898,7 @@ func (cs *ContainerService) Validate(isUpdate bool) error {
 }
 
 func (cs *ContainerService) validateLocation() error {
-	if cs.Properties != nil && cs.Properties.IsAzureStackCloud() && cs.Location == "" {
+	if cs.Properties != nil && cs.Properties.IsCustomCloudProfile() && cs.Location == "" {
 		return errors.New("missing ContainerService Location")
 	}
 	return nil

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -4032,7 +4033,22 @@ func TestValidateCustomCloudProfile(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "PortalURL is empty",
+			name: "PortalURL is empty for non-AzureStack CustomCloudProfile",
+			cs: &ContainerService{
+				Location: "testlocation",
+				Properties: &Properties{
+					CustomCloudProfile: &CustomCloudProfile{
+						Environment: &azure.Environment{
+							Name: "NonAzureStack",
+						},
+						AuthenticationMethod: "azure_ad",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "PortalURL is empty for AzureStack",
 			cs: &ContainerService{
 				Location: "testlocation",
 				Properties: &Properties{
@@ -4041,10 +4057,10 @@ func TestValidateCustomCloudProfile(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: errors.New("portalURL needs to be specified when CustomCloudProfile is provided"),
+			expectedErr: errors.New("portalURL needs to be specified when AzureStackCloud CustomCloudProfile is provided"),
 		},
 		{
-			name: "PortalURL is invalid",
+			name: "PortalURL is invalid for AzureStack",
 			cs: &ContainerService{
 				Location: "testlocation",
 				Properties: &Properties{

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -187,11 +187,13 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		cosmosEndPointURI = ""
 	}
 
-	if cs.Properties.IsAzureStackCloud() {
-		masterVars["apiVersionCompute"] = "2017-03-30"
-		masterVars["apiVersionStorage"] = "2017-10-01"
-		masterVars["apiVersionNetwork"] = "2017-10-01"
-		masterVars["apiVersionKeyVault"] = "2016-10-01"
+	if cs.Properties.IsCustomCloudProfile() {
+		if cs.Properties.IsAzureStackCloud() {
+			masterVars["apiVersionCompute"] = "2017-03-30"
+			masterVars["apiVersionStorage"] = "2017-10-01"
+			masterVars["apiVersionNetwork"] = "2017-10-01"
+			masterVars["apiVersionKeyVault"] = "2016-10-01"
+		}
 
 		environmentJSON, err := cs.Properties.GetCustomEnvironmentJSON(false)
 		if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -743,6 +743,15 @@ func getAddonFuncMap(addon api.KubernetesAddon, cs *api.ContainerService) templa
 		"HasWindows": func() bool {
 			return cs.Properties.HasWindows()
 		},
+		"IsCustomCloudProfile": func() bool {
+			return cs.Properties.IsCustomCloudProfile()
+		},
+		"GetCustomCloudRootCertificates": func() string {
+			return cs.Properties.GetCustomCloudRootCertificates()
+		},
+		"GetCustomCloudSourcesList": func() string {
+			return cs.Properties.GetCustomCloudSourcesList()
+		},
 		"IsAzureStackCloud": func() bool {
 			return cs.Properties.IsAzureStackCloud()
 		},

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -685,6 +685,9 @@ func getComponentFuncMap(component api.KubernetesComponent, cs *api.ContainerSer
 		"ContainerConfig": func(name string) string {
 			return component.Config[name]
 		},
+		"IsCustomCloudProfile": func() bool {
+			return cs.Properties.IsCustomCloudProfile()
+		},
 		"IsAzureStackCloud": func() bool {
 			return cs.Properties.IsAzureStackCloud()
 		},
@@ -745,12 +748,6 @@ func getAddonFuncMap(addon api.KubernetesAddon, cs *api.ContainerService) templa
 		},
 		"IsCustomCloudProfile": func() bool {
 			return cs.Properties.IsCustomCloudProfile()
-		},
-		"GetCustomCloudRootCertificates": func() string {
-			return cs.Properties.GetCustomCloudRootCertificates()
-		},
-		"GetCustomCloudSourcesList": func() string {
-			return cs.Properties.GetCustomCloudSourcesList()
 		},
 		"IsAzureStackCloud": func() bool {
 			return cs.Properties.IsAzureStackCloud()

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1740,7 +1740,6 @@ func TestVerifyGetBase64EncodedGzippedCustomScriptIsTransparent(t *testing.T) {
 				kubernetesDockerMonitorSystemdTimer,
 				dockerClearMountPropagationFlags,
 				auditdRules,
-				kubernetesCSECustomCloud,
 				systemdBPFMount,
 			} {
 				ret := getBase64EncodedGzippedCustomScript(file, c.cs)

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -245,6 +245,15 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 // all business logic is implemented in the underlying func
 func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 	return template.FuncMap{
+		"IsCustomCloudProfile": func() bool {
+			return cs.Properties.IsCustomCloudProfile()
+		},
+		"GetCustomCloudRootCertificates": func() string {
+			return cs.Properties.GetCustomCloudRootCertificates()
+		},
+		"GetCustomCloudSourcesList": func() string {
+			return cs.Properties.GetCustomCloudSourcesList()
+		},
 		"IsAzureStackCloud": func() bool {
 			return cs.Properties.IsAzureStackCloud()
 		},
@@ -674,7 +683,7 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 			return base64.StdEncoding.EncodeToString([]byte(customEnvironmentJSON))
 		},
 		"GetIdentitySystem": func() string {
-			if cs.Properties.IsAzureStackCloud() {
+			if cs.Properties.IsCustomCloudProfile() {
 				return cs.Properties.CustomCloudProfile.IdentitySystem
 			}
 

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -44,6 +44,9 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		t.Fatalf("Error generating function map: %v", err)
 	}
 	cases := []string{
+		"IsCustomCloudProfile",
+		"GetCustomCloudRootCertificates",
+		"GetCustomCloudSourcesList",
 		"IsAzureStackCloud",
 		"IsMultiMasterCluster",
 		"IsMasterVirtualMachineScaleSets",

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40509,6 +40509,7 @@ func k8sCloudInitArtifactsCse_configSh() (*asset, error) {
 var _k8sCloudInitArtifactsCse_customcloudSh = []byte(`#!/bin/bash
 
 {{- if IsCustomCloudProfile}}
+  {{- if not IsAzureStackCloud}}
 ensureCustomCloudRootCertificates() {
     CUSTOM_CLOUD_ROOT_CERTIFICATES="{{GetCustomCloudRootCertificates}}"
 
@@ -40545,6 +40546,7 @@ ensureCustomCloudSourcesList() {
         echo $CUSTOM_CLOUD_SOURCES_LIST | base64 -d > /etc/apt/sources.list
     fi
 }
+  {{end}}
 
 configureK8sCustomCloud() {
   KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40512,6 +40512,7 @@ var _k8sCloudInitArtifactsCse_customcloudSh = []byte(`#!/bin/bash
   {{- if not IsAzureStackCloud}}
 ensureCustomCloudRootCertificates() {
     CUSTOM_CLOUD_ROOT_CERTIFICATES="{{GetCustomCloudRootCertificates}}"
+    KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
 
     if [ ! -z $CUSTOM_CLOUD_ROOT_CERTIFICATES ]; then
         # Replace placeholder for ssl binding
@@ -40549,8 +40550,6 @@ ensureCustomCloudSourcesList() {
   {{end}}
 
 configureK8sCustomCloud() {
-  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
-
   {{- if IsAzureStackCloud}}
   export -f ensureAzureStackCertificates
   retrycmd 60 10 30 bash -c ensureAzureStackCertificates
@@ -40611,7 +40610,7 @@ ensureAzureStackCertificates() {
   AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
   curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
   CURL_RETURNCODE=$?
-
+  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
   if [ $CURL_RETURNCODE != 0 ]; then
     # Replace placeholder for ssl binding
     if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40508,41 +40508,50 @@ func k8sCloudInitArtifactsCse_configSh() (*asset, error) {
 
 var _k8sCloudInitArtifactsCse_customcloudSh = []byte(`#!/bin/bash
 
-ensureCertificates() {
-  AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
-  AZURESTACK_RESOURCE_MANAGER_ENDPOINT=$(jq .resourceManagerEndpoint $AZURESTACK_ENVIRONMENT_JSON_PATH | tr -d '"')
-  AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
-  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
-  CURL_RETURNCODE=$?
-  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
-  if [ $CURL_RETURNCODE != 0 ]; then
-    # Replace placeholder for ssl binding
-    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
-      sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
-      sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
-    fi
+{{- if IsCustomCloudProfile}}
+ensureCustomCloudRootCertificates() {
+    CUSTOM_CLOUD_ROOT_CERTIFICATES="{{GetCustomCloudRootCertificates}}"
 
-    # Copying the AzureStack root certificate to the appropriate store to be updated.
-    AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH="/var/lib/waagent/Certificates.pem"
-    AZURESTACK_ROOT_CERTIFICATE__DEST_PATH="/usr/local/share/ca-certificates/azsCertificate.crt"
-    cp $AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH $AZURESTACK_ROOT_CERTIFICATE__DEST_PATH
-    update-ca-certificates
-  else
-    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
-      # the ARM resource manager endpoint binding certificate is trusted, remove the placeholder for ssl binding
-      sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
-      sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
-    fi
-  fi
+    if [ ! -z $CUSTOM_CLOUD_ROOT_CERTIFICATES ]; then
+        # Replace placeholder for ssl binding
+        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+            sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
+            sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
+        fi
 
-  # ensureCertificates will be retried if the exit code is not 0
-  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
-  exit $?
+        local i=1
+        for cert in $(echo $CUSTOM_CLOUD_ROOT_CERTIFICATES | tr ',' '\n')
+        do
+            echo $cert | base64 -d > "/usr/local/share/ca-certificates/customCloudRootCertificate$i.crt"
+            ((i++))
+        done
+
+        update-ca-certificates
+    else
+        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+            # remove the placeholder for ssl binding
+            sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+            sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+        fi
+    fi
+}
+
+ensureCustomCloudSourcesList() {
+    CUSTOM_CLOUD_SOURCES_LIST="{{GetCustomCloudSourcesList}}"
+
+    if [ ! -z $CUSTOM_CLOUD_SOURCES_LIST ]; then
+        # Just in case, let's take a back up before we overwrite
+        cp /etc/apt/sources.list /etc/apt/sources.list.backup
+        echo $CUSTOM_CLOUD_SOURCES_LIST | base64 -d > /etc/apt/sources.list
+    fi
 }
 
 configureK8sCustomCloud() {
-  export -f ensureCertificates
-  retrycmd 60 10 30 bash -c ensureCertificates
+  KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
+
+  {{- if IsAzureStackCloud}}
+  export -f ensureAzureStackCertificates
+  retrycmd 60 10 30 bash -c ensureAzureStackCertificates
   set +x
   # When AUTHENTICATION_METHOD is client_certificate, the certificate is stored into key valut,
   # And SERVICE_PRINCIPAL_CLIENT_SECRET will be the following json payload with based64 encode
@@ -40586,6 +40595,44 @@ configureK8sCustomCloud() {
   ifconfig eth0 mtu 1350
 
   set -x
+  {{else}}
+  ensureCustomCloudRootCertificates
+  ensureCustomCloudSourcesList
+  {{end}}
+}
+{{end}}
+
+{{- if IsAzureStackCloud}}
+ensureAzureStackCertificates() {
+  AZURESTACK_ENVIRONMENT_JSON_PATH="/etc/kubernetes/azurestackcloud.json"
+  AZURESTACK_RESOURCE_MANAGER_ENDPOINT=$(jq .resourceManagerEndpoint $AZURESTACK_ENVIRONMENT_JSON_PATH | tr -d '"')
+  AZURESTACK_RESOURCE_METADATA_ENDPOINT="$AZURESTACK_RESOURCE_MANAGER_ENDPOINT/metadata/endpoints?api-version=2015-01-01"
+  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
+  CURL_RETURNCODE=$?
+
+  if [ $CURL_RETURNCODE != 0 ]; then
+    # Replace placeholder for ssl binding
+    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+      sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
+      sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
+    fi
+
+    # Copying the AzureStack root certificate to the appropriate store to be updated.
+    AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH="/var/lib/waagent/Certificates.pem"
+    AZURESTACK_ROOT_CERTIFICATE__DEST_PATH="/usr/local/share/ca-certificates/azsCertificate.crt"
+    cp $AZURESTACK_ROOT_CERTIFICATE_SOURCE_PATH $AZURESTACK_ROOT_CERTIFICATE__DEST_PATH
+    update-ca-certificates
+  else
+    if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+      # the ARM resource manager endpoint binding certificate is trusted, remove the placeholder for ssl binding
+      sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+      sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+    fi
+  fi
+
+  # ensureAzureStackCertificates will be retried if the exit code is not 0
+  curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
+  exit $?
 }
 
 configureAzureStackInterfaces() {
@@ -40682,6 +40729,7 @@ configureAzureStackInterfaces() {
 
   set -x
 }
+{{end}}
 #EOF
 `)
 
@@ -41213,7 +41261,7 @@ eval "$(apmz bash -d)"
 wait_for_file 3600 1 {{GetCSEConfigScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
 source {{GetCSEConfigScriptFilepath}}
 
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
 wait_for_file 3600 1 {{GetCustomCloudConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
 source {{GetCustomCloudConfigCSEScriptFilepath }}
 {{end}}
@@ -41365,9 +41413,9 @@ time_metric "EnsureDocker" ensureDocker
 
 time_metric "ConfigureK8s" configureK8s
 
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
 time_metric "ConfigureK8sCustomCloud" configureK8sCustomCloud
-{{- if IsAzureCNI}}
+{{- if and IsAzureStackCloud IsAzureCNI}}
 time_metric "ConfigureAzureStackInterfaces" configureAzureStackInterfaces
 {{end}}
 {{end}}
@@ -42876,7 +42924,7 @@ write_files:
   {{end}}
 {{end}}
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: {{GetCustomCloudConfigCSEScriptFilepath}}
   permissions: "0744"
   encoding: gzip
@@ -43200,7 +43248,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
 {{else}}
     KUBELET_NODE_LABELS={{GetMasterKubernetesLabelsDeprecated "',variables('labelResourceGroup'),'"}}
 {{end}}
-{{if IsAzureStackCloud }}
+{{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
 {{if AnyAgentIsLinux}}
@@ -43315,7 +43363,7 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
 {{end}}
     #EOF
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: "/etc/kubernetes/azurestackcloud.json"
   permissions: "0600"
   owner: "root"
@@ -43413,7 +43461,7 @@ write_files:
   {{end}}
 {{end}}
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: {{GetCustomCloudConfigCSEScriptFilepath}}
   permissions: "0744"
   encoding: gzip
@@ -43693,7 +43741,7 @@ write_files:
 {{else}}
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabelsDeprecated . "',variables('labelResourceGroup'),'"}}
 {{end}}
-{{if IsAzureStackCloud }}
+{{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
     #EOF
@@ -43710,7 +43758,7 @@ write_files:
 {{end}}
     #EOF
 
-{{if IsAzureStackCloud}}
+{{if IsCustomCloudProfile}}
 - path: "/etc/kubernetes/azurestackcloud.json"
   permissions: "0600"
   owner: "root"
@@ -44871,7 +44919,7 @@ try
             -ExcludeMasterFromStandardLB $global:ExcludeMasterFromStandardLB ` + "`" + `
             -TargetEnvironment $TargetEnvironment
 
-        {{if IsAzureStackCloud}}
+        {{if IsCustomCloudProfile}}
         $azureStackConfigFile = [io.path]::Combine($global:KubeDir, "azurestackcloud.json")
         $envJSON = "{{ GetBase64EncodedEnvironmentJSON }}"
         [io.file]::WriteAllBytes($azureStackConfigFile, [System.Convert]::FromBase64String($envJSON))
@@ -45237,7 +45285,7 @@ spec:
       imagePullPolicy: IfNotPresent
       command: [{{ContainerConfig "command"}}]
       args: [{{GetControllerManagerArgs}}]
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
       env:
       - name: AZURE_ENVIRONMENT_FILEPATH
         value: "/etc/kubernetes/azurestackcloud.json"
@@ -45255,7 +45303,7 @@ spec:
         - name: msi
           mountPath: /var/lib/waagent/ManagedIdentity-Settings
           readOnly: true
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
         <volumeMountssl>
 {{end}}
   volumes:
@@ -45273,7 +45321,7 @@ spec:
     - name: msi
       hostPath:
         path: /var/lib/waagent/ManagedIdentity-Settings
-{{- if IsAzureStackCloud}}
+{{- if IsCustomCloudProfile}}
     <volumessl>
 {{end}}
 `)

--- a/pkg/engine/testdata/customcloud/kubernetes.json
+++ b/pkg/engine/testdata/customcloud/kubernetes.json
@@ -4,7 +4,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.13",
+            "orchestratorRelease": "1.16",
             "kubernetesConfig": {
                 "kubernetesImageBase": "k8s.gcr.io/",
                 "useInstanceMetadata": false,

--- a/pkg/engine/testdata/customcloud/kubernetes.json
+++ b/pkg/engine/testdata/customcloud/kubernetes.json
@@ -1,0 +1,117 @@
+{
+    "apiVersion": "vlabs",
+    "location": "westus",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "1.13",
+            "kubernetesConfig": {
+                "kubernetesImageBase": "k8s.gcr.io/",
+                "useInstanceMetadata": false,
+                "networkPolicy": "none"
+            }
+        },
+        "customCloudProfile": {
+            "environment": {
+                "name": "SomeCustomCloud",
+                "managementPortalURL": "https://manage.windowsazure.com/",
+                "publishSettingsURL": "https://manage.windowsazure.com/publishsettings/index",
+                "serviceManagementEndpoint": "https://management.core.windows.net/",
+                "resourceManagerEndpoint": "https://management.azure.com/",
+                "activeDirectoryEndpoint": "https://login.microsoftonline.com/",
+                "galleryEndpoint": "https://gallery.azure.com/",
+                "keyVaultEndpoint": "https://vault.azure.net/",
+                "graphEndpoint": "https://graph.windows.net/",
+                "serviceBusEndpoint": "https://servicebus.windows.net/",
+                "batchManagementEndpoint": "https://batch.core.windows.net/",
+                "storageEndpointSuffix": "core.windows.net",
+                "sqlDatabaseDNSSuffix": "database.windows.net",
+                "trafficManagerDNSSuffix": "trafficmanager.net",
+                "keyVaultDNSSuffix": "vault.azure.net",
+                "serviceBusEndpointSuffix": "servicebus.windows.net",
+                "serviceManagementVMDNSSuffix": "cloudapp.net",
+                "resourceManagerVMDNSSuffix": "cloudapp.azure.com",
+                "containerRegistryDNSSuffix": "azurecr.io",
+                "cosmosDBDNSSuffix": "documents.azure.com",
+                "tokenAudience": "https://management.azure.com/",
+                "resourceIdentifiers": {
+                    "graph": "https://graph.windows.net/",
+                    "keyVault": "https://vault.azure.net",
+                    "datalake": "https://datalake.azure.net/",
+                    "batch": "https://batch.core.windows.net/",
+                    "operationalInsights": "https://api.loganalytics.io",
+                    "storage": "https://storage.azure.com/"
+                }
+            },
+            "customCloudRootCertificates": "customCloudRootCertificate1,customCloudRootCertificate2",
+            "customCloudSourcesList": "customSources.list"
+        },
+        "masterProfile": {
+            "dnsPrefix": "k111007",
+            "distro": "ubuntu",
+            "osDiskSizeGB": 200,
+            "count": 3,
+            "availabilityProfile": "AvailabilitySet",
+            "vmSize": "Standard_D2_v2"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "linuxpool",
+                "osDiskSizeGB": 200,
+                "count": 3,
+                "vmSize": "Standard_D2_v2",
+                "distro": "ubuntu",
+                "availabilityProfile": "AvailabilitySet",
+                "AcceleratedNetworkingEnabled": false
+            },
+            {
+                "name": "windowspool",
+                "osDiskSizeGB": 128,
+                "count": 3,
+                "vmSize": "Standard_D2_v2",
+                "osType": "Windows",
+                "availabilityProfile": "AvailabilitySet",
+                "AcceleratedNetworkingEnabled": false
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": "ssh-rsa publickey azure@linux"
+                    }
+                ]
+            }
+        },
+        "windowsProfile": {
+            "adminUsername": "azureuser",
+            "adminPassword": "myAdminPassword~1",
+            "sshEnabled": true
+        },
+        "servicePrincipalProfile": {
+            "clientId": "ServicePrincipalClientID",
+            "secret": "myServicePrincipalClientSecret"
+        },
+        "certificateProfile": {
+          "caCertificate": "caCertificate",
+          "caPrivateKey": "caPrivateKey",
+          "apiServerCertificate": "/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.KeyVault/vaults/my-kv/secrets/my-secret1/ver1",
+          "apiServerPrivateKey": "apiServerPrivateKey",
+          "clientCertificate": "clientCertificate",
+          "clientPrivateKey": "clientPrivateKey",
+          "kubeConfigCertificate": "kubeConfigCertificate",
+          "kubeConfigPrivateKey": "kubeConfigPrivateKey",
+          "etcdClientCertificate": "etcdClientCertificate",
+          "etcdClientPrivateKey": "etcdClientPrivateKey",
+          "etcdServerCertificate": "etcdServerCertificate",
+          "etcdServerPrivateKey": "etcdServerPrivateKey",
+          "etcdPeerCertificates": [
+            "etcdPeerCertificate0"
+          ],
+          "etcdPeerPrivateKeys": [
+            "etcdPeerPrivateKey0"
+          ]
+        }
+    }
+}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -170,9 +170,13 @@ func GetCloudTargetEnv(location string) string {
 // CustomCloudName is name of environment if customCloudProfile is provided, it will be empty string if customCloudProfile is empty.
 // Because customCloudProfile is empty for deployment for AzurePublicCloud, AzureChinaCloud,AzureGermanCloud,AzureUSGovernmentCloud,
 // The customCloudName value will be empty string for those clouds
+// This value is also used in azure.json file, which is used by Kubernetes to read various endpoints specific to cloud
 func GetTargetEnv(location, customCloudName string) string {
 	switch {
-	case customCloudName != "" && strings.EqualFold(customCloudName, "AzureStackCloud"):
+	// Kubernetes only understand "AzureStackCloud" env right now to read from custom endpoints:
+	// https://github.com/Azure/go-autorest/blob/master/autorest/azure/environments.go
+	// We should always return "AzureStackCloud" when CustomCloudProfile was used
+	case customCloudName != "":
 		return "AzureStackCloud"
 	default:
 		return GetCloudTargetEnv(location)

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -543,9 +543,9 @@ func TestGetTargetEnv(t *testing.T) {
 			"AzureStackCloud",
 		},
 		{
-			"azurestacklocation",
-			"azurestacklocation",
-			"AzurePublicCloud",
+			"customlocation",
+			"customcloud",
+			"AzureStackCloud",
 		},
 	}
 

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -111,6 +111,13 @@ func (c *Config) GetKubeConfig() string {
 	return kubeconfigPath
 }
 
+// IsCustomCloudProfile returns true if the cloud is a custom cloud
+func (c *Config) IsCustomCloudProfile() bool {
+	clusterDefinitionFullPath := fmt.Sprintf("%s/%s", c.CurrentWorkingDir, c.ClusterDefinition)
+	cs := parseVlabsContainerSerice(clusterDefinitionFullPath)
+	return cs.Properties.IsCustomCloudProfile()
+}
+
 // IsAzureStackCloud returns true if the cloud is AzureStack
 func (c *Config) IsAzureStackCloud() bool {
 	clusterDefinitionFullPath := fmt.Sprintf("%s/%s", c.CurrentWorkingDir, c.ClusterDefinition)

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -39,7 +39,7 @@ func main() {
 	}
 	cfg.CurrentWorkingDir = cwd
 
-	if cfg.IsAzureStackCloud() {
+	if cfg.IsCustomCloudProfile() {
 		cccfg, err = config.ParseCustomCloudConfig()
 
 		if err != nil {


### PR DESCRIPTION
**Reason for Change**:
Currently, when CustomCloudProfile is specified, aks-engine treats it as Azure Stack and executes many Azure Stack-specific logic (i.e. loading azure stack specific image, setting lower arm api versions, disabling instance metadata, etc).

This makes impossible for users to specify custom cloud endpoints without triggering Azure Stack specific logic.

This PR decouples Azure Stack logic from Custom Cloud logic by introducing an internally computed property "**IsCustomCloudProfile**".

The main idea is to use “**IsAzureStackCloud**” property for doing any Azure Stack specific works, and use “**IsCustomCloudProfile**” property for generating actual azure.json and azurestackcloud.json files in VMs in the end.

I also added following two additional fields to support specifying custom root certificates and sources.list:
1. "**customCloudRootCertificates**": comma-separated list of base64-encoded pem certificates, which will be installed to /usr/local/shared/ca-certificates folder
2. "**customCloudSourcesList**": base64-encoded custom sources.list file. It will overwrite /etc/apt/sources.list (while taking its backup)

Sample customCloudProfile section:
````
"customCloudProfile": {
      "environment": {
        "name": "MyCustomCloud",
        "resourceManagerEndpoint": "https://management.customcloud/",
        "activeDirectoryEndpoint": "https://login.customcloud/",
        ...
        }
      },
      "customCloudRootCertificates": "LS0tLS1CRUdJTiBDRV...",
      "customCloudSourcesList": "ZGViIGh0dHBzOi8vcmVwb2RlcG90LmF6dXJlLmVhZ2..."
    },
````
Produces **azure.json**:
````
{
    "cloud":"AzureStackCloud",
    "tenantId": "...",
    "subscriptionId": "...",
    ...
}
````
and produces **azurestackcloud.json**:
````
{
    "name": "MyCustomCloud",
    "resourceManagerEndpoint": "https://management.customcloud/",
    "activeDirectoryEndpoint": "https://login.customcloud/",
    ...
}
````
**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
