### PR TITLE
feat: EncryptionAtHost support(cherry-pick to branch aks-release-v0.47.0-1)

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -489,6 +489,7 @@ func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterP
 	vlabsProfile.SinglePlacementGroup = api.SinglePlacementGroup
 	vlabsProfile.CosmosEtcd = api.CosmosEtcd
 	vlabsProfile.AuditDEnabled = api.AuditDEnabled
+	vlabsProfile.EncryptionAtHost = api.EncryptionAtHost
 	convertCustomFilesToVlabs(api, vlabsProfile)
 }
 
@@ -535,6 +536,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	p.LoadBalancerBackendAddressPoolIDs = api.LoadBalancerBackendAddressPoolIDs
 	p.AuditDEnabled = api.AuditDEnabled
 	p.DiskEncryptionSetID = api.DiskEncryptionSetID
+	p.EncryptionAtHost = api.EncryptionAtHost
 
 	for k, v := range api.CustomNodeLabels {
 		p.CustomNodeLabels[k] = v

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -545,6 +545,7 @@ func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 	api.SinglePlacementGroup = vlabs.SinglePlacementGroup
 	api.CosmosEtcd = vlabs.CosmosEtcd
 	api.AuditDEnabled = vlabs.AuditDEnabled
+	api.EncryptionAtHost = vlabs.EncryptionAtHost
 	convertCustomFilesToAPI(vlabs, api)
 }
 
@@ -580,6 +581,7 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 	api.LoadBalancerBackendAddressPoolIDs = vlabs.LoadBalancerBackendAddressPoolIDs
 	api.AuditDEnabled = vlabs.AuditDEnabled
 	api.DiskEncryptionSetID = vlabs.DiskEncryptionSetID
+	api.EncryptionAtHost = vlabs.EncryptionAtHost
 
 	api.CustomNodeLabels = map[string]string{}
 	for k, v := range vlabs.CustomNodeLabels {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -529,6 +529,7 @@ type MasterProfile struct {
 	AvailabilityZones         []string          `json:"availabilityZones,omitempty"`
 	SinglePlacementGroup      *bool             `json:"singlePlacementGroup,omitempty"`
 	AuditDEnabled             *bool             `json:"auditDEnabled,omitempty"`
+	EncryptionAtHost          *bool             `json:"encryptionAtHost,omitempty"`
 	CustomVMTags              map[string]string `json:"customVMTags,omitempty"`
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376
@@ -612,6 +613,7 @@ type AgentPoolProfile struct {
 	AuditDEnabled                       *bool                `json:"auditDEnabled,omitempty"`
 	CustomVMTags                        map[string]string    `json:"customVMTags,omitempty"`
 	DiskEncryptionSetID                 string               `json:"diskEncryptionSetID,omitempty"`
+	EncryptionAtHost                    *bool                `json:"encryptionAtHost,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -658,16 +658,17 @@ func TestMasterProfileGetCosmosEndPointURI(t *testing.T) {
 
 func TestHasStorageProfile(t *testing.T) {
 	cases := []struct {
-		name              string
-		p                 Properties
-		expectedHasMD     bool
-		expectedHasSA     bool
-		expectedMasterMD  bool
-		expectedAgent0E   bool
-		expectedAgent0MD  bool
-		expectedPrivateJB bool
-		expectedHasDisks  bool
-		expectedDesID     string
+		name                     string
+		p                        Properties
+		expectedHasMD            bool
+		expectedHasSA            bool
+		expectedMasterMD         bool
+		expectedAgent0E          bool
+		expectedAgent0MD         bool
+		expectedPrivateJB        bool
+		expectedHasDisks         bool
+		expectedDesID            string
+                expectedEncryptionAtHost bool
 	}{
 		{
 			name: "Storage Account",
@@ -869,6 +870,35 @@ func TestHasStorageProfile(t *testing.T) {
 			expectedPrivateJB: false,
 			expectedDesID:     "DiskEncryptionSetID",
 		},
+		{
+			name: "EncryptionAtHost setting",
+			p: Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					StorageProfile:   ManagedDisks,
+					EncryptionAtHost: to.BoolPtr(true),
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						StorageProfile:   ManagedDisks,
+						EncryptionAtHost: to.BoolPtr(true),
+					},
+					{
+						StorageProfile:   ManagedDisks,
+						EncryptionAtHost: to.BoolPtr(true),
+					},
+				},
+			},
+			expectedHasMD:            true,
+			expectedHasSA:            false,
+			expectedMasterMD:         true,
+			expectedAgent0MD:         true,
+			expectedAgent0E:          false,
+			expectedPrivateJB:        false,
+			expectedEncryptionAtHost: true,
+		},
 	}
 
 	for _, c := range cases {
@@ -886,6 +916,9 @@ func TestHasStorageProfile(t *testing.T) {
 			}
 			if c.p.MasterProfile.IsStorageAccount() == c.expectedMasterMD {
 				t.Fatalf("expected IsStorageAccount() to return %t but instead returned %t", !c.expectedMasterMD, c.p.MasterProfile.IsStorageAccount())
+			}
+			if to.Bool(c.p.MasterProfile.EncryptionAtHost) != c.expectedEncryptionAtHost {
+				t.Fatalf("expected EncryptionAtHost to return %v but instead returned %v", c.expectedEncryptionAtHost, to.Bool(c.p.MasterProfile.EncryptionAtHost))
 			}
 			if c.p.AgentPoolProfiles[0].IsManagedDisks() != c.expectedAgent0MD {
 				t.Fatalf("expected IsManagedDisks() to return %t but instead returned %t", c.expectedAgent0MD, c.p.AgentPoolProfiles[0].IsManagedDisks())
@@ -905,6 +938,9 @@ func TestHasStorageProfile(t *testing.T) {
 			}
 			if c.p.AgentPoolProfiles[0].DiskEncryptionSetID != c.expectedDesID {
 				t.Fatalf("expected DiskEncryptionSetID to return %s but instead returned %s", c.expectedDesID, c.p.AgentPoolProfiles[0].DiskEncryptionSetID)
+			}
+			if to.Bool(c.p.AgentPoolProfiles[0].EncryptionAtHost) != c.expectedEncryptionAtHost {
+				t.Fatalf("expected EncryptionAtHost to return %v but instead returned %v", c.expectedEncryptionAtHost, to.Bool(c.p.AgentPoolProfiles[0].EncryptionAtHost))
 			}
 		})
 	}

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -419,6 +419,7 @@ type MasterProfile struct {
 	PlatformFaultDomainCount  *int              `json:"platformFaultDomainCount,omitEmpty"`
 	PlatformUpdateDomainCount *int              `json:"platformUpdateDomainCount"`
 	AuditDEnabled             *bool             `json:"auditDEnabled,omitempty"`
+	EncryptionAtHost          *bool             `json:"encryptionAtHost,omitempty"`
 	CustomVMTags              map[string]string `json:"customVMTags,omitempty"`
 
 	// subnet is internal
@@ -490,6 +491,7 @@ type AgentPoolProfile struct {
 	AuditDEnabled                       *bool                `json:"auditDEnabled,omitempty"`
 	CustomVMTags                        map[string]string    `json:"customVMTags,omitempty"`
 	DiskEncryptionSetID                 string               `json:"diskEncryptionSetID,omitempty"`
+	EncryptionAtHost                    *bool                `json:"encryptionAtHost,omitempty"`
 
 	// subnet is internal
 	subnet string

--- a/pkg/api/vlabs/types_test.go
+++ b/pkg/api/vlabs/types_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
 )
 
 func TestOrchestratorProfile(t *testing.T) {
@@ -140,6 +141,10 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.DiskEncryptionSetID is not empty after unmarshal")
 	}
 
+	if to.Bool(ap.EncryptionAtHost) {
+		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be false by default")
+	}
+
 	// With osType Windows
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Windows", "count": 1, "vmSize": "Standard_D2_v2",
 "availabilityProfile": "AvailabilitySet", "storageProfile" : "ManagedDisks", "vnetSubnetID" : "12345" }`
@@ -162,7 +167,7 @@ func TestAgentPoolProfile(t *testing.T) {
 
 	// With osType Windows and Ephemeral disks
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Windows", "count": 1, "vmSize": "Standard_D2_v2",
-"availabilityProfile": "AvailabilitySet", "storageProfile" : "Ephemeral", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID" }`
+"availabilityProfile": "AvailabilitySet", "storageProfile" : "Ephemeral", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID", "encryptionAtHost": true }`
 	ap = &AgentPoolProfile{}
 	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
 		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
@@ -188,6 +193,9 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.DiskEncryptionSetID is empty after unmarshal")
 	}
 
+	if !to.Bool(ap.EncryptionAtHost) {
+		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be true after unmarshal")
+	}
 	// With osType Linux and RHEL distro
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Linux", "distro" : "rhel", "count": 1, "vmSize": "Standard_D2_v2",
 "availabilityProfile": "AvailabilitySet", "storageProfile" : "ManagedDisks", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID" }`
@@ -222,7 +230,7 @@ func TestAgentPoolProfile(t *testing.T) {
 
 	// With VMSS and Spot VMs
 	AgentPoolProfileText = `{"name":"linuxpool1","osType":"Linux","distro":"rhel","count":1,"vmSize":"Standard_D2_v2",
-"availabilityProfile":"VirtualMachineScaleSets","scaleSetPriority":"Spot","ScaleSetEvictionPolicy":"Delete","SpotMaxPrice":88}`
+"availabilityProfile":"VirtualMachineScaleSets","scaleSetPriority":"Spot","ScaleSetEvictionPolicy":"Delete","SpotMaxPrice":88, "encryptionAtHost": true}`
 	ap = &AgentPoolProfile{}
 	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
 		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
@@ -240,6 +248,9 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("unexpectedly detected *AgentPoolProfile.SpotMaxPrice != float64(88) after unmarshal")
 	}
 
+	if !to.Bool(ap.EncryptionAtHost) {
+		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be true after unmarshal")
+	}
 	// With osType Linux and coreos distro
 	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Linux", "distro" : "coreos", "count": 1, "vmSize": "Standard_D2_v2",
 "availabilityProfile": "VirtualMachineScaleSets", "storageProfile" : "ManagedDisks", "diskSizesGB" : [750, 250, 600, 1000], "diskEncryptionSetID": "diskEncryptionSetID" }`


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
Ported from PR: https://github.com/Azure/aks-engine/pull/3041

This PR is actually a place holder, it's mainly for AKS to support  EncryptionAtHost(Enable Encryption at Host support for VM/VMSS) (JEDI requirement) which is going to be in private preview late this month.

EncryptionAtHost functionality actually does not work by this PR since it depends on
 - go sdk ready and upgrade to supported go sdk version
 - EncryptionAtHost feature on public regions ready
 - subs whitelist

Will make it work when the above 3 requirements are fullfilled.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

/assign @xuto2
cc @jluk
