### PR TITLE
fix: whitespace trimming in cloud-provider spec is broken

### DIFF
--- a/parts/k8s/addons/azure-cloud-provider.yaml
+++ b/parts/k8s/addons/azure-cloud-provider.yaml
@@ -81,7 +81,7 @@ subjects:
 - kind: ServiceAccount
   name: azure-cloud-provider
   namespace: kube-system
-{{end -}}
+{{- end}}
 {{- if UsesCloudControllerManager}}
 ---
 apiVersion: storage.k8s.io/v1
@@ -100,7 +100,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -109,7 +109,7 @@ allowedTopologies:
     values: {{GetZones}}
   {{else}}
 volumeBindingMode: Immediate
-  {{end -}}
+  {{- end}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -125,7 +125,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -134,7 +134,7 @@ allowedTopologies:
     values: {{GetZones}}
   {{else}}
 volumeBindingMode: Immediate
-  {{end -}}
+  {{- end}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -150,7 +150,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -159,7 +159,7 @@ allowedTopologies:
     values: {{GetZones}}
   {{else}}
 volumeBindingMode: Immediate
-  {{end -}}
+  {{- end}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -173,7 +173,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
 volumeBindingMode: Immediate
 {{else}}
   {{- if NeedsStorageAccountStorageClasses}}
@@ -227,8 +227,8 @@ metadata:
 provisioner: kubernetes.io/azure-file
 parameters:
   skuName: Standard_LRS
-    {{end -}}
-  {{end -}}
+    {{- end}}
+  {{- end}}
   {{- if NeedsManagedDiskStorageClasses}}
 ---
 apiVersion: storage.k8s.io/v1beta1
@@ -282,6 +282,6 @@ metadata:
 provisioner: kubernetes.io/azure-file
 parameters:
   skuName: Standard_LRS
-    {{end -}}
-  {{end -}}
-{{end -}}
+    {{- end}}
+  {{- end}}
+{{- end}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18251,7 +18251,7 @@ subjects:
 - kind: ServiceAccount
   name: azure-cloud-provider
   namespace: kube-system
-{{end -}}
+{{- end}}
 {{- if UsesCloudControllerManager}}
 ---
 apiVersion: storage.k8s.io/v1
@@ -18270,7 +18270,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -18279,7 +18279,7 @@ allowedTopologies:
     values: {{GetZones}}
   {{else}}
 volumeBindingMode: Immediate
-  {{end -}}
+  {{- end}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -18295,7 +18295,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -18304,7 +18304,7 @@ allowedTopologies:
     values: {{GetZones}}
   {{else}}
 volumeBindingMode: Immediate
-  {{end -}}
+  {{- end}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -18320,7 +18320,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -18329,7 +18329,7 @@ allowedTopologies:
     values: {{GetZones}}
   {{else}}
 volumeBindingMode: Immediate
-  {{end -}}
+  {{- end}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -18343,7 +18343,7 @@ parameters:
 reclaimPolicy: Delete
   {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{end -}}
+  {{- end}}
 volumeBindingMode: Immediate
 {{else}}
   {{- if NeedsStorageAccountStorageClasses}}
@@ -18397,8 +18397,8 @@ metadata:
 provisioner: kubernetes.io/azure-file
 parameters:
   skuName: Standard_LRS
-    {{end -}}
-  {{end -}}
+    {{- end}}
+  {{- end}}
   {{- if NeedsManagedDiskStorageClasses}}
 ---
 apiVersion: storage.k8s.io/v1beta1
@@ -18452,9 +18452,9 @@ metadata:
 provisioner: kubernetes.io/azure-file
 parameters:
   skuName: Standard_LRS
-    {{end -}}
-  {{end -}}
-{{end -}}
+    {{- end}}
+  {{- end}}
+{{- end}}
 `)
 
 func k8sAddonsAzureCloudProviderYamlBytes() ([]byte, error) {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

#3277 regressed the azure-cloud-provider yaml go template representation of the spec, doing the improper whitespace trimming.

Because we are putting the `{{end}}` *after* (duh) the literal text, separated by a whitespace, we need to use `{{- end}}` to trim that preceding newline.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
