### PR TITLE
fix: bypass AzurePublicCloud assumption in e2e suite

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -165,13 +165,15 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(dnsAddonName).NotTo(Equal(""))
 
-	env, err = azure.EnvironmentFromName("AzurePublicCloud") // TODO get this programmatically
-	if err != nil {
-		Expect(err).NotTo(HaveOccurred())
-	}
-	azureClient, err = armhelpers.NewAzureClientWithClientSecret(env, cfg.SubscriptionID, cfg.ClientID, cfg.ClientSecret)
-	if err != nil {
-		Expect(err).NotTo(HaveOccurred())
+	if !cfg.IsCustomCloudProfile() {
+		env, err = azure.EnvironmentFromName("AzurePublicCloud") // TODO get this programmatically
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		azureClient, err = armhelpers.NewAzureClientWithClientSecret(env, cfg.SubscriptionID, cfg.ClientID, cfg.ClientSecret)
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
 })
 
@@ -2146,7 +2148,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						break
 					}
 				}
-
+				// TODO refactor to remove the "compute" usage so the test can be run on Azure Stack
 				instanceIDs := &compute.VirtualMachineScaleSetVMInstanceIDs{&[]string{instanceID}}
 				err = azureClient.RestartVirtualMachineScaleSets(ctx, cfg.ResourceGroup, vmssName, instanceIDs)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**Reason for Change**:
E2E should not hard-code public Azure cloud as it breaks custom clouds running E2E.
This PR is not a proper fix, it just makes things work again for Azure Stack.

Introduced here PR #3144.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
