### PR TITLE
chore: use local kubeconfig if no outbound

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -469,6 +469,11 @@ createKubeManifestDir() {
 writeKubeConfig() {
   local DIR=/home/$ADMINUSER/.kube
   local FILE=$DIR/config
+{{- if HasBlockOutboundInternet}}
+  local SERVER=https://localhost
+{{else}}
+  local SERVER=$KUBECONFIG_SERVER
+{{- end}}
   mkdir -p $DIR
   touch $FILE
   chown $ADMINUSER:$ADMINUSER $DIR $FILE
@@ -481,7 +486,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: \"$CA_CERTIFICATE\"
-    server: $KUBECONFIG_SERVER
+    server: $SERVER
   name: \"$MASTER_FQDN\"
 contexts:
 - context:

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -818,6 +818,9 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"HasTelemetryEnabled": func() bool {
 			return cs.Properties.FeatureFlags != nil && cs.Properties.FeatureFlags.EnableTelemetry
 		},
+		"HasBlockOutboundInternet": func() bool {
+			return cs.Properties.FeatureFlags != nil && cs.Properties.FeatureFlags.BlockOutboundInternet
+		},
 		"GetCSEErrorCode": func(errorType string) int {
 			return GetCSEErrorCode(errorType)
 		},

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18328,6 +18328,11 @@ createKubeManifestDir() {
 writeKubeConfig() {
   local DIR=/home/$ADMINUSER/.kube
   local FILE=$DIR/config
+{{- if HasBlockOutboundInternet}}
+  local SERVER=https://localhost
+{{else}}
+  local SERVER=$KUBECONFIG_SERVER
+{{- end}}
   mkdir -p $DIR
   touch $FILE
   chown $ADMINUSER:$ADMINUSER $DIR $FILE
@@ -18340,7 +18345,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: \"$CA_CERTIFICATE\"
-    server: $KUBECONFIG_SERVER
+    server: $SERVER
   name: \"$MASTER_FQDN\"
 contexts:
 - context:


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

We use the `BlockOutboundInternet` feature flag for various "air gap" E2E testing scenarios. To better ensure that CSE on master nodes can run to completion, we should connect to the apiserver locally rather than via the public IP address.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
