### PR TITLE
fix: prevent panic in Windows scale if no tags

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -293,7 +293,11 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			sc.printScaleTargetEqualsExisting(currentNodeCount)
 			return nil
 		}
-		highestUsedIndex = indexes[len(indexes)-1]
+		if currentNodeCount > 0 {
+			highestUsedIndex = indexes[currentNodeCount-1]
+		} else {
+			return errors.New("None of the VMs in the provided resource group contain any nodes")
+		}
 
 		// VMAS Scale down Scenario
 		if currentNodeCount > sc.newDesiredAgentCount {
@@ -556,7 +560,11 @@ func (sc *scaleCmd) vmInAgentPool(vmName string, tags map[string]*string) bool {
 		}
 	}
 
-	// Fall back to checking the VM name to see if it fits the naming pattern.
+	// For Windows, we rely upon the tags
+	if sc.agentPool.OSType == api.Windows {
+		return false
+	}
+	// Fall back to checking the VM name to see if it fits the naming pattern for Linux
 	return strings.Contains(vmName, sc.nameSuffix[:5]) && strings.Contains(vmName, sc.agentPoolToScale)
 }
 

--- a/pkg/armhelpers/utils/util_test.go
+++ b/pkg/armhelpers/utils/util_test.go
@@ -111,6 +111,7 @@ func Test_WindowsVMNameParts(t *testing.T) {
 		{"4506k8s010", "4506", "k8s", 1, 0},
 		{"2314k8s03000001", "2314", "k8s", 3, 1},
 		{"2314k8s0310", "2314", "k8s", 3, 10},
+		{"7472k8s010", "7472", "k8s", 1, 0},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR improves the UX for edge case `aks-engine scale` scenarios against Windows VM nodes that are missing VM tags that help identify the node pool the VM is in.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
