### PR TITLE
chore: don't force create etcd_disk filesystem

### DIFF
--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -539,7 +539,6 @@ fs_setup:
     filesystem: ext4
     device: /dev/disk/azure/scsi1/lun0
     extra_opts:
-      - -F
       - -E
       - lazy_itable_init=1,lazy_journal_init=1
 mounts:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -37005,7 +37005,6 @@ fs_setup:
     filesystem: ext4
     device: /dev/disk/azure/scsi1/lun0
     extra_opts:
-      - -F
       - -E
       - lazy_itable_init=1,lazy_journal_init=1
 mounts:


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR removes the "force create" option when we create the etcd_disk filesystem via cloud-init.

If for some reason the device partition we target for etcd_disk already exists as a filesystem, we want cloud-init to throw an error, not forcibly create a new filesystem and ignore the previous state.

Ref:

```
-F     Force mke2fs to create a filesystem, even if the specified device is not a partition on a block special device, or if other parameters do not make sense.  In order to force mke2fs to create a filesystem even if the filesystem appears to be in use or is mounted (a truly dangerous thing to do), this option must be specified twice.
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
