### PR TITLE
refactor: drop "beta" from kubernetes.io/os label

### DIFF
--- a/docs/community/e2e-output-example.log
+++ b/docs/community/e2e-output-example.log
@@ -233,7 +233,7 @@ Roles:              agent
 Labels:             agentpool=agentpool1
                     beta.kubernetes.io/arch=amd64
                     beta.kubernetes.io/instance-type=Standard_D2_v3
-                    beta.kubernetes.io/os=linux
+                    kubernetes.io/os=linux
                     failure-domain.beta.kubernetes.io/region=westus2
                     failure-domain.beta.kubernetes.io/zone=0
                     foo=bar
@@ -337,7 +337,7 @@ Roles:              agent
 Labels:             agentpool=agentpool1
                     beta.kubernetes.io/arch=amd64
                     beta.kubernetes.io/instance-type=Standard_D2_v3
-                    beta.kubernetes.io/os=linux
+                    kubernetes.io/os=linux
                     failure-domain.beta.kubernetes.io/region=westus2
                     failure-domain.beta.kubernetes.io/zone=1
                     foo=bar
@@ -439,7 +439,7 @@ Name:               k8s-master-24731180-0
 Roles:              master
 Labels:             beta.kubernetes.io/arch=amd64
                     beta.kubernetes.io/instance-type=Standard_D2_v3
-                    beta.kubernetes.io/os=linux
+                    kubernetes.io/os=linux
                     failure-domain.beta.kubernetes.io/region=westus2
                     failure-domain.beta.kubernetes.io/zone=0
                     kubernetes.azure.com/cluster=kubernetes-westus2-13811
@@ -1065,12 +1065,12 @@ kube-system   service/kube-dns         ClusterIP   10.0.0.10     <none>        5
 kube-system   service/metrics-server   ClusterIP   10.0.87.235   <none>        443/TCP                  3m3s    k8s-app=metrics-server
 
 NAMESPACE     NAME                                              DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                 AGE    CONTAINERS                                           IMAGES                                                                                                                                                                                  SELECTOR
-kube-system   daemonset.apps/azure-cni-networkmonitor           3         3         3       3            3           beta.kubernetes.io/os=linux   3m1s   azure-cnms                                           mcr.microsoft.com/containernetworking/networkmonitor:v0.0.8                                                                                                                             k8s-app=azure-cnms
-kube-system   daemonset.apps/azure-ip-masq-agent                3         3         3       3            3           beta.kubernetes.io/os=linux   3m3s   azure-ip-masq-agent                                  mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0                                                                                                                                   k8s-app=azure-ip-masq-agent,tier=node
-kube-system   daemonset.apps/blobfuse-flexvol-installer         2         2         2       2            2           beta.kubernetes.io/os=linux   3m4s   blobfuse-flexvol-installer                           mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8                                                                                                                              name=blobfuse
-kube-system   daemonset.apps/csi-secrets-store                  2         2         2       2            2           beta.kubernetes.io/os=linux   3m     node-driver-registrar,secrets-store,liveness-probe   mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.0,mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.9,mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0   app=csi-secrets-store
-kube-system   daemonset.apps/csi-secrets-store-provider-azure   2         2         2       2            2           beta.kubernetes.io/os=linux   3m     provider-azure-installer                             mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.4                                                                                                                            app=csi-secrets-store-provider-azure
-kube-system   daemonset.apps/kube-proxy                         3         3         3       3            3           beta.kubernetes.io/os=linux   3m3s   kube-proxy                                           mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.2                                                                                                                                     component=kube-proxy,k8s-app=kube-proxy,tier=node
+kube-system   daemonset.apps/azure-cni-networkmonitor           3         3         3       3            3           kubernetes.io/os=linux        3m1s   azure-cnms                                           mcr.microsoft.com/containernetworking/networkmonitor:v0.0.8                                                                                                                             k8s-app=azure-cnms
+kube-system   daemonset.apps/azure-ip-masq-agent                3         3         3       3            3           kubernetes.io/os=linux        3m3s   azure-ip-masq-agent                                  mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0                                                                                                                                   k8s-app=azure-ip-masq-agent,tier=node
+kube-system   daemonset.apps/blobfuse-flexvol-installer         2         2         2       2            2           kubernetes.io/os=linux        3m4s   blobfuse-flexvol-installer                           mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8                                                                                                                              name=blobfuse
+kube-system   daemonset.apps/csi-secrets-store                  2         2         2       2            2           kubernetes.io/os=linux        3m     node-driver-registrar,secrets-store,liveness-probe   mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.0,mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.9,mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0   app=csi-secrets-store
+kube-system   daemonset.apps/csi-secrets-store-provider-azure   2         2         2       2            2           kubernetes.io/os=linux        3m     provider-azure-installer                             mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.4                                                                                                                            app=csi-secrets-store-provider-azure
+kube-system   daemonset.apps/kube-proxy                         3         3         3       3            3           kubernetes.io/os=linux        3m3s   kube-proxy                                           mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.2                                                                                                                                     component=kube-proxy,k8s-app=kube-proxy,tier=node
 
 NAMESPACE     NAME                                           DATA   AGE
 kube-system   configmap/azure-ip-masq-agent-config           1      3m5s
@@ -1324,7 +1324,7 @@ Volumes:
     SecretName:  coredns-token-rlkf7
     Optional:    false
 QoS Class:       Burstable
-Node-Selectors:  beta.kubernetes.io/os=linux
+Node-Selectors:  kubernetes.io/os=linux
 Tolerations:     :NoExecute
                  :NoSchedule
                  CriticalAddonsOnly
@@ -1407,7 +1407,7 @@ Volumes:
     SecretName:  coredns-autoscaler-token-wczlj
     Optional:    false
 QoS Class:       Burstable
-Node-Selectors:  beta.kubernetes.io/os=linux
+Node-Selectors:  kubernetes.io/os=linux
 Tolerations:     :NoExecute
                  :NoSchedule
                  CriticalAddonsOnly

--- a/docs/howto/mixed-cluster-ingress.md
+++ b/docs/howto/mixed-cluster-ingress.md
@@ -10,23 +10,23 @@
 ### Configure Helm
 
 ```console
-helm init --upgrade --node-selectors "beta.kubernetes.io/os=linux"
+helm init --upgrade --node-selectors "kubernetes.io/os=linux"
 ```
 
 ### Set up NGINX
 
 ```console
 helm install --name nginx-ingress `
-    --set controller.nodeSelector."beta\.kubernetes\.io\/os"=linux `
-    --set defaultBackend.nodeSelector."beta\.kubernetes\.io\/os"=linux `
+    --set controller.nodeSelector."kubernetes\.io\/os"=linux `
+    --set defaultBackend.nodeSelector."kubernetes\.io\/os"=linux `
      --set rbac.create=true `
     stable/nginx-ingress
 ```
 
 ```console
 helm install --name nginx-ingress \
-    --set controller.nodeSelector."beta\.kubernetes\.io\/os"=linux \
-    --set defaultBackend.nodeSelector."beta\.kubernetes\.io\/os"=linux \
+    --set controller.nodeSelector."kubernetes\.io\/os"=linux \
+    --set defaultBackend.nodeSelector."kubernetes\.io\/os"=linux \
     --set rbac.create=true \
     stable/nginx-ingress
 ```
@@ -132,7 +132,7 @@ spec:
         ports:
           - containerPort: 80
       nodeSelector:
-        "beta.kubernetes.io/os": windows
+        "kubernetes.io/os": windows
   selector:
     matchLabels:
       app: iis-1803

--- a/docs/topics/calico-3.3.1-cleanup-after-upgrade.yaml
+++ b/docs/topics/calico-3.3.1-cleanup-after-upgrade.yaml
@@ -198,7 +198,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/docs/topics/sgx.md
+++ b/docs/topics/sgx.md
@@ -84,11 +84,11 @@ You can install the SGX device plugin which surfaces the usage of Intel SGX’s 
 
 #### Running on Azure
 
-*NOTE: For kubernetes versions before v1.17, replace 
+*NOTE: For kubernetes versions before v1.17, replace
 1. `node.kubernetes.io/instance-type` -> `beta.kubernetes.io/instance-type`
 2. `kubernetes.io/os` -> `beta.kubernetes.io/os`
 
-If you are deploying your cluster on Azure, you can leverage the `node.kubernetes.io/instance-type` label in your node selector rules to target only the [DCsv2-series](https://docs.microsoft.com/en-us/azure/virtual-machines/dcv2-series) nodes - 
+If you are deploying your cluster on Azure, you can leverage the `node.kubernetes.io/instance-type` label in your node selector rules to target only the [DCsv2-series](https://docs.microsoft.com/en-us/azure/virtual-machines/dcv2-series) nodes -
 
 ```yaml
 nodeAffinity:
@@ -141,7 +141,7 @@ spec:
               - key: kubernetes.io/os
                 operator: In
                 values:
-                - linux 
+                - linux
       containers:
       - name: sgx-device-plugin
         image: mcr.microsoft.com/aks/acc/sgx-device-plugin:1.0
@@ -233,7 +233,7 @@ Confirm that the device plugin is advertising the available EPC RAM to the Kuber
 $ kubectl get nodes <node-name> -o yaml
 ```
 
-Under the status field you should see the total allocable resources with a name of `kubernetes.azure.com/sgx_epc_mem_in_MiB` 
+Under the status field you should see the total allocable resources with a name of `kubernetes.azure.com/sgx_epc_mem_in_MiB`
 ```bash
 <snip>
 status:
@@ -244,7 +244,7 @@ status:
 
 ### Scheduling Pods to TEE enabled Hardware
 
-The following pod specification demonstrates how you would schedule a pod to have access to a TEE by defining a limit on the specific EPC memory that is advertised to the Kubernetes scheduler by the device plugin available in alpha. 
+The following pod specification demonstrates how you would schedule a pod to have access to a TEE by defining a limit on the specific EPC memory that is advertised to the Kubernetes scheduler by the device plugin available in alpha.
 
 ```yaml
 apiVersion: apps/v1
@@ -341,5 +341,3 @@ $ kubectl logs -l app=sgx-test
 Hello world from the enclave
 Enclave called into host to print: Hello World!
 ```
-
-

--- a/docs/topics/windows-and-kubernetes.md
+++ b/docs/topics/windows-and-kubernetes.md
@@ -232,7 +232,7 @@ spec:
           - "$i=0; while ($true) { Start-Sleep -Seconds 10; $msg = 'Hello from the servercore container, count is {0}' -f $i; Set-Content -Path C:\\poddata\\iisstart.htm -Value $msg; $i++; }"
 
       nodeSelector:
-        beta.kubernetes.io/os: windows
+        kubernetes.io/os: windows
 ```
 
 ## Troubleshooting

--- a/docs/topics/windows.md
+++ b/docs/topics/windows.md
@@ -471,7 +471,7 @@ spec:
         ports:
           - containerPort: 80
       nodeSelector:
-        "beta.kubernetes.io/os": windows
+        "kubernetes.io/os": windows
   selector:
     matchLabels:
       app: iis-2019

--- a/parts/k8s/addons/1.15/calico.yaml
+++ b/parts/k8s/addons/1.15/calico.yaml
@@ -356,7 +356,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Mark the pod as a critical add-on for rescheduling. */}}
@@ -447,7 +447,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Make sure calico-node gets scheduled on all nodes. */}}

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-blobfuse-flexvolume-installer.yaml
@@ -41,4 +41,4 @@ spec:
         hostPath:
           path: /etc/kubernetes/volumeplugins/
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -57,7 +57,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-heapster-deployment.yaml
@@ -167,4 +167,4 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -44,4 +44,4 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -206,4 +206,4 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -116,4 +116,4 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-smb-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-smb-flexvolume-installer.yaml
@@ -41,4 +41,4 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.16/kubernetesmasteraddons-tiller-deployment.yaml
+++ b/parts/k8s/addons/1.16/kubernetesmasteraddons-tiller-deployment.yaml
@@ -97,4 +97,4 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -59,7 +59,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-heapster-deployment.yaml
@@ -167,4 +167,4 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -46,4 +46,4 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -206,4 +206,4 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -116,4 +116,4 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-smb-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-smb-flexvolume-installer.yaml
@@ -43,4 +43,4 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.17/kubernetesmasteraddons-tiller-deployment.yaml
+++ b/parts/k8s/addons/1.17/kubernetesmasteraddons-tiller-deployment.yaml
@@ -97,4 +97,4 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -59,7 +59,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-heapster-deployment.yaml
@@ -167,4 +167,4 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -46,4 +46,4 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -206,4 +206,4 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -125,4 +125,4 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-smb-flexvolume-installer.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-smb-flexvolume-installer.yaml
@@ -43,4 +43,4 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/1.18/kubernetesmasteraddons-tiller-deployment.yaml
+++ b/parts/k8s/addons/1.18/kubernetesmasteraddons-tiller-deployment.yaml
@@ -97,4 +97,4 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/aad-pod-identity.yaml
+++ b/parts/k8s/addons/aad-pod-identity.yaml
@@ -142,7 +142,7 @@ spec:
             add:
             - NET_ADMIN
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal

--- a/parts/k8s/addons/aci-connector.yaml
+++ b/parts/k8s/addons/aci-connector.yaml
@@ -85,7 +85,7 @@ spec:
     spec:
       serviceAccountName: aci-connector
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: aci-connector
         image: {{ContainerImage "aci-connector"}}

--- a/parts/k8s/addons/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/addons/azure-cni-networkmonitor.yaml
@@ -43,7 +43,7 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.2"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
       containers:
         - name: azure-cnms

--- a/parts/k8s/addons/azure-network-policy.yaml
+++ b/parts/k8s/addons/azure-network-policy.yaml
@@ -78,7 +78,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-alpha.3")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
         - name: azure-npm
           image: {{ContainerImage "azure-npm-daemonset"}}

--- a/parts/k8s/addons/blobfuse-flexvolume.yaml
+++ b/parts/k8s/addons/blobfuse-flexvolume.yaml
@@ -45,4 +45,4 @@ spec:
         hostPath:
           path: /etc/kubernetes/volumeplugins/
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/calico.yaml
+++ b/parts/k8s/addons/calico.yaml
@@ -355,7 +355,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Mark the pod as a critical add-on for rescheduling. */}}
@@ -444,7 +444,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Make sure calico-node gets scheduled on all nodes. */}}

--- a/parts/k8s/addons/cluster-autoscaler.yaml
+++ b/parts/k8s/addons/cluster-autoscaler.yaml
@@ -187,7 +187,7 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.2"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
       containers:
       - image: {{ContainerImage "cluster-autoscaler"}}

--- a/parts/k8s/addons/container-monitoring.yaml
+++ b/parts/k8s/addons/container-monitoring.yaml
@@ -387,7 +387,7 @@ spec:
             - mountPath: /etc/config/settings
               name: settings-vol-config
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -399,11 +399,11 @@ spec:
                   values:
                   - virtual-kubelet
       tolerations:
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoSchedule"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoExecute"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
         - name: host-root
@@ -522,7 +522,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 60
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -534,11 +534,11 @@ spec:
                   values:
                   - virtual-kubelet
       tolerations:
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoSchedule"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoExecute"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
         - name: docker-sock

--- a/parts/k8s/addons/coredns.yaml
+++ b/parts/k8s/addons/coredns.yaml
@@ -154,7 +154,7 @@ spec:
         - operator: "Exists"
           effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         {{- if ContainerConfig "use-host-network"}}
         kubernetes.azure.com/role: agent
         {{end}}
@@ -330,7 +330,7 @@ spec:
         - operator: "Exists"
           effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: autoscaler
         image: {{ContainerImage "coredns-autoscaler"}}

--- a/parts/k8s/addons/ip-masq-agent.yaml
+++ b/parts/k8s/addons/ip-masq-agent.yaml
@@ -28,7 +28,7 @@ spec:
       priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/parts/k8s/addons/kube-rescheduler.yaml
+++ b/parts/k8s/addons/kube-rescheduler.yaml
@@ -25,7 +25,7 @@ spec:
       priorityClassName: system-node-critical
 {{- end}}
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-alpha.3")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - image: {{ContainerImage "rescheduler"}}
         imagePullPolicy: IfNotPresent

--- a/parts/k8s/addons/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -55,7 +55,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready

--- a/parts/k8s/addons/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-heapster-deployment.yaml
@@ -169,4 +169,4 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-keyvault-flexvolume-installer.yaml
@@ -41,4 +41,4 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -209,4 +209,4 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -87,4 +87,4 @@ spec:
           path: /lib/modules/
         name: kernelmodules
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/kubernetesmasteraddons-smb-flexvolume-installer.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-smb-flexvolume-installer.yaml
@@ -31,14 +31,14 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/      
+          mountPath: /var/log/
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/              
+          path: /var/log/
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/kubernetesmasteraddons-tiller-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-tiller-deployment.yaml
@@ -93,4 +93,4 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/metrics-server.yaml
+++ b/parts/k8s/addons/metrics-server.yaml
@@ -143,7 +143,7 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.3"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
 ---
 apiVersion: apiregistration.k8s.io/v1beta1

--- a/parts/k8s/addons/node-problem-detector.yaml
+++ b/parts/k8s/addons/node-problem-detector.yaml
@@ -90,7 +90,7 @@ spec:
           path: /dev/kmsg
           type: "CharDevice"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: node-problem-detector
       tolerations:
       - operator: "Exists"

--- a/parts/k8s/addons/nvidia-device-plugin.yaml
+++ b/parts/k8s/addons/nvidia-device-plugin.yaml
@@ -68,6 +68,6 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.3"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
         accelerator: nvidia

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -240,7 +240,7 @@ spec:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -284,4 +284,4 @@ spec:
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -6776,7 +6776,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Mark the pod as a critical add-on for rescheduling. */}}
@@ -6867,7 +6867,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Make sure calico-node gets scheduled on all nodes. */}}
@@ -7249,7 +7249,7 @@ spec:
         hostPath:
           path: /etc/kubernetes/volumeplugins/
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons116KubernetesmasteraddonsBlobfuseFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -7326,7 +7326,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready
@@ -7607,7 +7607,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons116KubernetesmasteraddonsHeapsterDeploymentYamlBytes() ([]byte, error) {
@@ -7671,7 +7671,7 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons116KubernetesmasteraddonsKeyvaultFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -7897,7 +7897,7 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons116KubernetesmasteraddonsKubeDnsDeploymentYamlBytes() ([]byte, error) {
@@ -8033,7 +8033,7 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons116KubernetesmasteraddonsKubeProxyDaemonsetYamlBytes() ([]byte, error) {
@@ -8094,7 +8094,7 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons116KubernetesmasteraddonsSmbFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -8211,7 +8211,7 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons116KubernetesmasteraddonsTillerDeploymentYamlBytes() ([]byte, error) {
@@ -8290,7 +8290,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready
@@ -8571,7 +8571,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons117KubernetesmasteraddonsHeapsterDeploymentYamlBytes() ([]byte, error) {
@@ -8637,7 +8637,7 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons117KubernetesmasteraddonsKeyvaultFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -8863,7 +8863,7 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons117KubernetesmasteraddonsKubeDnsDeploymentYamlBytes() ([]byte, error) {
@@ -8999,7 +8999,7 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons117KubernetesmasteraddonsKubeProxyDaemonsetYamlBytes() ([]byte, error) {
@@ -9062,7 +9062,7 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons117KubernetesmasteraddonsSmbFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -9179,7 +9179,7 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons117KubernetesmasteraddonsTillerDeploymentYamlBytes() ([]byte, error) {
@@ -9258,7 +9258,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready
@@ -9539,7 +9539,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons118KubernetesmasteraddonsHeapsterDeploymentYamlBytes() ([]byte, error) {
@@ -9605,7 +9605,7 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons118KubernetesmasteraddonsKeyvaultFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -9831,7 +9831,7 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons118KubernetesmasteraddonsKubeDnsDeploymentYamlBytes() ([]byte, error) {
@@ -9976,7 +9976,7 @@ spec:
           name: kube-proxy-config
         name: kube-proxy-config-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons118KubernetesmasteraddonsKubeProxyDaemonsetYamlBytes() ([]byte, error) {
@@ -10039,7 +10039,7 @@ spec:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons118KubernetesmasteraddonsSmbFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -10156,7 +10156,7 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddons118KubernetesmasteraddonsTillerDeploymentYamlBytes() ([]byte, error) {
@@ -11327,7 +11327,7 @@ spec:
             add:
             - NET_ADMIN
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: {{GetAADPodIdentityTaintKey}}
         operator: Equal
@@ -11532,7 +11532,7 @@ spec:
     spec:
       serviceAccountName: aci-connector
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: aci-connector
         image: {{ContainerImage "aci-connector"}}
@@ -12732,7 +12732,7 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.2"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
       containers:
         - name: azure-cnms
@@ -12871,7 +12871,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-alpha.3")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
         - name: azure-npm
           image: {{ContainerImage "azure-npm-daemonset"}}
@@ -15895,7 +15895,7 @@ spec:
         hostPath:
           path: /etc/kubernetes/volumeplugins/
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsBlobfuseFlexvolumeYamlBytes() ([]byte, error) {
@@ -16270,7 +16270,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Mark the pod as a critical add-on for rescheduling. */}}
@@ -16359,7 +16359,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       {{- /* Make sure calico-node gets scheduled on all nodes. */}}
@@ -17915,7 +17915,7 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.2"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
       containers:
       - image: {{ContainerImage "cluster-autoscaler"}}
@@ -18424,7 +18424,7 @@ spec:
             - mountPath: /etc/config/settings
               name: settings-vol-config
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -18436,11 +18436,11 @@ spec:
                   values:
                   - virtual-kubelet
       tolerations:
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoSchedule"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoExecute"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
         - name: host-root
@@ -18559,7 +18559,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 60
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -18571,11 +18571,11 @@ spec:
                   values:
                   - virtual-kubelet
       tolerations:
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoSchedule"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "NoExecute"
-        - operator: "Exists" 
+        - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
         - name: docker-sock
@@ -18808,7 +18808,7 @@ spec:
         - operator: "Exists"
           effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         {{- if ContainerConfig "use-host-network"}}
         kubernetes.azure.com/role: agent
         {{end}}
@@ -18984,7 +18984,7 @@ spec:
         - operator: "Exists"
           effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: autoscaler
         image: {{ContainerImage "coredns-autoscaler"}}
@@ -19049,7 +19049,7 @@ spec:
       priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-beta.0")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -19155,7 +19155,7 @@ spec:
       priorityClassName: system-node-critical
 {{- end}}
       nodeSelector:
-        {{if not (IsKubernetesVersionGe "1.19.0-alpha.3")}}beta.{{end}}kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - image: {{ContainerImage "rescheduler"}}
         imagePullPolicy: IfNotPresent
@@ -19581,7 +19581,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:
         - key: node.kubernetes.io/not-ready
@@ -19864,7 +19864,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsKubernetesmasteraddonsHeapsterDeploymentYamlBytes() ([]byte, error) {
@@ -19925,7 +19925,7 @@ spec:
           path: /etc/kubernetes/volumeplugins
         name: volplugins
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsKubernetesmasteraddonsKeyvaultFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -20154,7 +20154,7 @@ spec:
       dnsPolicy: Default
       serviceAccountName: kube-dns
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsKubernetesmasteraddonsKubeDnsDeploymentYamlBytes() ([]byte, error) {
@@ -20261,7 +20261,7 @@ spec:
           path: /lib/modules/
         name: kernelmodules
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsKubernetesmasteraddonsKubeProxyDaemonsetYamlBytes() ([]byte, error) {
@@ -20312,17 +20312,17 @@ spec:
         - name: volplugins
           mountPath: /etc/kubernetes/volumeplugins/
         - name: varlog
-          mountPath: /var/log/      
+          mountPath: /var/log/
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log/              
+          path: /var/log/
       - name: volplugins
         hostPath:
           path: /etc/kubernetes/volumeplugins/
           type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsKubernetesmasteraddonsSmbFlexvolumeInstallerYamlBytes() ([]byte, error) {
@@ -20435,7 +20435,7 @@ spec:
             cpu: {{ContainerCPULimits "tiller"}}
             memory: {{ContainerMemLimits "tiller"}}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsKubernetesmasteraddonsTillerDeploymentYamlBytes() ([]byte, error) {
@@ -20598,7 +20598,7 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.3"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
 ---
 apiVersion: apiregistration.k8s.io/v1beta1
@@ -20726,7 +20726,7 @@ spec:
           path: /dev/kmsg
           type: "CharDevice"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: node-problem-detector
       tolerations:
       - operator: "Exists"
@@ -20838,7 +20838,7 @@ spec:
 {{- if IsKubernetesVersionGe "1.19.0-alpha.3"}}
         kubernetes.io/os: linux
 {{else}}
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- end}}
         accelerator: nvidia
 `)
@@ -21604,7 +21604,7 @@ spec:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -21648,7 +21648,7 @@ spec:
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsSecretsStoreCsiDriverYamlBytes() ([]byte, error) {

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -142,7 +142,7 @@ spec:
             cpu: 10m
             memory: 10M
       nodeSelector:
-        beta.kubernetes.io/os: %s
+        kubernetes.io/os: %s
 `
 
 // CreateLinuxDeploy will create a deployment for a given image with a name in a namespace
@@ -227,7 +227,7 @@ spec:
         - -c
         - "%s"
       nodeSelector:
-        beta.kubernetes.io/os: %s
+        kubernetes.io/os: %s
 `
 
 // RunLinuxDeploy will create a deployment that runs a bash command in a pod
@@ -420,7 +420,7 @@ spec:
         ports:
         - containerPort: %d%s
       nodeSelector:
-        beta.kubernetes.io/os: %s
+        kubernetes.io/os: %s
 `
 
 // CreateWindowsDeployWithHostport will create a deployment for a given image with a name in a namespace and create a service mapping a hostPort

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -186,9 +186,9 @@ func CreatePodFromFileIfNotExist(filename, name, namespace string, sleep, timeou
 }
 
 // RunLinuxPod will create a pod that runs a bash command
-// --overrides := `"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}`
+// --overrides := `"spec": {"nodeSelector":{"kubernetes.io/os":"linux"}}}`
 func RunLinuxPod(image, name, namespace, command string, printOutput bool, sleep, commandTimeout, podGetTimeout time.Duration) (*Pod, error) {
-	overrides := `{ "spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}`
+	overrides := `{ "spec": {"nodeSelector":{"kubernetes.io/os":"linux"}}}`
 	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--restart=Never", "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command)
 	var out []byte
 	var err error
@@ -210,9 +210,9 @@ func RunLinuxPod(image, name, namespace, command string, printOutput bool, sleep
 }
 
 // RunWindowsPod will create a pod that runs a powershell command
-// --overrides := `"spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}`
+// --overrides := `"spec": {"nodeSelector":{"kubernetes.io/os":"windows"}}}`
 func RunWindowsPod(image, name, namespace, command string, printOutput bool, sleep, commandTimeout time.Duration, podGetTimeout time.Duration) (*Pod, error) {
-	overrides := `{ "spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}`
+	overrides := `{ "spec": {"nodeSelector":{"kubernetes.io/os":"windows"}}}`
 	cmd := exec.Command("k", "run", name, "-n", namespace, "--image", image, "--image-pull-policy=IfNotPresent", "--restart=Never", "--overrides", overrides, "--command", "--", "powershell", command)
 	var out []byte
 	var err error

--- a/test/e2e/kubernetes/workloads/busybox-agent.yaml
+++ b/test/e2e/kubernetes/workloads/busybox-agent.yaml
@@ -25,5 +25,5 @@ spec:
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/role: agent
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
   backoffLimit: 0

--- a/test/e2e/kubernetes/workloads/busybox-master.yaml
+++ b/test/e2e/kubernetes/workloads/busybox-master.yaml
@@ -33,5 +33,5 @@ spec:
         effect: NoSchedule
       nodeSelector:
         kubernetes.io/role: master
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
   backoffLimit: 0

--- a/test/e2e/kubernetes/workloads/cuda-vector-add.yaml
+++ b/test/e2e/kubernetes/workloads/cuda-vector-add.yaml
@@ -12,5 +12,5 @@ spec:
       - name: cuda-vector-add
         image: k8s.gcr.io/cuda-vector-add:v0.1
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         accelerator: nvidia

--- a/test/e2e/kubernetes/workloads/dns-liveness.yaml
+++ b/test/e2e/kubernetes/workloads/dns-liveness.yaml
@@ -18,4 +18,4 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 5
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux

--- a/test/e2e/kubernetes/workloads/iis-azurefile.yaml
+++ b/test/e2e/kubernetes/workloads/iis-azurefile.yaml
@@ -13,7 +13,7 @@ spec:
     - name: azurefilevol
       mountPath: '/mnt/azure'
   nodeSelector:
-    beta.kubernetes.io/os: windows
+    kubernetes.io/os: windows
   volumes:
   - name: azurefilevol
     persistentVolumeClaim:

--- a/test/e2e/kubernetes/workloads/pod-pvc.yaml
+++ b/test/e2e/kubernetes/workloads/pod-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pv-pod
 spec:
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   containers:
     - name: myfrontend
       image: nginx

--- a/test/e2e/kubernetes/workloads/validate-dns-linux.yaml
+++ b/test/e2e/kubernetes/workloads/validate-dns-linux.yaml
@@ -12,4 +12,4 @@ spec:
         image: library/busybox
         command: ['sh', '-c', 'until nslookup www.bing.com || nslookup google.com; do echo waiting for DNS resolution; sleep 1; done;']
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/test/e2e/kubernetes/workloads/validate-dns-windows-tcp.yaml
+++ b/test/e2e/kubernetes/workloads/validate-dns-windows-tcp.yaml
@@ -15,4 +15,4 @@ spec:
         image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
         command: ['powershell', 'Resolve-DnsName', '-Name', 'google.com', '-DnsOnly', '-Type', 'A', '-TcpOnly']
       nodeSelector:
-        beta.kubernetes.io/os: windows
+        kubernetes.io/os: windows

--- a/test/e2e/kubernetes/workloads/validate-dns-windows.yaml
+++ b/test/e2e/kubernetes/workloads/validate-dns-windows.yaml
@@ -15,4 +15,4 @@ spec:
         image: {{ .ServerCore }}
         command: ['powershell', 'Resolve-DnsName', '-Name', 'google.com', '-DnsOnly', '-Type', 'A']
       nodeSelector:
-        beta.kubernetes.io/os: windows
+        kubernetes.io/os: windows


### PR DESCRIPTION
**Reason for Change**:

Changes the `beta.kubernetes.io/os` label to `kubernetes.io/os`, which is accepted by all versions of k8s that AKS Engine supports.

**Issue Fixed**:

Fixes #3362

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
