### PR TITLE
[WIP] feat: enable N series nodes without nvidia-device-plugin addon

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -550,7 +550,7 @@ configAddons() {
   mkdir -p $ADDONS_DIR/init && cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{- end}}
 }
-{{- if HasNSeriesSKU}}
+{{- if IsNvidiaDevicePluginEnabled}}
 {{- /* installNvidiaDrivers is idempotent, it will uninstall itself if it is already installed, and then install anew */}}
 installNvidiaDrivers() {
   NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -59,7 +59,7 @@ time_metric "ConfigureAdminUser" configureAdminUser
   {{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd
   {{end}}
-  {{- if HasNSeriesSKU}}
+  {{- if IsNvidiaDevicePluginEnabled}}
 if [[ ${GPU_NODE} != "true" ]]; then
   time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
 fi
@@ -136,7 +136,7 @@ fi
 {{/* this will capture the amount of time to install of the network plugin during cse */}}
 time_metric "InstallNetworkPlugin" installNetworkPlugin
 
-{{- if HasNSeriesSKU}}
+{{- if IsNvidiaDevicePluginEnabled}}
 if [[ ${GPU_NODE} == true ]]; then
   if $FULL_INSTALL_REQUIRED; then
     time_metric "DownloadGPUDrivers" downloadGPUDrivers

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -738,8 +738,8 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 			}
 			return val
 		},
-		"HasNSeriesSKU": func() bool {
-			return cs.Properties.HasNSeriesSKU()
+		"IsNvidiaDevicePluginEnabled": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.NVIDIADevicePluginAddonName)
 		},
 		"HasDCSeriesSKU": func() bool {
 			return cs.Properties.HasDCSeriesSKU()

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27560,7 +27560,7 @@ configAddons() {
   mkdir -p $ADDONS_DIR/init && cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{- end}}
 }
-{{- if HasNSeriesSKU}}
+{{- if IsNvidiaDevicePluginEnabled}}
 {{- /* installNvidiaDrivers is idempotent, it will uninstall itself if it is already installed, and then install anew */}}
 installNvidiaDrivers() {
   NVIDIA_DKMS_DIR="/var/lib/dkms/nvidia/${GPU_DV}"
@@ -28472,7 +28472,7 @@ time_metric "ConfigureAdminUser" configureAdminUser
   {{- if not NeedsContainerd}}
 time_metric "CleanupContainerd" cleanUpContainerd
   {{end}}
-  {{- if HasNSeriesSKU}}
+  {{- if IsNvidiaDevicePluginEnabled}}
 if [[ ${GPU_NODE} != "true" ]]; then
   time_metric "CleanupGPUDrivers" cleanUpGPUDrivers
 fi
@@ -28549,7 +28549,7 @@ fi
 {{/* this will capture the amount of time to install of the network plugin during cse */}}
 time_metric "InstallNetworkPlugin" installNetworkPlugin
 
-{{- if HasNSeriesSKU}}
+{{- if IsNvidiaDevicePluginEnabled}}
 if [[ ${GPU_NODE} == true ]]; then
   if $FULL_INSTALL_REQUIRED; then
     time_metric "DownloadGPUDrivers" downloadGPUDrivers

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1551,7 +1551,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 	Describe("with a GPU-enabled agent pool", func() {
 		It("should be able to run a nvidia-gpu job", func() {
-			if eng.ExpandedDefinition.Properties.HasNSeriesSKU() {
+			if hasAddon, _ := eng.HasAddon("nvidia-device-plugin"); hasAddon {
 				j, err := job.CreateJobFromFileDeleteIfExists(filepath.Join(WorkloadDir, "cuda-vector-add.yaml"), "cuda-vector-add", "default", 3*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				ready, err := j.WaitOnSucceeded(30*time.Second, cfg.Timeout)


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR allows folks to manually disable the `nvidia-device-plugin` addon, which will bring up working N series nodes without GPU drivers already installed by AKS Engine.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3307

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
