### PR TITLE
fix: Do not mutate OrchestratorVersion when set default

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -117,9 +117,11 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		return
 	}
 	o := a.OrchestratorProfile
-	o.OrchestratorVersion = common.GetValidPatchVersion(
-		o.OrchestratorType,
-		o.OrchestratorVersion, isUpdate, a.HasWindows())
+	if o.OrchestratorVersion == "" {
+		o.OrchestratorVersion = common.GetValidPatchVersion(
+			o.OrchestratorType,
+			o.OrchestratorVersion, isUpdate, a.HasWindows())
+	}
 
 	switch o.OrchestratorType {
 	case Kubernetes:

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2670,6 +2670,41 @@ func TestSetCertDefaultsVMSS(t *testing.T) {
 	}
 }
 
+func TestSetOrchestratorDefaultsVMAS(t *testing.T) {
+	cs := &ContainerService{
+		Properties: &Properties{
+			ServicePrincipalProfile: &ServicePrincipalProfile{
+				ClientID: "barClientID",
+				Secret:   "bazSecret",
+			},
+			MasterProfile: &MasterProfile{
+				Count:               3,
+				DNSPrefix:           "myprefix1",
+				VMSize:              "Standard_DS2_v2",
+				AvailabilityProfile: AvailabilitySet,
+			},
+			OrchestratorProfile: &OrchestratorProfile{
+				OrchestratorType:    Kubernetes,
+				OrchestratorVersion: "1.12.8",
+				KubernetesConfig: &KubernetesConfig{
+					NetworkPlugin: NetworkPluginAzure,
+				},
+			},
+		},
+	}
+
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.12.8" {
+		t.Error("setMasterProfileDefaults should not adjust given OrchestratorVersion")
+	}
+
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = ""
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.13.12" {
+		t.Error("setMasterProfileDefaults should not adjust given OrchestratorVersion")
+	}
+}
+
 func TestProxyModeDefaults(t *testing.T) {
 	// Test that default is what we expect
 	mockCS := getMockBaseContainerService("1.10.12")

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -2695,13 +2695,13 @@ func TestSetOrchestratorDefaultsVMAS(t *testing.T) {
 
 	cs.setOrchestratorDefaults(false, false)
 	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.12.8" {
-		t.Error("setMasterProfileDefaults should not adjust given OrchestratorVersion")
+		t.Error("setOrchestratorDefaults should not adjust given OrchestratorVersion")
 	}
 
 	cs.Properties.OrchestratorProfile.OrchestratorVersion = ""
 	cs.setOrchestratorDefaults(false, false)
-	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.13.12" {
-		t.Error("setMasterProfileDefaults should not adjust given OrchestratorVersion")
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion == "" {
+		t.Error("setOrchestratorDefaults should provide a version if it is not given.")
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

When provision or update VMAS cluster, AKS RP will first call deployTemplateWithoutAgentPool.
When call deployTemplateWithoutAgentPool, it will follow the below calling trace and AKS-Engine changes the managed cluster's OrchestratorVersion silently.

deployTemplateWithoutAgentPool =>
GenerateTemplate() => 
SetPropertiesDefaults() =>
setOrchestratorDefaults() =>
    o.OrchestratorVersion = common.GetValidPatchVersion(
        o.OrchestratorType,
        o.OrchestratorVersion, isUpdate, a.HasWindows())

This is out of the expectation of AKS RP behavior, we should not adjust the MC's OrchestratorVersion if already given one.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
