### PR TITLE
fix: use right nodeSelector for cluster-autoscaler addon

### DIFF
--- a/parts/k8s/addons/cluster-autoscaler.yaml
+++ b/parts/k8s/addons/cluster-autoscaler.yaml
@@ -179,7 +179,11 @@ spec:
         value: "true"
         key: node-role.kubernetes.io/master
       nodeSelector:
+{{- if IsKubernetesVersionGe "1.16.0"}}
+        kubernetes.azure.com/role: master
+{{else}}
         kubernetes.io/role: master
+{{- end}}
 {{- if IsKubernetesVersionGe "1.19.0-alpha.2"}}
         kubernetes.io/os: linux
 {{else}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -21718,7 +21718,11 @@ spec:
         value: "true"
         key: node-role.kubernetes.io/master
       nodeSelector:
+{{- if IsKubernetesVersionGe "1.16.0"}}
+        kubernetes.azure.com/role: master
+{{else}}
         kubernetes.io/role: master
+{{- end}}
 {{- if IsKubernetesVersionGe "1.19.0-alpha.2"}}
         kubernetes.io/os: linux
 {{else}}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR uses the right nodeSelector for the cluster-autoscaler addon for the version of Kubernetes, so we don't have to wait for systemd to apply labels out of band from a master VM.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3326

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
