### PR TITLE
test: rationalize "everything" E2E config for coredns autoscaler test

### DIFF
--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -62,6 +62,14 @@
 						{
 							"name": "rescheduler",
 							"enabled": true
+						},
+						{
+							"name": "coredns",
+							"enabled": true,
+							"config": {
+								"min-replicas": "1",
+								"nodes-per-replica": "8"
+							}
 						}
 					],
 					"components": [
@@ -83,7 +91,10 @@
 				"firstConsecutiveStaticIP": "10.239.255.239",
 				"vnetCidr": "10.239.0.0/16",
 				"auditDEnabled": true,
-				"availabilityZones": ["1", "2"]
+				"availabilityZones": [
+					"1",
+					"2"
+				]
 			},
 			"agentPoolProfiles": [
 				{
@@ -99,7 +110,10 @@
 					"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
 					"scalesetPriority": "Spot",
 					"auditDEnabled": true,
-					"availabilityZones": ["1", "2"]
+					"availabilityZones": [
+						"1",
+						"2"
+					]
 				},
 				{
 					"name": "poolgpu",


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR delivers a coredns addon configuration so that its autoscale configuration is tuned to be engaged at the first node added to the cluster.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
