### PR TITLE
fix: Set spg only when spg is not set 

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -344,11 +344,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
-			if a.HasAvailabilityZones() {
-				a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
-			} else {
-				a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = DefaultLoadBalancerSku
-			}
+			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = a.GetLoadBalancerDefault()
 		}
 
 		if strings.ToLower(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku) == strings.ToLower(BasicLoadBalancerSku) {
@@ -651,7 +647,10 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 			}
 
 			if profile.SinglePlacementGroup == nil {
-				if p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku {
+				if p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
+					p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = p.GetLoadBalancerDefault()
+				}
+				if strings.EqualFold(p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) {
 					profile.SinglePlacementGroup = to.BoolPtr(false)
 				} else {
 					profile.SinglePlacementGroup = to.BoolPtr(DefaultSinglePlacementGroup)

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -649,11 +649,12 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 			if profile.VMSSOverProvisioningEnabled == nil {
 				profile.VMSSOverProvisioningEnabled = to.BoolPtr(DefaultVMSSOverProvisioningEnabled && !isUpgrade && !isScale)
 			}
-			if profile.Count > 100 {
-				profile.SinglePlacementGroup = to.BoolPtr(false)
-			}
+
 			if profile.SinglePlacementGroup == nil {
 				profile.SinglePlacementGroup = to.BoolPtr(DefaultSinglePlacementGroup)
+				if profile.Count > 100 {
+					profile.SinglePlacementGroup = to.BoolPtr(false)
+				}
 			}
 		}
 		// set default OSType to Linux

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -651,9 +651,10 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 			}
 
 			if profile.SinglePlacementGroup == nil {
-				profile.SinglePlacementGroup = to.BoolPtr(DefaultSinglePlacementGroup)
-				if profile.Count > 100 {
+				if p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku {
 					profile.SinglePlacementGroup = to.BoolPtr(false)
+				} else {
+					profile.SinglePlacementGroup = to.BoolPtr(DefaultSinglePlacementGroup)
 				}
 			}
 		}

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -33,6 +33,31 @@ type PropertiesDefaultsParams struct {
 	PkiKeySize int
 }
 
+func (p *Properties) setLoadBalancerSkuDefaults() {
+	if p.OrchestratorProfile == nil {
+		p.OrchestratorProfile = &OrchestratorProfile{}
+	}
+
+	if p.OrchestratorProfile.KubernetesConfig == nil {
+		p.OrchestratorProfile.KubernetesConfig = &KubernetesConfig{}
+	}
+
+	if p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
+		if p.HasAvailabilityZones() {
+			p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
+		} else {
+			p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = DefaultLoadBalancerSku
+		}
+	}
+
+	// normalize sku
+	if strings.EqualFold(p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, BasicLoadBalancerSku) {
+		p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = BasicLoadBalancerSku
+	} else if strings.EqualFold(p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) {
+		p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
+	}
+}
+
 // SetPropertiesDefaults for the container Properties, returns true if certs are generated
 func (cs *ContainerService) SetPropertiesDefaults(params PropertiesDefaultsParams) (bool, error) {
 	properties := cs.Properties
@@ -52,6 +77,9 @@ func (cs *ContainerService) SetPropertiesDefaults(params PropertiesDefaultsParam
 	if cs.Properties.MasterProfile != nil {
 		properties.setMasterProfileDefaults(params.IsUpgrade)
 	}
+
+	// move load balancer sku defaults logic from setOrchestratorDefaults() to here to serve LB checking at setAgentProfileDefaults()
+	properties.setLoadBalancerSkuDefaults()
 
 	properties.setAgentProfileDefaults(params.IsUpgrade, params.IsScale)
 
@@ -341,16 +369,6 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			} else {
 				a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata = to.BoolPtr(DefaultUseInstanceMetadata)
 			}
-		}
-
-		if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
-			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = a.GetLoadBalancerDefault()
-		}
-
-		if strings.ToLower(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku) == strings.ToLower(BasicLoadBalancerSku) {
-			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = BasicLoadBalancerSku
-		} else if strings.ToLower(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku) == strings.ToLower(StandardLoadBalancerSku) {
-			a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku && a.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB == nil {
@@ -647,9 +665,6 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 			}
 
 			if profile.SinglePlacementGroup == nil {
-				if p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
-					p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = p.GetLoadBalancerDefault()
-				}
 				if strings.EqualFold(p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) {
 					profile.SinglePlacementGroup = to.BoolPtr(false)
 				} else {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -3681,7 +3681,7 @@ func TestDefaultLoadBalancerSKU(t *testing.T) {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			c.cs.setOrchestratorDefaults(false, false)
+			c.cs.Properties.setLoadBalancerSkuDefaults()
 			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != c.expected {
 				t.Errorf("expected %s, but got %s", c.expected, c.cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku)
 			}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1259,6 +1259,14 @@ func (p *Properties) HasNonRegularPriorityScaleset() bool {
 	return false
 }
 
+// GetLoadBalancerDefault returns default load balancer sku
+func (a *Properties) GetLoadBalancerDefault() string {
+	if a.HasAvailabilityZones() {
+		return StandardLoadBalancerSku
+	}
+	return DefaultLoadBalancerSku
+}
+
 // GetNonMasqueradeCIDR returns the non-masquerade CIDR for the ip-masq-agent.
 func (p *Properties) GetNonMasqueradeCIDR() string {
 	var nonMasqCidr string

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1259,14 +1259,6 @@ func (p *Properties) HasNonRegularPriorityScaleset() bool {
 	return false
 }
 
-// GetLoadBalancerDefault returns default load balancer sku
-func (a *Properties) GetLoadBalancerDefault() string {
-	if a.HasAvailabilityZones() {
-		return StandardLoadBalancerSku
-	}
-	return DefaultLoadBalancerSku
-}
-
 // GetNonMasqueradeCIDR returns the non-masquerade CIDR for the ip-masq-agent.
 func (p *Properties) GetNonMasqueradeCIDR() string {
 	var nonMasqCidr string


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
We need to set SinglePlacementGroup default value only when it is not set even node count > 100.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
