### PR TITLE
fix: always use /var/run/reboot-required

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -259,7 +259,7 @@ configureCNI() {
   {{if HasCiliumNetworkPlugin}}
   systemctl enable sys-fs-bpf.mount
   systemctl restart sys-fs-bpf.mount
-  REBOOTREQUIRED=true
+  touch /var/run/reboot-required
   {{end}}
 {{- if IsAzureStackCloud}}
   if [[ ${NETWORK_PLUGIN} == "azure" ]]; then
@@ -459,7 +459,7 @@ installKubeletAndKubectl() {
   rm -rf ${binPath}/kubelet-* ${binPath}/kubectl-* /home/hyperkube-downloads &
 }
 ensureK8sControlPlane() {
-  if $REBOOTREQUIRED || [ "$NO_OUTBOUND" = "true" ]; then
+  if [ -f /var/run/reboot-required ] || [ "$NO_OUTBOUND" = "true" ]; then
     return
   fi
   retrycmd 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}}

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -46,13 +46,6 @@ ETCD_PEER_CERT=$(echo ${ETCD_PEER_CERTIFICATES} | cut -d'[' -f 2 | cut -d']' -f 
 ETCD_PEER_KEY=$(echo ${ETCD_PEER_PRIVATE_KEYS} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))
 set -x
 
-if [ -f /var/run/reboot-required ]; then
-  REBOOTREQUIRED=true
-  trace_info "RebootRequired" "reboot=true"
-else
-  REBOOTREQUIRED=false
-fi
-
 time_metric "ConfigureAdminUser" configureAdminUser
 
 {{- if HasVHDDistroNodes}}
@@ -300,8 +293,8 @@ fi
 
 {{end}}
 
-if $REBOOTREQUIRED; then
-  echo 'reboot required, rebooting node in 1 minute'
+if [ -f /var/run/reboot-required ]; then
+  trace_info "RebootRequired" "reboot=true"
   /bin/bash -c "shutdown -r 1 &"
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
     aptmarkWALinuxAgent unhold &


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR standardizes the CSE bootstrapping script to always evaluate `[ -f /var/run/reboot-required ]` (does the file exist?) to determine whether or not we need to reboot.

In addition, in the case where we *want* to reboot, we touch that file, which as far as I can tell is a safe tactic as `/var/run` is tmpfs and files therein will be reliably removed upon reboot. Cf:

```
azureuser@k8s-master-31453872-1:~$ ls -la /var/run
lrwxrwxrwx 1 root root 4 Nov 13  2019 /var/run -> /run
azureuser@k8s-master-31453872-1:~$ df -h /run
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           796M  1.2M  795M   1% /run
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3533

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
