### PR TITLE
fix: ensure /mnt is ext4

### DIFF
--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -541,6 +541,10 @@ fs_setup:
     extra_opts:
       - -E
       - lazy_itable_init=1,lazy_journal_init=1
+  - label: ephemeral0
+    filesystem: ext4
+    device: ephemeral0.1
+    replace_fs: ntfs
 mounts:
   - - LABEL=etcd_disk
     - /var/lib/etcddisk

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -541,6 +541,8 @@ fs_setup:
     extra_opts:
       - -E
       - lazy_itable_init=1,lazy_journal_init=1
+{{- /* ephemeral (/mnt) filesystem is explicitly configured, see: */}}
+{{- /* https://bugs.launchpad.net/cloud-init/+bug/1879552 */}}
   - label: ephemeral0
     filesystem: ext4
     device: ephemeral0.1

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -31551,6 +31551,10 @@ fs_setup:
     extra_opts:
       - -E
       - lazy_itable_init=1,lazy_journal_init=1
+  - label: ephemeral0
+    filesystem: ext4
+    device: ephemeral0.1
+    replace_fs: ntfs
 mounts:
   - - LABEL=etcd_disk
     - /var/lib/etcddisk

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -31551,6 +31551,8 @@ fs_setup:
     extra_opts:
       - -E
       - lazy_itable_init=1,lazy_journal_init=1
+{{- /* ephemeral (/mnt) filesystem is explicitly configured, see: */}}
+{{- /* https://bugs.launchpad.net/cloud-init/+bug/1879552 */}}
   - label: ephemeral0
     filesystem: ext4
     device: ephemeral0.1

--- a/test/e2e/kubernetes/scripts/host-os-fs.sh
+++ b/test/e2e/kubernetes/scripts/host-os-fs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -x
+[ $(findmnt /mnt -no FSTYPE) == "ext4" ] || exit 1
+if [[ $MASTER_NODE == "true" ]]; then
+  [ $(findmnt /var/lib/etcddisk -no FSTYPE) == "ext4" ] || exit 1
+fi


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR follows on from #3273 to ensure that `/mnt` is mounted as ext4 filesystem type via cloud-init.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
