### PR TITLE
fix: mount etcd data disk with label

### DIFF
--- a/parts/k8s/cloud-init/artifacts/mountetcd.sh
+++ b/parts/k8s/cloud-init/artifacts/mountetcd.sh
@@ -12,7 +12,7 @@ if mount | grep $MOUNTPOINT; then
   umount /dev/sdc1
 fi
 if ! grep "/dev/sdc1" /etc/fstab; then
-  echo "$PARTITION       $MOUNTPOINT       auto    defaults,nofail       0       2" >>/etc/fstab
+  echo "LABEL=etcd_disk       $MOUNTPOINT       auto    defaults,nofail       0       2" >>/etc/fstab
 fi
 if ! ls $PARTITION; then
   /sbin/sgdisk --new 1 $DISK

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -35807,7 +35807,7 @@ if mount | grep $MOUNTPOINT; then
   umount /dev/sdc1
 fi
 if ! grep "/dev/sdc1" /etc/fstab; then
-  echo "$PARTITION       $MOUNTPOINT       auto    defaults,nofail       0       2" >>/etc/fstab
+  echo "LABEL=etcd_disk       $MOUNTPOINT       auto    defaults,nofail       0       2" >>/etc/fstab
 fi
 if ! ls $PARTITION; then
   /sbin/sgdisk --new 1 $DISK


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR changes the `/etc/fstab` mount definition for the etcd data disk so that it references the disk partition label instead of the device path, as the device path may not be consistent across reboots.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3246

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
