### PR TITLE
fix: scale + AvailabilitySet errata

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -291,6 +291,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			if len(indexes) > 0 {
 				break
 			}
+			log.Warnf("Found no VMs in resource group %s that match pool name %s\n", sc.resourceGroupName, sc.agentPool.Name)
 			time.Sleep(30 * time.Second)
 		}
 		sortedIndexes := sort.IntSlice(indexes)

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -570,11 +570,14 @@ func (sc *scaleCmd) vmInAgentPool(vmName string, tags map[string]*string) bool {
 		}
 	}
 
-	// For Windows, we rely upon the tags
-	if sc.agentPool.OSType == api.Windows {
+	// Fall back to checking the VM name to see if it fits the naming pattern
+	if sc.agentPool.OSType == api.Windows && strings.HasPrefix(vmName, sc.containerService.Properties.GetClusterID()[:4]) {
+		_, _, winPoolIndex, _, err := utils.WindowsVMNameParts(vmName)
+		if err == nil {
+			return vmName[:9] == sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, winPoolIndex)[:9]
+		}
 		return false
 	}
-	// Fall back to checking the VM name to see if it fits the naming pattern for Linux
 	return strings.Contains(vmName, sc.nameSuffix[:5]) && strings.Contains(vmName, sc.agentPoolToScale)
 }
 


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR addresses three errors observed:

- `printScaleTargetEqualsExisting` convenience func doesn't return at the right time when it can't print
- retry calling the VM API when looking for nodes in the case where the call produces no matching VMs
- don't rely on tags being present on Windows VMs to correlate VMs w/ node pools, because in practice tags just sometimes aren't there :(

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3489 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
