### PR TITLE
feat: add support for Kubernetes 1.19.0-alpha.2

### DIFF
--- a/parts/k8s/addons/1.19/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/addons/1.19/azure-cni-networkmonitor.yaml
@@ -30,7 +30,7 @@ spec:
       - operator: "Exists"
         effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
         - name: azure-cnms
           image: {{ContainerImage "azure-cni-networkmonitor"}}

--- a/parts/k8s/addons/1.19/ip-masq-agent.yaml
+++ b/parts/k8s/addons/1.19/ip-masq-agent.yaml
@@ -24,7 +24,7 @@ spec:
       priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -138,7 +138,7 @@ spec:
             add:
             - NET_ADMIN
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-aci-connector-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-aci-connector-deployment.yaml
@@ -83,7 +83,7 @@ spec:
     spec:
       serviceAccountName: aci-connector
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: aci-connector
         image: {{ContainerImage "aci-connector"}}

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-azure-npm-daemonset.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-azure-npm-daemonset.yaml
@@ -73,7 +73,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
         - name: azure-npm
           image: {{ContainerImage "azure-npm-daemonset"}}

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
@@ -43,4 +43,4 @@ spec:
         hostPath:
           path: /etc/kubernetes/volumeplugins/
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-calico-daemonset.yaml
@@ -355,7 +355,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Mark the pod as a critical add-on for rescheduling. */}}
@@ -442,7 +442,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Make sure calico-node gets scheduled on all nodes. */}}

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-cluster-autoscaler-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-cluster-autoscaler-deployment.yaml
@@ -169,7 +169,7 @@ spec:
         key: node-role.kubernetes.io/master
       nodeSelector:
         kubernetes.io/role: master
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - image: {{ContainerImage "cluster-autoscaler"}}
         imagePullPolicy: IfNotPresent

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -59,7 +59,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-heapster-deployment.yaml
@@ -167,4 +167,4 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -46,4 +46,4 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -206,4 +206,4 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -125,4 +125,4 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - image: {{ContainerImage "rescheduler"}}
         imagePullPolicy: IfNotPresent

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
@@ -126,4 +126,4 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-metrics-server-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-metrics-server-deployment.yaml
@@ -130,7 +130,7 @@ spec:
         - /metrics-server
         - --kubelet-insecure-tls
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-nvidia-device-plugin-daemonset.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-nvidia-device-plugin-daemonset.yaml
@@ -59,5 +59,5 @@ spec:
           hostPath:
             path: /var/lib/kubelet/device-plugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         accelerator: nvidia

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-smb-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-smb-flexvolume-installer.yaml
@@ -43,4 +43,4 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-tiller-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-tiller-deployment.yaml
@@ -97,4 +97,4 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -189,6 +189,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.18.1":         true,
 	"1.18.2":         true,
 	"1.19.0-alpha.1": true,
+	"1.19.0-alpha.2": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -22066,7 +22066,7 @@ spec:
       - operator: "Exists"
         effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
         - name: azure-cnms
           image: {{ContainerImage "azure-cni-networkmonitor"}}
@@ -22143,7 +22143,7 @@ spec:
       priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -22415,7 +22415,7 @@ spec:
             add:
             - NET_ADMIN
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -22611,7 +22611,7 @@ spec:
     spec:
       serviceAccountName: aci-connector
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: aci-connector
         image: {{ContainerImage "aci-connector"}}
@@ -23037,7 +23037,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
         - name: azure-npm
           image: {{ContainerImage "azure-npm-daemonset"}}
@@ -23134,7 +23134,7 @@ spec:
         hostPath:
           path: /etc/kubernetes/volumeplugins/
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsBlobfuseFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -23509,7 +23509,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Mark the pod as a critical add-on for rescheduling. */}}
@@ -23596,7 +23596,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Make sure calico-node gets scheduled on all nodes. */}}
@@ -25133,7 +25133,7 @@ spec:
         key: node-role.kubernetes.io/master
       nodeSelector:
         kubernetes.io/role: master
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - image: {{ContainerImage "cluster-autoscaler"}}
         imagePullPolicy: IfNotPresent
@@ -25311,7 +25311,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready
@@ -25592,7 +25592,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsHeapsterDeploymentYamlBytes() ([]byte, error) {
@@ -25658,7 +25658,7 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsKeyvaultFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -25884,7 +25884,7 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsKubeDnsDeploymentYamlBytes() ([]byte, error) {
@@ -26029,7 +26029,7 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsKubeProxyDaemonsetYamlBytes() ([]byte, error) {
@@ -26068,7 +26068,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - image: {{ContainerImage "rescheduler"}}
         imagePullPolicy: IfNotPresent
@@ -26229,7 +26229,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsKubernetesDashboardDeploymentYamlBytes() ([]byte, error) {
@@ -26379,7 +26379,7 @@ spec:
         - /metrics-server
         - --kubelet-insecure-tls
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
@@ -26475,7 +26475,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/device-plugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         accelerator: nvidia
 `)
 
@@ -26688,7 +26688,7 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsSmbFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -26805,7 +26805,7 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons119KubernetesmasteraddonsTillerDeploymentYamlBytes() ([]byte, error) {

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -86,7 +86,8 @@ function Get-FilesToCacheOnVHD
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.17.5/windowszip/v1.17.5-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.0/windowszip/v1.18.0-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.1/windowszip/v1.18.1-1int.zip",
-            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.2/windowszip/v1.18.2-1int.zip"
+            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.2/windowszip/v1.18.2-1int.zip",
+            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.19.0-alpha.2/windowszip/v1.19.0-alpha.2-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
             "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -342,6 +342,7 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="
+1.19.0-alpha.2
 1.18.2
 1.18.1
 1.17.5


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1190-alpha1

**Issue Fixed**:

**Requirements**:

- [x] Kubernetes artifacts built and pushed by Azure Pipelines
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
There is a problem building 1.19.0-alpha.2 currently in the Azure Pipeline. I will update this PR when we have it fixed. cc: @sozercan 
