### PR TITLE
ci: remove gofmt linter because goimports includes it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - gofmt
     - goimports
     - gosimple
     - golint


### PR DESCRIPTION
**Reason for Change**:

>  [Goimports does everything](https://github.com/golangci/golangci-lint#disabled-by-default-linters--e--enable) that gofmt does. Additionally it checks unused imports

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

This was cherry-picked from #2839 as that larger changeset is still being tested.
