### PR TITLE
feat: add warning message for empty Location string

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1964,10 +1964,9 @@ func (cs *ContainerService) Validate(isUpdate bool) error {
 func (cs *ContainerService) validateLocation() error {
 	if cs.Properties != nil && cs.Properties.IsCustomCloudProfile() && cs.Location == "" {
 		return errors.New("missing ContainerService Location")
-	} else {
-		if cs.Location == "" {
-			log.Warnf("No \"location\" value was specified, AKS Engine will generate an ARM template configuration valid for regions in public cloud only")
-		}
+	}
+	if cs.Location == "" {
+		log.Warnf("No \"location\" value was specified, AKS Engine will generate an ARM template configuration valid for regions in public cloud only")
 	}
 	return nil
 }

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1964,6 +1964,10 @@ func (cs *ContainerService) Validate(isUpdate bool) error {
 func (cs *ContainerService) validateLocation() error {
 	if cs.Properties != nil && cs.Properties.IsCustomCloudProfile() && cs.Location == "" {
 		return errors.New("missing ContainerService Location")
+	} else {
+		if cs.Location == "" {
+			log.Warnf("No \"location\" value was specified, AKS Engine will generate an ARM template configuration valid for regions in public cloud only")
+		}
 	}
 	return nil
 }

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -3093,6 +3093,19 @@ func TestProperties_ValidateZones(t *testing.T) {
 	}
 }
 
+func ExampleProperties_validateLocation() {
+	log.SetOutput(os.Stdout)
+	log.SetFormatter(&log.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	})
+	cs := getK8sDefaultContainerService(true)
+	cs.Location = ""
+	cs.validateLocation()
+	// Output:
+	// level=warning msg="No \"location\" value was specified, AKS Engine will generate an ARM template configuration valid for regions in public cloud only"
+}
+
 func ExampleProperties_validateZones() {
 	log.SetOutput(os.Stdout)
 	log.SetFormatter(&log.TextFormatter{


### PR DESCRIPTION
<!-- Thank you for helping aks-engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in aks-engine? -->

This PR introduces a stdout warning message when AKS Engine template generation observes an empty "location" value in the input api model. We want to tell folks pro-actively that AKS Engine will treat that empty string significantly, and that the resultant ARM templates will work *exclusively* for public cloud regions.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Addresses part of #3170

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
