### PR TITLE
test: rationalize E2E env defaults

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -26,27 +26,27 @@ import (
 // Config holds global test configuration
 type Config struct {
 	SkipTest            bool          `envconfig:"SKIP_TEST" default:"false"`
-	SkipLogsCollection  bool          `envconfig:"SKIP_LOGS_COLLECTION" default:"false"`
+	SkipLogsCollection  bool          `envconfig:"SKIP_LOGS_COLLECTION" default:"true"`
 	Orchestrator        string        `envconfig:"ORCHESTRATOR" default:"kubernetes"`
-	Name                string        `envconfig:"NAME"`                                                                  // Name allows you to set the name of a cluster already created
-	Location            string        `envconfig:"LOCATION"`                                                              // Location where you want to create the cluster
-	Regions             []string      `envconfig:"REGIONS"`                                                               // A whitelist of availableregions
+	Name                string        `envconfig:"NAME" default:""`                                                       // Name allows you to set the name of a cluster already created
+	Location            string        `envconfig:"LOCATION" default:""`                                                   // Location where you want to create the cluster
+	Regions             []string      `envconfig:"REGIONS" default:""`                                                    // A whitelist of availableregions
 	ClusterDefinition   string        `envconfig:"CLUSTER_DEFINITION" required:"true" default:"examples/kubernetes.json"` // ClusterDefinition is the path on disk to the json template these are normally located in examples/
 	CleanUpOnExit       bool          `envconfig:"CLEANUP_ON_EXIT" default:"false"`                                       // if true the tests will clean up rgs when tests finish
-	CleanUpIfFail       bool          `envconfig:"CLEANUP_IF_FAIL" default:"true"`
+	CleanUpIfFail       bool          `envconfig:"CLEANUP_IF_FAIL" default:"false"`
 	RetainSSH           bool          `envconfig:"RETAIN_SSH" default:"true"`
-	StabilityIterations int           `envconfig:"STABILITY_ITERATIONS"`
+	StabilityIterations int           `envconfig:"STABILITY_ITERATIONS" default:"3"`
 	ClusterInitPodName  string        `envconfig:"CLUSTER_INIT_POD_NAME" default:""`
 	ClusterInitJobName  string        `envconfig:"CLUSTER_INIT_JOB_NAME" default:""`
 	Timeout             time.Duration `envconfig:"TIMEOUT" default:"20m"`
 	LBTimeout           time.Duration `envconfig:"LB_TIMEOUT" default:"20m"`
 	CurrentWorkingDir   string
-	SoakClusterName     string `envconfig:"SOAK_CLUSTER_NAME"`
-	ForceDeploy         bool   `envconfig:"FORCE_DEPLOY"`
-	UseDeployCommand    bool   `envconfig:"USE_DEPLOY_COMMAND"`
-	GinkgoFocus         string `envconfig:"GINKGO_FOCUS"`
-	GinkgoSkip          string `envconfig:"GINKGO_SKIP"`
-	GinkgoFailFast      bool   `envconfig:"GINKGO_FAIL_FAST" default:"false"`
+	SoakClusterName     string `envconfig:"SOAK_CLUSTER_NAME" default:""`
+	ForceDeploy         bool   `envconfig:"FORCE_DEPLOY" default:"false"`
+	UseDeployCommand    bool   `envconfig:"USE_DEPLOY_COMMAND" default:"false"`
+	GinkgoFocus         string `envconfig:"GINKGO_FOCUS" default:""`
+	GinkgoSkip          string `envconfig:"GINKGO_SKIP" default:""`
+	GinkgoFailFast      bool   `envconfig:"GINKGO_FAIL_FAST" default:"true"`
 	DebugAfterSuite     bool   `envconfig:"DEBUG_AFTERSUITE" default:"false"`
 	BlockSSHPort        bool   `envconfig:"BLOCK_SSH" default:"false"`
 	AddNodePoolInput    string `envconfig:"ADD_NODE_POOL_INPUT" default:""`
@@ -55,23 +55,23 @@ type Config struct {
 
 // CustomCloudConfig holds configurations for custom clould
 type CustomCloudConfig struct {
-	ServiceManagementEndpoint    string `envconfig:"SERVICE_MANAGEMENT_ENDPOINT"`
-	ResourceManagerEndpoint      string `envconfig:"RESOURCE_MANAGER_ENDPOINT"`
-	ActiveDirectoryEndpoint      string `envconfig:"ACTIVE_DIRECTORY_ENDPOINT"`
-	GalleryEndpoint              string `envconfig:"GALLERY_ENDPOINT"`
-	StorageEndpointSuffix        string `envconfig:"STORAGE_ENDPOINT_SUFFIX"`
-	KeyVaultDNSSuffix            string `envconfig:"KEY_VAULT_DNS_SUFFIX"`
-	GraphEndpoint                string `envconfig:"GRAPH_ENDPOINT"`
-	ServiceManagementVMDNSSuffix string `envconfig:"SERVICE_MANAGEMENT_VM_DNS_SUFFIX"`
-	ResourceManagerVMDNSSuffix   string `envconfig:"RESOURCE_MANAGER_VM_DNS_SUFFIX"`
-	IdentitySystem               string `envconfig:"IDENTITY_SYSTEM"`
-	AuthenticationMethod         string `envconfig:"AUTHENTICATION_METHOD"`
-	VaultID                      string `envconfig:"VAULT_ID"`
-	SecretName                   string `envconfig:"SECRET_NAME"`
-	CustomCloudClientID          string `envconfig:"CUSTOM_CLOUD_CLIENT_ID"`
-	CustomCloudSecret            string `envconfig:"CUSTOM_CLOUD_SECRET"`
-	APIProfile                   string `envconfig:"API_PROFILE"`
-	PortalURL                    string `envconfig:"PORTAL_ENDPOINT"`
+	ServiceManagementEndpoint    string `envconfig:"SERVICE_MANAGEMENT_ENDPOINT" default:""`
+	ResourceManagerEndpoint      string `envconfig:"RESOURCE_MANAGER_ENDPOINT" default:""`
+	ActiveDirectoryEndpoint      string `envconfig:"ACTIVE_DIRECTORY_ENDPOINT" default:""`
+	GalleryEndpoint              string `envconfig:"GALLERY_ENDPOINT" default:""`
+	StorageEndpointSuffix        string `envconfig:"STORAGE_ENDPOINT_SUFFIX" default:""`
+	KeyVaultDNSSuffix            string `envconfig:"KEY_VAULT_DNS_SUFFIX" default:""`
+	GraphEndpoint                string `envconfig:"GRAPH_ENDPOINT" default:""`
+	ServiceManagementVMDNSSuffix string `envconfig:"SERVICE_MANAGEMENT_VM_DNS_SUFFIX" default:""`
+	ResourceManagerVMDNSSuffix   string `envconfig:"RESOURCE_MANAGER_VM_DNS_SUFFIX" default:""`
+	IdentitySystem               string `envconfig:"IDENTITY_SYSTEM" default:""`
+	AuthenticationMethod         string `envconfig:"AUTHENTICATION_METHOD" default:""`
+	VaultID                      string `envconfig:"VAULT_ID" default:""`
+	SecretName                   string `envconfig:"SECRET_NAME" default:""`
+	CustomCloudClientID          string `envconfig:"CUSTOM_CLOUD_CLIENT_ID" default:""`
+	CustomCloudSecret            string `envconfig:"CUSTOM_CLOUD_SECRET" default:""`
+	APIProfile                   string `envconfig:"API_PROFILE" default:""`
+	PortalURL                    string `envconfig:"PORTAL_ENDPOINT" default:""`
 	TimeoutCommands              bool
 }
 

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -28,15 +28,15 @@ import (
 
 // Config represents the configuration values of a template stored as env vars
 type Config struct {
-	ClientID                       string `envconfig:"CLIENT_ID"`
-	ClientSecret                   string `envconfig:"CLIENT_SECRET"`
-	ClientObjectID                 string `envconfig:"CLIENT_OBJECTID"`
-	LogAnalyticsWorkspaceKey       string `envconfig:"LOG_ANALYTICS_WORKSPACE_KEY"`
-	MasterDNSPrefix                string `envconfig:"DNS_PREFIX"`
-	AgentDNSPrefix                 string `envconfig:"DNS_PREFIX"`
-	MSIUserAssignedID              string `envconfig:"MSI_USER_ASSIGNED_ID"`
-	PublicSSHKey                   string `envconfig:"PUBLIC_SSH_KEY"`
-	WindowsAdminPasssword          string `envconfig:"WINDOWS_ADMIN_PASSWORD"`
+	ClientID                       string `envconfig:"CLIENT_ID" required:"true"`
+	ClientSecret                   string `envconfig:"CLIENT_SECRET" required:"true"`
+	ClientObjectID                 string `envconfig:"CLIENT_OBJECTID" default:""`
+	LogAnalyticsWorkspaceKey       string `envconfig:"LOG_ANALYTICS_WORKSPACE_KEY" default:""`
+	MasterDNSPrefix                string `envconfig:"DNS_PREFIX" default:""`
+	AgentDNSPrefix                 string `envconfig:"DNS_PREFIX" default:""`
+	MSIUserAssignedID              string `envconfig:"MSI_USER_ASSIGNED_ID" default:""`
+	PublicSSHKey                   string `envconfig:"PUBLIC_SSH_KEY" default:""`
+	WindowsAdminPasssword          string `envconfig:"WINDOWS_ADMIN_PASSWORD" default:""`
 	WindowsNodeImageGallery        string `envconfig:"WINDOWS_NODE_IMAGE_GALLERY" default:""`
 	WindowsNodeImageName           string `envconfig:"WINDOWS_NODE_IMAGE_NAME" default:""`
 	WindowsNodeImageResourceGroup  string `envconfig:"WINDOWS_NODE_IMAGE_RESOURCE_GROUP" default:""`
@@ -50,20 +50,20 @@ type Config struct {
 	LinuxNodeImageVersion          string `envconfig:"LINUX_NODE_IMAGE_VERSION" default:""`
 	OSDiskSizeGB                   string `envconfig:"OS_DISK_SIZE_GB" default:""`
 	ContainerRuntime               string `envconfig:"CONTAINER_RUNTIME" default:""`
-	OrchestratorRelease            string `envconfig:"ORCHESTRATOR_RELEASE"`
-	OrchestratorVersion            string `envconfig:"ORCHESTRATOR_VERSION"`
+	OrchestratorRelease            string `envconfig:"ORCHESTRATOR_RELEASE" default:""`
+	OrchestratorVersion            string `envconfig:"ORCHESTRATOR_VERSION" default:""`
 	OutputDirectory                string `envconfig:"OUTPUT_DIR" default:"_output"`
 	CreateVNET                     bool   `envconfig:"CREATE_VNET" default:"false"`
 	EnableKMSEncryption            bool   `envconfig:"ENABLE_KMS_ENCRYPTION" default:"false"`
 	Distro                         string `envconfig:"DISTRO" default:""`
-	SubscriptionID                 string `envconfig:"SUBSCRIPTION_ID"`
-	InfraResourceGroup             string `envconfig:"INFRA_RESOURCE_GROUP"`
-	Location                       string `envconfig:"LOCATION"`
-	TenantID                       string `envconfig:"TENANT_ID"`
-	ImageName                      string `envconfig:"IMAGE_NAME"`
-	ImageResourceGroup             string `envconfig:"IMAGE_RESOURCE_GROUP"`
+	SubscriptionID                 string `envconfig:"SUBSCRIPTION_ID" required:"true"`
+	InfraResourceGroup             string `envconfig:"INFRA_RESOURCE_GROUP" default:""`
+	Location                       string `envconfig:"LOCATION" default:""`
+	TenantID                       string `envconfig:"TENANT_ID" required:"true"`
+	ImageName                      string `envconfig:"IMAGE_NAME" default:""`
+	ImageResourceGroup             string `envconfig:"IMAGE_RESOURCE_GROUP" default:""`
 	DebugCrashingPods              bool   `envconfig:"DEBUG_CRASHING_PODS" default:"false"`
-	CustomHyperKubeImage           string `envconfig:"CUSTOM_HYPERKUBE_IMAGE"`
+	CustomHyperKubeImage           string `envconfig:"CUSTOM_HYPERKUBE_IMAGE" default:""`
 	EnableTelemetry                bool   `envconfig:"ENABLE_TELEMETRY" default:"true"`
 	KubernetesImageBase            string `envconfig:"KUBERNETES_IMAGE_BASE" default:""`
 	KubernetesImageBaseType        string `envconfig:"KUBERNETES_IMAGE_BASE_TYPE" default:""`


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR adds defaults for all environment variable configuration values interpreted by the E2E runner.

- changed `CLEANUP_IF_FAIL` default to false
- changed `STABILITY_ITERATIONS` default to 3
- changed `SKIP_LOGS_COLLECTION` default to true
- changed `GINKGO_FAIL_FAST` default to true (because the skip/focus configs don't work otherwise)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
