### PR TITLE
fix: Enable e2e to install ginko if required

### DIFF
--- a/docs/community/running-tests.md
+++ b/docs/community/running-tests.md
@@ -5,7 +5,15 @@ If you are an AKS Engine developer, running local E2E tests to validate changes 
 As mentioned briefly in the [developer guide](developer-guide.md), a `make` target is maintained to provide convenient shell invocation of the E2E test runner across for generic, configurable usage:
 
 ```sh
-$ ORCHESTRATOR_RELEASE=1.18 CLUSTER_DEFINITION=examples/kubernetes.json SUBSCRIPTION_ID=$TEST_AZURE_SUB_ID CLIENT_ID=$TEST_AZURE_SP_ID CLIENT_SECRET=$TEST_AZURE_SP_PW TENANT_ID=$TEST_AZURE_TENANT_ID LOCATION=$AZURE_REGION CLEANUP_ON_EXIT=false make test-kubernetes
+$ ORCHESTRATOR_RELEASE=1.18 \
+    CLUSTER_DEFINITION=examples/kubernetes.json \
+    SUBSCRIPTION_ID=$TEST_AZURE_SUB_ID \
+    CLIENT_ID=$TEST_AZURE_SP_ID \
+    CLIENT_SECRET=$TEST_AZURE_SP_PW \
+    TENANT_ID=$TEST_AZURE_TENANT_ID \
+    LOCATION=$AZURE_REGION \
+    CLEANUP_ON_EXIT=false \
+    make test-kubernetes
 ```
 
 The above, simple example describes an E2E test invocation against a base cluster configuration defined by the API model at `examples/kubernetes.json`, overriding any specific Kubernetes version therein to validate the most recent, supported v1.18 release; using Azure service principal authentication defined in the various `$TEST_AZURE_`* environment variables; deployed to the region defined by the environment variable `$AZURE_REGION`; and finally, we tell the E2E test runner not to delete the cluster resources (i.e., the resource group) following the completion of the tests.

--- a/docs/community/running-tests.md
+++ b/docs/community/running-tests.md
@@ -1,8 +1,8 @@
 # Running Tests
 
-If you are an AKS Engine developer, running local E2E tests to validate changes can greatly increase iterative velocity.
+If you are an AKS Engine developer, running local E2E tests to validate changes can greatly increase iterative velocity.  
 
-As mentioned briefly in the [developer guide](developer-guide.md), a `make` target is maintained to provide convenient shell invocation of the E2E test runner across for generic, configurable usage:
+As mentioned briefly in the [developer guide](developer-guide.md), a `make` target is maintained to provide convenient shell invocation of the E2E test runner across for generic, configurable usage.  In addition you can run the tests from a [dev contianer](developer-guide.md#docker-development-environment) using `make dev` then run the following commands:
 
 ```sh
 # build local a copy of aks-engine

--- a/docs/community/running-tests.md
+++ b/docs/community/running-tests.md
@@ -5,6 +5,10 @@ If you are an AKS Engine developer, running local E2E tests to validate changes 
 As mentioned briefly in the [developer guide](developer-guide.md), a `make` target is maintained to provide convenient shell invocation of the E2E test runner across for generic, configurable usage:
 
 ```sh
+# build local a copy of aks-engine
+$ make build
+
+# run e2e tests
 $ ORCHESTRATOR_RELEASE=1.18 \
     CLUSTER_DEFINITION=examples/kubernetes.json \
     SUBSCRIPTION_ID=$TEST_AZURE_SUB_ID \
@@ -13,6 +17,7 @@ $ ORCHESTRATOR_RELEASE=1.18 \
     TENANT_ID=$TEST_AZURE_TENANT_ID \
     LOCATION=$AZURE_REGION \
     CLEANUP_ON_EXIT=false \
+    OUTPUT_DIR=./_output \
     make test-kubernetes
 ```
 

--- a/test.mk
+++ b/test.mk
@@ -21,7 +21,7 @@ test-interactive:
 
 test-functional: test-kubernetes
 
-test-kubernetes:
+test-kubernetes: ginkgoBuild
 	make -C ./test/e2e build
 	@ORCHESTRATOR=kubernetes bash -c 'pgrep ssh-agent || eval `ssh-agent` && ./test/e2e/bin/e2e-runner'
 


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
I was doing e2e test walk through on fresh git pull.  Had not run any other commands so ginko was not pulled.

Also made the readme easier to see all variables in example command.

Note this file has CLRF line endings. When copying command to terminal in ubuntu it has extra lines.  I could fix line ending but didn't want to slam you with wall of red.  Let me know if I should push a fix for this.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
cc: @marosset 