### PR TITLE
ci: enable multiple static resource group exclusions in cleanup script

### DIFF
--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -41,7 +41,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 # find resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
 if [ -z "$RESOURCE_GROUP_SUBSTRING" ]; then
-  for resourceGroup in $(az group list | jq --arg dl $deadline '.[] | select(.name | contains("acse-test") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+  for resourceGroup in $(az group list | jq --arg dl $deadline '.[] | select([.name] | inside(["acse-test", "aksimages"]) | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
     for deployment in $(az deployment group list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
       echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
       az deployment group delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."
@@ -51,7 +51,7 @@ if [ -z "$RESOURCE_GROUP_SUBSTRING" ]; then
     az group delete -y -n $resourceGroup --no-wait >> delete.log || echo "unable to delete resource group ${resourceGroup}, will continue..."
   done
 else
-  for resourceGroup in $(az group list | jq --arg dl $deadline --arg rg $RESOURCE_GROUP_SUBSTRING '.[] | select(.name | contains("acse-test") | not) | select(.name | contains($rg)) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+  for resourceGroup in $(az group list | jq --arg dl $deadline --arg rg $RESOURCE_GROUP_SUBSTRING '.[] | select([.name] | inside(["acse-test", "aksimages"]) | not) | select(.name | contains($rg)) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
     for deployment in $(az deployment group list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
       echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
       az deployment group delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -41,7 +41,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 # find resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
 if [ -z "$RESOURCE_GROUP_SUBSTRING" ]; then
-  for resourceGroup in $(az group list | jq --arg dl $deadline '.[] | select([.name] | inside(["acse-test", "aksimages"]) | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+  for resourceGroup in $(az group list | jq --arg dl $deadline '.[] | select(.name | contains("acse-test") or contains("aksimages") or contains("NetworkWatcherRG") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
     for deployment in $(az deployment group list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
       echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
       az deployment group delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."
@@ -51,7 +51,7 @@ if [ -z "$RESOURCE_GROUP_SUBSTRING" ]; then
     az group delete -y -n $resourceGroup --no-wait >> delete.log || echo "unable to delete resource group ${resourceGroup}, will continue..."
   done
 else
-  for resourceGroup in $(az group list | jq --arg dl $deadline --arg rg $RESOURCE_GROUP_SUBSTRING '.[] | select([.name] | inside(["acse-test", "aksimages"]) | not) | select(.name | contains($rg)) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+  for resourceGroup in $(az group list | jq --arg dl $deadline --arg rg $RESOURCE_GROUP_SUBSTRING '.[] | select(.name | contains("acse-test") or contains("aksimages") or contains ("NetworkWatcherRG") | not) | select(.name | contains($rg)) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
     for deployment in $(az deployment group list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
       echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
       az deployment group delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,8 +49,6 @@ github.com/BurntSushi/toml
 # github.com/Jeffail/gabs v1.1.1
 ## explicit
 github.com/Jeffail/gabs
-# github.com/Masterminds/godir v0.0.0-20160728192234-40ddaca750b2
-## explicit
 # github.com/blang/semver v3.5.1+incompatible
 ## explicit
 github.com/blang/semver
@@ -145,8 +143,6 @@ github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.10
 ## explicit
 github.com/mattn/go-isatty
-# github.com/mattn/goveralls v0.0.5
-## explicit
 # github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 ## explicit
 github.com/mgutz/ansi
@@ -213,8 +209,6 @@ github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.3
 ## explicit
 github.com/spf13/pflag
-# github.com/urfave/cli v1.22.4
-## explicit
 # github.com/x-cray/logrus-prefixed-formatter v0.5.2
 ## explicit
 github.com/x-cray/logrus-prefixed-formatter

--- a/vhd/packer/vhd-rg-cleanup.sh
+++ b/vhd/packer/vhd-rg-cleanup.sh
@@ -48,7 +48,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 
 # find packer resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
-for resourceGroup in $( az group list --query "[?contains(name, 'packer-Resource-Group')]" | jq --arg dl $deadline '.[] | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
+for resourceGroup in $( az group list | jq --arg dl $deadline '.[] | select(.name | contains("packer-Resource-Group") or contains("pkr-Resource-Group")) | select(.tags.now < $dl).name' | tr -d '\"' || ""); do
     for deployment in $(az deployment group list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""); do
         echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
         if [[ "${DRY_RUN}" = false ]]; then


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR enables us to configure a set of "never delete" resource group substrings in the cleanup script.

In this PR we add the "aksimages" reserved exclusion, to ensure that we never accidentally delete these VHD CI-produced image resource group(s).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
