### PR TITLE
chore: rev Linux VHDs to 2020.06.22

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -166,7 +166,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-engine-ubuntu-1604-202006",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.06.02",
+		ImageVersion:   "2020.06.22",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
@@ -174,7 +174,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-engine-ubuntu-1804-202006",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.06.02",
+		ImageVersion:   "2020.06.22",
 	}
 
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019

--- a/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202006_2020.06.22.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1604/aks-engine-ubuntu-1604-202006_2020.06.22.txt
@@ -1,0 +1,161 @@
+Starting build on  Mon Jun 22 22:37:29 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dkms
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - gcc
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - linux-headers-4.15.0-1089-azure
+  - make
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - apmz v0.5.1
+  - bpftrace
+  - moby v3.0.12
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.22
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.1.3
+  - Azure CNI version 1.1.2
+  - Azure CNI version 1.1.0
+  - CNI plugin version 0.8.6
+  - img
+Docker images pre-pulled:
+  - mcr.microsoft.com/oss/kubernetes/dashboard:v2.0.1
+  - mcr.microsoft.com/oss/kubernetes/dashboard:v2.0.0
+  - mcr.microsoft.com/oss/kubernetes/metrics-scraper:v1.0.4
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.6
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.6
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.1.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/pause:1.4.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.17.2
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.16.5
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.15.6
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.9
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.8
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.1.4
+  - mcr.microsoft.com/oss/nvidia/k8s-device-plugin:1.0.0-beta6
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.11
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.10-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.12
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.12
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.12-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.11-azs
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.5.0
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.7.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.6.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.5.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v2.0.0
+  - mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v2.0.0
+  - k8s.gcr.io/node-problem-detector:v0.8.2
+  - mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.6
+  - mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.11
+  - mcr.microsoft.com/k8s/aad-pod-identity/mic:1.6.1
+  - mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.6.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-proportional-autoscaler:1.7.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-proportional-autoscaler:1.1.2-r2
+  - registry:2.7.1
+Using kernel:
+Linux version 4.15.0-1089-azure (buildd@lcy01-amd64-009) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)) #99~16.04.1-Ubuntu SMP Fri Jun 5 15:30:32 UTC 2020
+Install completed successfully on  Mon Jun 22 22:53:22 UTC 2020
+VSTS Build NUMBER: 20200622.8
+VSTS Build ID: 32203850
+Commit: c54b4146a9bd2875c913779bb1ffba6f065dd9a3
+Feature flags:

--- a/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202006_2020.06.22.txt
+++ b/vhd/release-notes/aks-engine-ubuntu-1804/aks-engine-ubuntu-1804-202006_2020.06.22.txt
@@ -1,0 +1,163 @@
+Starting build on  Mon Jun 22 22:38:18 UTC 2020
+Components downloaded in this VHD build (some of the below components might get deleted during cluster provisioning if they are not needed):
+  - apache2-utils
+  - apt-transport-https
+  - auditd
+  - blobfuse
+  - ca-certificates
+  - ceph-common
+  - cgroup-lite
+  - cifs-utils
+  - conntrack
+  - cracklib-runtime
+  - dkms
+  - dbus
+  - ebtables
+  - ethtool
+  - fuse
+  - gcc
+  - git
+  - glusterfs-client
+  - init-system-helpers
+  - iproute2
+  - ipset
+  - iptables
+  - jq
+  - libpam-pwquality
+  - libpwquality-tools
+  - linux-headers-5.3.0-1028-azure
+  - make
+  - mount
+  - nfs-common
+  - pigz socat
+  - traceroute
+  - util-linux
+  - xz-utils
+  - zip
+  - ntp
+  - ntpstat
+  - apmz v0.5.1
+  - bpftrace
+  - moby v3.0.12
+  - nvidia-docker2 nvidia-container-runtime
+  - etcd v3.3.22
+  - bcc-tools
+  - libbcc-examples
+  - Azure CNI version 1.1.3
+  - Azure CNI version 1.1.2
+  - Azure CNI version 1.1.0
+  - CNI plugin version 0.8.6
+  - img
+Docker images pre-pulled:
+  - mcr.microsoft.com/oss/kubernetes/dashboard:v2.0.1
+  - mcr.microsoft.com/oss/kubernetes/dashboard:v2.0.0
+  - mcr.microsoft.com/oss/kubernetes/metrics-scraper:v1.0.4
+  - k8s.gcr.io/addon-resizer:1.8.7
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.7
+  - k8s.gcr.io/addon-resizer:1.8.4
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:1.8.4
+  - k8s.gcr.io/metrics-server-amd64:v0.3.6
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.6
+  - k8s.gcr.io/metrics-server-amd64:v0.3.5
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.5
+  - k8s.gcr.io/metrics-server-amd64:v0.3.4
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.4
+  - k8s.gcr.io/metrics-server-amd64:v0.2.1
+  - mcr.microsoft.com/oss/kubernetes/metrics-server:v0.2.1
+  - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-kube-dns:1.15.4
+  - k8s.gcr.io/kube-addon-manager-amd64:v9.1.1
+  - mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.1
+  - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4
+  - mcr.microsoft.com/oss/kubernetes/pause:1.4.0
+  - k8s.gcr.io/pause-amd64:3.1
+  - gcr.io/kubernetes-helm/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/tiller:v2.13.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.18.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.17.2
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.16.5
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v1.15.6
+  - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/k8s-dns-sidecar:1.14.10
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.9
+  - mcr.microsoft.com/oss/kubernetes/coredns:1.6.7
+  - k8s.gcr.io/rescheduler:v0.4.0
+  - mcr.microsoft.com/oss/kubernetes/rescheduler:v0.4.0
+  - microsoft/virtual-kubelet:latest
+  - mcr.microsoft.com/containernetworking/networkmonitor:v0.0.8
+  - mcr.microsoft.com/containernetworking/azure-npm:v1.1.4
+  - mcr.microsoft.com/oss/nvidia/k8s-device-plugin:1.0.0-beta6
+  - mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.16
+  - mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8
+  - k8s.gcr.io/ip-masq-agent-amd64:v2.5.0
+  - mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v2.5.0
+  - mcr.microsoft.com/k8s/kms/keyvault:v0.0.9
+  - quay.io/coreos/flannel:v0.10.0-amd64
+  - quay.io/coreos/flannel:v0.8.0-amd64
+  - busybox
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.19.0-beta.2
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.4
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.3
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.7
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.7-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.6
+  - mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.6-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.11
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.10
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.10-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.12
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.12
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.12-azs
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v1.15.11
+  - mcr.microsoft.com/oss/kubernetes/hyperkube:v1.15.11-azs
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.5.0
+  - mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.5.0
+  - mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.7.0
+  - mcr.microsoft.com/k8s/csi/azurefile-csi:v0.6.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.5.0
+  - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.3.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v1.1.0
+  - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v2.0.0
+  - mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v2.0.0
+  - k8s.gcr.io/node-problem-detector:v0.8.2
+  - mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.6
+  - mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.11
+  - mcr.microsoft.com/k8s/aad-pod-identity/mic:1.6.1
+  - mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.6.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-proportional-autoscaler:1.7.1
+  - mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-proportional-autoscaler:1.1.2-r2
+  - registry:2.7.1
+Using kernel:
+Linux version 5.3.0-1028-azure (buildd@lcy01-amd64-003) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #29~18.04.1-Ubuntu SMP Fri Jun 5 14:32:34 UTC 2020
+Install completed successfully on  Mon Jun 22 22:55:18 UTC 2020
+VSTS Build NUMBER: 20200622.9
+VSTS Build ID: 32203860
+Commit: c54b4146a9bd2875c913779bb1ffba6f065dd9a3
+Feature flags:


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Updates Linux VHD references to the 2020.06.22 vintage.

Includes the following pre-downloaded container images:

- k8s.gcr.io/metrics-server-amd64:v0.3.6
- mcr.microsoft.com/oss/kubernetes/metrics-server:v0.3.6
- k8s.gcr.io/kube-addon-manager-amd64:v9.1.1
- mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.1
- mcr.microsoft.com/oss/kubernetes/pause:1.4.0
- mcr.microsoft.com/containernetworking/azure-npm:v1.1.4
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.19.0-beta.2
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.19.0-beta.2
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.19.0-beta.2
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.19.0-beta.2
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.4
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.4
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.4
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.4
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.7
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.7
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.7
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.7
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.7-azs
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.7-azs
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.7-azs
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.7-azs
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.11
- k8s.gcr.io/node-problem-detector:v0.8.2
- mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.6
- mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.11
- mcr.microsoft.com/k8s/aad-pod-identity/mic:1.6.1
- mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.6.1

No longer pre-downloading these container images:

- k8s.gcr.io/kube-addon-manager-amd64:v9.0.2
- mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.0.2
- mcr.microsoft.com/oss/kubernetes/pause:1.3.1
- mcr.microsoft.com/containernetworking/azure-npm:v1.1.2
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.19.0-beta.0
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.19.0-beta.0
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.19.0-beta.0
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.19.0-beta.0
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.2
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.18.2
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.18.2
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.18.2
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.5
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.5
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.5
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.5
- mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.17.5-azs
- mcr.microsoft.com/oss/kubernetes/kube-controller-manager:v1.17.5-azs
- mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.17.5-azs
- mcr.microsoft.com/oss/kubernetes/kube-scheduler:v1.17.5-azs
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.9
- mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.9-azs
- k8s.gcr.io/node-problem-detector:v0.8.1
- mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.5
- mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.10

Includes a new 18.04-LTS kernel:

- Linux version 5.3.0-1028-azure (buildd@lcy01-amd64-003) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #29~18.04.1-Ubuntu SMP Fri Jun 5 14:32:34 UTC 2020

Includes a new 16.04-LTS kernel:

- Linux version 4.15.0-1089-azure (buildd@lcy01-amd64-009) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)) #99~16.04.1-Ubuntu SMP Fri Jun 5 15:30:32 UTC 2020

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
