### PR TITLE
fix: FlexVolume broken issue on Windows

### DIFF
--- a/parts/k8s/kubeletstart.ps1
+++ b/parts/k8s/kubeletstart.ps1
@@ -12,7 +12,6 @@ $global:NetworkMode = "L2Bridge"
 $global:ExternalNetwork = "ext"
 $global:CNIConfig = "$CNIConfig"
 $global:HNSModule = "c:\k\hns.psm1"
-#$global:VolumePluginDir = "$VolumePluginDir" TODO ksbrmnn remove as this seems to be calculated later 
 $global:NetworkPlugin = $Global:ClusterConfiguration.Cni.Name
 $global:KubeletNodeLabels = $Global:ClusterConfiguration.Kubernetes.Kubelet.NodeLabels
 $global:ContainerRuntime = $Global:ClusterConfiguration.Cri.Name
@@ -33,9 +32,9 @@ $KubeNetwork = "azure"
 #TODO ksbrmnn refactor to be sensical instead of if if if ...
 
 # Calculate some local paths
-$VolumePluginDir = [Io.path]::Combine($global:KubeDir, "volumeplugins")
+$global:VolumePluginDir = [Io.path]::Combine($global:KubeDir, "volumeplugins")
+mkdir $global:VolumePluginDir
 
-#mkdir $VolumePluginDir TODO ksbrmnn figure out how this is already created
 $KubeletArgList = $Global:ClusterConfiguration.Kubernetes.Kubelet.ConfigArgs # This is the initial list passed in from aks-engine
 $KubeletArgList += "--node-labels=$global:KubeletNodeLabels"
 # $KubeletArgList += "--hostname-override=$global:AzureHostname" TODO: remove - dead code?

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -22026,7 +22026,6 @@ $global:NetworkMode = "L2Bridge"
 $global:ExternalNetwork = "ext"
 $global:CNIConfig = "$CNIConfig"
 $global:HNSModule = "c:\k\hns.psm1"
-#$global:VolumePluginDir = "$VolumePluginDir" TODO ksbrmnn remove as this seems to be calculated later 
 $global:NetworkPlugin = $Global:ClusterConfiguration.Cni.Name
 $global:KubeletNodeLabels = $Global:ClusterConfiguration.Kubernetes.Kubelet.NodeLabels
 $global:ContainerRuntime = $Global:ClusterConfiguration.Cri.Name
@@ -22047,9 +22046,9 @@ $KubeNetwork = "azure"
 #TODO ksbrmnn refactor to be sensical instead of if if if ...
 
 # Calculate some local paths
-$VolumePluginDir = [Io.path]::Combine($global:KubeDir, "volumeplugins")
+$global:VolumePluginDir = [Io.path]::Combine($global:KubeDir, "volumeplugins")
+mkdir $global:VolumePluginDir
 
-#mkdir $VolumePluginDir TODO ksbrmnn figure out how this is already created
 $KubeletArgList = $Global:ClusterConfiguration.Kubernetes.Kubelet.ConfigArgs # This is the initial list passed in from aks-engine
 $KubeletArgList += "--node-labels=$global:KubeletNodeLabels"
 # $KubeletArgList += "--hostname-override=$global:AzureHostname" TODO: remove - dead code?


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Original `$global:VolumePluginDir` is actually empty value and FlexVolume is broken on Windows

```
$KubeletArgList += "--volume-plugin-dir=$global:VolumePluginDir"
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
