### PR TITLE
style: override linguist's default language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * -crlf
+
+# Fix misidentification of Go templates as Raku or Perl
+*.t linguist-language=Go


### PR DESCRIPTION
**Reason for Change**:
Overrides the default language detection for `github-linguist` so Go template files aren't identified as Raku or Perl.

Before:
```
# github-linguist --breakdown
91.54%  Go
2.79%   Raku
2.61%   Shell
1.99%   PowerShell
0.90%   Perl
0.14%   Makefile
0.03%   Python
0.00%   Batchfile
```

After:
```
# github-linguist --breakdown
95.22%  Go
2.61%   Shell
1.99%   PowerShell
0.14%   Makefile
0.03%   Python
0.00%   Batchfile

```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I realize this is entirely trivial, but it's the kind of thing that bothers me.
