### PR TITLE
fix: don't skip Windows VMSS node pools during upgrade

### DIFF
--- a/test/e2e/test_cluster_configs/base.json
+++ b/test/e2e/test_cluster_configs/base.json
@@ -18,12 +18,12 @@
 			},
 			"agentPoolProfiles": [
 				{
-					"name": "agentpool1",
+					"name": "poollinux",
 					"count": 1,
 					"vmSize": "Standard_D2_v3"
 				},
 				{
-					"name": "agentwin1",
+					"name": "poolwin",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"osType": "Windows"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR enables Windows VMSS node pools to be upgraded.

Prior to this change, the upgrade code path uses a Linux-specific VMSS instance naming convention check to determine whether or not the VMSS is an aks-engine-created VMSS instance. Because aks-engine uses an entirely different naming schema for Linux and Windows, this means that `aks-engine upgrade` always thinks that Windows VMSS are not participating in the aks-engine-created Kubernetes cluster, and thus doesn't include them for upgrade.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3017 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
