### PR TITLE
feat: Create Windows containerd VHDs

### DIFF
--- a/.pipelines/vhd-builder-windows.yaml
+++ b/.pipelines/vhd-builder-windows.yaml
@@ -4,6 +4,7 @@
 # - BUILD_POOL - Azure DevOps build pool to use
 # - CLIENT_ID - Service principal ID
 # - CLIENT_SECRET - Service principal secret
+# - CONTAINER_RUNTIME - Container runtime to in for VHD - Valid values are 'containerd' or 'docker'
 # - COPY_VHD - Set to 'True' if VHD should be copied to classic storage account in preparation for publishing
 # - DEIS_GO_DEV_IMAGE - Dev container image ID
 # - PACKER_VM_SIZE - VM Size to be used during packer build operation
@@ -38,6 +39,7 @@ jobs:
       -e GIT_VERSION=$(Build.SourceVersion) \
       -e BUILD_ID=$(Build.BuildId) \
       -e BUILD_NUMBER=$(Build.BuildNumber) \
+      -e CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) \
       ${DEIS_GO_DEV_IMAGE} make run-packer-windows
     displayName: Building windows VHD
 

--- a/vhd/packer/windows-vhd-builder.json
+++ b/vhd/packer/windows-vhd-builder.json
@@ -7,6 +7,7 @@
         "build_repo": "{{env `GIT_REPO`}}",
         "client_id": "{{env `AZURE_CLIENT_ID`}}",
         "client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
         "tenant_id": "{{env `AZURE_TENANT_ID`}}",
         "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
         "location": "{{env `AZURE_LOCATION`}}",
@@ -46,7 +47,10 @@
         {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
-            "environment_vars": "ProvisioningPhase=1",
+            "environment_vars": [
+                "ProvisioningPhase=1",
+                "ContainerRuntime={{user `container_runtime`}}"
+            ],
             "type": "powershell",
             "script": "vhd/packer/configure-windows-vhd.ps1"
         },
@@ -61,7 +65,10 @@
         {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
-            "environment_vars": "ProvisioningPhase=2",
+            "environment_vars": [
+                "ProvisioningPhase=2",
+                "ContainerRuntime={{user `container_runtime`}}"
+            ],
             "type": "powershell",
             "script": "vhd/packer/configure-windows-vhd.ps1"
         },


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->
This PR adds support to the existing Windows VHD packer/scripts to install containerd and use containerd to perform image pulls.
A new environment variable `CONTINAINER_RUNTIME` is used to target either docker or containerd as the container runtime configured in the windows VHDs.

**Note:** docker is still installed when using containerd because there is additional cleanup that is needed in the Windows CSE scripts to not assume docker is installed.
This will get addressed in separate PRSs

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
