### PR TITLE
chore: set update strategy for the azure-cnms addon

### DIFF
--- a/parts/k8s/addons/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/addons/azure-cni-networkmonitor.yaml
@@ -14,6 +14,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: azure-cnms
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/parts/k8s/addons/azure-network-policy.yaml
+++ b/parts/k8s/addons/azure-network-policy.yaml
@@ -61,6 +61,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: azure-npm
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -8796,6 +8796,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: azure-cnms
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -8943,6 +8945,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: azure-npm
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
**Reason for Change**:
Our air-gap validations show that the `azure-cni-networkmonitor` pods running on control-plane nodes do not reach the `Running` state after an upgrade operation (AKSe v0.48+K8s v1.15 to v1.16). Switching `updateStrategy.type` to `RollingUpdate` (from default `OnDelete`) fixes the problem.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
Should we update all addons `updateStrategy`?