### PR TITLE
chore: change MTU only if not Azure CNI on Azure Stack

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -82,12 +82,12 @@ configureK8sCustomCloud() {
   fi
   set -x
 
-    {{- if not IsAzureCNI}}
-    # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
-    echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
-    echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
-    ifconfig eth0 mtu 1350
-    {{end}}
+  {{- if not IsAzureCNI}}
+  # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
+  echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
+  echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
+  ifconfig eth0 mtu 1350
+  {{end}}
 
   {{else}}
   ensureCustomCloudRootCertificates

--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -80,14 +80,15 @@ configureK8sCustomCloud() {
     # shellcheck disable=SC2002,SC2005
     echo $(cat "${AZURE_JSON_PATH}" | jq '.tenantId = "adfs"') >${AZURE_JSON_PATH}
   fi
-
-  # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
-  echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
-  echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
-
-  ifconfig eth0 mtu 1350
-
   set -x
+
+    {{- if not IsAzureCNI}}
+    # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
+    echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
+    echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
+    ifconfig eth0 mtu 1350
+    {{end}}
+
   {{else}}
   ensureCustomCloudRootCertificates
   ensureCustomCloudSourcesList

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27393,14 +27393,15 @@ configureK8sCustomCloud() {
     # shellcheck disable=SC2002,SC2005
     echo $(cat "${AZURE_JSON_PATH}" | jq '.tenantId = "adfs"') >${AZURE_JSON_PATH}
   fi
-
-  # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
-  echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
-  echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
-
-  ifconfig eth0 mtu 1350
-
   set -x
+
+    {{- if not IsAzureCNI}}
+    # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
+    echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
+    echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
+    ifconfig eth0 mtu 1350
+    {{end}}
+
   {{else}}
   ensureCustomCloudRootCertificates
   ensureCustomCloudSourcesList

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -27395,12 +27395,12 @@ configureK8sCustomCloud() {
   fi
   set -x
 
-    {{- if not IsAzureCNI}}
-    # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
-    echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
-    echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
-    ifconfig eth0 mtu 1350
-    {{end}}
+  {{- if not IsAzureCNI}}
+  # Decrease eth0 MTU to mitigate Azure Stack's NRP issue
+  echo "iface eth0 inet dhcp" | sudo tee -a /etc/network/interfaces
+  echo "    post-up /sbin/ifconfig eth0 mtu 1350" | sudo tee -a /etc/network/interfaces
+  ifconfig eth0 mtu 1350
+  {{end}}
 
   {{else}}
   ensureCustomCloudRootCertificates


### PR DESCRIPTION
**Reason for Change**:

Azure CNI is not using encap, no need to reduce MTU on Azure Stack

**Issue Fixed**:

Related #1346

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version