### PR TITLE
[WIP] refactor: don't deliver kubeconfig w/ secrets to masters

### DIFF
--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -325,6 +325,7 @@ func (rcc *rotateCertsCmd) deleteServiceAccounts() error {
 	return nil
 }
 
+// TODO get rid of this
 func (rcc *rotateCertsCmd) updateKubeconfig() error {
 	kubeconfig, err := engine.GenerateKubeConfig(rcc.containerService.Properties, rcc.location)
 	if err != nil {

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -4,7 +4,7 @@ NODE_NAME=$(hostname)
 PRIVATE_IP=$(hostname -I | cut -d' ' -f1)
 ETCD_PEER_URL="https://${PRIVATE_IP}:2380"
 ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
-KUBECTL="/usr/local/bin/kubectl --kubeconfig=/home/$ADMINUSER/.kube/config"
+KUBECTL="/usr/local/bin/kubectl --kubeconfig=/var/lib/kubelet/kubeconfig"
 MOUNT_ETCD_SCRIPT=/opt/azure/containers/mountetcd.sh
 
 systemctlEnableAndStart() {
@@ -440,39 +440,6 @@ ensureEtcd() {
 createKubeManifestDir() {
   KUBEMANIFESTDIR=/etc/kubernetes/manifests
   mkdir -p $KUBEMANIFESTDIR
-}
-writeKubeConfig() {
-  local DIR=/home/$ADMINUSER/.kube
-  local FILE=$DIR/config
-  mkdir -p $DIR
-  touch $FILE
-  chown $ADMINUSER:$ADMINUSER $DIR $FILE
-  chmod 700 $DIR
-  chmod 600 $FILE
-  set +x
-  echo "
----
-apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority-data: \"$CA_CERTIFICATE\"
-    server: $KUBECONFIG_SERVER
-  name: \"$MASTER_FQDN\"
-contexts:
-- context:
-    cluster: \"$MASTER_FQDN\"
-    user: \"$MASTER_FQDN-admin\"
-  name: \"$MASTER_FQDN\"
-current-context: \"$MASTER_FQDN\"
-kind: Config
-users:
-- name: \"$MASTER_FQDN-admin\"
-  user:
-    client-certificate-data: \"$KUBECONFIG_CERTIFICATE\"
-    client-key-data: \"$KUBECONFIG_KEY\"
-" >$FILE
-  set -x
-  KUBECTL="$KUBECTL --kubeconfig=$FILE"
 }
 {{- if IsClusterAutoscalerAddonEnabled}}
 configClusterAutoscalerAddon() {

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -228,7 +228,6 @@ if [[ -n ${MASTER_NODE} ]]; then
     time_metric "EnsureTaints" ensureTaints
 {{end}}
   fi
-  time_metric "WriteKubeConfig" writeKubeConfig
   if [[ -z ${COSMOS_URI} ]]; then
     if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
       time_metric "EnsureEtcd" ensureEtcd

--- a/parts/k8s/cloud-init/artifacts/label-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/label-nodes.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-KUBECONFIG="$(find /home/*/.kube/config)"
+KUBECONFIG=/var/lib/kubelet/kubeconfig
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
 
 MASTER_SELECTOR="kubernetes.azure.com/role!=agent,kubernetes.io/role!=agent"

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-KUBECONFIG="$(find /home/*/.kube/config)"
-KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+KUBECTL="kubectl --kubeconfig=/var/lib/kubelet/kubeconfig"
 AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -75,6 +75,13 @@ write_files:
   content: !!binary |
     {{CloudInitData "kubeletSystemdService"}}
 
+- path: /opt/azure/containers/label-nodes.sh
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "labelNodesScript"}}
+
 {{- if not .MasterProfile.IsVHDDistro}}
 - path: /usr/local/bin/health-monitor.sh
   permissions: "0544"
@@ -103,13 +110,6 @@ write_files:
   owner: root
   content: !!binary |
     {{CloudInitData "dockerMonitorSystemdService"}}
-
-- path: /opt/azure/containers/label-nodes.sh
-  permissions: "0744"
-  encoding: gzip
-  owner: root
-  content: !!binary |
-    {{CloudInitData "labelNodesScript"}}
 
 - path: /etc/systemd/system/label-nodes.service
   permissions: "0644"

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -131,18 +131,6 @@
       },
       "type": "securestring"
     },
-    "kubeConfigCertificate": {
-      "metadata": {
-        "description": "The base 64 certificate used by cli to communicate with the master"
-      },
-      "type": "string"
-    },
-    "kubeConfigPrivateKey": {
-      "metadata": {
-        "description": "The base 64 private key used by cli to communicate with the master"
-      },
-      "type": "securestring"
-    },
     "generatorCode": {
       "metadata": {
         "description": "The generator code used to identify the generator"

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -222,9 +222,9 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 	}
 	if !isHostedMaster {
 		if isMasterVMSS {
-			masterVars["provisionScriptParametersMaster"] = fmt.Sprintf("[concat('COSMOS_URI=%s MASTER_NODE=true NO_OUTBOUND=%t AUDITD_ENABLED=%s CLUSTER_AUTOSCALER_ADDON=%s ACI_CONNECTOR_ADDON=',parameters('kubernetesACIConnectorEnabled'),' APISERVER_PRIVATE_KEY=',parameters('apiServerPrivateKey'),' CA_CERTIFICATE=',parameters('caCertificate'),' CA_PRIVATE_KEY=',parameters('caPrivateKey'),' MASTER_FQDN=',variables('masterFqdnPrefix'),' KUBECONFIG_CERTIFICATE=',parameters('kubeConfigCertificate'),' KUBECONFIG_KEY=',parameters('kubeConfigPrivateKey'),' ETCD_SERVER_CERTIFICATE=',parameters('etcdServerCertificate'),' ETCD_CLIENT_CERTIFICATE=',parameters('etcdClientCertificate'),' ETCD_SERVER_PRIVATE_KEY=',parameters('etcdServerPrivateKey'),' ETCD_CLIENT_PRIVATE_KEY=',parameters('etcdClientPrivateKey'),' ETCD_PEER_CERTIFICATES=',string(variables('etcdPeerCertificates')),' ETCD_PEER_PRIVATE_KEYS=',string(variables('etcdPeerPrivateKeys')),' ENABLE_AGGREGATED_APIS=',string(parameters('enableAggregatedAPIs')),' KUBECONFIG_SERVER=',variables('kubeconfigServer'))]", cosmosEndPointURI, blockOutboundInternet, auditDEnabled, clusterAutoscalerEnabled)
+			masterVars["provisionScriptParametersMaster"] = fmt.Sprintf("[concat('COSMOS_URI=%s MASTER_NODE=true NO_OUTBOUND=%t AUDITD_ENABLED=%s CLUSTER_AUTOSCALER_ADDON=%s ACI_CONNECTOR_ADDON=',parameters('kubernetesACIConnectorEnabled'),' APISERVER_PRIVATE_KEY=',parameters('apiServerPrivateKey'),' CA_PRIVATE_KEY=',parameters('caPrivateKey'),' ETCD_SERVER_CERTIFICATE=',parameters('etcdServerCertificate'),' ETCD_CLIENT_CERTIFICATE=',parameters('etcdClientCertificate'),' ETCD_SERVER_PRIVATE_KEY=',parameters('etcdServerPrivateKey'),' ETCD_CLIENT_PRIVATE_KEY=',parameters('etcdClientPrivateKey'),' ETCD_PEER_CERTIFICATES=',string(variables('etcdPeerCertificates')),' ETCD_PEER_PRIVATE_KEYS=',string(variables('etcdPeerPrivateKeys')),' ENABLE_AGGREGATED_APIS=',string(parameters('enableAggregatedAPIs')))]", cosmosEndPointURI, blockOutboundInternet, auditDEnabled, clusterAutoscalerEnabled)
 		} else {
-			masterVars["provisionScriptParametersMaster"] = fmt.Sprintf("[concat('COSMOS_URI=%s MASTER_VM_NAME=',variables('masterVMNames')[variables('masterOffset')],' ETCD_PEER_URL=',variables('masterEtcdPeerURLs')[variables('masterOffset')],' ETCD_CLIENT_URL=',variables('masterEtcdClientURLs')[variables('masterOffset')],' MASTER_NODE=true NO_OUTBOUND=%t AUDITD_ENABLED=%s CLUSTER_AUTOSCALER_ADDON=%s ACI_CONNECTOR_ADDON=',parameters('kubernetesACIConnectorEnabled'),' APISERVER_PRIVATE_KEY=',parameters('apiServerPrivateKey'),' CA_CERTIFICATE=',parameters('caCertificate'),' CA_PRIVATE_KEY=',parameters('caPrivateKey'),' MASTER_FQDN=',variables('masterFqdnPrefix'),' KUBECONFIG_CERTIFICATE=',parameters('kubeConfigCertificate'),' KUBECONFIG_KEY=',parameters('kubeConfigPrivateKey'),' ETCD_SERVER_CERTIFICATE=',parameters('etcdServerCertificate'),' ETCD_CLIENT_CERTIFICATE=',parameters('etcdClientCertificate'),' ETCD_SERVER_PRIVATE_KEY=',parameters('etcdServerPrivateKey'),' ETCD_CLIENT_PRIVATE_KEY=',parameters('etcdClientPrivateKey'),' ETCD_PEER_CERTIFICATES=',string(variables('etcdPeerCertificates')),' ETCD_PEER_PRIVATE_KEYS=',string(variables('etcdPeerPrivateKeys')),' ENABLE_AGGREGATED_APIS=',string(parameters('enableAggregatedAPIs')),' KUBECONFIG_SERVER=',variables('kubeconfigServer'))]", cosmosEndPointURI, blockOutboundInternet, auditDEnabled, clusterAutoscalerEnabled)
+			masterVars["provisionScriptParametersMaster"] = fmt.Sprintf("[concat('COSMOS_URI=%s MASTER_VM_NAME=',variables('masterVMNames')[variables('masterOffset')],' ETCD_PEER_URL=',variables('masterEtcdPeerURLs')[variables('masterOffset')],' ETCD_CLIENT_URL=',variables('masterEtcdClientURLs')[variables('masterOffset')],' MASTER_NODE=true NO_OUTBOUND=%t AUDITD_ENABLED=%s CLUSTER_AUTOSCALER_ADDON=%s ACI_CONNECTOR_ADDON=',parameters('kubernetesACIConnectorEnabled'),' APISERVER_PRIVATE_KEY=',parameters('apiServerPrivateKey'),' CA_PRIVATE_KEY=',parameters('caPrivateKey'),' ETCD_SERVER_CERTIFICATE=',parameters('etcdServerCertificate'),' ETCD_CLIENT_CERTIFICATE=',parameters('etcdClientCertificate'),' ETCD_SERVER_PRIVATE_KEY=',parameters('etcdServerPrivateKey'),' ETCD_CLIENT_PRIVATE_KEY=',parameters('etcdClientPrivateKey'),' ETCD_PEER_CERTIFICATES=',string(variables('etcdPeerCertificates')),' ETCD_PEER_PRIVATE_KEYS=',string(variables('etcdPeerPrivateKeys')),' ENABLE_AGGREGATED_APIS=',string(parameters('enableAggregatedAPIs')))]", cosmosEndPointURI, blockOutboundInternet, auditDEnabled, clusterAutoscalerEnabled)
 		}
 	}
 
@@ -433,7 +433,6 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 			masterVars["masterLbName"] = "[concat(parameters('orchestratorName'), '-master-lb-', parameters('nameSuffix'))]"
 		}
 		if cs.Properties.OrchestratorProfile.IsPrivateCluster() {
-			masterVars["kubeconfigServer"] = "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]"
 			if provisionJumpbox {
 				masterVars["jumpboxOSDiskName"] = "[concat(parameters('jumpboxVMName'), '-osdisk')]"
 				masterVars["jumpboxPublicIpAddressName"] = "[concat(parameters('jumpboxVMName'), '-ip')]"
@@ -458,8 +457,6 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 				}
 
 			}
-		} else {
-			masterVars["kubeconfigServer"] = "[concat('https://', variables('masterFqdnPrefix'), '.', variables('location'), '.', parameters('fqdnEndpointSuffix'))]"
 		}
 
 		if masterProfile.HasMultipleNodes() {

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -144,8 +144,6 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 		 - caCertificate
 		 - clientCertificate
 		 - clientPrivateKey
-		 - kubeConfigCertificate
-		 - kubeConfigPrivateKey
 		 - servicePrincipalClientSecret
 		 - etcdClientCertificate
 		 - etcdClientPrivateKey
@@ -183,8 +181,6 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 			addSecret(parametersMap, "caPrivateKey", certificateProfile.CaPrivateKey, true)
 			addSecret(parametersMap, "clientCertificate", certificateProfile.ClientCertificate, true)
 			addSecret(parametersMap, "clientPrivateKey", certificateProfile.ClientPrivateKey, true)
-			addSecret(parametersMap, "kubeConfigCertificate", certificateProfile.KubeConfigCertificate, true)
-			addSecret(parametersMap, "kubeConfigPrivateKey", certificateProfile.KubeConfigPrivateKey, true)
 			if properties.MasterProfile != nil {
 				addSecret(parametersMap, "etcdServerCertificate", certificateProfile.EtcdServerCertificate, true)
 				addSecret(parametersMap, "etcdServerPrivateKey", certificateProfile.EtcdServerPrivateKey, true)

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -38884,7 +38884,7 @@ var _k8sCloudInitArtifactsLabelNodesSh = []byte(`#!/usr/bin/env bash
 
 set -euo pipefail
 
-KUBECONFIG="$(find /home/*/.kube/config)"
+KUBECONFIG=/var/lib/kubelet/kubeconfig
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
 
 MASTER_SELECTOR="kubernetes.azure.com/role!=agent,kubernetes.io/role!=agent"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -36620,7 +36620,7 @@ NODE_NAME=$(hostname)
 PRIVATE_IP=$(hostname -I | cut -d' ' -f1)
 ETCD_PEER_URL="https://${PRIVATE_IP}:2380"
 ETCD_CLIENT_URL="https://${PRIVATE_IP}:2379"
-KUBECTL="/usr/local/bin/kubectl --kubeconfig=/home/$ADMINUSER/.kube/config"
+KUBECTL="/usr/local/bin/kubectl --kubeconfig=/var/lib/kubelet/kubeconfig"
 MOUNT_ETCD_SCRIPT=/opt/azure/containers/mountetcd.sh
 
 systemctlEnableAndStart() {
@@ -37056,39 +37056,6 @@ ensureEtcd() {
 createKubeManifestDir() {
   KUBEMANIFESTDIR=/etc/kubernetes/manifests
   mkdir -p $KUBEMANIFESTDIR
-}
-writeKubeConfig() {
-  local DIR=/home/$ADMINUSER/.kube
-  local FILE=$DIR/config
-  mkdir -p $DIR
-  touch $FILE
-  chown $ADMINUSER:$ADMINUSER $DIR $FILE
-  chmod 700 $DIR
-  chmod 600 $FILE
-  set +x
-  echo "
----
-apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority-data: \"$CA_CERTIFICATE\"
-    server: $KUBECONFIG_SERVER
-  name: \"$MASTER_FQDN\"
-contexts:
-- context:
-    cluster: \"$MASTER_FQDN\"
-    user: \"$MASTER_FQDN-admin\"
-  name: \"$MASTER_FQDN\"
-current-context: \"$MASTER_FQDN\"
-kind: Config
-users:
-- name: \"$MASTER_FQDN-admin\"
-  user:
-    client-certificate-data: \"$KUBECONFIG_CERTIFICATE\"
-    client-key-data: \"$KUBECONFIG_KEY\"
-" >$FILE
-  set -x
-  KUBECTL="$KUBECTL --kubeconfig=$FILE"
 }
 {{- if IsClusterAutoscalerAddonEnabled}}
 configClusterAutoscalerAddon() {
@@ -38221,7 +38188,6 @@ if [[ -n ${MASTER_NODE} ]]; then
     time_metric "EnsureTaints" ensureTaints
 {{end}}
   fi
-  time_metric "WriteKubeConfig" writeKubeConfig
   if [[ -z ${COSMOS_URI} ]]; then
     if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
       time_metric "EnsureEtcd" ensureEtcd
@@ -41158,18 +41124,6 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
     "clientPrivateKey": {
       "metadata": {
         "description": "The base 64 client private key used to communicate with the master"
-      },
-      "type": "securestring"
-    },
-    "kubeConfigCertificate": {
-      "metadata": {
-        "description": "The base 64 certificate used by cli to communicate with the master"
-      },
-      "type": "string"
-    },
-    "kubeConfigPrivateKey": {
-      "metadata": {
-        "description": "The base 64 private key used by cli to communicate with the master"
       },
       "type": "securestring"
     },

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39584,8 +39584,7 @@ func k8sCloudInitArtifactsUntaintNodesService() (*asset, error) {
 
 var _k8sCloudInitArtifactsUntaintNodesSh = []byte(`#!/usr/bin/env bash
 
-KUBECONFIG="$(find /home/*/.kube/config)"
-KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+KUBECTL="kubectl --kubeconfig=/var/lib/kubelet/kubeconfig"
 AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -39738,6 +39738,13 @@ write_files:
   content: !!binary |
     {{CloudInitData "kubeletSystemdService"}}
 
+- path: /opt/azure/containers/label-nodes.sh
+  permissions: "0744"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{CloudInitData "labelNodesScript"}}
+
 {{- if not .MasterProfile.IsVHDDistro}}
 - path: /usr/local/bin/health-monitor.sh
   permissions: "0544"
@@ -39766,13 +39773,6 @@ write_files:
   owner: root
   content: !!binary |
     {{CloudInitData "dockerMonitorSystemdService"}}
-
-- path: /opt/azure/containers/label-nodes.sh
-  permissions: "0744"
-  encoding: gzip
-  owner: root
-  content: !!binary |
-    {{CloudInitData "labelNodesScript"}}
 
 - path: /etc/systemd/system/label-nodes.service
   permissions: "0644"


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR rolls back the "pave a fully-contained kubeconfig file to the admin user's home directory on master VMs" functionality.

We already have a fully operational kubeconfig at `/var/lib/kubelet/kubeconfig`.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
