### PR TITLE
chore: aad-pod-identity taint

### DIFF
--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -137,6 +137,11 @@ spec:
             - NET_ADMIN
       nodeSelector:
         beta.kubernetes.io/os: linux
+      tolerations:
+      - key: node.kubernetes.io/aad-pod-identity-not-ready
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -138,7 +138,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -140,7 +140,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -139,6 +139,11 @@ spec:
             - NET_ADMIN
       nodeSelector:
         beta.kubernetes.io/os: linux
+      tolerations:
+      - key: node.kubernetes.io/aad-pod-identity-not-ready
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -140,7 +140,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaint}}
         operator: Equal
         value: "true"
         effect: NoSchedule

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -140,7 +140,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: {{GetAADPodIdentityTaint}}
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -139,6 +139,11 @@ spec:
             - NET_ADMIN
       nodeSelector:
         beta.kubernetes.io/os: linux
+      tolerations:
+      - key: node.kubernetes.io/aad-pod-identity-not-ready
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -139,6 +139,11 @@ spec:
             - NET_ADMIN
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+      - key: node.kubernetes.io/aad-pod-identity-not-ready
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/parts/k8s/addons/1.19/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/1.19/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -140,7 +140,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule

--- a/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -134,7 +134,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule

--- a/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -133,6 +133,11 @@ spec:
             - NET_ADMIN
       nodeSelector:
         beta.kubernetes.io/os: linux
+      tolerations:
+      - key: node.kubernetes.io/aad-pod-identity-not-ready
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -387,6 +387,15 @@ ensureLabelNodes() {
   wait_for_file 1200 1 $LABEL_NODES_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
   systemctlEnableAndStart label-nodes || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
+{{- if IsAADPodIdentityAddonEnabled}}
+ensureTaints() {
+  UNTAINT_NODES_SCRIPT_FILE=/opt/azure/containers/untaint-nodes.sh
+  wait_for_file 1200 1 $UNTAINT_NODES_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  UNTAINT_NODES_SYSTEMD_FILE=/etc/systemd/system/untaint-nodes.service
+  wait_for_file 1200 1 $UNTAINT_NODES_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  systemctlEnableAndStart untaint-nodes || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+}
+{{end}}
 ensureJournal() {
   {
     echo "Storage=persistent"

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -389,10 +389,8 @@ ensureLabelNodes() {
 }
 {{- if IsAADPodIdentityAddonEnabled}}
 ensureTaints() {
-  UNTAINT_NODES_SCRIPT_FILE=/opt/azure/containers/untaint-nodes.sh
-  wait_for_file 1200 1 $UNTAINT_NODES_SCRIPT_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  UNTAINT_NODES_SYSTEMD_FILE=/etc/systemd/system/untaint-nodes.service
-  wait_for_file 1200 1 $UNTAINT_NODES_SYSTEMD_FILE || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  wait_for_file 1200 1 /opt/azure/containers/untaint-nodes.sh || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  wait_for_file 1200 1 /etc/systemd/system/untaint-nodes.service || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
   systemctlEnableAndStart untaint-nodes || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 {{end}}

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -224,6 +224,9 @@ time_metric "EnsureJournal" ensureJournal
 if [[ -n ${MASTER_NODE} ]]; then
   if version_gte ${KUBERNETES_VERSION} 1.16; then
     time_metric "EnsureLabelNodes" ensureLabelNodes
+{{- if IsAADPodIdentityAddonEnabled}}
+    time_metric "EnsureTaints" ensureTaints
+{{end}}
   fi
   time_metric "WriteKubeConfig" writeKubeConfig
   if [[ -z ${COSMOS_URI} ]]; then

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.service
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Untaint nodes when pre-scheduling conditions are fulfilled
+After=kubelet.service
+[Service]
+Restart=always
+RestartSec=60
+ExecStart=/bin/bash /opt/azure/containers/untaint-nodes.sh
+[Install]
+WantedBy=multi-user.target
+#EOF

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
@@ -2,17 +2,17 @@
 
 KUBECONFIG="$(find /home/*/.kube/config)"
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
-AAD_POD_IDENTITY_TAINT={{GetAADPodIdentityTaint}}=true:NoSchedule
+AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}=true:NoSchedule
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then
   for node in $(${KUBECTL} get nodes -o json | jq -e -r '.items[] | .metadata.name'); do
-    ${KUBECTL} taint nodes $node $AAD_POD_IDENTITY_TAINT- 2>&1 | grep -v 'not found';
+    ${KUBECTL} taint nodes $node $AAD_POD_ID_TAINT_KEY=true:NoSchedule- 2>&1 | grep -v 'not found';
   done
   exit 0
 fi
 for pod in $(${KUBECTL} get pods -n kube-system -o json | jq -r '.items[] | select(.status.phase == "Running") | .metadata.name'); do
   if [[ "$pod" =~ ^nmi ]]; then
-    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_IDENTITY_TAINT- 2>&1 | grep -v 'not found';
+    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_ID_TAINT_KEY=true:NoSchedule- 2>&1 | grep -v 'not found';
   fi;
 done
 exit 0

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
@@ -2,12 +2,17 @@
 
 KUBECONFIG="$(find /home/*/.kube/config)"
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+AAD_POD_IDENTITY_TAINT=node.kubernetes.io/aad-pod-identity-not-ready=true:NoSchedule
 
+if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then
+  for node in $(${KUBECTL} get nodes -o json | jq -e -r '.items[] | .metadata.name'); do
+    ${KUBECTL} taint nodes $node $AAD_POD_IDENTITY_TAINT- 2>&1 | grep -v 'not found';
+  done
+  exit 0
+fi
 for pod in $(${KUBECTL} get pods -n kube-system -o json | jq -r '.items[] | select(.status.phase == "Running") | .metadata.name'); do
-{{if IsAADPodIdentityAddonEnabled}}
   if [[ "$pod" =~ ^nmi ]]; then
-    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') node.kubernetes.io/aad-pod-identity-not-ready=true:NoSchedule- 2>&1 | grep -v 'not found';
+    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_IDENTITY_TAINT- 2>&1 | grep -v 'not found';
   fi;
-{{end}}
 done
 #EOF

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
@@ -2,7 +2,7 @@
 
 KUBECONFIG="$(find /home/*/.kube/config)"
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
-AAD_POD_IDENTITY_TAINT=node.kubernetes.io/aad-pod-identity-not-ready=true:NoSchedule
+AAD_POD_IDENTITY_TAINT={{GetAADPodIdentityTaint}}=true:NoSchedule
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then
   for node in $(${KUBECTL} get nodes -o json | jq -e -r '.items[] | .metadata.name'); do
@@ -15,4 +15,5 @@ for pod in $(${KUBECTL} get pods -n kube-system -o json | jq -r '.items[] | sele
     ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_IDENTITY_TAINT- 2>&1 | grep -v 'not found';
   fi;
 done
+exit 0
 #EOF

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
@@ -2,7 +2,7 @@
 
 KUBECONFIG="$(find /home/*/.kube/config)"
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
-AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}=true:NoSchedule
+AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then
   for node in $(${KUBECTL} get nodes -o json | jq -e -r '.items[] | .metadata.name'); do

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+KUBECONFIG="$(find /home/*/.kube/config)"
+KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+
+for pod in $(${KUBECTL} get pods -n kube-system -o json | jq -r '.items[] | select(.status.phase == "Running") | .metadata.name'); do
+{{if IsAADPodIdentityAddonEnabled}}
+  if [[ "$pod" =~ ^nmi ]]; then
+    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') node.kubernetes.io/aad-pod-identity-not-ready=true:NoSchedule- 2>&1 | grep -v 'not found';
+  fi;
+{{end}}
+done
+#EOF

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -133,6 +133,22 @@ write_files:
     {{CloudInitData "aptPreferences"}}
 {{end}}
 
+{{if IsAADPodIdentityAddonEnabled}}
+- path: /opt/azure/containers/untaint-nodes.sh
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "untaintNodesScript"}}
+
+- path: /etc/systemd/system/untaint-nodes.service
+  permissions: "0644"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "untaintNodesSystemdService"}}
+{{end}}
+
 - path: /etc/apt/apt.conf.d/99periodic
   permissions: "0644"
   owner: root

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -314,6 +314,9 @@ write_files:
 {{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
+{{if IsAADPodIdentityAddonEnabled}}
+    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints=node.kubernetes.io/aad-pod-identity-not-ready=true:NoSchedule
+{{end}}
     #EOF
 
 - path: /opt/azure/containers/kubelet.sh

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -314,9 +314,6 @@ write_files:
 {{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
-{{if IsAADPodIdentityAddonEnabled}}
-    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints={{GetAADPodIdentityTaintKey}}=true:NoSchedule
-{{end}}
     #EOF
 
 - path: /opt/azure/containers/kubelet.sh

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -315,7 +315,7 @@ write_files:
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
 {{if IsAADPodIdentityAddonEnabled}}
-    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints={{GetAADPodIdentityTaint}}=true:NoSchedule
+    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints={{GetAADPodIdentityTaintKey}}=true:NoSchedule
 {{end}}
     #EOF
 

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -315,7 +315,7 @@ write_files:
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
 {{if IsAADPodIdentityAddonEnabled}}
-    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints=node.kubernetes.io/aad-pod-identity-not-ready=true:NoSchedule
+    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints={{GetAADPodIdentityTaint}}=true:NoSchedule
 {{end}}
     #EOF
 

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -375,3 +375,4 @@ const (
 )
 
 const MasterNodeTaint string = "node-role.kubernetes.io/master=true:NoSchedule"
+const AADPodIdentityTaint string = "node.kubernetes.io/aad-pod-identity-not-ready"

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -374,5 +374,10 @@ const (
 	AntreaNetworkPolicyOnlyMode   = "networkPolicyOnly"
 )
 
-const MasterNodeTaint string = "node-role.kubernetes.io/master=true:NoSchedule"
-const AADPodIdentityTaint string = "node.kubernetes.io/aad-pod-identity-not-ready"
+// Node Taint consts
+const (
+	// MasterNodeTaint is the node taint we apply to all master nodes
+	MasterNodeTaint string = "node-role.kubernetes.io/master=true:NoSchedule"
+	// AADPodIdentityTaintKey is the node taint key for AAD Pod Identity-enabled clusters before NMI daemonset is ready
+	AADPodIdentityTaintKey string = "node.kubernetes.io/aad-pod-identity-not-ready"
+)

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -85,7 +85,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 				key, val, expected[key])
 		}
 	}
-	linuxProfileKubeletConfig["--register-with-taints"] = fmt.Sprintf("node-role.kubernetes.io/customtaint=true:NoSchedule,node-role.kubernetes.io/customtaint2=true:NoSchedule")
+	linuxProfileKubeletConfig["--register-with-taints"] = "node-role.kubernetes.io/customtaint=true:NoSchedule,node-role.kubernetes.io/customtaint2=true:NoSchedule"
 	cs.setKubeletConfig(false)
 	expected["--register-with-taints"] = fmt.Sprintf("node-role.kubernetes.io/customtaint=true:NoSchedule,node-role.kubernetes.io/customtaint2=true:NoSchedule,%s", fmt.Sprintf("%s=true:NoSchedule", common.AADPodIdentityTaintKey))
 	for key, val := range linuxProfileKubeletConfig {

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -153,6 +153,11 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		"kubeletSystemdService":     getBase64EncodedGzippedCustomScript(kubeletSystemdService, cs),
 	}
 
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.AADPodIdentityAddonName) {
+		cloudInitFiles["untaintNodesScript"] = getBase64EncodedGzippedCustomScript(untaintNodesScript, cs)
+		cloudInitFiles["untaintNodesSystemdService"] = getBase64EncodedGzippedCustomScript(untaintNodesSystemdService, cs)
+	}
+
 	if !cs.Properties.IsVHDDistroForAllNodes() {
 		cloudInitFiles["provisionCIS"] = getBase64EncodedGzippedCustomScript(kubernetesCISScript, cs)
 		cloudInitFiles["kmsSystemdService"] = getBase64EncodedGzippedCustomScript(kmsSystemdService, cs)

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -196,6 +196,39 @@ func TestK8sVars(t *testing.T) {
 		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
 	}
 
+	// Test with AAD Pod Identity
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.AADPodIdentityAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+	}
+	varMap, err = GetKubernetesVariables(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedMap["cloudInitFiles"] = map[string]interface{}{
+		"provisionScript":            getBase64EncodedGzippedCustomScript(kubernetesCSEMainScript, cs),
+		"provisionSource":            getBase64EncodedGzippedCustomScript(kubernetesCSEHelpersScript, cs),
+		"provisionInstalls":          getBase64EncodedGzippedCustomScript(kubernetesCSEInstall, cs),
+		"provisionConfigs":           getBase64EncodedGzippedCustomScript(kubernetesCSEConfig, cs),
+		"customSearchDomainsScript":  getBase64EncodedGzippedCustomScript(kubernetesCustomSearchDomainsScript, cs),
+		"generateProxyCertsScript":   getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript, cs),
+		"mountEtcdScript":            getBase64EncodedGzippedCustomScript(kubernetesMountEtcd, cs),
+		"etcdSystemdService":         getBase64EncodedGzippedCustomScript(etcdSystemdService, cs),
+		"dhcpv6ConfigurationScript":  getBase64EncodedGzippedCustomScript(dhcpv6ConfigurationScript, cs),
+		"dhcpv6SystemdService":       getBase64EncodedGzippedCustomScript(dhcpv6SystemdService, cs),
+		"kubeletSystemdService":      getBase64EncodedGzippedCustomScript(kubeletSystemdService, cs),
+		"untaintNodesScript":         getBase64EncodedGzippedCustomScript(untaintNodesScript, cs),
+		"untaintNodesSystemdService": getBase64EncodedGzippedCustomScript(untaintNodesSystemdService, cs),
+	}
+
+	diff = cmp.Diff(varMap, expectedMap)
+
+	if diff != "" {
+		t.Errorf("unexpected diff while expecting equal structs: %s", diff)
+	}
+
 	// Test with MSI
 	cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
 	varMap, err = GetKubernetesVariables(cs)
@@ -215,6 +248,7 @@ func TestK8sVars(t *testing.T) {
 	}
 
 	// Test with ubuntu 16.04 distro
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{}
 	cs.Properties.AgentPoolProfiles[0].Distro = api.Ubuntu
 	cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = false
 	varMap, err = GetKubernetesVariables(cs)

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -110,6 +110,8 @@ const (
 	kubernetesDockerMonitorSystemdService    = "k8s/cloud-init/artifacts/docker-monitor.service"
 	labelNodesScript                         = "k8s/cloud-init/artifacts/label-nodes.sh"
 	labelNodesSystemdService                 = "k8s/cloud-init/artifacts/label-nodes.service"
+	untaintNodesScript                       = "k8s/cloud-init/artifacts/untaint-nodes.sh"
+	untaintNodesSystemdService               = "k8s/cloud-init/artifacts/untaint-nodes.service"
 	kubernetesMountEtcd                      = "k8s/cloud-init/artifacts/mountetcd.sh"
 	kubernetesMasterGenerateProxyCertsScript = "k8s/cloud-init/artifacts/generateproxycerts.sh"
 	kubernetesCustomSearchDomainsScript      = "k8s/cloud-init/artifacts/setup-custom-search-domains.sh"

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -805,6 +805,9 @@ func getAddonFuncMap(addon api.KubernetesAddon, cs *api.ContainerService) templa
 		"IsKubernetesVersionGe": func(version string) bool {
 			return common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, version)
 		},
+		"GetAADPodIdentityTaintKey": func() string {
+			return common.AADPodIdentityTaintKey
+		},
 	}
 }
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -3061,6 +3061,11 @@ func TestGetAddonFuncMap(t *testing.T) {
 			if ret[0].Interface() != c.expectedIsKubernetesVersionGeOneDotSixteenDotZero {
 				t.Errorf("expected funcMap invocation of IsKubernetesVersionGe for 1.16.0 to return %t, instead got %t", c.expectedIsKubernetesVersionGeOneDotSixteenDotZero, ret[0].Interface())
 			}
+			v = reflect.ValueOf(funcMap["GetAADPodIdentityTaintKey"])
+			ret = v.Call(make([]reflect.Value, 0))
+			if ret[0].Interface() != common.AADPodIdentityTaintKey {
+				t.Errorf("expected funcMap invocation of GetAADPodIdentityTaintKey to return %s, instead got %s", common.AADPodIdentityTaintKey, ret[0].Interface())
+			}
 		})
 	}
 }

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -744,6 +744,9 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"IsAADPodIdentityAddonEnabled": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.AADPodIdentityAddonName)
 		},
+		"GetAADPodIdentityTaint": func() string {
+			return common.AADPodIdentityTaint
+		},
 		"GetHyperkubeImageReference": func() string {
 			hyperkubeImageBase := cs.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase
 			k8sComponents := api.GetK8sComponentsByVersionMap(cs.Properties.OrchestratorProfile.KubernetesConfig)[cs.Properties.OrchestratorProfile.OrchestratorVersion]

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -744,8 +744,8 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"IsAADPodIdentityAddonEnabled": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.AADPodIdentityAddonName)
 		},
-		"GetAADPodIdentityTaint": func() string {
-			return common.AADPodIdentityTaint
+		"GetAADPodIdentityTaintKey": func() string {
+			return common.AADPodIdentityTaintKey
 		},
 		"GetHyperkubeImageReference": func() string {
 			hyperkubeImageBase := cs.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -741,6 +741,9 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"IsClusterAutoscalerAddonEnabled": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.ClusterAutoscalerAddonName)
 		},
+		"IsAADPodIdentityAddonEnabled": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.AADPodIdentityAddonName)
+		},
 		"GetHyperkubeImageReference": func() string {
 			hyperkubeImageBase := cs.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase
 			k8sComponents := api.GetK8sComponentsByVersionMap(cs.Properties.OrchestratorProfile.KubernetesConfig)[cs.Properties.OrchestratorProfile.OrchestratorVersion]

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39620,7 +39620,7 @@ var _k8sCloudInitArtifactsUntaintNodesSh = []byte(`#!/usr/bin/env bash
 
 KUBECONFIG="$(find /home/*/.kube/config)"
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
-AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}=true:NoSchedule
+AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then
   for node in $(${KUBECTL} get nodes -o json | jq -e -r '.items[] | .metadata.name'); do

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39830,6 +39830,22 @@ write_files:
     {{CloudInitData "aptPreferences"}}
 {{end}}
 
+{{if IsAADPodIdentityAddonEnabled}}
+- path: /opt/azure/containers/untaint-nodes.sh
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "untaintNodesScript"}}
+
+- path: /etc/systemd/system/untaint-nodes.service
+  permissions: "0644"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "untaintNodesSystemdService"}}
+{{end}}
+
 - path: /etc/apt/apt.conf.d/99periodic
   permissions: "0644"
   owner: root
@@ -40321,22 +40337,6 @@ write_files:
     {{CloudInitData "aptPreferences"}}
 {{end}}
 
-{{if IsAADPodIdentityAddonEnabled}}
-- path: /opt/azure/containers/untaint-nodes.sh
-  permissions: "0744"
-  encoding: gzip
-  owner: root
-  content: !!binary |
-    {{CloudInitData "untaintNodesScript"}}
-
-- path: /etc/systemd/system/untaint-nodes.service
-  permissions: "0644"
-  encoding: gzip
-  owner: root
-  content: !!binary |
-    {{CloudInitData "untaintNodesSystemdService"}}
-{{end}}
-
 - path: /etc/apt/apt.conf.d/99periodic
   permissions: "0644"
   owner: root
@@ -40523,9 +40523,6 @@ write_files:
 {{end}}
 {{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
-{{end}}
-{{if IsAADPodIdentityAddonEnabled}}
-    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints={{GetAADPodIdentityTaintKey}}=true:NoSchedule
 {{end}}
     #EOF
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -8200,7 +8200,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule
@@ -12762,7 +12762,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule
@@ -21992,7 +21992,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule
@@ -28711,7 +28711,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node.kubernetes.io/aad-pod-identity-not-ready
+      - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
         value: "true"
         effect: NoSchedule


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR introduces an aad-pod-identity-specific taint when the aad-pod-identity addon is enabled, and then adds systemd-enforced reconciliation to remove that taint after the `nmi` daemonset has been scheduled successfully onto a node (and thus the node is ready for schedulable, aad-pod-identity-enforced workloads).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
