### PR TITLE
refactor: enable generic --register-with-taints and --register-node

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -387,7 +387,7 @@ The above is the pattern we use to pass in a `cluster-init` spec for loading at 
 
 #### kubeletConfig
 
-`kubeletConfig` declares runtime configuration for the kubelet running on all master and agent nodes. It is a generic key/value object, and a child property of `kubernetesConfig`. An example custom kubelet config:
+`kubeletConfig` declares runtime configuration for the kubelet running on all master and agent nodes. It is a generic key/value object, and a child property of `kubernetesConfig`. The `kubeletConfig` configuration under `kubernetesConfig` will be inherited by a similar `kubeletConfig` configuration under the `masterProfile` configuration object, and by each `agentPoolProfile` in the `agentPoolProfiles` array. Specific master and per-pool kubelet configurations should be applied there. An example custom kubelet config:
 
 ```
 "kubernetesConfig": {
@@ -426,6 +426,7 @@ Below is a list of kubelet options that aks-engine will configure by default:
 | "--tls-cipher-suites"                 | "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256" |
 | "--authentication-token-webhook"      | "true" (this default is set for clusters >= 1.16.0 )                                                                                                                                                                                                                                                      |
 | "--read-only-port"                    | "0" (this default is set for clusters >= 1.16.0 )                                                                                                                                                                                                                                                         |
+| "--register-with-taints" | "node-role.kubernetes.io/master=true:NoSchedule" (`masterProfile` only; Note: you may add your own master-specific taints in the `kubeletConfig` under `masterProfile`, which will augment the built-in "node-role.kubernetes.io/master=true:NoSchedule" taint, which will always be present.) |
 
 Below is a list of kubelet options that are _not_ currently user-configurable, either because a higher order configuration vector is available that enforces kubelet configuration, or because a static configuration is required to build a functional cluster:
 
@@ -437,8 +438,6 @@ Below is a list of kubelet options that are _not_ currently user-configurable, e
 | "--node-labels"                              | (based on Azure node metadata)                   |
 | "--cgroups-per-qos"                          | "true"                                           |
 | "--kubeconfig"                               | "/var/lib/kubelet/kubeconfig"                    |
-| "--register-node" (master nodes only)        | "true"                                           |
-| "--register-with-taints" (master nodes only) | "node-role.kubernetes.io/master=true:NoSchedule" |
 | "--keep-terminated-pod-volumes"              | "false"                                          |
 
 <a name="feat-controller-manager-config"></a>
@@ -743,6 +742,7 @@ Below is a list of sysctl configuration that aks-engine will configure by defaul
 | customVMTags                                                   | no                                                                                                | Specifies a list of custom tags to be added to the master VMs or Scale Sets. Each tag is a key/value pair (ie: `"myTagKey": "myTagValue"`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | sysctldConfig                    | no                        | Configure Linux kernel parameters via /etc/sysctl.d/. See `sysctldConfig` [below](#feat-sysctld-config)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | proximityPlacementGroupID        | no                        | Specifies the resource id of the Proximity Placement Group (PPG) to be used for master VMs.  Please find more details about PPG in this [Azure blog](https://azure.microsoft.com/en-us/blog/introducing-proximity-placement-groups). Note that the PPG should be created in advance. The following [Azure CLI documentation](https://docs.microsoft.com/en-us/cli/azure/ppg?view=azure-cli-latest#az-ppg-create) explains how to create a PPG. |
+| kubeletConfig                    | no                        | Configure various runtime configuration for kubelet running on master nodes. See `kubeletConfig` [above](#feat-kubelet-config) |
 
 ### agentPoolProfiles
 
@@ -782,6 +782,8 @@ A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for
 | preProvisionExtension | no | Specifies an extension to be run before the cluster is brought up. More details about [agentPoolProfiles extensions](extensions.md#agentpoolprofiles) |
 | sysctldConfig                    | no                        | Configure Linux kernel parameters via /etc/sysctl.d/. See `sysctldConfig` [below](#feat-sysctld-config) |
 | proximityPlacementGroupID        | no                        | Specifies the resource id of the Proximity Placement Group (PPG) to be used for this agentpool.  Please find more details about PPG in this [Azure blog](https://azure.microsoft.com/en-us/blog/introducing-proximity-placement-groups). Note that the PPG should be created in advance. The following [Azure CLI documentation](https://docs.microsoft.com/en-us/cli/azure/ppg?view=azure-cli-latest#az-ppg-create) explains how to create a PPG. |
+| kubeletConfig                    | no                        | Configure various runtime configuration for kubelet running on this node pool. See `kubeletConfig` [above](#feat-kubelet-config) |
+
 ### linuxProfile
 
 `linuxProfile` provides the linux configuration for each linux node in the cluster

--- a/parts/k8s/cloud-init/artifacts/kubelet.service
+++ b/parts/k8s/cloud-init/artifacts/kubelet.service
@@ -24,8 +24,6 @@ ExecStart=/usr/local/bin/kubelet \
         --node-labels="${KUBELET_NODE_LABELS}" \
         --v=2 {{if NeedsContainerd}}--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock{{end}} \
         --volume-plugin-dir=/etc/kubernetes/volumeplugins \
-        $KUBELET_CONFIG \
-        $KUBELET_REGISTER_NODE $KUBELET_REGISTER_WITH_TAINTS
-
+        $KUBELET_CONFIG
 [Install]
 WantedBy=multi-user.target

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -361,10 +361,6 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
 {{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
 {{end}}
-{{if AnyAgentIsLinux}}
-    KUBELET_REGISTER_NODE=--register-node=true
-    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints=node-role.kubernetes.io/master=true:NoSchedule
-{{end}}
     #EOF
 
 - path: /opt/azure/containers/kubelet.sh

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -373,3 +373,5 @@ const (
 	AntreaInstallCniChainCmd      = "install_cni_chaining"
 	AntreaNetworkPolicyOnlyMode   = "networkPolicyOnly"
 )
+
+const MasterNodeTaint string = "node-role.kubernetes.io/master=true:NoSchedule"

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -208,7 +208,6 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 					cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"] += fmt.Sprintf(",%s", common.MasterNodeTaint)
 				}
 			}
-			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-node"] = "true"
 		}
 	}
 

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -199,6 +200,16 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		}
 
 		removeKubeletFlags(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)
+		if cs.Properties.AnyAgentIsLinux() {
+			if val, ok := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"]; !ok {
+				cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"] = common.MasterNodeTaint
+			} else {
+				if !strings.Contains(val, common.MasterNodeTaint) {
+					cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"] += fmt.Sprintf(",%s", common.MasterNodeTaint)
+				}
+			}
+			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-node"] = "true"
+		}
 	}
 
 	// Agent-specific kubelet config changes go here

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -69,7 +69,6 @@ func TestKubeletConfigDefaults(t *testing.T) {
 				key, val, expected[key])
 		}
 	}
-	expected["--register-node"] = "true"
 	expected["--register-with-taints"] = common.MasterNodeTaint
 	masterKubeletConfig := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
 	for key, val := range masterKubeletConfig {
@@ -88,7 +87,6 @@ func TestKubeletConfigDefaults(t *testing.T) {
 				key, val, expected[key])
 		}
 	}
-	delete(expected, "--register-node")
 	delete(expected, "--register-with-taints")
 	linuxProfileKubeletConfig := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
 	for key, val := range linuxProfileKubeletConfig {
@@ -217,7 +215,6 @@ func TestKubeletConfigAzureStackDefaults(t *testing.T) {
 		"--tls-cert-file":                     "/etc/kubernetes/certs/kubeletserver.crt",
 		"--tls-private-key-file":              "/etc/kubernetes/certs/kubeletserver.key",
 		"--register-with-taints":              common.MasterNodeTaint,
-		"--register-node":                     "true",
 	}
 	for key, val := range kubeletConfig {
 		if expected[key] != val {
@@ -884,9 +881,6 @@ func TestStaticWindowsConfig(t *testing.T) {
 	}
 	if _, ok := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"]; ok {
 		t.Fatalf("got unexpected --register-with-taints kubelet config with no Linux node pools")
-	}
-	if _, ok := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-node"]; ok {
-		t.Fatalf("got unexpected --register-node kubelet config with no Linux node pools")
 	}
 }
 

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -77,9 +77,29 @@ func TestKubeletConfigDefaults(t *testing.T) {
 				key, val, expected[key])
 		}
 	}
-	cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"] = "mycustomtaint"
+	cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"] = "node-role.kubernetes.io/customtaint=true:NoSchedule"
 	cs.setKubeletConfig(false)
-	expected["--register-with-taints"] = fmt.Sprintf("mycustomtaint,%s", common.MasterNodeTaint)
+	expected["--register-with-taints"] = fmt.Sprintf("node-role.kubernetes.io/customtaint=true:NoSchedule,%s", common.MasterNodeTaint)
+	masterKubeletConfig = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	for key, val := range masterKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected masterProfile kubelet config value for %s: %s, expected %s",
+				key, val, expected[key])
+		}
+	}
+	cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"] = fmt.Sprintf("node-role.kubernetes.io/customtaint=true:NoSchedule,node-role.kubernetes.io/customtaint2=true:NoSchedule,%s", common.MasterNodeTaint)
+	cs.setKubeletConfig(false)
+	expected["--register-with-taints"] = fmt.Sprintf("node-role.kubernetes.io/customtaint=true:NoSchedule,node-role.kubernetes.io/customtaint2=true:NoSchedule,%s", common.MasterNodeTaint)
+	masterKubeletConfig = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	for key, val := range masterKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected masterProfile kubelet config value for %s: %s, expected %s",
+				key, val, expected[key])
+		}
+	}
+	cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--register-with-taints"] = fmt.Sprintf("%s,node-role.kubernetes.io/customtaint=true:NoSchedule,node-role.kubernetes.io/customtaint2=true:NoSchedule", common.MasterNodeTaint)
+	cs.setKubeletConfig(false)
+	expected["--register-with-taints"] = fmt.Sprintf("%s,node-role.kubernetes.io/customtaint=true:NoSchedule,node-role.kubernetes.io/customtaint2=true:NoSchedule", common.MasterNodeTaint)
 	masterKubeletConfig = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
 	for key, val := range masterKubeletConfig {
 		if expected[key] != val {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -38824,9 +38824,7 @@ ExecStart=/usr/local/bin/kubelet \
         --node-labels="${KUBELET_NODE_LABELS}" \
         --v=2 {{if NeedsContainerd}}--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock{{end}} \
         --volume-plugin-dir=/etc/kubernetes/volumeplugins \
-        $KUBELET_CONFIG \
-        $KUBELET_REGISTER_NODE $KUBELET_REGISTER_WITH_TAINTS
-
+        $KUBELET_CONFIG
 [Install]
 WantedBy=multi-user.target
 `)
@@ -39959,10 +39957,6 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
 {{end}}
 {{if IsCustomCloudProfile }}
     AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/azurestackcloud.json
-{{end}}
-{{if AnyAgentIsLinux}}
-    KUBELET_REGISTER_NODE=--register-node=true
-    KUBELET_REGISTER_WITH_TAINTS=--register-with-taints=node-role.kubernetes.io/master=true:NoSchedule
 {{end}}
     #EOF
 


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR unwinds some weirdness in the implementation of `--register-with-taints`, especially for masterProfile configuration.

Also addressed some strange `--register-node` configuration.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
