### PR TITLE
test: reduce node count in E2E "everything" config

### DIFF
--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -88,7 +88,7 @@
 			"agentPoolProfiles": [
 				{
 					"name": "pool1",
-					"count": 10,
+					"count": 1,
 					"availabilityProfile": "VirtualMachineScaleSets",
 					"vmSize": "Standard_D2_v3",
 					"OSDiskSizeGB": 200,


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Building a cluster w/ 10 nodes and a "1" min-nodes cluster-autoscaler configuration can yield unpredictable results in tests, as cluster-autoscaler will be scaling down nodes quickly after the cluster has been created. That's not really what we want to test, and it introduces flakes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
