### PR TITLE
fix: fetch go-dev image from Docker Hub

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go for aks-engine",
-	"image": "quay.io/deis/go-dev:v1.27.0",
+	"image": "deis/go-dev:v1.27.0",
 	"extensions": [
 		"ms-vscode.go"
 	],

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -17,7 +17,7 @@ pr:
 resources:
   containers:
   - container: dev1
-    image: quay.io/deis/go-dev:v1.27.0
+    image: deis/go-dev:v1.27.0
 
 jobs:
 - job: unit_tests

--- a/.pipelines/vhd-builder-ubuntu-gen2.yaml
+++ b/.pipelines/vhd-builder-ubuntu-gen2.yaml
@@ -7,7 +7,7 @@ trigger: none
 # - POST a new SKU to azure marketplace
 
 variables:
-  CONTAINER_IMAGE:  'quay.io/deis/go-dev:v1.27.0'
+  CONTAINER_IMAGE:  'deis/go-dev:v1.27.0'
 
 phases:
 - phase: build_vhd

--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -7,7 +7,7 @@ trigger: none
 # - POST a new SKU to azure marketplace
 
 variables:
-  CONTAINER_IMAGE:  'quay.io/deis/go-dev:v1.27.0'
+  CONTAINER_IMAGE:  'deis/go-dev:v1.27.0'
 
 phases:
 - phase: build_vhd

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(GITTAG),)
 GITTAG := $(VERSION_SHORT)
 endif
 
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.27.0
+DEV_ENV_IMAGE := deis/go-dev:v1.27.0
 DEV_ENV_WORK_DIR := /aks-engine
 DEV_ENV_OPTS := --rm -v $(GOPATH)/pkg/mod:/go/pkg/mod -v $(CURDIR):$(DEV_ENV_WORK_DIR) -w $(DEV_ENV_WORK_DIR) $(DEV_ENV_VARS)
 DEV_ENV_CMD := docker run $(DEV_ENV_OPTS) $(DEV_ENV_IMAGE)

--- a/jenkins/Jenkinsfile.azure.kubernetes
+++ b/jenkins/Jenkinsfile.azure.kubernetes
@@ -13,7 +13,7 @@ node(env.NODE? env.NODE : 'slave') {
           checkout scm
         }
 
-        img = docker.image("quay.io/deis/go-dev:${GO_DEV_TAG}")
+        img = docker.image("deis/go-dev:${GO_DEV_TAG}")
         img.inside("-u root -v /var/run/docker.sock:/var/run/docker.sock") {
           env.CLIENT_ID = "${CLIENT_ID}"
           env.CLIENT_SECRET = "${CLIENT_SECRET}"

--- a/makedev.ps1
+++ b/makedev.ps1
@@ -1,4 +1,4 @@
-$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.27.0"
+$DEV_ENV_IMAGE = "deis/go-dev:v1.27.0"
 $DEV_ENV_WORK_DIR = "/aks-engine"
 
 # Ensure docker is configured for linux containers


### PR DESCRIPTION
**Reason for Change**:
The [quay.io](https://status.quay.io/) image repository is having issues.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
flannel and the scheduled maintenance addon have the other references to quay.io.