### PR TITLE
chore: get-logs collects vhd-install.complete

### DIFF
--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -18,6 +18,10 @@ collectCloudProviderJson() {
     if [ -f /etc/kubernetes/azurestackcloud.json ]; then
         jq . /etc/kubernetes/azurestackcloud.json > ${DIR}/azurestackcloud.json
     fi
+    if [ -f /opt/azure/vhd-install.complete ]; then
+        mkdir -p ${OUTDIR}/opt/azure
+        cp /opt/azure/vhd-install.complete ${OUTDIR}/opt/azure
+    fi
 }
 
 collectDirLogs() {


### PR DESCRIPTION
**Reason for Change**:
Collecting vhd install logs will allow support engs to resolve some cases faster. 

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
 - [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
