### PR TITLE
feat: disable dashboard addon by default

### DIFF
--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -2027,7 +2027,7 @@ func TestSetAddonsConfig(t *testing.T) {
 			expectedAddons: []KubernetesAddon{
 				{
 					Name:    common.DashboardAddonName,
-					Enabled: to.BoolPtr(true),
+					Enabled: to.BoolPtr(false),
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:           common.DashboardAddonName,
@@ -4613,7 +4613,7 @@ func getDefaultAddons(version, kubernetesImageBase, kubernetesImageBaseType stri
 		},
 		{
 			Name:    common.DashboardAddonName,
-			Enabled: to.BoolPtr(true),
+			Enabled: to.BoolPtr(false),
 			Containers: []KubernetesContainerSpec{
 				{
 					Name:           common.DashboardAddonName,

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -155,7 +155,7 @@ const (
 	// DefaultKeyVaultFlexVolumeAddonEnabled determines the aks-engine provided default for enabling key vault flexvolume addon
 	DefaultKeyVaultFlexVolumeAddonEnabled = true
 	// DefaultDashboardAddonEnabled determines the aks-engine provided default for enabling kubernetes-dashboard addon
-	DefaultDashboardAddonEnabled = true
+	DefaultDashboardAddonEnabled = false
 	// DefaultReschedulerAddonEnabled determines the aks-engine provided default for enabling kubernetes-rescheduler addon
 	DefaultReschedulerAddonEnabled = false
 	// DefaultAzureCNIMonitoringAddonEnabled determines the aks-engine provided default for enabling azurecni-network monitoring addon


### PR DESCRIPTION
**Reason for Change**:
The kubernetes-dashboard implementation is stale and [not considered compatible](https://github.com/kubernetes/dashboard/releases/tag/v1.10.1) with current versions of Kubernetes, so this change disables it by default. It can still be turned on if desired by enabling it explicitly in a cluster config (apimodel).

**Issue Fixed**:
Fixes #3021

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Users can try out the new pre-release versions by following the [current documentation for Kubernetes Dashboard](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/).