### PR TITLE
fix: kube-proxy upgrade from v1.15 to v1.16

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -43,6 +43,7 @@ type upgradeCmd struct {
 	resourceGroupName                        string
 	apiModelPath                             string
 	deploymentDirectory                      string
+	currentVersion                           string
 	upgradeVersion                           string
 	location                                 string
 	kubeconfigPath                           string
@@ -246,6 +247,7 @@ func (uc *upgradeCmd) initialize() error {
 			return errors.Wrap(err, "Invalid upgrade target version. Consider using --force if you really want to proceed")
 		}
 	}
+	uc.currentVersion = uc.containerService.Properties.OrchestratorProfile.OrchestratorVersion
 	uc.containerService.Properties.OrchestratorProfile.OrchestratorVersion = uc.upgradeVersion
 
 	//allows to identify VMs in the resource group that belong to this cluster.
@@ -312,6 +314,7 @@ func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	upgradeCluster.IsVMSSToBeUpgraded = isVMSSNameInAgentPoolsArray
+	upgradeCluster.CurrentVersion = uc.currentVersion
 
 	if err = upgradeCluster.UpgradeCluster(uc.client, kubeConfig, BuildTag); err != nil {
 		return errors.Wrap(err, "upgrading cluster")

--- a/pkg/armhelpers/azurestack/kubeclient.go
+++ b/pkg/armhelpers/azurestack/kubeclient.go
@@ -117,6 +117,11 @@ func (c *KubernetesClientSetClient) SupportEviction() (string, error) {
 	return "", nil
 }
 
+// DeleteDaemonSet deletes the passed in daemonset.
+func (c *KubernetesClientSetClient) DeleteDaemonSet(daemonset *appsv1.DaemonSet) error {
+	return c.clientset.AppsV1().DaemonSets(daemonset.Namespace).Delete(daemonset.Name, &metav1.DeleteOptions{})
+}
+
 // DeletePod deletes the passed in pod.
 func (c *KubernetesClientSetClient) DeletePod(pod *v1.Pod) error {
 	return c.clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
@@ -170,6 +175,11 @@ func (c *KubernetesClientSetClient) WaitForDelete(logger *log.Entry, pods []v1.P
 		return true, nil
 	})
 	return pods, err
+}
+
+// GetDaemonSet returns a given daemonset in a namespace.
+func (c *KubernetesClientSetClient) GetDaemonSet(namespace, name string) (*appsv1.DaemonSet, error) {
+	return c.clientset.AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
 }
 
 // GetDeployment returns a given deployment in a namespace.

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -241,6 +241,8 @@ type KubernetesClient interface {
 	ListNodes() (*v1.NodeList, error)
 	// ListServiceAccounts returns a list of Service Accounts in a namespace
 	ListServiceAccounts(namespace string) (*v1.ServiceAccountList, error)
+	// GetDaemonSet returns details about DaemonSet with passed in name.
+	GetDaemonSet(namespace, name string) (*appsv1.DaemonSet, error)
 	// GetNode returns details about node with passed in name.
 	GetNode(name string) (*v1.Node, error)
 	// UpdateNode updates the node in the api server with the passed in info.
@@ -249,6 +251,8 @@ type KubernetesClient interface {
 	DeleteNode(name string) error
 	// SupportEviction queries the api server to discover if it supports eviction, and returns supported type if it is supported.
 	SupportEviction() (string, error)
+	// DeleteDaemonSet deletes the passed in DaemonSet.
+	DeleteDaemonSet(ds *appsv1.DaemonSet) error
 	// DeletePod deletes the passed in pod.
 	DeletePod(pod *v1.Pod) error
 	// DeleteServiceAccount deletes the passed in service account.

--- a/pkg/armhelpers/kubeclient.go
+++ b/pkg/armhelpers/kubeclient.go
@@ -116,6 +116,11 @@ func (c *KubernetesClientSetClient) SupportEviction() (string, error) {
 	return "", nil
 }
 
+// DeleteDaemonSet deletes the passed in daemonset.
+func (c *KubernetesClientSetClient) DeleteDaemonSet(daemonset *appsv1.DaemonSet) error {
+	return c.clientset.AppsV1().DaemonSets(daemonset.Namespace).Delete(daemonset.Name, &metav1.DeleteOptions{})
+}
+
 // DeletePod deletes the passed in pod.
 func (c *KubernetesClientSetClient) DeletePod(pod *v1.Pod) error {
 	return c.clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
@@ -169,6 +174,11 @@ func (c *KubernetesClientSetClient) WaitForDelete(logger *log.Entry, pods []v1.P
 		return true, nil
 	})
 	return pods, err
+}
+
+// GetDaemonSet returns a given daemonset in a namespace.
+func (c *KubernetesClientSetClient) GetDaemonSet(namespace, name string) (*appsv1.DaemonSet, error) {
+	return c.clientset.AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
 }
 
 // GetDeployment returns a given deployment in a namespace.

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -85,6 +85,7 @@ type MockKubernetesClient struct {
 	FailDeleteServiceAccount  bool
 	FailSupportEviction       bool
 	FailDeletePod             bool
+	FailDeleteDaemonSet       bool
 	FailEvictPod              bool
 	FailWaitForDelete         bool
 	ShouldSupportEviction     bool
@@ -394,6 +395,14 @@ func (mkc *MockKubernetesClient) SupportEviction() (string, error) {
 	return "", nil
 }
 
+//DeleteDaemonSet deletes the passed in daemonset
+func (mkc *MockKubernetesClient) DeleteDaemonSet(pod *appsv1.DaemonSet) error {
+	if mkc.FailDeleteDaemonSet {
+		return errors.New("DaemonSet failed")
+	}
+	return nil
+}
+
 //DeletePod deletes the passed in pod
 func (mkc *MockKubernetesClient) DeletePod(pod *v1.Pod) error {
 	if mkc.FailDeletePod {
@@ -416,6 +425,13 @@ func (mkc *MockKubernetesClient) WaitForDelete(logger *log.Entry, pods []v1.Pod,
 		return nil, errors.New("WaitForDelete failed")
 	}
 	return []v1.Pod{}, nil
+}
+
+// DaemonSet returns a given daemonset in a namespace.
+func (mkc *MockKubernetesClient) GetDaemonSet(namespace, name string) (*appsv1.DaemonSet, error) {
+	return &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{},
+	}, nil
 }
 
 // GetDeployment returns a given deployment in a namespace.

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -78,6 +78,7 @@ type UpgradeCluster struct {
 	UpgradeWorkFlow    UpgradeWorkFlow
 	Force              bool
 	ControlPlaneOnly   bool
+	CurrentVersion     string
 }
 
 // MasterPoolName pool name
@@ -179,6 +180,7 @@ func (uc *UpgradeCluster) getUpgradeWorkflow(kubeConfig string, aksEngineVersion
 	}
 	u := &Upgrader{}
 	u.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, uc.CordonDrainTimeout, aksEngineVersion, uc.ControlPlaneOnly)
+	u.CurrentVersion = uc.CurrentVersion
 	return u
 }
 

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -100,13 +100,13 @@ func (ku *Upgrader) handleUnreconcilableAddons() {
 	// deleting daemonset so addon-manager recreates instead of patching
 	upgradeVersion := ku.DataModel.Properties.OrchestratorProfile.OrchestratorVersion
 	if !common.IsKubernetesVersionGe(ku.CurrentVersion, "1.16.0") && common.IsKubernetesVersionGe(upgradeVersion, "1.16.0") {
-		ku.logger.Errorf("Attempting to delete kube-proxy daemonset.")
+		ku.logger.Infof("Attempting to delete kube-proxy daemonset.")
 		client, err := ku.getKubernetesClient(getResourceTimeout)
 		if err != nil {
 			ku.logger.Errorf("Error getting Kubernetes client: %v", err)
 			return
 		}
-		ds, err := client.GetDaemonSet("kube-system", "kube-proxy")
+		ds, err := client.GetDaemonSet("kube-system", common.KubeProxyAddonName)
 		if err != nil {
 			ku.logger.Errorf("Error getting kube-proxy daemonset: %v", err)
 			return
@@ -116,7 +116,7 @@ func (ku *Upgrader) handleUnreconcilableAddons() {
 			ku.logger.Errorf("Error deleting kube-proxy daemonset: %v", err)
 			return
 		}
-		ku.logger.Errorf("Deleted kube-proxy daemonset. Addon-manager will recreate it.")
+		ku.logger.Infof("Deleted kube-proxy daemonset. Addon-manager will recreate it.")
 	}
 }
 

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -79,7 +79,7 @@ func (ku *Upgrader) RunUpgrade() error {
 		return err
 	}
 
-	ku.handleUnreconcilableAddons(ctx)
+	ku.handleUnreconcilableAddons()
 
 	if ku.ControlPlaneOnly {
 		return nil
@@ -95,7 +95,7 @@ func (ku *Upgrader) RunUpgrade() error {
 
 // handleUnreconcilableAddons ensures addon upgrades that addon-manager cannot handle by itself.
 // This method fails silently otherwide it would break test "Should not fail if a Kubernetes client cannot be created" (upgradecluster_test.go)
-func (ku *Upgrader) handleUnreconcilableAddons(ctx context.Context) {
+func (ku *Upgrader) handleUnreconcilableAddons() {
 	// kube-proxy upgrade fails from v1.15 to 1.16: https://github.com/Azure/aks-engine/issues/3557
 	// deleting daemonset so addon-manager recreates instead of patching
 	upgradeVersion := ku.DataModel.Properties.OrchestratorProfile.OrchestratorVersion

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/armhelpers"
@@ -22,8 +20,11 @@ import (
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/aks-engine/pkg/i18n"
 	"github.com/Azure/aks-engine/pkg/operations"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Upgrader holds information on upgrading an AKS cluster
@@ -106,10 +107,11 @@ func (ku *Upgrader) handleUnreconcilableAddons() {
 			ku.logger.Errorf("Error getting Kubernetes client: %v", err)
 			return
 		}
-		ds, err := client.GetDaemonSet("kube-system", common.KubeProxyAddonName)
-		if err != nil {
-			ku.logger.Errorf("Error getting kube-proxy daemonset: %v", err)
-			return
+		ds := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      common.KubeProxyAddonName,
+			},
 		}
 		err = client.DeleteDaemonSet(ds)
 		if err != nil {

--- a/test/e2e/kubernetes/daemonset/daemonset.go
+++ b/test/e2e/kubernetes/daemonset/daemonset.go
@@ -18,6 +18,7 @@ import (
 // Daemonset is used to parse data from kubectl get daemonsets
 type Daemonset struct {
 	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
 	Status   Status   `json:"status"`
 }
 
@@ -27,6 +28,25 @@ type Metadata struct {
 	Labels    map[string]string `json:"labels"`
 	Name      string            `json:"name"`
 	Namespace string            `json:"namespace"`
+}
+
+type Spec struct {
+	Template Template `json:"template"`
+}
+
+// Template is used for fetching the daemonset spec -> containers
+type Template struct {
+	TemplateSpec TemplateSpec `json:"spec"`
+}
+
+// TemplateSpec holds the list of containers for a daemonset
+type TemplateSpec struct {
+	Containers []Container `json:"containers"`
+}
+
+// Container holds information like image
+type Container struct {
+	Image string `json:"image"`
 }
 
 // Status holds information like hostIP and phase

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -704,13 +704,17 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have core kube-system addons running the correct version", func() {
-			By(fmt.Sprintf("Ensuring that the %s addon image matches orchestrator version", common.KubeProxyAddonName))
-			ds, err := daemonset.Get(common.KubeProxyAddonName, "kube-system", 3)
-			Expect(err).NotTo(HaveOccurred())
-			log.Printf("Image: %s", ds.Spec.Template.TemplateSpec.Containers[0].Image)
-			log.Printf("OrchestratorVersion: %s", eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion)
-			version := eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion
-			Expect(strings.HasSuffix(ds.Spec.Template.TemplateSpec.Containers[0].Image, version)).To(Equal(true))
+			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.CustomKubeProxyImage == "" {
+				By(fmt.Sprintf("Ensuring that the %s addon image matches orchestrator version", common.KubeProxyAddonName))
+				ds, err := daemonset.Get(common.KubeProxyAddonName, "kube-system", 3)
+				Expect(err).NotTo(HaveOccurred())
+				log.Printf("Image: %s", ds.Spec.Template.TemplateSpec.Containers[0].Image)
+				log.Printf("OrchestratorVersion: %s", eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion)
+				version := eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion
+				Expect(strings.HasSuffix(ds.Spec.Template.TemplateSpec.Containers[0].Image, version)).To(Equal(true))
+			} else {
+				Skip("Skipping as testing custom kube-proxy image")
+			}
 		})
 
 		It("Should not have any unready or crashing pods right after deployment", func() {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/aks-engine/pkg/armhelpers"
 	"github.com/Azure/aks-engine/test/e2e/config"
 	"github.com/Azure/aks-engine/test/e2e/engine"
+	"github.com/Azure/aks-engine/test/e2e/kubernetes/daemonset"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/deployment"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/event"
 	"github.com/Azure/aks-engine/test/e2e/kubernetes/hpa"
@@ -700,6 +701,16 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				Expect(running).To(Equal(true))
 			}
+		})
+
+		It("should have core kube-system addons running the correct version", func() {
+			By(fmt.Sprintf("Ensuring that the %s addon image matches orchestrator version", common.KubeProxyAddonName))
+			ds, err := daemonset.Get(common.KubeProxyAddonName, "kube-system", 3)
+			Expect(err).NotTo(HaveOccurred())
+			log.Printf("Image: %s", ds.Spec.Template.TemplateSpec.Containers[0].Image)
+			log.Printf("OrchestratorVersion: %s", eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion)
+			version := eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion
+			Expect(strings.HasSuffix(ds.Spec.Template.TemplateSpec.Containers[0].Image, version)).To(Equal(true))
 		})
 
 		It("Should not have any unready or crashing pods right after deployment", func() {


### PR DESCRIPTION
**Reason for Change**:
Added an extra step in between control-plane and agent upgrades to delete the kube-proxy daemon if the upgrade version is 1.16.

**Issue Fixed**:
Fixes #3557

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
This extra step will fail silently otherwise it would break test "Should not fail if a Kubernetes client cannot be created" (upgradecluster_test.go)