### PR TITLE
chore: updating windows VHD used by aks-engine to include June k8s packages

### DIFF
--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -231,7 +231,7 @@ function Write-KubeClusterConfig {
     $Global:ClusterConfiguration | Add-Member -MemberType NoteProperty -Name Cri -Value @{
         Name   = $global:ContainerRuntime;
         Images = @{
-            "Pause" = "mcr.microsoft.com/oss/kubernetes/pause:1.3.1"
+            "Pause" = "mcr.microsoft.com/oss/kubernetes/pause:1.4.0"
         }
     }
 

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -162,7 +162,7 @@ New-InfraContainer {
     $clusterConfig = ConvertFrom-Json ((Get-Content $global:KubeClusterConfigPath -ErrorAction Stop) | Out-String)
     $defaultPauseImage = $clusterConfig.Cri.Images.Pause
 
-    $pauseImageVersions = @("1803", "1809", "1903", "1909")
+    $pauseImageVersions = @("1809", "1903", "1909", "2004")
 
     if ($pauseImageVersions -icontains $windowsVersion) {
         $imageList = docker images $defaultPauseImage --format "{{.Repository}}:{{.Tag}}"

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -196,7 +196,7 @@ var (
 		ImageOffer:     "aks-windows",
 		ImageSku:       "2019-datacenter-core-smalldisk-2006",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "17763.1282.200610",
+		ImageVersion:   "17763.1282.200625",
 	}
 
 	// WindowsServer2019OSImageConfig is the 'vanilla' Windows Server 2019 image
@@ -204,7 +204,7 @@ var (
 		ImageOffer:     "WindowsServer",
 		ImageSku:       "2019-Datacenter-Core-with-Containers-smalldisk",
 		ImagePublisher: "MicrosoftWindowsServer",
-		ImageVersion:   "17763.1217.2005081535",
+		ImageVersion:   "17763.1282.2006061953",
 	}
 
 	// ACC1604OSImageConfig is the ACC image based on Ubuntu 16.04.

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -182,6 +182,18 @@ func getKubeConfigs() map[string]map[string]string {
 
 func getVersionOverrides(v string) map[string]string {
 	switch v {
+	case "1.18.4":
+		return map[string]string{"windowszip": "v1.18.4-hotfix.20200624/windowszip/v1.18.4-hotfix.20200624-1int.zip"}
+	case "1.18.2":
+		return map[string]string{"windowszip": "v1.18.2-hotfix.20200624/windowszip/v1.18.2-hotfix.20200624-1int.zip"}
+	case "1.17.7":
+		return map[string]string{"windowszip": "v1.17.7-hotfix.20200624/windowszip/v1.17.7-hotfix.20200624-1int.zip"}
+	case "1.16.11":
+		return map[string]string{"windowszip": "v1.16.11-hotfix.20200617/windowszip/v1.16.11-hotfix.20200617-1int.zip"}
+	case "1.16.10":
+		return map[string]string{"windowszip": "v1.16.10-hotfix.20200623/windowszip/v1.16.10-hotfix.20200623-1int.zip"}
+	case "1.15.12":
+		return map[string]string{"windowszip": "v1.15.12-hotfix.20200623/windowszip/v1.15.12-hotfix.20200623-1int.zip"}
 	case "1.8.11":
 		return map[string]string{"kube-dns": "k8s-dns-kube-dns-amd64:1.14.9"}
 	case "1.8.9":

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -41645,7 +41645,7 @@ function Write-KubeClusterConfig {
     $Global:ClusterConfiguration | Add-Member -MemberType NoteProperty -Name Cri -Value @{
         Name   = $global:ContainerRuntime;
         Images = @{
-            "Pause" = "mcr.microsoft.com/oss/kubernetes/pause:1.3.1"
+            "Pause" = "mcr.microsoft.com/oss/kubernetes/pause:1.4.0"
         }
     }
 
@@ -43676,7 +43676,7 @@ New-InfraContainer {
     $clusterConfig = ConvertFrom-Json ((Get-Content $global:KubeClusterConfigPath -ErrorAction Stop) | Out-String)
     $defaultPauseImage = $clusterConfig.Cri.Images.Pause
 
-    $pauseImageVersions = @("1803", "1809", "1903", "1909")
+    $pauseImageVersions = @("1809", "1903", "1909", "2004")
 
     if ($pauseImageVersions -icontains $windowsVersion) {
         $imageList = docker images $defaultPauseImage --format "{{.Repository}}:{{.Tag}}"

--- a/vhd/release-notes/aks-windows/2019-datacenter-core-smalldisk-17763.1282.200625.txt
+++ b/vhd/release-notes/aks-windows/2019-datacenter-core-smalldisk-17763.1282.200625.txt
@@ -1,0 +1,135 @@
+﻿Build Number: 20200625.3
+Build Id:     8437
+Build Repo:   https://github.com/Azure/aks-engine
+Build Branch: master
+Commit:       2ebdadb6d4b60baa99193b45e853661877db9953
+
+VHD ID:      0999abf5-624a-473d-b2ef-6c997f923b4d
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.1282
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB4552924 : Update          : http://support.microsoft.com/?kbid=4552924
+	KB4549947 : Security Update : http://support.microsoft.com/?kbid=4549947
+	KB4561608 : Security Update : http://support.microsoft.com/?kbid=4561608
+
+Installed Updates
+	2020-05 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB4556441)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.319.173.0)
+	2020-06 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB4561608)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+
+Docker Info
+Version: Docker version 19.03.5, build 2ee0c57608
+
+Images:
+
+Repository                                                     Tag                               ID          
+----------                                                     ---                               --          
+mcr.microsoft.com/oss/kubernetes/pause                         1.4.0                             23d55e3daca0
+mcr.microsoft.com/windows/servercore                           ltsc2019                          486def14a6bd
+mcr.microsoft.com/windows/nanoserver                           1809                              96b4b0f16026
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v1.2.1-alpha.1-windows-1809-amd64 927caec05c10
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.0.1-alpha.1-windows-1809-amd64 7c4afdb7e0d6
+
+
+
+Cached Files:
+
+File                                                                             Sha256                                                           SizeBytes
+----                                                                             ------                                                           ---------
+c:\akse-cache\collect-windows-logs.ps1                                           8CCABC979D689753F1C92294A065953DB1CA3D2F5F714F928321B17276A4D3CD      3554
+c:\akse-cache\collectlogs.ps1                                                    F979A04A6907690681074937337FA3C3F93278DDC6152E4571D8F220FA0AA5E5      7950
+c:\akse-cache\dumpVfpPolicies.ps1                                                02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                        BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                           A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                         4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\portReservationTest.ps1                                            0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                  3A566462ADBD27A0DCAB4049EF4A1A3EE7AECF2FCFEC6ED8A1CAE305AE7EF562       408
+c:\akse-cache\startpacketcapture.cmd                                             3E31690E507C8B18AC5CC569C89B51CE1901630A501472DA1BC1FBF2737AA5BC       756
+c:\akse-cache\stoppacketcapture.cmd                                              BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                           3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                     CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\containerd\containerd-0.0.87-public.zip                            8A40E7ECE59C79D29E878F6F5CC4546E6D672844EC7CF958EF92710573B84106  80967297
+c:\akse-cache\win-k8s\v1.15.10-1int.zip                                          F8E1941625136C61FE3FE1193F4DB59953E615EBB27390968530F0756D54CAAD  99075694
+c:\akse-cache\win-k8s\v1.15.10-azs-1int.zip                                      D6EB58BF38C512D9B8546BF62748840689E7FF6ACD423CD42C83CEBE9BA38828  99079937
+c:\akse-cache\win-k8s\v1.15.11-1int.zip                                          FD31594C5D6C3C0EDD97269FB09630EC751353894166521F919C48DB3F58ADD9  99122881
+c:\akse-cache\win-k8s\v1.15.11-azs-1int.zip                                      10576CBA08115EC246CAE44F6AD52ECB26EC88DBBF77A7571F79AD769B5E3B31  99130288
+c:\akse-cache\win-k8s\v1.15.12-1int.zip                                          18E0124DEB357EE6E599DD583AD0B74E3DFBEF41C70E0E79EB1846C5839E5116  99183450
+c:\akse-cache\win-k8s\v1.15.12-azs-1int.zip                                      BC930FFAD50B823B0D15C3DBF21CC2D85CF9C84873C9852BA2F87968D298ECA8  99182019
+c:\akse-cache\win-k8s\v1.15.12-hotfix.20200623-1int.zip                          8DD2BD7B8FC854755083E2EF5633473AC418FBA2A960228EAFF6E118448583BA  99175484
+c:\akse-cache\win-k8s\v1.16.10-1int.zip                                          E55A3FA96344AB221C71A8760E21590284908A0215DE18D66B7E94D027004E50  98024468
+c:\akse-cache\win-k8s\v1.16.10-azs-1int.zip                                      2FAC2F9925AC71B23E68D682B088F1B2D6301B2A720D32132D0AE4DC1386278D  98018630
+c:\akse-cache\win-k8s\v1.16.10-hotfix.20200623-1int.zip                          404035F596A4D22CB0FE4095B237E7E672D965E06C3CADBB43E01ECF020D0BD3  98025136
+c:\akse-cache\win-k8s\v1.16.11-1int.zip                                          2FF745A1D8641CF70294A900159D505334B0037958CE5624108B7A5801F00A43  98022699
+c:\akse-cache\win-k8s\v1.16.11-azs-1int.zip                                      8ED214C47F558BFC13996575FBFFFB991040600C9B4C71217650924D331824C3  98025326
+c:\akse-cache\win-k8s\v1.16.11-hotfix.20200617-1int.zip                          4E0C815657D4ABEAA2A07F6BBEB7F416BB1FBF2C2AD243400B6102D1050EEC7E  98024306
+c:\akse-cache\win-k8s\v1.16.8-1int.zip                                           EC79CB805E21DD0BC07D2E67FDB34A97D53DB104A7F0D3FD4016BD61FA2481BA  97976592
+c:\akse-cache\win-k8s\v1.16.9-1int.zip                                           900606A4B3BCD54C8F47874AB427F5187F76A3318DBA96459AE049244823FAC4  97998180
+c:\akse-cache\win-k8s\v1.16.9-azs-1int.zip                                       6FE2C265DEAEFEADE1B3894EAA6550A65E3BB62B2CECEB2FF8D948BD7300273C  98006329
+c:\akse-cache\win-k8s\v1.17.5-1int.zip                                           BD6829690C6699CDCCC40CAF347080DD5935D36A6C5398F22C42D890E920C100  57341983
+c:\akse-cache\win-k8s\v1.17.5-azs-1int.zip                                       3CDA19E607233B8528CAEE7BC0F54851E11FDA2C5FDD55AB8832E56EF46D6168  98279104
+c:\akse-cache\win-k8s\v1.17.6-1int.zip                                           C0E7975B8DFEB877D8A567FE2A47BB85F7661E4300B5189B44F1EE0E290C4DA0  57391554
+c:\akse-cache\win-k8s\v1.17.6-azs-1int.zip                                       1D989412D6024A298C94A3A16844C27A4EBCBD010EA328C19762703FD20C657E  98278575
+c:\akse-cache\win-k8s\v1.17.7-1int.zip                                           9C493A8FB39654B9DAA2845BA422A034E4EB396103B62B02A9681372DEB54CE1  57398282
+c:\akse-cache\win-k8s\v1.17.7-azs-1int.zip                                       005E16989A46DBC6610EAA5C36696A35A847F47C1B990FC233D06D7748F27405  98299089
+c:\akse-cache\win-k8s\v1.17.7-hotfix.20200624-1int.zip                           AD6AD63B116BC8FC9ACE17B69D8F0C64E90FCB429EDF434800171E9482FCCDA0  57396417
+c:\akse-cache\win-k8s\v1.18.2-1int.zip                                           6F326FF16F063F7DC3A81CB09715DE5EC3674164E870D4E978C3D915D80076E7  57971836
+c:\akse-cache\win-k8s\v1.18.2-hotfix.20200624-1int.zip                           44273A8FE3AA64158B04B6EC265DB98697EE449CF7F0D539D03A3D33E0CD9A6F  58017104
+c:\akse-cache\win-k8s\v1.18.3-1int.zip                                           EE26BD5FE719E87845078590CDA54B93B27D44C1FE840861E1139648B29B9E5F  58020535
+c:\akse-cache\win-k8s\v1.18.4-1int.zip                                           F231B45D9C29DFA40B39F9FFA9BD70B144A48D0D544888EB3CDE53E221876CD8  58022668
+c:\akse-cache\win-k8s\v1.18.4-hotfix.20200624-1int.zip                           E3EA456C92D91695A421BCAC3F407E2B4885E1DB69262ADF6EFF9D4299532C57  58028344
+c:\akse-cache\win-k8s\v1.19.0-beta.2-1int.zip                                    CAC727B0D897CEF24C3A18E8C19849803DC3E773F4D54CFE9D765B8BD0098FA4  60262513
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.1.2.zip 60F21CAD6439446FCBD1D9A634E7D739D3BF589D17D7D0EAF4A90A63B544466B  23792148
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip 1E660EC0A5923A3E9F62B81BBC5F21923DB82F4F61F06A8067C7E5EB7A549799  23790847
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-windows-amd64-v1.1.0.zip               9733A37F242478D6B5E4DD3D548715FAC916D33B29EBF833FB4BC4A7A22449B0  22131536
+
+
+
+


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
1. cherry-pick commit from master branch: chore: updating windows VHD used by aks-engine to include June k8s packages (#3550)

2. use hotfix Windows builds for 1.18.4, 1.18.2, 1.17.7, 1.16.11, 1.16.10 and 1.15.12: from master branch:
    1. fix: use hotfix Windows builds for 1.18.4, 1.17.7, and 1.16.11 (#3510)
    1. fix: add windows hotfix overrides for 1.18.2, 1.16.10, 1.15.12 for AKS (#3528)
    1. fix: updating hotfix packages used for windows to include hyperkube and iptables fixes (#3539)


3. Update PauseImage to 1.4.0 for Windows: from master branch:
    chore: Updates the pause image to 1.4.0 (#3516)


