### PR TITLE
fix: addons bootstrapping errata

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -47,6 +47,10 @@
               "min-replicas": "1",
               "nodes-per-replica": "10"
             }
+          },
+          {
+            "name": "azure-policy",
+            "enabled": true
           }
         ]
       }

--- a/parts/k8s/addons/azure-policy-deployment.yaml
+++ b/parts/k8s/addons/azure-policy-deployment.yaml
@@ -391,6 +391,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
+      nodeSelector:
+        kubernetes.io/os: linux
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -691,3 +693,5 @@ spec:
           path: /etc/kubernetes/azure.json
           type: File
         name: acs-credential
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/parts/k8s/addons/kubernetes-dashboard.yaml
+++ b/parts/k8s/addons/kubernetes-dashboard.yaml
@@ -5,9 +5,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
   name: kubernetes-dashboard
-
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -16,9 +14,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: kubernetes-dashboard
   namespace: kubernetes-dashboard
-
 ---
-
 kind: Service
 apiVersion: v1
 metadata:
@@ -33,9 +29,7 @@ spec:
       targetPort: 8443
   selector:
     k8s-app: kubernetes-dashboard
-
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -45,9 +39,7 @@ metadata:
   name: kubernetes-dashboard-certs
   namespace: kubernetes-dashboard
 type: Opaque
-
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -59,9 +51,7 @@ metadata:
 type: Opaque
 data:
   csrf: ""
-
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -71,9 +61,7 @@ metadata:
   name: kubernetes-dashboard-key-holder
   namespace: kubernetes-dashboard
 type: Opaque
-
 ---
-
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -82,9 +70,7 @@ metadata:
     addonmanager.kubernetes.io/mode: EnsureExists
   name: kubernetes-dashboard-settings
   namespace: kubernetes-dashboard
-
 ---
-
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -94,17 +80,17 @@ metadata:
   name: kubernetes-dashboard
   namespace: kubernetes-dashboard
 rules:
-  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+  {{- /* Allow Dashboard to get, update and delete Dashboard exclusive secrets. */}}
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
     verbs: ["get", "update", "delete"]
-    # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+    {{- /* Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map. */}}
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["kubernetes-dashboard-settings"]
     verbs: ["get", "update"]
-    # Allow Dashboard to get metrics.
+    {{- /* Allow Dashboard to get metrics. */}}
   - apiGroups: [""]
     resources: ["services"]
     resourceNames: ["heapster", "dashboard-metrics-scraper"]
@@ -113,9 +99,7 @@ rules:
     resources: ["services/proxy"]
     resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
     verbs: ["get"]
-
 ---
-
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -124,13 +108,11 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: kubernetes-dashboard
 rules:
-  # Allow Metrics Scraper to get metrics from the Metrics server
+  {{- /* Allow Metrics Scraper to get metrics from the Metrics server */}}
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods", "nodes"]
     verbs: ["get", "list", "watch"]
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -147,9 +129,7 @@ subjects:
   - kind: ServiceAccount
     name: kubernetes-dashboard
     namespace: kubernetes-dashboard
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -164,9 +144,7 @@ subjects:
   - kind: ServiceAccount
     name: kubernetes-dashboard
     namespace: kubernetes-dashboard
-
 ---
-
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -196,10 +174,10 @@ spec:
           args:
             - --auto-generate-certificates
             - --namespace=kubernetes-dashboard
-            # Uncomment the following line to manually specify Kubernetes API server Host
-            # If not specified, Dashboard will attempt to auto discover the API server and connect
-            # to it. Uncomment only if the default does not work.
-            # - --apiserver-host=http://my-address:port
+            {{- /* Uncomment the following line to manually specify Kubernetes API server Host */}}
+            {{- /* If not specified, Dashboard will attempt to auto discover the API server and connect */}}
+            {{- /* to it. Uncomment only if the default does not work. */}}
+            {{- /* - --apiserver-host=http://my-address:port */}}
           resources:
             requests:
               cpu: {{ContainerCPUReqs "kubernetes-dashboard"}}
@@ -210,7 +188,7 @@ spec:
           volumeMounts:
             - name: kubernetes-dashboard-certs
               mountPath: /certs
-              # Create on-disk volume to store exec logs
+              {{- /* Create on-disk volume to store exec logs */}}
             - mountPath: /tmp
               name: tmp-volume
           livenessProbe:
@@ -234,13 +212,11 @@ spec:
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
         kubernetes.io/os: linux
-      # Comment the following tolerations if Dashboard must not be deployed on master
+      {{/* Comment the following tolerations if Dashboard must not be deployed on master */}}
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-
 ---
-
 kind: Service
 apiVersion: v1
 metadata:
@@ -255,9 +231,7 @@ spec:
       targetPort: 8000
   selector:
     k8s-app: dashboard-metrics-scraper
-
 ---
-
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -310,7 +284,7 @@ spec:
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
         kubernetes.io/os: linux
-      # Comment the following tolerations if Dashboard must not be deployed on master
+        {{- /* Comment the following tolerations if Dashboard must not be deployed on master */}}
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -457,15 +457,6 @@ ensureK8sControlPlane() {
 }
 {{- if IsAzurePolicyAddonEnabled}}
 ensureLabelExclusionForAzurePolicyAddon() {
-  GATEKEEPER_NAMESPACE="gatekeeper-system"
-  NS_YAML="/opt/kubernetes/gatekeeper-system.yaml"
-cat <<EOF >"${NS_YAML}"
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ${GATEKEEPER_NAMESPACE}
-EOF
-  retrycmd 120 5 25 $KUBECTL apply -f ${NS_YAML} 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
   retrycmd 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager --overwrite 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{end}}

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -458,9 +458,15 @@ ensureK8sControlPlane() {
 {{- if IsAzurePolicyAddonEnabled}}
 ensureLabelExclusionForAzurePolicyAddon() {
   GATEKEEPER_NAMESPACE="gatekeeper-system"
-  retrycmd 120 5 25 $KUBECTL create ns --save-config $GATEKEEPER_NAMESPACE 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
-
-  retrycmd 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  NS_YAML="/opt/kubernetes/gatekeeper-system.yaml"
+cat <<EOF >"${NS_YAML}"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${GATEKEEPER_NAMESPACE}
+EOF
+  retrycmd 120 5 25 $KUBECTL apply -f ${NS_YAML} 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
+  retrycmd 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager --overwrite 2>/dev/null || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}
 }
 {{end}}
 ensureEtcd() {

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -225,6 +225,9 @@ time_metric "EnsureDHCPv6" ensureDHCPv6
 
 time_metric "EnsureKubelet" ensureKubelet
 if [[ -n ${MASTER_NODE} ]]; then
+{{if IsAzurePolicyAddonEnabled}}
+  time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
+{{end}}
   time_metric "EnsureAddons" ensureAddons
 fi
 time_metric "EnsureJournal" ensureJournal
@@ -242,9 +245,6 @@ if [[ -n ${MASTER_NODE} ]]; then
     fi
   fi
   time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
-  {{if IsAzurePolicyAddonEnabled}}
-  time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
-  {{end}}
   {{- if HasClusterInitComponent}}
   if [[ $NODE_INDEX == 0 ]]; then
     retrycmd 120 5 30 $KUBECTL apply -f /opt/azure/containers/cluster-init.yaml || exit {{GetCSEErrorCode "ERR_CLUSTER_INIT_FAIL"}}

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -402,6 +402,30 @@ MASTER_CUSTOM_FILES_PLACEHOLDER
 
 MASTER_CONTAINER_ADDONS_PLACEHOLDER
 
+{{- if or (IsDashboardAddonEnabled) (IsAzurePolicyAddonEnabled)}}
+- path: /etc/kubernetes/addons/init/namespaces.yaml
+  permissions: "0644"
+  owner: root
+  content: |
+  {{- if IsDashboardAddonEnabled}}
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: kubernetes-dashboard
+      labels:
+        addonmanager.kubernetes.io/mode: EnsureExists
+    ---
+  {{- end}}
+  {{- if IsAzurePolicyAddonEnabled}}
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: gatekeeper-system
+      labels:
+        addonmanager.kubernetes.io/mode: EnsureExists
+  {{- end}}
+{{- end}}
+
 - path: /etc/default/kubelet
   permissions: "0644"
   owner: root

--- a/parts/k8s/manifests/kubernetesmaster-kube-addon-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-addon-manager.yaml
@@ -16,6 +16,8 @@ spec:
     env:
     - name: KUBECONFIG
       value: "/var/lib/kubelet/kubeconfig"
+    - name: ADDON_PATH
+      value: "/etc/kubernetes/addons/init"
     resources:
       requests:
         cpu: 5m

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -830,9 +830,6 @@ func (a *Properties) validateAddons() error {
 					if !isValidVersion {
 						return errors.New("Azure Policy add-on can only be used with Kubernetes v1.14 and above. Please specify a compatible version")
 					}
-					if a.ServicePrincipalProfile == nil || a.OrchestratorProfile.KubernetesConfig.UseManagedIdentity {
-						return errors.New("Azure Policy add-on requires service principal profile to be specified")
-					}
 				case common.KubeDNSAddonName:
 					kubeDNSEnabled = true
 				case common.CoreDNSAddonName:

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -2021,9 +2021,9 @@ func Test_Properties_ValidateAddons(t *testing.T) {
 			},
 		},
 	}
-	if err := p.validateAddons(); err == nil {
+	if err := p.validateAddons(); err != nil {
 		t.Errorf(
-			"should error on azure-policy when ServicePrincipalProfile is empty",
+			"should not error on azure-policy when ServicePrincipalProfile is empty",
 		)
 	}
 	p.ServicePrincipalProfile = &ServicePrincipalProfile{
@@ -2050,9 +2050,9 @@ func Test_Properties_ValidateAddons(t *testing.T) {
 	}
 
 	p.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
-	if err := p.validateAddons(); err == nil {
+	if err := p.validateAddons(); err != nil {
 		t.Errorf(
-			"should error on azure-policy with managed identity",
+			"should not error on azure-policy with managed identity",
 		)
 	}
 

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -762,6 +762,9 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"IsAADPodIdentityAddonEnabled": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.AADPodIdentityAddonName)
 		},
+		"IsDashboardAddonEnabled": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.DashboardAddonName)
+		},
 		"GetAADPodIdentityTaintKey": func() string {
 			return common.AADPodIdentityTaintKey
 		},

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -9411,6 +9411,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
+      nodeSelector:
+        kubernetes.io/os: linux
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -9711,6 +9713,8 @@ spec:
           path: /etc/kubernetes/azure.json
           type: File
         name: acs-credential
+      nodeSelector:
+        kubernetes.io/os: linux
 `)
 
 func k8sAddonsAzurePolicyDeploymentYamlBytes() ([]byte, error) {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19703,6 +19703,9 @@ time_metric "EnsureDHCPv6" ensureDHCPv6
 
 time_metric "EnsureKubelet" ensureKubelet
 if [[ -n ${MASTER_NODE} ]]; then
+{{if IsAzurePolicyAddonEnabled}}
+  time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
+{{end}}
   time_metric "EnsureAddons" ensureAddons
 fi
 time_metric "EnsureJournal" ensureJournal
@@ -19720,9 +19723,6 @@ if [[ -n ${MASTER_NODE} ]]; then
     fi
   fi
   time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
-  {{if IsAzurePolicyAddonEnabled}}
-  time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
-  {{end}}
   {{- if HasClusterInitComponent}}
   if [[ $NODE_INDEX == 0 ]]; then
     retrycmd 120 5 30 $KUBECTL apply -f /opt/azure/containers/cluster-init.yaml || exit {{GetCSEErrorCode "ERR_CLUSTER_INIT_FAIL"}}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that we perform azure-policy namespace and label bootstrapping prerequisites before we load the gatekeeper spec via kube-addon-manager.

We also load the kubernetes-dashboard namespace prior to the spec to ensure we always create the namespace first.

Also adds a fix to ensure the change in #3313 actually happens, and that addons order loading is strictly enforced. Debugging azure-policy teased out this gap. Specifically, kube-addon-manager needs the `ADDON_PATH` env var to tell it where to source addons from. In our case we want to launch kube-addon-manager w/ a `ADDON_PATH=/etc/kubernetes/addons/init` so that it loads only the manifests thereunder at bootstrap time.

https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/kube-addons.sh#L61

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3480
Fixes #3491 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
