### PR TITLE
fix: aad-pod-identity taints foo works in k8s < 1.16

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -224,10 +224,10 @@ time_metric "EnsureJournal" ensureJournal
 if [[ -n ${MASTER_NODE} ]]; then
   if version_gte ${KUBERNETES_VERSION} 1.16; then
     time_metric "EnsureLabelNodes" ensureLabelNodes
-{{- if IsAADPodIdentityAddonEnabled}}
-    time_metric "EnsureTaints" ensureTaints
-{{end}}
   fi
+{{- if IsAADPodIdentityAddonEnabled}}
+  time_metric "EnsureTaints" ensureTaints
+{{end}}
   time_metric "WriteKubeConfig" writeKubeConfig
   if [[ -z ${COSMOS_URI} ]]; then
     if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then

--- a/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/untaint-nodes.sh
@@ -6,13 +6,13 @@ AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then
   for node in $(${KUBECTL} get nodes -o json | jq -e -r '.items[] | .metadata.name'); do
-    ${KUBECTL} taint nodes $node $AAD_POD_ID_TAINT_KEY=true:NoSchedule- 2>&1 | grep -v 'not found';
+    ${KUBECTL} taint nodes $node $AAD_POD_ID_TAINT_KEY:NoSchedule- 2>&1 | grep -v 'not found';
   done
   exit 0
 fi
 for pod in $(${KUBECTL} get pods -n kube-system -o json | jq -r '.items[] | select(.status.phase == "Running") | .metadata.name'); do
   if [[ "$pod" =~ ^nmi ]]; then
-    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_ID_TAINT_KEY=true:NoSchedule- 2>&1 | grep -v 'not found';
+    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_ID_TAINT_KEY:NoSchedule- 2>&1 | grep -v 'not found';
   fi;
 done
 exit 0

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37905,10 +37905,10 @@ time_metric "EnsureJournal" ensureJournal
 if [[ -n ${MASTER_NODE} ]]; then
   if version_gte ${KUBERNETES_VERSION} 1.16; then
     time_metric "EnsureLabelNodes" ensureLabelNodes
-{{- if IsAADPodIdentityAddonEnabled}}
-    time_metric "EnsureTaints" ensureTaints
-{{end}}
   fi
+{{- if IsAADPodIdentityAddonEnabled}}
+  time_metric "EnsureTaints" ensureTaints
+{{end}}
   time_metric "WriteKubeConfig" writeKubeConfig
   if [[ -z ${COSMOS_URI} ]]; then
     if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
@@ -39300,13 +39300,13 @@ AAD_POD_ID_TAINT_KEY={{GetAADPodIdentityTaintKey}}
 
 if ! ${KUBECTL} get daemonsets -n kube-system -o json | jq -e -r '.items[] | select(.metadata.name == "nmi")' > /dev/null; then
   for node in $(${KUBECTL} get nodes -o json | jq -e -r '.items[] | .metadata.name'); do
-    ${KUBECTL} taint nodes $node $AAD_POD_ID_TAINT_KEY=true:NoSchedule- 2>&1 | grep -v 'not found';
+    ${KUBECTL} taint nodes $node $AAD_POD_ID_TAINT_KEY:NoSchedule- 2>&1 | grep -v 'not found';
   done
   exit 0
 fi
 for pod in $(${KUBECTL} get pods -n kube-system -o json | jq -r '.items[] | select(.status.phase == "Running") | .metadata.name'); do
   if [[ "$pod" =~ ^nmi ]]; then
-    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_ID_TAINT_KEY=true:NoSchedule- 2>&1 | grep -v 'not found';
+    ${KUBECTL} taint nodes $(${KUBECTL} get pod ${pod} -n kube-system -o json | jq -r '.spec.nodeName') $AAD_POD_ID_TAINT_KEY:NoSchedule- 2>&1 | grep -v 'not found';
   fi;
 done
 exit 0


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR fixes two errata surfaced in 1.14 and 1.15 tests that include aad-pod-identity.

1. move the `ensureTaints` CSE func out of the "is k8s version >= 1.16?" block
2. use the documented `kubectl taint nodes` syntax (remove the `=true` expression after the taint key, which I guess works in 1.16+)
  - Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
