### PR TITLE
fix: don't validate Windows version in update scenario

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -173,7 +173,7 @@ func (a *Properties) validate(isUpdate bool) error {
 		return e
 	}
 
-	if e := a.validateWindowsProfile(); e != nil {
+	if e := a.validateWindowsProfile(isUpdate); e != nil {
 		return e
 	}
 	return nil
@@ -1146,7 +1146,7 @@ func validateVMSS(o *OrchestratorProfile, isUpdate bool, storageProfile string) 
 	return nil
 }
 
-func (a *Properties) validateWindowsProfile() error {
+func (a *Properties) validateWindowsProfile(isUpdate bool) error {
 	hasWindowsAgentPools := false
 	for _, profile := range a.AgentPoolProfiles {
 		if profile.OSType == Windows {
@@ -1176,7 +1176,7 @@ func (a *Properties) validateWindowsProfile() error {
 			false,
 			true)
 
-		if version == "" {
+		if version == "" && !isUpdate {
 			return errors.Errorf("Orchestrator %s version %s does not support Windows", o.OrchestratorType, o.OrchestratorVersion)
 		}
 	default:

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1173,10 +1173,10 @@ func (a *Properties) validateWindowsProfile(isUpdate bool) error {
 			o.OrchestratorType,
 			o.OrchestratorRelease,
 			o.OrchestratorVersion,
-			false,
+			isUpdate,
 			true)
 
-		if version == "" && !isUpdate {
+		if version == "" {
 			return errors.Errorf("Orchestrator %s version %s does not support Windows", o.OrchestratorType, o.OrchestratorVersion)
 		}
 	default:


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR doesn't throw a validation error for the Kubernetes Version on a Windows-enabled cluster during scale/upgrade contexts.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3217

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
