### PR TITLE
chore: Use moby 19.03.x packages

### DIFF
--- a/.pipelines/e2e-step-template.yaml
+++ b/.pipelines/e2e-step-template.yaml
@@ -28,4 +28,4 @@ steps:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: '**/junit.xml'
-    condition: false
+    condition: always()

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -222,7 +222,7 @@
       }
     },
     "mobyVersion": {
-      "defaultValue": "3.0.13",
+      "defaultValue": "19.03.11",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -238,7 +238,8 @@
          "3.0.10",
          "3.0.11",
          "3.0.12",
-         "3.0.13"
+         "3.0.13",
+         "19.03.11"
        ],
       "type": "string"
     },

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -222,7 +222,7 @@
       }
     },
     "mobyVersion": {
-      "defaultValue": "19.03.11",
+      "defaultValue": "19.03.12",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -239,7 +239,8 @@
          "3.0.11",
          "3.0.12",
          "3.0.13",
-         "19.03.11"
+         "19.03.11",
+         "19.03.12"
        ],
       "type": "string"
     },

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -466,7 +466,7 @@ const (
 	// DefaultKubernetesDNSServiceIPv6 specifies the IPv6 address that kube-dns listens on by default. must by in the default Service CIDR range.
 	DefaultKubernetesDNSServiceIPv6 = "fd00::10"
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
-	DefaultMobyVersion = "3.0.13"
+	DefaultMobyVersion = "19.03.11"
 	// DefaultContainerdVersion specifies the default containerd version to install.
 	DefaultContainerdVersion = "1.3.2"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -466,7 +466,7 @@ const (
 	// DefaultKubernetesDNSServiceIPv6 specifies the IPv6 address that kube-dns listens on by default. must by in the default Service CIDR range.
 	DefaultKubernetesDNSServiceIPv6 = "fd00::10"
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
-	DefaultMobyVersion = "19.03.11"
+	DefaultMobyVersion = "19.03.12"
 	// DefaultContainerdVersion specifies the default containerd version to install.
 	DefaultContainerdVersion = "1.3.2"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -22536,7 +22536,7 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
       }
     },
     "mobyVersion": {
-      "defaultValue": "19.03.11",
+      "defaultValue": "19.03.12",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -22553,7 +22553,8 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
          "3.0.11",
          "3.0.12",
          "3.0.13",
-         "19.03.11"
+         "19.03.11",
+         "19.03.12"
        ],
       "type": "string"
     },

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -22536,7 +22536,7 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
       }
     },
     "mobyVersion": {
-      "defaultValue": "3.0.13",
+      "defaultValue": "19.03.11",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -22552,7 +22552,8 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
          "3.0.10",
          "3.0.11",
          "3.0.12",
-         "3.0.13"
+         "3.0.13",
+         "19.03.11"
        ],
       "type": "string"
     },

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -70,6 +70,7 @@ echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
 MOBY_VERSION="19.03.12"
 installMoby
+systemctl start docker
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
 downloadGPUDrivers
 echo "  - nvidia-docker2 nvidia-container-runtime" >> ${VHD_LOGS_FILEPATH}

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -68,7 +68,7 @@ echo "  - apmz $apmz_version" >> ${VHD_LOGS_FILEPATH}
 installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
-MOBY_VERSION="3.0.13"
+MOBY_VERSION="19.03.11"
 installMoby
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
 downloadGPUDrivers

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -68,7 +68,7 @@ echo "  - apmz $apmz_version" >> ${VHD_LOGS_FILEPATH}
 installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
-MOBY_VERSION="19.03.11"
+MOBY_VERSION="19.03.12"
 installMoby
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
 downloadGPUDrivers


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Update moby verison.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

N/A

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:


This is the same as 3.0.13, except the new versioning to match upstream
and things are packaged differently (e.g. containerd is now managed with
systemd instead of by dockerd).
The packaging/build changes are fairly significant, but the underlying
moby commits are the same.
