### PR TITLE
test: enable daemonset E2E test conveniences

### DIFF
--- a/test/e2e/kubernetes/daemonset/daemonset.go
+++ b/test/e2e/kubernetes/daemonset/daemonset.go
@@ -1,0 +1,129 @@
+//+build test
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package daemonset
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os/exec"
+	"time"
+
+	"github.com/Azure/aks-engine/test/e2e/kubernetes/util"
+	"github.com/pkg/errors"
+)
+
+// Daemonset is used to parse data from kubectl get daemonsets
+type Daemonset struct {
+	Metadata Metadata `json:"metadata"`
+	Status   Status   `json:"status"`
+}
+
+// Metadata holds information like name, createdat, labels, and namespace
+type Metadata struct {
+	CreatedAt time.Time         `json:"creationTimestamp"`
+	Labels    map[string]string `json:"labels"`
+	Name      string            `json:"name"`
+	Namespace string            `json:"namespace"`
+}
+
+// Status holds information like hostIP and phase
+type Status struct {
+	CurrentNumberScheduled int `json:"currentNumberScheduled"`
+	DesiredNumberScheduled int `json:"desiredNumberScheduled"`
+	NumberAvailable        int `json:"numberAvailable"`
+	NumberReady            int `json:"numberReady"`
+}
+
+// List is a container that holds all pods returned from doing a kubectl get daemonsets
+type List struct {
+	Daemonsets []Daemonset `json:"items"`
+}
+
+// GetResult is a return struct for GetAsync
+type GetResult struct {
+	ds  *Daemonset
+	err error
+}
+
+// CreateDaemonsetFromFile will create a Pod from file with a name
+func CreateDaemonsetFromFile(filename, name, namespace string, sleep, timeout time.Duration) (*Daemonset, error) {
+	cmd := exec.Command("k", "apply", "-f", filename)
+	util.PrintCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error trying to create Daemonset %s:%s\n", name, string(out))
+		return nil, err
+	}
+	d, err := GetWithRetry(name, namespace, sleep, timeout)
+	if err != nil {
+		log.Printf("Error while trying to fetch Pod %s:%s\n", name, err)
+		return nil, err
+	}
+	return d, nil
+}
+
+// Get will return a daemonset with a given name and namespace
+func Get(dsName, namespace string, retries int) (*Daemonset, error) {
+	ds := Daemonset{}
+	var out []byte
+	var err error
+	for i := 0; i < retries; i++ {
+		cmd := exec.Command("k", "get", "daemonsets", dsName, "-n", namespace, "-o", "json")
+		out, err = cmd.CombinedOutput()
+		if err == nil {
+			jsonErr := json.Unmarshal(out, &ds)
+			if jsonErr != nil {
+				log.Printf("Error unmarshalling pods json:%s\n", jsonErr)
+				err = jsonErr
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return &ds, err
+}
+
+// GetAsync wraps Get with a struct response for goroutine + channel usage
+func GetAsync(dsName, namespace string) GetResult {
+	ds, err := Get(dsName, namespace, 1)
+	return GetResult{
+		ds:  ds,
+		err: err,
+	}
+}
+
+// GetWithRetry gets a daemonset, allowing for retries
+func GetWithRetry(dsName, namespace string, sleep, timeout time.Duration) (*Daemonset, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ch := make(chan GetResult)
+	var mostRecentGetWithRetryError error
+	var ds *Daemonset
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				ch <- GetAsync(dsName, namespace)
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case result := <-ch:
+			mostRecentGetWithRetryError = result.err
+			ds = result.ds
+			if mostRecentGetWithRetryError == nil {
+				if ds != nil {
+					return ds, nil
+				}
+			}
+		case <-ctx.Done():
+			return nil, errors.Errorf("GetWithRetry timed out: %s\n", mostRecentGetWithRetryError)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR enables more convenient daemonset testing, as well as retrieving pods by label, which is a common way of deterministically correlating a pod from its originating daemonset spec.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
