### PR TITLE
docs: add missing link to upgrade doc

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -261,3 +261,4 @@ Now you're ready to start using your Kubernetes cluster with `kubectl`!
 [homebrew-install]: https://brew.sh/#install
 [scale]: ../topics/scale.md
 [sp]: ../topics/service-principals.md
+[upgrade]: ../topics/upgrade.md


### PR DESCRIPTION
**Reason for Change**:
There are two references to `[upgrade][]` in this doc but they didn't have a URL target.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
