### PR TITLE
feat: enable configurable apiserver --anonymous-auth

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -590,6 +590,7 @@ Below is a list of apiserver options that AKS Engine will configure by default:
 
 | apiserver option                | default value                                                                                                                                                                                                                   |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "--anonymous-auth"                          | "false                                                                                  |
 | "--admission-control"           | "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota" (Kubernetes versions prior to 1.9.0)                                                                                                          |
 | "--enable-admission-plugins"`*` | "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,ExtendedResourceToleration" (Kubernetes versions 1.9.0 and later) |
 | "--authorization-mode"          | "Node", "RBAC" (_the latter if enabledRbac is true_)                                                                                                                                                                            |
@@ -611,7 +612,6 @@ Below is a list of apiserver options that are _not_ currently user-configurable,
 | "--bind-address"                            | "0.0.0.0"                                                                               |
 | "--advertise-address"                       | _calculated value that represents listening URI for API server_                         |
 | "--allow-privileged"                        | "true"                                                                                  |
-| "--anonymous-auth"                          | "false                                                                                  |
 | "--audit-log-path"                          | "/var/log/apiserver/audit.log"                                                          |
 | "--insecure-port"                           | "0"                                                                                     |
 | "--secure-port"                             | "443"                                                                                   |

--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -590,7 +590,7 @@ Below is a list of apiserver options that AKS Engine will configure by default:
 
 | apiserver option                | default value                                                                                                                                                                                                                   |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "--anonymous-auth"                          | "false                                                                                  |
+| "--anonymous-auth"                          | "false"                                                                                  |
 | "--admission-control"           | "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota" (Kubernetes versions prior to 1.9.0)                                                                                                          |
 | "--enable-admission-plugins"`*` | "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,ExtendedResourceToleration" (Kubernetes versions 1.9.0 and later) |
 | "--authorization-mode"          | "Node", "RBAC" (_the latter if enabledRbac is true_)                                                                                                                                                                            |

--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -19,7 +19,6 @@ func (cs *ContainerService) setAPIServerConfig() {
 		"--bind-address":                "0.0.0.0",
 		"--advertise-address":           "<advertiseAddr>",
 		"--allow-privileged":            "true",
-		"--anonymous-auth":              "false",
 		"--audit-log-path":              "/var/log/kubeaudit/audit.log",
 		"--insecure-port":               "0",
 		"--secure-port":                 "443",
@@ -51,6 +50,7 @@ func (cs *ContainerService) setAPIServerConfig() {
 
 	// Default apiserver config
 	defaultAPIServerConfig := map[string]string{
+		"--anonymous-auth":      "false",
 		"--audit-log-maxage":    "30",
 		"--audit-log-maxbackup": "10",
 		"--audit-log-maxsize":   "100",

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -506,3 +506,26 @@ func TestAPIServerIPv6Only(t *testing.T) {
 		}
 	}
 }
+
+func TestAPIServerAnonymousAuth(t *testing.T) {
+	// Validate anonymous-auth default is false
+	cs := CreateMockContainerService("testcluster", "1.15.12", 3, 2, false)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--anonymous-auth"] != "false" {
+		t.Fatalf("got unexpected '--anonymous-auth' API server config value for k8s v%s: %s",
+			"1.15.12", a["--anonymous-auth"])
+	}
+
+	// Validate anonymous-auth enabled
+	cs = CreateMockContainerService("testcluster", "1.15.12", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
+		"--anonymous-auth": "true",
+	}
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--anonymous-auth"] != "true" {
+		t.Fatalf("got unexpected '--anonymous-auth' API server config value for k8s v%s: %s",
+			"1.15.12", a["--anonymous-auth"])
+	}
+}

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -71,7 +71,10 @@
 							"data": "YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IGFrcy1lbmdpbmUtcG9kLWluaXQKc3BlYzoKICBjb250YWluZXJzOgogIC0gbmFtZTogYWtzLWVuZ2luZS1wb2QtaW5pdAogICAgaW1hZ2U6IGJ1c3lib3g6MS4zMS4xCiAgICBhcmdzOgogICAgLSAvYmluL3NoCiAgICAtIC1jCiAgICAtIHdoaWxlIHRydWU7IGRvIHNsZWVwIDYwMDsgZG9uZQogIG5vZGVTZWxlY3RvcjoKICAgIGJldGEua3ViZXJuZXRlcy5pby9vczogbGludXgKLS0tCmFwaVZlcnNpb246IGJhdGNoL3YxCmtpbmQ6IEpvYgptZXRhZGF0YToKICBuYW1lOiBha3MtZW5naW5lLWpvYi1pbml0CnNwZWM6CiAgdGVtcGxhdGU6CiAgICBzcGVjOgogICAgICBjb250YWluZXJzOgogICAgICAtIGltYWdlOiBidXN5Ym94OjEuMzEuMQogICAgICAgIG5hbWU6IGJ1c3lib3gtYWdlbnQKICAgICAgICBjb21tYW5kOiBbJ3NoJywgJy1jJywgJ1sgJChlY2hvICJIZWxsbywgV29ybGQhIiB8IHNoYTI1NnN1bSB8IGN1dCAtZCIgIiAtZjEpID0gImM5OGMyNGI2NzdlZmY0NDg2MGFmZWE2ZjQ5M2JiYWVjNWJiMWM0Y2JiMjA5YzZmYzJiYmI0N2Y2NmZmMmFkMzEiIF0nXQogICAgICByZXN0YXJ0UG9saWN5OiBOZXZlcgogICAgICBub2RlU2VsZWN0b3I6CiAgICAgICAgYmV0YS5rdWJlcm5ldGVzLmlvL29zOiBsaW51eAogIGJhY2tvZmZMaW1pdDogMAo="
 						}
 					],
-					"loadBalancerOutboundIPs": 2
+					"loadBalancerOutboundIPs": 2,
+					"apiServerConfig": {
+						"--anonymous-auth": "true"
+					}
 				}
 			},
 			"masterProfile": {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR allows users to enable the `--anonymous-auth` apiserver flag, now that RBAC support is statically enabled for all clusters.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
