### PR TITLE
feat: block imds from VMSS nodes if aad-pod-identity + msi

### DIFF
--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -321,12 +321,13 @@ write_files:
   owner: root
   content: |
     #!/bin/bash
+{{- if and (IsVirtualMachineScaleSets .) IsAADPodIdentityAddonEnabled}}
+    {{- /* Disable TCP access to IMDS endpoint, aad-pod-identity nmi component will provide a complementary iptables rule to re-route this traffic */}}
+    iptables -A OUTPUT -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DROP
+{{end}}
 {{- if not IsIPMasqAgentEnabled}}
     {{if IsAzureCNI}}
     iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsParameter "vnetCidr"}} -j MASQUERADE
-    {{end}}
-    {{if BlockIMDS}}
-    iptables -A OUTPUT -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DROP
     {{end}}
 {{end}}
     #EOF

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -321,7 +321,7 @@ write_files:
   owner: root
   content: |
     #!/bin/bash
-{{- if and (IsVirtualMachineScaleSets .) IsAADPodIdentityAddonEnabled}}
+{{- if and (IsVirtualMachineScaleSets .) IsAADPodIdentityAddonEnabled UseManagedIdentity}}
     {{- /* Disable TCP access to IMDS endpoint, aad-pod-identity nmi component will provide a complementary iptables rule to re-route this traffic */}}
     iptables -A OUTPUT -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DROP
 {{end}}

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -325,6 +325,9 @@ write_files:
     {{if IsAzureCNI}}
     iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsParameter "vnetCidr"}} -j MASQUERADE
     {{end}}
+    {{if BlockIMDS}}
+    iptables -A OUTPUT -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DROP
+    {{end}}
 {{end}}
     #EOF
 

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -263,6 +263,9 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"IsMasterVirtualMachineScaleSets": func() bool {
 			return cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.IsVirtualMachineScaleSets()
 		},
+		"IsVirtualMachineScaleSets": func(profile *api.AgentPoolProfile) bool {
+			return profile.IsVirtualMachineScaleSets()
+		},
 		"IsHostedMaster": func() bool {
 			return cs.Properties.IsHostedMasterProfile()
 		},

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -188,6 +188,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 		expectedHasVHDDistroNodes             bool
 		expectedIsVHDDistroForAllNodes        bool
 		expectedHasClusterInitComponent       bool
+		expectedIsVirtualMachineScaleSets     bool
 	}{
 		{
 			name: "1.15 release",
@@ -221,6 +222,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
 			expectedGetCSEErrorCodeVals:          []int{-1},
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "1.16 release",
@@ -253,6 +255,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "1.17 release",
@@ -285,6 +288,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "1.17 release w/ VHD distro",
@@ -320,6 +324,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedGetSysctlDConfigKeyVals:      "",
 			expectedHasVHDDistroNodes:            true,
 			expectedIsVHDDistroForAllNodes:       true,
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "custom search domain",
@@ -359,6 +364,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "custom nodes DNS",
@@ -396,6 +402,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "1.17 release with custom kube images",
@@ -431,6 +438,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "china cloud",
@@ -464,6 +472,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "german cloud",
@@ -497,6 +506,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "usgov cloud",
@@ -530,6 +540,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "Azure Stack",
@@ -567,6 +578,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "N series SKU",
@@ -600,6 +612,39 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsNSeriesSKU:                 true,
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    true,
+		},
+		{
+			name: "AvailabilitySet pool",
+			cs: &api.ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							ContainerRuntime:        api.Docker,
+							KubernetesImageBaseType: common.KubernetesImageBaseTypeGCR,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "pool1",
+							Count:               1,
+							AvailabilityProfile: api.AvailabilitySet,
+						},
+					},
+				},
+			},
+			expectedHasCustomSearchDomain:        false,
+			expectedGetSearchDomainName:          "",
+			expectedGetSearchDomainRealmUser:     "",
+			expectedGetSearchDomainRealmPassword: "",
+			expectedHasCustomNodesDNS:            false,
+			expectedGetHyperkubeImageReference:   "hyperkube-amd64:v1.15.4",
+			expectedGetTargetEnvironment:         "AzurePublicCloud",
+			expectedIsDockerContainerRuntime:     true,
+			expectedGetSysctlDConfigKeyVals:      "",
+			expectedIsVirtualMachineScaleSets:    false,
 		},
 		{
 			name: "PrivateAzureRegistryServer",
@@ -635,6 +680,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedHasPrivateAzureRegistryServer: true,
 			expectedGetPrivateAzureRegistryServer: "my-server",
 			expectedGetSysctlDConfigKeyVals:       "",
+			expectedIsVirtualMachineScaleSets:     true,
 		},
 		{
 			name: "cluster-init config",
@@ -674,6 +720,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedIsDockerContainerRuntime:     true,
 			expectedGetSysctlDConfigKeyVals:      "",
 			expectedHasClusterInitComponent:      true,
+			expectedIsVirtualMachineScaleSets:    true,
 		},
 		{
 			name: "sysctl config",
@@ -729,6 +776,7 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			expectedGetTargetEnvironment:         "AzurePublicCloud",
 			expectedIsNSeriesSKU:                 false,
 			expectedIsDockerContainerRuntime:     true,
+			expectedIsVirtualMachineScaleSets:    true,
 			expectedGetSysctlDConfigKeyVals: `net.core.message_burst = 80
     net.core.message_cost = 40
     net.core.somaxconn = 16384
@@ -868,6 +916,13 @@ func TestGetContainerServiceFuncMap(t *testing.T) {
 			ret = v.Call(make([]reflect.Value, 0))
 			if ret[0].Interface() != c.expectedHasClusterInitComponent {
 				t.Errorf("expected funcMap invocation of HasClusterInitComponent to return %t, instead got %t", c.expectedHasClusterInitComponent, ret[0].Interface())
+			}
+			if len(c.cs.Properties.AgentPoolProfiles) > 0 {
+				v = reflect.ValueOf(funcMap["IsVirtualMachineScaleSets"])
+				ret = v.Call([]reflect.Value{reflect.ValueOf(c.cs.Properties.AgentPoolProfiles[0])})
+				if ret[0].Interface() != c.expectedIsVirtualMachineScaleSets {
+					t.Errorf("expected funcMap invocation of IsVirtualMachineScaleSets to return %t, instead got %t", c.expectedIsVirtualMachineScaleSets, ret[0].Interface())
+				}
 			}
 		})
 	}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40529,6 +40529,10 @@ write_files:
   owner: root
   content: |
     #!/bin/bash
+{{- if and (IsVirtualMachineScaleSets .) IsAADPodIdentityAddonEnabled}}
+    {{- /* Disable TCP access to IMDS endpoint, aad-pod-identity nmi component will provide a complementary iptables rule to re-route this traffic */}}
+    iptables -A OUTPUT -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DROP
+{{end}}
 {{- if not IsIPMasqAgentEnabled}}
     {{if IsAzureCNI}}
     iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsParameter "vnetCidr"}} -j MASQUERADE

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -40529,7 +40529,7 @@ write_files:
   owner: root
   content: |
     #!/bin/bash
-{{- if and (IsVirtualMachineScaleSets .) IsAADPodIdentityAddonEnabled}}
+{{- if and (IsVirtualMachineScaleSets .) IsAADPodIdentityAddonEnabled UseManagedIdentity}}
     {{- /* Disable TCP access to IMDS endpoint, aad-pod-identity nmi component will provide a complementary iptables rule to re-route this traffic */}}
     iptables -A OUTPUT -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DROP
 {{end}}


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

In an aad-pod-identity cluster configuration, access to IMDS from nodes is proxy'd by the aad-pod-identity nmi daemonset running on each node. This PR introduces an explicit iptables rule that blocks access to IMDS for aad-pod-identity + VMSS configurations when using msi. Because instances in a VMSS share a common msi, we want to prevent a pod container getting a VMSS-scoped msi token between the time that a node comes online and before the nmi daemonset can write its own iptables rules to re-route IMDS to the aad-pod-identity componentry.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3135 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
