### PR TITLE
fix: Add latest DC-Series VM SKUs

### DIFF
--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -245,11 +245,27 @@ func GetDCSeriesVMCasesForTesting() []struct {
 		Expected bool
 	}{
 		{
+			"Standard_DC1s_v2",
+			true,
+		},
+		{
 			"Standard_DC2s",
 			true,
 		},
 		{
+			"Standard_DC2s_v2",
+			true,
+		},
+		{
 			"Standard_DC4s",
+			true,
+		},
+		{
+			"Standard_DC4s_v2",
+			true,
+		},
+		{
+			"Standard_DC8_v2",
 			true,
 		},
 		{
@@ -271,11 +287,22 @@ func GetDCSeriesVMCasesForTesting() []struct {
 
 // IsSgxEnabledSKU determines if an VM SKU has SGX driver support
 func IsSgxEnabledSKU(vmSize string) bool {
-	switch vmSize {
-	case "Standard_DC2s", "Standard_DC4s":
-		return true
+        dm := map[string]bool{
+                "Standard_DC1s_v2":   true,
+                "Standard_DC2s":  true,
+                "Standard_DC2s_v2":  true,
+                "Standard_DC4s": true,
+                "Standard_DC4s_v2": true,
+                "Standard_DC8_v2": true,
+                "Standard_DC8s": true,
 	}
-	return false
+        // Trim the optional _Promo suffix.
+        vmSize = strings.TrimSuffix(vmSize, "_Promo")
+        if _, ok := dm[vmSize]; ok {
+                return dm[vmSize]
+        }
+
+        return false
 }
 
 // GetMasterKubernetesLabels returns a k8s API-compliant labels string.

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -95,13 +95,33 @@ func getCSeriesVMCasesForTesting() []struct {
 		Expected bool
 	}{
 		{
+			"Standard_DC1s_v2",
+			"Standard_DC1s_v2",
+			true,
+		},
+		{
 			"Standard_DC2s",
 			"Standard_DC2s",
 			true,
 		},
 		{
+			"Standard_DC2s_v2",
+			"Standard_DC2s_v2",
+			true,
+		},
+		{
 			"Standard_DC4s",
 			"Standard_DC4s",
+			true,
+		},
+		{
+			"Standard_DC4s_v2",
+			"Standard_DC4s_v2",
+			true,
+		},
+		{
+			"Standard_DC8_v2",
+			"Standard_DC8_v2",
 			true,
 		},
 		{


### PR DESCRIPTION
**Reason for Change**:
VM SKUs used to detect DC-Series VMs are outdated, and the code doesn't check for newer SKUs (DCv2 VMs in particular)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
