### PR TITLE
refactor: simplify kubelet systemd service

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -427,18 +427,29 @@ Below is a list of kubelet options that aks-engine will configure by default:
 | "--authentication-token-webhook"      | "true" (this default is set for clusters >= 1.16.0 )                                                                                                                                                                                                                                                      |
 | "--read-only-port"                    | "0" (this default is set for clusters >= 1.16.0 )                                                                                                                                                                                                                                                         |
 | "--register-with-taints" | "node-role.kubernetes.io/master=true:NoSchedule" (`masterProfile` only; Note: you may add your own master-specific taints in the `kubeletConfig` under `masterProfile`, which will augment the built-in "node-role.kubernetes.io/master=true:NoSchedule" taint, which will always be present.) |
+| "--container-runtime" | "remote" if in a containerd configuration, otherwise this configuration is not passed to kubelet runtime |
+| "--runtime-request-timeout" | "15m" if in a containerd configuration, otherwise this configuration is not passed to kubelet runtime |
+| "--container-runtime-endpoint" | "unix:///run/containerd/containerd.sock" if in a containerd configuration, otherwise this configuration is not passed to kubelet runtime |
 
 Below is a list of kubelet options that are _not_ currently user-configurable, either because a higher order configuration vector is available that enforces kubelet configuration, or because a static configuration is required to build a functional cluster:
 
-| kubelet option                               | default value                                    |
-| -------------------------------------------- | ------------------------------------------------ |
-| "--address"                                  | "0.0.0.0"                                        |
-| "--allow-privileged"                         | "true"                                           |
-| "--pod-manifest-path"                        | "/etc/kubernetes/manifests"                      |
-| "--node-labels"                              | (based on Azure node metadata)                   |
-| "--cgroups-per-qos"                          | "true"                                           |
-| "--kubeconfig"                               | "/var/lib/kubelet/kubeconfig"                    |
-| "--keep-terminated-pod-volumes"              | "false"                                          |
+| kubelet option                               | default value                                      |
+| -------------------------------------------- | ---------------------------------------------------|
+| "--address"                                  | "0.0.0.0"                                          |
+| "--allow-privileged"                         | "true"                                             |
+| "--anonymous-auth"                           | "false"                                            |
+| "--authorization-mode"                       | "webhook"                                          |
+| "--client-ca-file"                           | "/etc/kubernetes/certs/ca.crt"                     |
+| "--cluster-dns"                              | "10.0.0.10" (if ipv4, or "fd00::10" if using ipv6) |
+| "--pod-manifest-path"                        | "/etc/kubernetes/manifests"                        |
+| "--node-labels"                              | (based on Azure node metadata)                     |
+| "--cgroups-per-qos"                          | "true"                                             |
+| "--kubeconfig"                               | "/var/lib/kubelet/kubeconfig"                      |
+| "--keep-terminated-pod-volumes"              | "false"                                            |
+| "--tls-cert-file"                            | "/etc/kubernetes/certs/kubeletserver.crt"          |
+| "--tls-private-key-file"                     | "/etc/kubernetes/certs/kubeletserver.key"          |
+| "--v"                                        | "2"                                                |
+| "--volume-plugin-dir"                        | "/etc/kubernetes/volumeplugins"                    |
 
 <a name="feat-controller-manager-config"></a>
 

--- a/parts/k8s/cloud-init/artifacts/kubelet.service
+++ b/parts/k8s/cloud-init/artifacts/kubelet.service
@@ -10,15 +10,6 @@ Restart=always
 EnvironmentFile=/etc/default/kubelet
 SuccessExitStatus=143
 ExecStartPre=/bin/bash /opt/azure/containers/kubelet.sh
-ExecStartPre=/bin/mkdir -p /var/lib/kubelet
-ExecStartPre=/bin/mkdir -p /var/lib/cni
-ExecStartPre=/bin/bash -c "if [ $(mount | grep \"/var/lib/kubelet\" | wc -l) -le 0 ] ; then /bin/mount --bind /var/lib/kubelet /var/lib/kubelet ; fi"
-ExecStartPre=/bin/mount --make-shared /var/lib/kubelet
-{{/* This is a partial workaround to this upstream Kubernetes issue: */}}
-{{/* https://github.com/kubernetes/kubernetes/issues/41916#issuecomment-312428731 */}}
-
-ExecStartPre=-/sbin/ebtables -t nat --list
-ExecStartPre=-/sbin/iptables -t nat --numeric --list
 ExecStart=/usr/local/bin/kubelet \
         --enable-server \
         --node-labels="${KUBELET_NODE_LABELS}" \

--- a/parts/k8s/cloud-init/artifacts/kubelet.service
+++ b/parts/k8s/cloud-init/artifacts/kubelet.service
@@ -11,10 +11,7 @@ EnvironmentFile=/etc/default/kubelet
 SuccessExitStatus=143
 ExecStartPre=/bin/bash /opt/azure/containers/kubelet.sh
 ExecStart=/usr/local/bin/kubelet \
-        --enable-server \
         --node-labels="${KUBELET_NODE_LABELS}" \
-        --v=2 {{if NeedsContainerd}}--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock{{end}} \
-        --volume-plugin-dir=/etc/kubernetes/volumeplugins \
         $KUBELET_CONFIG
 [Install]
 WantedBy=multi-user.target

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -382,13 +382,19 @@ MASTER_CONTAINER_ADDONS_PLACEHOLDER
   content: |
     #!/bin/bash
     set -e
+    MOUNT_DIR=/var/lib/kubelet
+    mkdir -p $MOUNT_DIR /var/lib/cni
+    if ! [[ $(findmnt -rno SOURCE,TARGET ${MOUNT_DIR}) ]]; then
+      mount --bind $MOUNT_DIR $MOUNT_DIR
+    fi
+    mount --make-shared $MOUNT_DIR
     PRIVATE_IP=$(hostname -i | cut -d" " -f1)
 {{- if IsMasterVirtualMachineScaleSets}}
     PRIVATE_IP=$(hostname -i | cut -d" " -f1)
     sed -i "s|<SERVERIP>|https://$PRIVATE_IP:443|g" "/var/lib/kubelet/kubeconfig"
 {{end}}
 {{- if gt .MasterProfile.Count 1}}
-    # Redirect ILB (4443) traffic to port 443 (ELB) in the prerouting chain
+    {{- /* Redirect ILB (4443) traffic to port 443 (ELB) in the prerouting chain */}}
     iptables -t nat -A PREROUTING -p tcp --dport 4443 -j REDIRECT --to-port 443
 {{end}}
     sed -i "s|<advertiseAddr>|$PRIVATE_IP|g" /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -321,6 +321,12 @@ write_files:
   owner: root
   content: |
     #!/bin/bash
+    MOUNT_DIR=/var/lib/kubelet
+    mkdir -p $MOUNT_DIR /var/lib/cni
+    if ! [[ $(findmnt -rno SOURCE,TARGET ${MOUNT_DIR}) ]]; then
+      mount --bind $MOUNT_DIR $MOUNT_DIR
+    fi
+    mount --make-shared $MOUNT_DIR
 {{- if and (IsVirtualMachineScaleSets .) IsAADPodIdentityAddonEnabled UseManagedIdentity}}
     {{- /* Disable TCP access to IMDS endpoint, aad-pod-identity nmi component will provide a complementary iptables rule to re-route this traffic */}}
     iptables -A OUTPUT -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DROP

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -28,6 +28,8 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		"--keep-terminated-pod-volumes": "false",
 		"--tls-cert-file":               "/etc/kubernetes/certs/kubeletserver.crt",
 		"--tls-private-key-file":        "/etc/kubernetes/certs/kubeletserver.key",
+		"--v":                           "2",
+		"--volume-plugin-dir":           "/etc/kubernetes/volumeplugins",
 	}
 
 	for key := range staticLinuxKubeletConfig {
@@ -126,6 +128,12 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		if !cs.Properties.IsHostedMasterProfile() { // Skip for AKS until it supports metrics-server v0.3
 			defaultKubeletConfig["--read-only-port"] = "0" // we only have metrics-server v0.3 support in 1.16.0 and above
 		}
+	}
+
+	if o.KubernetesConfig.NeedsContainerd() {
+		defaultKubeletConfig["--container-runtime"] = "remote"
+		defaultKubeletConfig["--runtime-request-timeout"] = "15m"
+		defaultKubeletConfig["--container-runtime-endpoint"] = "unix:///run/containerd/containerd.sock"
 	}
 
 	// If no user-configurable kubelet config values exists, use the defaults

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -94,6 +94,17 @@ func TestKubeletConfigDefaults(t *testing.T) {
 				key, val, expected[key])
 		}
 	}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
+	cs.setKubeletConfig(false)
+	expected["--container-runtime"] = "remote"
+	expected["--runtime-request-timeout"] = "15m"
+	expected["--container-runtime-endpoint"] = "unix:///run/containerd/containerd.sock"
+	for key, val := range linuxProfileKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected Linux agent profile kubelet config value for %s: %s, expected %s",
+				key, val, expected[key])
+		}
+	}
 	delete(expected, "--register-with-taints")
 
 	windowsProfileKubeletConfig := cs.Properties.AgentPoolProfiles[1].KubernetesConfig.KubeletConfig
@@ -119,6 +130,9 @@ func TestKubeletConfigDefaults(t *testing.T) {
 				key, val, expected[key])
 		}
 	}
+	delete(expected, "--container-runtime")
+	delete(expected, "--runtime-request-timeout")
+	delete(expected, "--container-runtime-endpoint")
 
 	// validate aad-pod-identity disabled scenario
 	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(Kubernetes, common.KubernetesDefaultRelease, "", false, false), 3, 2, false)
@@ -222,6 +236,8 @@ func getDefaultLinuxKubeletConfig(cs *ContainerService) map[string]string {
 		"--tls-cipher-suites":                 TLSStrongCipherSuitesKubelet,
 		"--tls-cert-file":                     "/etc/kubernetes/certs/kubeletserver.crt",
 		"--tls-private-key-file":              "/etc/kubernetes/certs/kubeletserver.key",
+		"--v":                                 "2",
+		"--volume-plugin-dir":                 "/etc/kubernetes/volumeplugins",
 	}
 }
 
@@ -273,6 +289,8 @@ func TestKubeletConfigAzureStackDefaults(t *testing.T) {
 		"--tls-cert-file":                     "/etc/kubernetes/certs/kubeletserver.crt",
 		"--tls-private-key-file":              "/etc/kubernetes/certs/kubeletserver.key",
 		"--register-with-taints":              common.MasterNodeTaint,
+		"--v":                                 "2",
+		"--volume-plugin-dir":                 "/etc/kubernetes/volumeplugins",
 	}
 	for key, val := range kubeletConfig {
 		if expected[key] != val {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -38883,10 +38883,7 @@ EnvironmentFile=/etc/default/kubelet
 SuccessExitStatus=143
 ExecStartPre=/bin/bash /opt/azure/containers/kubelet.sh
 ExecStart=/usr/local/bin/kubelet \
-        --enable-server \
         --node-labels="${KUBELET_NODE_LABELS}" \
-        --v=2 {{if NeedsContainerd}}--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock{{end}} \
-        --volume-plugin-dir=/etc/kubernetes/volumeplugins \
         $KUBELET_CONFIG
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR dusts off the cobwebs from the kubelet systemd implementation. Specifically:

- moves bash block statements out from single line systemd `ExecStartPre` strings into the pre-existing `/opt/azure/containers/kubelet.sh` script (a `ExecStartPre` dependency)
- enables the following containerd kubelet configuration to be overridden via api model:
  - `--container-runtime`
  - `--runtime-request-timeout`
  - `--container-runtime-endpoint`
- removes iptables output from start of kubelet logs

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
