### PR TITLE
ci: enable staticcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - staticcheck
     - unconvert
     - unparam
     - unused

--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -177,10 +177,16 @@ func TestLoadContainerServiceWithNilProperties(t *testing.T) {
         }`
 
 	tmpFile, err := ioutil.TempFile("", "containerService-invalid")
+	if err != nil {
+		t.Error(err)
+	}
 	fileName := tmpFile.Name()
 	defer os.Remove(fileName)
 
 	err = ioutil.WriteFile(fileName, []byte(jsonWithoutProperties), os.ModeAppend)
+	if err != nil {
+		t.Error(err)
+	}
 
 	apiloader := &Apiloader{}
 	existingContainerService := &ContainerService{Name: "test",
@@ -265,10 +271,16 @@ func TestLoadContainerServiceWithEmptyLocationCustomCloud(t *testing.T) {
 	}`
 
 	tmpFile, err := ioutil.TempFile("", "containerService-nolocation")
+	if err != nil {
+		t.Error(err)
+	}
 	fileName := tmpFile.Name()
 	defer os.Remove(fileName)
 
 	err = ioutil.WriteFile(fileName, []byte(jsonWithoutlocationcustomcloud), os.ModeAppend)
+	if err != nil {
+		t.Error(err)
+	}
 
 	apiloader := &Apiloader{}
 	_, _, err = apiloader.LoadContainerServiceFromFile(fileName, true, false, nil)
@@ -328,10 +340,16 @@ func TestLoadContainerServiceWithEmptyLocationCustomCloud(t *testing.T) {
 	}`
 
 	tmpFilewithoutlocationpubliccloud, err := ioutil.TempFile("", "containerService-nolocationpubliccloud")
+	if err != nil {
+		t.Error(err)
+	}
 	fileNamewithoutlocationpubliccloud := tmpFilewithoutlocationpubliccloud.Name()
 	defer os.Remove(fileNamewithoutlocationpubliccloud)
 
 	err = ioutil.WriteFile(fileNamewithoutlocationpubliccloud, []byte(jsonWithoutlocationpubliccloud), os.ModeAppend)
+	if err != nil {
+		t.Error(err)
+	}
 
 	apiloaderwithoutlocationpubliccloud := &Apiloader{}
 	_, _, err = apiloaderwithoutlocationpubliccloud.LoadContainerServiceFromFile(fileNamewithoutlocationpubliccloud, true, false, nil)

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -392,9 +392,9 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 		}
 
-		if strings.ToLower(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku) == strings.ToLower(BasicLoadBalancerSku) {
+		if strings.EqualFold(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, BasicLoadBalancerSku) {
 			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = BasicLoadBalancerSku
-		} else if strings.ToLower(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku) == strings.ToLower(StandardLoadBalancerSku) {
+		} else if strings.EqualFold(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) {
 			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 		}
 

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -302,7 +302,7 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 				}
 
 				if o.KubernetesConfig.LoadBalancerSku != "" {
-					if strings.ToLower(o.KubernetesConfig.LoadBalancerSku) != strings.ToLower(StandardLoadBalancerSku) && strings.ToLower(o.KubernetesConfig.LoadBalancerSku) != strings.ToLower(BasicLoadBalancerSku) {
+					if !strings.EqualFold(o.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) && !strings.EqualFold(o.KubernetesConfig.LoadBalancerSku, BasicLoadBalancerSku) {
 						return errors.Errorf("Invalid value for loadBalancerSku, only %s and %s are supported", StandardLoadBalancerSku, BasicLoadBalancerSku)
 					}
 				}
@@ -656,7 +656,7 @@ func (a *Properties) validateZones() error {
 						return errors.New("Availability Zones are not supported with an AvailabilitySet. Please either remove availabilityProfile or set availabilityProfile to VirtualMachineScaleSets")
 					}
 				}
-				if a.OrchestratorProfile.KubernetesConfig != nil && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "" && strings.ToLower(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku) != strings.ToLower(StandardLoadBalancerSku) {
+				if a.OrchestratorProfile.KubernetesConfig != nil && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "" && !strings.EqualFold(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) {
 					return errors.New("Availability Zones requires Standard LoadBalancer. Please set KubernetesConfig \"LoadBalancerSku\" to \"Standard\"")
 				}
 			}

--- a/pkg/armhelpers/azurestack/compute.go
+++ b/pkg/armhelpers/azurestack/compute.go
@@ -181,17 +181,15 @@ func (az *AzureClient) GetAvailabilitySet(ctx context.Context, resourceGroup, av
 // GetAvailabilitySetFaultDomainCount returns the first existing fault domain count it finds from the IDs provided.
 func (az *AzureClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
 	var count int
-	for _, id := range vmasIDs {
-		// extract the last element of the id for VMAS name
-		ss := strings.Split(id, "/")
-		name := ss[len(ss)-1]
-		vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
-		if err != nil {
-			return 0, err
-		}
-		// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
-		count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
-		break
+	id := vmasIDs[0]
+	// extract the last element of the id for VMAS name
+	ss := strings.Split(id, "/")
+	name := ss[len(ss)-1]
+	vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
+	if err != nil {
+		return 0, err
 	}
+	// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
+	count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
 	return count, nil
 }

--- a/pkg/armhelpers/azurestack/compute.go
+++ b/pkg/armhelpers/azurestack/compute.go
@@ -181,15 +181,17 @@ func (az *AzureClient) GetAvailabilitySet(ctx context.Context, resourceGroup, av
 // GetAvailabilitySetFaultDomainCount returns the first existing fault domain count it finds from the IDs provided.
 func (az *AzureClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
 	var count int
-	id := vmasIDs[0]
-	// extract the last element of the id for VMAS name
-	ss := strings.Split(id, "/")
-	name := ss[len(ss)-1]
-	vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
-	if err != nil {
-		return 0, err
+	if len(vmasIDs) > 0 {
+		id := vmasIDs[0]
+		// extract the last element of the id for VMAS name
+		ss := strings.Split(id, "/")
+		name := ss[len(ss)-1]
+		vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
+		if err != nil {
+			return 0, err
+		}
+		// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
+		count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
 	}
-	// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
-	count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
 	return count, nil
 }

--- a/pkg/armhelpers/compute.go
+++ b/pkg/armhelpers/compute.go
@@ -136,15 +136,17 @@ func (az *AzureClient) GetAvailabilitySet(ctx context.Context, resourceGroup, av
 // GetAvailabilitySetFaultDomainCount returns the first existing fault domain count it finds from the IDs provided.
 func (az *AzureClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
 	var count int
-	id := vmasIDs[0]
-	// extract the last element of the id for VMAS name
-	ss := strings.Split(id, "/")
-	name := ss[len(ss)-1]
-	vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
-	if err != nil {
-		return 0, err
+	if len(vmasIDs) > 0 {
+		id := vmasIDs[0]
+		// extract the last element of the id for VMAS name
+		ss := strings.Split(id, "/")
+		name := ss[len(ss)-1]
+		vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
+		if err != nil {
+			return 0, err
+		}
+		// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
+		count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
 	}
-	// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
-	count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
 	return count, nil
 }

--- a/pkg/armhelpers/compute.go
+++ b/pkg/armhelpers/compute.go
@@ -136,17 +136,15 @@ func (az *AzureClient) GetAvailabilitySet(ctx context.Context, resourceGroup, av
 // GetAvailabilitySetFaultDomainCount returns the first existing fault domain count it finds from the IDs provided.
 func (az *AzureClient) GetAvailabilitySetFaultDomainCount(ctx context.Context, resourceGroup string, vmasIDs []string) (int, error) {
 	var count int
-	for _, id := range vmasIDs {
-		// extract the last element of the id for VMAS name
-		ss := strings.Split(id, "/")
-		name := ss[len(ss)-1]
-		vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
-		if err != nil {
-			return 0, err
-		}
-		// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
-		count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
-		break
+	id := vmasIDs[0]
+	// extract the last element of the id for VMAS name
+	ss := strings.Split(id, "/")
+	name := ss[len(ss)-1]
+	vmas, err := az.GetAvailabilitySet(ctx, resourceGroup, name)
+	if err != nil {
+		return 0, err
 	}
+	// Assume that all VMASes in the cluster share a value for platformFaultDomainCount
+	count = int(*vmas.AvailabilitySetProperties.PlatformFaultDomainCount)
 	return count, nil
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -122,7 +122,7 @@ func TestExpected(t *testing.T) {
 				continue
 			}
 
-			certsGenerated, err := containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+			certsGenerated, _ := containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 				IsScale:    false,
 				IsUpgrade:  false,
 				PkiKeySize: helpers.DefaultPkiKeySize,
@@ -152,7 +152,7 @@ func TestExpected(t *testing.T) {
 
 			for i := 0; i < 3; i++ {
 				if i > 0 {
-					certsGenerated, err = containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+					certsGenerated, _ = containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 						IsScale:    false,
 						IsUpgrade:  false,
 						PkiKeySize: helpers.DefaultPkiKeySize,
@@ -234,7 +234,7 @@ func TestExpected(t *testing.T) {
 				continue
 			}
 
-			certsGenerated, err := containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+			certsGenerated, _ := containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 				IsScale:    false,
 				IsUpgrade:  false,
 				PkiKeySize: helpers.DefaultPkiKeySize,
@@ -264,7 +264,7 @@ func TestExpected(t *testing.T) {
 
 			for i := 0; i < 3; i++ {
 				if i > 0 {
-					certsGenerated, err = containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+					certsGenerated, _ = containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 						IsScale:    false,
 						IsUpgrade:  false,
 						PkiKeySize: helpers.DefaultPkiKeySize,

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -380,6 +380,10 @@ func (uc *UpgradeCluster) addVMToAgentPool(vm compute.VirtualMachine, isUpgradab
 
 	if vm.StorageProfile.OsDisk.OsType == compute.Windows {
 		poolPrefix, _, _, _, err = utils.WindowsVMNameParts(*vm.Name)
+		if err != nil {
+			uc.Logger.Errorf(err.Error())
+			return err
+		}
 		if !strings.Contains(uc.NameSuffix, poolPrefix) {
 			uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s",
 				*vm.Name, uc.NameSuffix)


### PR DESCRIPTION
**Reason for Change**:
The `staticcheck` linter is enabled by default in golangci-lint, although AKS Engine has had it disabled. It points out where errors are being assigned but not actually checked, and some other simplifications.


**Issue Fixed**:
Refs #1032 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
