### PR TITLE
fix: correct destination filename for scheduled maintenance addon

### DIFF
--- a/pkg/engine/artifacts.go
+++ b/pkg/engine/artifacts.go
@@ -233,7 +233,7 @@ func kubernetesAddonSettingsInit(p *api.Properties) map[string]kubernetesCompone
 		common.ScheduledMaintenanceAddonName: {
 			sourceFile:      scheduledMaintenanceAddonSourceFilename,
 			base64Data:      k.GetAddonScript(common.ScheduledMaintenanceAddonName),
-			destinationFile: scheduledMaintenanceAddonSourceFilename,
+			destinationFile: scheduledMaintenanceAddonDestinationFilename,
 		},
 		common.SecretsStoreCSIDriverAddonName: {
 			sourceFile:      secretsStoreCSIDriverAddonSourceFileName,


### PR DESCRIPTION
**Reason for Change**:
s/Source/Destination

Tested on a local cluster with the `scheduled-maintenance` addon enabled:

```shell
azureuser@k8s-master-26399701-0:~$ ls /etc/kubernetes/addons/
audit-policy.yaml                     coredns.yaml                         pod-security-policy.yaml
azure-cloud-provider-deployment.yaml  ip-masq-agent.yaml                   scheduled-maintenance-deployment.yaml
azure-cni-networkmonitor.yaml         kube-metrics-server-deployment.yaml  secrets-store-csi-driver.yaml
blobfuse-flexvolume-installer.yaml    kube-proxy-daemonset.yaml
azureuser@k8s-master-26399701-0:~$ kubectl get po -A
NAMESPACE          NAME                                                READY   STATUS    RESTARTS   AGE
drainsafe-system   drainsafe-controller-manager-f5dd84c94-4q7pt        2/2     Running   0          77s
drainsafe-system   drainsafe-controller-scheduledevent-manager-9jhmc   1/1     Running   0          77s
drainsafe-system   drainsafe-controller-scheduledevent-manager-xt4jk   1/1     Running   0          77s
...
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I tested this on a local cluster just to ensure 