### PR TITLE
feat: configurable calico logging verbosity

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -123,6 +123,7 @@ $ aks-engine get-versions
 | [audit-policy](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy)                            | true                                                                                | 0    | defines rules about what events should be recorded and what data they should include                                                                                                                                                                         |
 | azure-cloud-provider                            | true                                                                                | 0    | Delivers required ClusterRole, ClusterRoleBinding, and StorageClass resources required for running the Azure cloudprovider runtime. May not be disabled.                                                                                                                                                                         |
 | aad                            | true if adminGroupID is specified in the aadProfile configuration                                                                                | 0     | ClusterRoleBinding specification that adds an admin group matching the adminGroupID                                                                                                                                                                   |
+| [calico](https://docs.projectcalico.org/archive/v3.8/introduction/)                            | true if networkPolicy is "calico";                                                                                 | 6     | A NetworkPolicy implementation by the Calico project (currently supports v3.8) |
 | [cilium](https://docs.cilium.io/en/v1.4/kubernetes/policy/#ciliumnetworkpolicy)                            | true if networkPolicy is "cilium"; currently validated against Kubernetes v1.13, v1.14, and v1.15                                                                                | 0     | A NetworkPolicy CRD implementation by the Cilium project (currently supports v1.4)                                                                                                                                                                  |
 | [flannel](https://coreos.com/flannel/docs/0.8.0/index.html)                            | false                                                                                | 0     | An addon that delivers flannel: a virtual network that gives a subnet to each host for use with container runtimes. If `networkPlugin` is set to `"flannel"` this addon will be enabled automatically. Not compatible with any other `networkPlugin` or `networkPolicy`.                                                                                                                                                                 |
 | [csi-secrets-store](../../examples/addons/csi-secrets-store/README.md)                                | true (for 1.16+ clusters)                                                                                | as many as linux agent nodes    | Integrates secrets stores (Azure keyvault) via a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/) volume.                                                                                                                                                                    |
@@ -267,7 +268,29 @@ The `coredns` addon includes integration with the `cluster-proportional-autoscal
 }
 ```
 
-The above example configuration would ship a coredns configuration that has at least 3 pod replicas at all times, and then scales out to 4 when the 97th node, or the 1537th core (whichever comes frirst) is observed running in the cluster (and so on and so on).
+#### coredns
+
+The `calico` addon includes configurable verbosity via the `logSeverityScreen` configuration property. The default is "info". To override that default, (e.g., to "error"), see this example:
+
+```
+...
+"kubernetesConfig": {
+    "addons": [
+        ...
+        {
+          "name": "calico",
+          "enabled": true,
+          "config": {
+            "logSeverityScreen": "error"
+          }
+        }
+        ...
+    ]
+}
+...
+```
+
+Available options for `logSeverityScreen` are documented [here](https://docs.projectcalico.org/reference/resources/felixconfig).
 
 #### components
 

--- a/parts/k8s/addons/1.15/calico.yaml
+++ b/parts/k8s/addons/1.15/calico.yaml
@@ -46,7 +46,7 @@ kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -62,7 +62,7 @@ kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -78,7 +78,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -94,7 +94,7 @@ kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -110,7 +110,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -126,7 +126,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -142,7 +142,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -158,7 +158,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -174,7 +174,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -192,7 +192,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 {{- /* The CNI plugin needs to get pods, nodes, and namespaces. */}}
 - apiGroups: [""]
@@ -294,7 +294,7 @@ kind: ClusterRoleBinding
 metadata:
   name: calico-node
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -314,7 +314,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   ports:
   - port: 5473
@@ -332,7 +332,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   {{- /* Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
   typha_service_name variable in the calico-config ConfigMap above.
@@ -426,7 +426,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-node
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   selector:
     matchLabels:
@@ -550,7 +550,7 @@ spec:
           value: "false"
         {{- /* Set Felix logging to "info" */}}
         - name: FELIX_LOGSEVERITYSCREEN
-          value: "info"
+          value: {{ContainerConfig "logSeverityScreen"}}
         - name: FELIX_HEALTHENABLED
           value: "true"
         - name: CALICO_IPV4POOL_IPIP
@@ -631,7 +631,7 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 ---
 {{- /* Typha Horizontal Autoscaler ConfigMap */}}
 kind: ConfigMap
@@ -667,7 +667,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha-autoscaler
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   replicas: 1
   template:
@@ -704,7 +704,7 @@ kind: ClusterRole
 metadata:
   name: typha-cpha
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -717,7 +717,7 @@ kind: ClusterRoleBinding
 metadata:
   name: typha-cpha
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -734,7 +734,7 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -751,7 +751,7 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -768,4 +768,4 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"

--- a/parts/k8s/addons/calico.yaml
+++ b/parts/k8s/addons/calico.yaml
@@ -46,7 +46,7 @@ kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -62,7 +62,7 @@ kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -78,7 +78,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -94,7 +94,7 @@ kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -110,7 +110,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -126,7 +126,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -142,7 +142,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -158,7 +158,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -174,7 +174,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -192,7 +192,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 {{- /* The CNI plugin needs to get pods, nodes, and namespaces. */}}
 - apiGroups: [""]
@@ -295,7 +295,7 @@ metadata:
   name: calico-node
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -316,7 +316,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   ports:
   - port: 5473
@@ -334,7 +334,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   {{- /* Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
   typha_service_name variable in the calico-config ConfigMap above.
@@ -424,7 +424,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-node
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   selector:
     matchLabels:
@@ -537,7 +537,7 @@ spec:
           value: "false"
         {{- /* Set Felix logging to "info" */}}
         - name: FELIX_LOGSEVERITYSCREEN
-          value: "info"
+          value: {{ContainerConfig "logSeverityScreen"}}
         - name: FELIX_HEALTHENABLED
           value: "true"
         - name: CALICO_IPV4POOL_IPIP
@@ -606,7 +606,7 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 ---
 {{- /* Typha Horizontal Autoscaler ConfigMap */}}
 kind: ConfigMap
@@ -644,7 +644,7 @@ metadata:
   labels:
     k8s-app: calico-typha-autoscaler
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   replicas: 1
   selector:
@@ -683,7 +683,7 @@ metadata:
   name: typha-cpha
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -697,7 +697,7 @@ metadata:
   name: typha-cpha
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -715,7 +715,7 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -733,7 +733,7 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -350,6 +350,9 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 	defaultsCalicoDaemonSetAddonsConfig := KubernetesAddon{
 		Name:    common.CalicoAddonName,
 		Enabled: to.BoolPtr(o.KubernetesConfig.NetworkPolicy == NetworkPolicyCalico),
+		Config: map[string]string{
+			"logSeverityScreen": "info",
+		},
 		Containers: []KubernetesContainerSpec{
 			{
 				Name:  common.CalicoTyphaComponentName,

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -1699,6 +1699,71 @@ func TestSetAddonsConfig(t *testing.T) {
 				{
 					Name:    common.CalicoAddonName,
 					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"logSeverityScreen": "info",
+					},
+					Containers: []KubernetesContainerSpec{
+						{
+							Name:  common.CalicoTyphaComponentName,
+							Image: specConfig.CalicoImageBase + k8sComponentsByVersionMap["1.15.4"][common.CalicoTyphaComponentName],
+						},
+						{
+							Name:  common.CalicoCNIComponentName,
+							Image: specConfig.CalicoImageBase + k8sComponentsByVersionMap["1.15.4"][common.CalicoCNIComponentName],
+						},
+						{
+							Name:  common.CalicoNodeComponentName,
+							Image: specConfig.CalicoImageBase + k8sComponentsByVersionMap["1.15.4"][common.CalicoNodeComponentName],
+						},
+						{
+							Name:  common.CalicoPod2DaemonComponentName,
+							Image: specConfig.CalicoImageBase + k8sComponentsByVersionMap["1.15.4"][common.CalicoPod2DaemonComponentName],
+						},
+						{
+							Name:  common.CalicoClusterAutoscalerComponentName,
+							Image: k8sComponentsByVersionMap["1.15.4"][common.CalicoClusterAutoscalerComponentName],
+						},
+					},
+				},
+			}, "1.15.4")),
+		},
+		{
+			name: "calico addon enabled with configurable log severity",
+			cs: &ContainerService{
+				Properties: &Properties{
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &KubernetesConfig{
+							KubernetesImageBaseType: common.KubernetesImageBaseTypeMCR,
+							DNSServiceIP:            DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: DefaultKubernetesSubnet,
+							ProxyMode:     KubeProxyModeIPTables,
+							NetworkPlugin: NetworkPluginAzure,
+							NetworkPolicy: NetworkPolicyCalico,
+							Addons: []KubernetesAddon{
+								{
+									Name:    common.CalicoAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"logSeverityScreen": "error",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: omitFromAddons([]string{common.AzureCNINetworkMonitorAddonName}, concatenateDefaultAddons([]KubernetesAddon{
+				{
+					Name:    common.CalicoAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"logSeverityScreen": "error",
+					},
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CalicoTyphaComponentName,
@@ -1744,6 +1809,9 @@ func TestSetAddonsConfig(t *testing.T) {
 								{
 									Name:    common.CalicoAddonName,
 									Enabled: to.BoolPtr(false),
+									Config: map[string]string{
+										"logSeverityScreen": "info",
+									},
 									Containers: []KubernetesContainerSpec{
 										{
 											Name:  common.CalicoTyphaComponentName,
@@ -1777,6 +1845,9 @@ func TestSetAddonsConfig(t *testing.T) {
 				{
 					Name:    common.CalicoAddonName,
 					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"logSeverityScreen": "info",
+					},
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:  common.CalicoTyphaComponentName,

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -6448,7 +6448,7 @@ kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -6464,7 +6464,7 @@ kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -6480,7 +6480,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -6496,7 +6496,7 @@ kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -6512,7 +6512,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -6528,7 +6528,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -6544,7 +6544,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -6560,7 +6560,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -6576,7 +6576,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -6594,7 +6594,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 {{- /* The CNI plugin needs to get pods, nodes, and namespaces. */}}
 - apiGroups: [""]
@@ -6696,7 +6696,7 @@ kind: ClusterRoleBinding
 metadata:
   name: calico-node
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -6716,7 +6716,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   ports:
   - port: 5473
@@ -6734,7 +6734,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   {{- /* Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
   typha_service_name variable in the calico-config ConfigMap above.
@@ -6828,7 +6828,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-node
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   selector:
     matchLabels:
@@ -6952,7 +6952,7 @@ spec:
           value: "false"
         {{- /* Set Felix logging to "info" */}}
         - name: FELIX_LOGSEVERITYSCREEN
-          value: "info"
+          value: {{ContainerConfig "logSeverityScreen"}}
         - name: FELIX_HEALTHENABLED
           value: "true"
         - name: CALICO_IPV4POOL_IPIP
@@ -7033,7 +7033,7 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 ---
 {{- /* Typha Horizontal Autoscaler ConfigMap */}}
 kind: ConfigMap
@@ -7069,7 +7069,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha-autoscaler
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   replicas: 1
   template:
@@ -7106,7 +7106,7 @@ kind: ClusterRole
 metadata:
   name: typha-cpha
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -7119,7 +7119,7 @@ kind: ClusterRoleBinding
 metadata:
   name: typha-cpha
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -7136,7 +7136,7 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -7153,7 +7153,7 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -7170,7 +7170,7 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 `)
 
 func k8sAddons115CalicoYamlBytes() ([]byte, error) {
@@ -13278,7 +13278,7 @@ kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -13294,7 +13294,7 @@ kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -13310,7 +13310,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -13326,7 +13326,7 @@ kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -13342,7 +13342,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -13358,7 +13358,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -13374,7 +13374,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -13390,7 +13390,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -13406,7 +13406,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -13424,7 +13424,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 {{- /* The CNI plugin needs to get pods, nodes, and namespaces. */}}
 - apiGroups: [""]
@@ -13527,7 +13527,7 @@ metadata:
   name: calico-node
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13548,7 +13548,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   ports:
   - port: 5473
@@ -13566,7 +13566,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   {{- /* Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
   typha_service_name variable in the calico-config ConfigMap above.
@@ -13656,7 +13656,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-node
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   selector:
     matchLabels:
@@ -13769,7 +13769,7 @@ spec:
           value: "false"
         {{- /* Set Felix logging to "info" */}}
         - name: FELIX_LOGSEVERITYSCREEN
-          value: "info"
+          value: {{ContainerConfig "logSeverityScreen"}}
         - name: FELIX_HEALTHENABLED
           value: "true"
         - name: CALICO_IPV4POOL_IPIP
@@ -13838,7 +13838,7 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 ---
 {{- /* Typha Horizontal Autoscaler ConfigMap */}}
 kind: ConfigMap
@@ -13876,7 +13876,7 @@ metadata:
   labels:
     k8s-app: calico-typha-autoscaler
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   replicas: 1
   selector:
@@ -13915,7 +13915,7 @@ metadata:
   name: typha-cpha
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -13929,7 +13929,7 @@ metadata:
   name: typha-cpha
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13947,7 +13947,7 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -13965,7 +13965,7 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: "Reconcile"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/e2e/test_cluster_configs/network_policy/calico.json
+++ b/test/e2e/test_cluster_configs/network_policy/calico.json
@@ -9,7 +9,16 @@
 				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPolicy": "calico",
-					"clusterSubnet": "10.239.0.0/16"
+					"clusterSubnet": "10.239.0.0/16",
+					"addons": [
+						{
+							"name": "calico",
+							"enabled": true,
+							"config": {
+								"logSeverityScreen": "error"
+							}
+						}
+					]
 				}
 			},
 			"masterProfile": {

--- a/test/e2e/test_cluster_configs/network_policy/calico_azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/calico_azure.json
@@ -6,7 +6,16 @@
 				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPolicy": "calico",
-					"networkPlugin": "azure"
+					"networkPlugin": "azure",
+					"addons": [
+						{
+							"name": "calico",
+							"enabled": true,
+							"config": {
+								"logSeverityScreen": "error"
+							}
+						}
+					]
 				}
 			},
 			"masterProfile": {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR introduces configurable logging verbosity for the calico addon. E.g.:

```
...
"kubernetesConfig": {
    "addons": [
        ...
        {
          "name": "calico",
          "enabled": true,
          "config": {
            "logSeverityScreen": "error"
          }
        }
        ...
    ]
}
...
```

In addition, the calico addon spec has been changed to `EnsureExists` to better enable folks to customize the configuration on their cluster over time.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2111 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
