### PR TITLE
chore: k8s v1.17 conformance model for Azure Stack

### DIFF
--- a/examples/azure-stack/conformance/kubernetes1.17.json
+++ b/examples/azure-stack/conformance/kubernetes1.17.json
@@ -1,0 +1,48 @@
+{
+    "apiVersion": "vlabs",
+    "location": "",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "1.17",
+            "kubernetesConfig": {
+                "useInstanceMetadata": false,
+                "networkPlugin": "kubenet"
+            }
+        },
+        "customCloudProfile": {
+            "portalURL": "",
+            "identitySystem": ""
+        },
+        "masterProfile": {
+            "dnsPrefix": "",
+            "distro": "ubuntu",
+            "count": 3,
+            "vmSize": "Standard_D2_v2"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "linuxpool",
+                "count": 3,
+                "vmSize": "Standard_D2_v2",
+                "distro": "ubuntu",
+                "availabilityProfile": "AvailabilitySet",
+                "AcceleratedNetworkingEnabled": false
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": ""
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientId": "",
+            "secret": ""
+        }
+    }
+}


### PR DESCRIPTION
**Reason for Change**:
Add cluster definition required to replicate k8s-conformance for v1.17
Related: https://github.com/cncf/k8s-conformance/pull/979

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version