### PR TITLE
fix: ensure pod-security-policy is the first addon loaded

### DIFF
--- a/parts/k8s/addons/pod-security-policy.yaml
+++ b/parts/k8s/addons/pod-security-policy.yaml
@@ -138,3 +138,4 @@ subjects:
 - kind: Group
   name: system:nodes
   apiGroup: rbac.authorization.k8s.io
+#EOF

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -379,7 +379,8 @@ ensureAddons() {
   retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   rm -Rf ${ADDONS_DIR}/init
 {{- end}}
-  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC
+  wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -397,7 +397,7 @@ ensureKubelet() {
 ensureAddons() {
   retrycmd 120 5 30 $KUBECTL get pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
 {{- if not HasCustomPodSecurityPolicy}}
-  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   rm -Rf ${ADDONS_DIR}/init
 {{- end}}
   sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -530,6 +530,7 @@ configAzurePolicyAddon() {
 }
 {{end}}
 configAddons() {
+  mkdir -p $ADDONS_DIR/init
   {{if IsClusterAutoscalerAddonEnabled}}
   if [[ ${CLUSTER_AUTOSCALER_ADDON} == true ]]; then
     configClusterAutoscalerAddon
@@ -545,8 +546,6 @@ configAddons() {
   {{end}}
   {{- if not HasCustomPodSecurityPolicy}}
   wait_for_file 1200 1 $POD_SECURITY_POLICY_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  mkdir -p $ADDONS_DIR/init
   cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/
   {{- end}}
 }

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -381,6 +381,7 @@ ensureAddons() {
 {{- end}}
   wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
   sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
@@ -531,7 +532,6 @@ configAzurePolicyAddon() {
 }
 {{end}}
 configAddons() {
-  mkdir -p $ADDONS_DIR/init
   {{if IsClusterAutoscalerAddonEnabled}}
   if [[ ${CLUSTER_AUTOSCALER_ADDON} == true ]]; then
     configClusterAutoscalerAddon
@@ -547,7 +547,7 @@ configAddons() {
   {{end}}
   {{- if not HasCustomPodSecurityPolicy}}
   wait_for_file 1200 1 $POD_SECURITY_POLICY_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/
+  mkdir -p $ADDONS_DIR/init && cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{- end}}
 }
 {{- if HasNSeriesSKU}}

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -230,7 +230,6 @@ if [[ -n ${MASTER_NODE} ]]; then
 {{- if IsAADPodIdentityAddonEnabled}}
   time_metric "EnsureTaints" ensureTaints
 {{end}}
-  time_metric "WriteKubeConfig" writeKubeConfig
   if [[ -z ${COSMOS_URI} ]]; then
     if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
       time_metric "EnsureEtcd" ensureEtcd

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -197,11 +197,10 @@ time_metric "ConfigureAzureStackInterfaces" configureAzureStackInterfaces
 
 time_metric "ConfigureCNI" configureCNI
 
-{{if or IsClusterAutoscalerAddonEnabled IsACIConnectorAddonEnabled IsAzurePolicyAddonEnabled}}
 if [[ -n ${MASTER_NODE} ]]; then
   time_metric "ConfigAddons" configAddons
+  time_metric "WriteKubeConfig" writeKubeConfig
 fi
-{{end}}
 
 {{- if NeedsContainerd}}
 time_metric "EnsureContainerd" ensureContainerd
@@ -219,6 +218,9 @@ time_metric "EnsureDHCPv6" ensureDHCPv6
 {{end}}
 
 time_metric "EnsureKubelet" ensureKubelet
+if [[ -n ${MASTER_NODE} ]]; then
+  time_metric "EnsureAddons" ensureAddons
+fi
 time_metric "EnsureJournal" ensureJournal
 
 if [[ -n ${MASTER_NODE} ]]; then

--- a/parts/k8s/manifests/kubernetesmaster-kube-addon-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-addon-manager.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kube-addon-manager
   namespace: kube-system
   version: v1
+  labels:
+    app: kube-addon-manager
 spec:
   priorityClassName: system-node-critical
   hostNetwork: true
@@ -17,7 +19,7 @@ spec:
         memory: 50Mi
     volumeMounts:
     - name: addons
-      mountPath: /etc/kubernetes/addons
+      mountPath: /etc/kubernetes/addons/init
       readOnly: true
     - name: msi
       mountPath: /var/lib/waagent/ManagedIdentity-Settings
@@ -25,7 +27,8 @@ spec:
   volumes:
   - name: addons
     hostPath:
-      path: /etc/kubernetes/addons
+      path: /etc/kubernetes/addons/init
   - name: msi
     hostPath:
       path: /var/lib/waagent/ManagedIdentity-Settings
+#EOF

--- a/pkg/engine/const.go
+++ b/pkg/engine/const.go
@@ -247,7 +247,7 @@ const (
 	kubeProxyAddonSourceFilename                   string = "kubernetesmasteraddons-kube-proxy-daemonset.yaml"
 	kubeProxyAddonDestinationFilename              string = "kube-proxy-daemonset.yaml"
 	podSecurityPolicyAddonSourceFilename           string = "pod-security-policy.yaml"
-	podSecurityPolicyAddonDestinationFilename      string = "0-pod-security-policy.yaml"
+	podSecurityPolicyAddonDestinationFilename      string = "pod-security-policy.yaml"
 	aadDefaultAdminGroupAddonSourceFilename        string = "aad-default-admin-group-rbac.yaml"
 	aadDefaultAdminGroupDestinationFilename        string = "aad-default-admin-group-rbac.yaml"
 	ciliumAddonSourceFilename                      string = "cilium.yaml"

--- a/pkg/engine/cse.go
+++ b/pkg/engine/cse.go
@@ -31,6 +31,7 @@ var cseErrorCodes = map[string]int{
 	"ERR_IMG_DOWNLOAD_TIMEOUT":                   33,
 	"ERR_KUBELET_START_FAIL":                     34,
 	"ERR_CONTAINER_IMG_PULL_TIMEOUT":             35,
+	"ERR_ADDONS_START_FAIL":                      36,
 	"ERR_CNI_DOWNLOAD_TIMEOUT":                   41,
 	"ERR_MS_PROD_DEB_DOWNLOAD_TIMEOUT":           42,
 	"ERR_MS_PROD_DEB_PKG_ADD_FAIL":               43,

--- a/pkg/engine/cse_test.go
+++ b/pkg/engine/cse_test.go
@@ -44,6 +44,7 @@ func TestGetCSEErrorCode(t *testing.T) {
 				"ERR_IMG_DOWNLOAD_TIMEOUT":                   33,
 				"ERR_KUBELET_START_FAIL":                     34,
 				"ERR_CONTAINER_IMG_PULL_TIMEOUT":             35,
+				"ERR_ADDONS_START_FAIL":                      36,
 				"ERR_CNI_DOWNLOAD_TIMEOUT":                   41,
 				"ERR_MS_PROD_DEB_DOWNLOAD_TIMEOUT":           42,
 				"ERR_MS_PROD_DEB_PKG_ADD_FAIL":               43,

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -762,6 +762,17 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"GetAADPodIdentityTaintKey": func() string {
 			return common.AADPodIdentityTaintKey
 		},
+		"HasCustomPodSecurityPolicy": func() bool {
+			if to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.EnablePodSecurityPolicy) &&
+				cs.Properties.OrchestratorProfile.KubernetesConfig.PodSecurityPolicyConfig != nil {
+				return true
+			}
+			if cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.PodSecurityPolicyAddonName) {
+				return cs.Properties.OrchestratorProfile.KubernetesConfig.GetAddonByName(common.PodSecurityPolicyAddonName).Data != ""
+
+			}
+			return false
+		},
 		"GetHyperkubeImageReference": func() string {
 			hyperkubeImageBase := cs.Properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase
 			k8sComponents := api.GetK8sComponentsByVersionMap(cs.Properties.OrchestratorProfile.KubernetesConfig)[cs.Properties.OrchestratorProfile.OrchestratorVersion]

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27755,6 +27755,7 @@ configAzurePolicyAddon() {
 }
 {{end}}
 configAddons() {
+  mkdir -p $ADDONS_DIR/init
   {{if IsClusterAutoscalerAddonEnabled}}
   if [[ ${CLUSTER_AUTOSCALER_ADDON} == true ]]; then
     configClusterAutoscalerAddon
@@ -27770,8 +27771,6 @@ configAddons() {
   {{end}}
   {{- if not HasCustomPodSecurityPolicy}}
   wait_for_file 1200 1 $POD_SECURITY_POLICY_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  mkdir -p $ADDONS_DIR/init
   cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/
   {{- end}}
 }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27604,7 +27604,8 @@ ensureAddons() {
   retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   rm -Rf ${ADDONS_DIR}/init
 {{- end}}
-  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC
+  wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27622,7 +27622,7 @@ ensureKubelet() {
 ensureAddons() {
   retrycmd 120 5 30 $KUBECTL get pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
 {{- if not HasCustomPodSecurityPolicy}}
-  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   rm -Rf ${ADDONS_DIR}/init
 {{- end}}
   sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27596,6 +27596,16 @@ ensureKubelet() {
   wait_for_file 1200 1 $KUBELET_SLICE_FILE || exit {{GetCSEErrorCode "ERR_KUBELET_SLICE_SETUP_FAIL"}}
   {{- end}}
   systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+}
+
+ensureAddons() {
+  retrycmd 120 5 30 $KUBECTL get pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+{{- if not HasCustomPodSecurityPolicy}}
+  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  rm -Rf ${ADDONS_DIR}/init
+{{- end}}
+  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC
+  retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
     sleep 3
@@ -27617,16 +27627,6 @@ ensureKubelet() {
     sleep 3
   done
   {{end}}
-}
-
-ensureAddons() {
-  retrycmd 120 5 30 $KUBECTL get pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
-{{- if not HasCustomPodSecurityPolicy}}
-  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
-  rm -Rf ${ADDONS_DIR}/init
-{{- end}}
-  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC
-  retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
 }
 ensureLabelNodes() {
   LABEL_NODES_SCRIPT_FILE=/opt/azure/containers/label-nodes.sh


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that the PodSecurityPolicy resources are loaded before other addons. This is accomplished by:

- changing the `kube-addon-manager` spec so that it sources from `/etc/kubernetes/addons/init`
- copying the pod-security-policy addon spec to the `/etc/kubernetes/addons/init` directory at runtime
- wait for the `privileged` and `restricted` PodSecurityPolicy resources to be present in the cluster
- change the `kube-addon-manager` spec to source from `/etc/kubernetes/addons`
- delete the active `kube-addon-manager` pod (to force a new reconciliation from the fully populated `/etc/kubernetes/addons` directory

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #1851

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
