### PR TITLE
chore: use Ubuntu 18.04-LTS as default

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -76,10 +76,10 @@
         "storageProfile": "Ephemeral"
       },
       {
-        "name": "pool1804vhd",
+        "name": "pool1604vhd",
         "count": 1,
         "vmSize": "Standard_D2_v3",
-        "distro": "aks-ubuntu-18.04",
+        "distro": "aks-ubuntu-16.04",
         "availabilityProfile": "VirtualMachineScaleSets",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
       },

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -453,12 +453,12 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			// Distro assignment for masterProfile
 			if cs.Properties.MasterProfile.ImageRef == nil {
 				if cs.Properties.MasterProfile.Distro == "" {
-					if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
-						cs.Properties.MasterProfile.Distro = AKSUbuntu1604
+					if o.KubernetesConfig.CustomHyperkubeImage == "" {
+						cs.Properties.MasterProfile.Distro = AKSUbuntu1804
 					} else {
-						cs.Properties.MasterProfile.Distro = Ubuntu
+						cs.Properties.MasterProfile.Distro = Ubuntu1804
 					}
-				} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
+				} else if isUpgrade || isScale {
 					if cs.Properties.MasterProfile.Distro == AKSDockerEngine || cs.Properties.MasterProfile.Distro == AKS1604Deprecated {
 						cs.Properties.MasterProfile.Distro = AKSUbuntu1604
 					} else if cs.Properties.MasterProfile.Distro == AKS1804Deprecated {
@@ -467,7 +467,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 				}
 				// The AKS Distro is not available in Azure German Cloud.
 				if cloudSpecConfig.CloudName == AzureGermanCloud {
-					cs.Properties.MasterProfile.Distro = Ubuntu
+					cs.Properties.MasterProfile.Distro = Ubuntu1804
 				}
 			}
 		}
@@ -495,14 +495,14 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			if profile.OSType != Windows {
 				if profile.ImageRef == nil {
 					if profile.Distro == "" {
-						if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
+						if o.KubernetesConfig.CustomHyperkubeImage == "" {
 							if profile.OSDiskSizeGB != 0 && profile.OSDiskSizeGB < VHDDiskSizeAKS {
-								profile.Distro = Ubuntu
+								profile.Distro = Ubuntu1804
 							} else {
-								profile.Distro = AKSUbuntu1604
+								profile.Distro = AKSUbuntu1804
 							}
 						} else {
-							profile.Distro = Ubuntu
+							profile.Distro = Ubuntu1804
 						}
 						// Ensure deprecated distros are overridden
 						// Previous versions of aks-engine required the docker-engine distro for N series vms,
@@ -516,7 +516,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 					}
 					// The AKS Distro is not available in Azure German Cloud.
 					if cloudSpecConfig.CloudName == AzureGermanCloud {
-						profile.Distro = Ubuntu
+						profile.Distro = Ubuntu1804
 					}
 				}
 			}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1744,8 +1744,8 @@ func TestDistroDefaults(t *testing.T) {
 			},
 			"",
 			"",
-			AKSUbuntu1604,
-			AKSUbuntu1604,
+			AKSUbuntu1804,
+			AKSUbuntu1804,
 			false,
 			false,
 			AzurePublicCloud,
@@ -1758,8 +1758,8 @@ func TestDistroDefaults(t *testing.T) {
 			},
 			"",
 			"",
-			AKSUbuntu1604,
-			AKSUbuntu1604,
+			AKSUbuntu1804,
+			AKSUbuntu1804,
 			false,
 			false,
 			AzureUSGovernmentCloud,
@@ -1784,10 +1784,24 @@ func TestDistroDefaults(t *testing.T) {
 				OrchestratorType: Kubernetes,
 				KubernetesConfig: &KubernetesConfig{},
 			},
+			"",
+			"",
+			Ubuntu1804,
+			Ubuntu1804,
+			false,
+			false,
+			AzureGermanCloud,
+		},
+		{
+			"germancloud_upgrade",
+			OrchestratorProfile{
+				OrchestratorType: Kubernetes,
+				KubernetesConfig: &KubernetesConfig{},
+			},
 			AKS1604Deprecated,
 			AKS1604Deprecated,
-			Ubuntu,
-			Ubuntu,
+			Ubuntu1804,
+			Ubuntu1804,
 			true,
 			false,
 			AzureGermanCloud,
@@ -3621,7 +3635,7 @@ func TestPreserveNodesProperties(t *testing.T) {
 
 func TestUbuntu1804Flags(t *testing.T) {
 	// Validate --resolv-conf is missing with 16.04 distro and present with 18.04
-	cs := CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs := CreateMockContainerService("testcluster", "1.17.4", 3, 2, false)
 	cs.Properties.MasterProfile.Distro = AKSUbuntu1604
 	cs.Properties.AgentPoolProfiles[0].Distro = AKSUbuntu1804
 	cs.Properties.AgentPoolProfiles[0].OSType = Linux
@@ -3641,7 +3655,7 @@ func TestUbuntu1804Flags(t *testing.T) {
 			ka["--resolv-conf"], "/run/systemd/resolve/resolv.conf")
 	}
 
-	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs = CreateMockContainerService("testcluster", "1.17.4", 3, 2, false)
 	cs.Properties.MasterProfile.Distro = Ubuntu1804
 	cs.Properties.AgentPoolProfiles[0].Distro = Ubuntu
 	cs.Properties.AgentPoolProfiles[0].OSType = Linux
@@ -4332,12 +4346,12 @@ func TestImageReference(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro:   AKSUbuntu1604,
+				Distro:   AKSUbuntu1804,
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro:   AKSUbuntu1604,
+					Distro:   AKSUbuntu1804,
 					ImageRef: nil,
 				},
 			},
@@ -4417,7 +4431,7 @@ func TestImageReference(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro:   AKSUbuntu1604,
+				Distro:   AKSUbuntu1804,
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
@@ -4432,7 +4446,7 @@ func TestImageReference(t *testing.T) {
 					},
 				},
 				{
-					Distro:   AKSUbuntu1604,
+					Distro:   AKSUbuntu1804,
 					ImageRef: nil,
 				},
 			},
@@ -4531,12 +4545,12 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro:   AKSUbuntu1604,
+				Distro:   AKSUbuntu1804,
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro:   AKSUbuntu1604,
+					Distro:   AKSUbuntu1804,
 					ImageRef: nil,
 				},
 			},
@@ -4558,11 +4572,11 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro: Ubuntu,
+				Distro: Ubuntu1804,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro: Ubuntu,
+					Distro: Ubuntu1804,
 				},
 			},
 		},
@@ -4609,7 +4623,7 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 					AgentPoolProfiles: []*AgentPoolProfile{
 						{
 							Name:   "pool1",
-							Distro: Ubuntu1804,
+							Distro: Ubuntu,
 						},
 						{
 							Name: "pool2",
@@ -4618,14 +4632,14 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro: Ubuntu,
+				Distro: Ubuntu1804,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro: Ubuntu1804,
+					Distro: Ubuntu,
 				},
 				{
-					Distro: Ubuntu,
+					Distro: Ubuntu1804,
 				},
 			},
 		},

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -111,7 +111,7 @@
 					"vmSize": "Standard_D16_v3",
 					"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
 					"scalesetPriority": "Spot",
-					"distro": "ubuntu"
+					"distro": "ubuntu1804"
 				},
 				{
 					"name": "poolwin",


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR moves default Linux OS forward from 16.04-LTS to 18.04-LTS. 18.04 has been supported for a long while and lots of folks are using it in production, so there's no reason to continue a conservative default configuration going forward.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
