### PR TITLE
feat: add support for Kubernetes 1.19.0-alpha.3

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -190,6 +190,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.18.2":         true,
 	"1.19.0-alpha.1": true,
 	"1.19.0-alpha.2": true,
+	"1.19.0-alpha.3": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -101,7 +101,7 @@ function Get-FilesToCacheOnVHD
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.0/windowszip/v1.18.0-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.1/windowszip/v1.18.1-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.2/windowszip/v1.18.2-1int.zip",
-            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.19.0-alpha.2/windowszip/v1.19.0-alpha.2-1int.zip"
+            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.19.0-alpha.3/windowszip/v1.19.0-alpha.3-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
             "https://kubernetesartifacts.azureedge.net/azure-cni/v1.0.30/binaries/azure-vnet-cni-windows-amd64-v1.0.30.zip",
@@ -305,7 +305,7 @@ switch ($env:ProvisioningPhase)
         # TODO: make decision on if we want to install docker along with containerd (will need to update CSE too,)
         Install-Docker
         if ($containerRuntime -eq 'containerd') {
-            Install-ContainerD 
+            Install-ContainerD
         }
         Get-ContainerImages -containerRuntime $containerRuntime
         Get-FilesToCacheOnVHD

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -350,7 +350,7 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="
-1.19.0-alpha.2
+1.19.0-alpha.3
 1.18.2
 1.18.1
 1.17.5


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1190-alpha2

**Issue Fixed**:

**Requirements**:

- [x] Kubernetes artifacts built and pushed by Azure Pipelines
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
There were several APIs deprecated with this release, but I think we should defer updating them. See #3196.