### PR TITLE
chore: rev pause image to 1.3.1

### DIFF
--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -505,7 +505,7 @@ version = 2
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    sandbox_image = "foo/k8s/core/pause:1.2.0"
+    sandbox_image = "foo/oss/kubernetes/pause:1.3.1"
     [plugins."io.containerd.grpc.v1.cri".cni]
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "runc"
@@ -522,7 +522,7 @@ version = 2
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    sandbox_image = "foo/k8s/core/pause:1.2.0"
+    sandbox_image = "foo/oss/kubernetes/pause:1.3.1"
     [plugins."io.containerd.grpc.v1.cri".cni]
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "runc"
@@ -538,7 +538,7 @@ version = 2
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    sandbox_image = "foo/k8s/core/pause:1.2.0"
+    sandbox_image = "foo/oss/kubernetes/pause:1.3.1"
     [plugins."io.containerd.grpc.v1.cri".cni]
       conf_template = "/etc/containerd/kubenet_template.conf"
     [plugins."io.containerd.grpc.v1.cri".containerd]
@@ -556,7 +556,7 @@ version = 2
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    sandbox_image = "foo/k8s/core/pause:1.2.0"
+    sandbox_image = "foo/oss/kubernetes/pause:1.3.1"
     [plugins."io.containerd.grpc.v1.cri".cni]
       conf_template = "/etc/containerd/kubenet_template.conf"
     [plugins."io.containerd.grpc.v1.cri".containerd]

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -530,7 +530,7 @@ func TestGetContainerdConfig(t *testing.T) {
 			want: containerdImageConfigString,
 			fail: false,
 			overrides: []func(*ContainerdConfig) error{
-				ContainerdSandboxImageOverrider("foo/k8s/core/pause:1.2.0"),
+				ContainerdSandboxImageOverrider("foo/oss/kubernetes/pause:1.3.1"),
 			},
 		},
 		{

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	pauseImageReference                               string = "k8s/core/pause:1.2.0"
+	pauseImageReference                               string = "oss/kubernetes/pause:1.3.1"
 	blobfuseFlexVolumeImageReference                  string = "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8"
 	smbFlexVolumeImageReference                       string = "mcr.microsoft.com/k8s/flexvolume/smb-flexvolume:1.0.2"
 	keyvaultFlexVolumeImageReference                  string = "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16"

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -119,7 +119,7 @@ func TestOrchestratorProfile_GetPodInfraContainerSpec(t *testing.T) {
 		},
 		OrchestratorVersion: "1.16.0",
 	}
-	expected := "foo/k8s/core/pause:1.2.0"
+	expected := "foo/oss/kubernetes/pause:1.3.1"
 	actual := o.GetPodInfraContainerSpec()
 	if actual != expected {
 		t.Fatalf("expected GetPodInfraContainerSpec to return %s, but got %s", expected, actual)

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -1135,7 +1135,7 @@ func TestTemplateGenerator_FunctionMap(t *testing.T) {
 				cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.16.0"
 				return cs
 			},
-			ExpectedResult: "foo/k8s/core/pause:1.2.0",
+			ExpectedResult: "foo/oss/kubernetes/pause:1.3.1",
 		},
 		{
 			Name:     "HasCiliumNetworkPolicy - cilium",

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -192,10 +192,10 @@ for KUBE_DNS_MASQ_VERSION in ${KUBE_DNS_MASQ_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
-MCR_PAUSE_VERSIONS="1.2.0"
+MCR_PAUSE_VERSIONS="1.3.1"
 for PAUSE_VERSION in ${MCR_PAUSE_VERSIONS}; do
     # Pull the arch independent MCR pause image which is built for Linux and Windows
-    CONTAINER_IMAGE="mcr.microsoft.com/k8s/core/pause:${PAUSE_VERSION}"
+    CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/pause:${PAUSE_VERSION}"
     pullContainerImage "docker" "${CONTAINER_IMAGE}"
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR updates the pause image to 1.3.1 for Linux nodes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3368

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
