### PR TITLE
test: generic async top nodes interface for E2E

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1465,27 +1465,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should be able to get nodes metrics", func() {
-			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.IsRBACEnabled() {
-				success := false
-				var err error
-				var out []byte
-				// TODO make a 1st class go func retry implementation of this
-				for i := 0; i < 10; i++ {
-					cmd := exec.Command("k", "top", "nodes")
-					util.PrintCommand(cmd)
-					out, err = cmd.CombinedOutput()
-					if err == nil {
-						success = true
-						break
-					}
-					time.Sleep(1 * time.Minute)
-				}
-				if err != nil {
-					pod.PrintPodsLogs("metrics-server", "kube-system", 5*time.Second, 1*time.Minute)
-					log.Println(string(out))
-				}
-				Expect(success).To(BeTrue())
-			}
+			err := node.TopNodesWithRetry(1*time.Second, cfg.Timeout)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should create a pv by deploying a pod that consumes a pvc", func() {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR improves the way we're validating `top nodes` in E2E tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
