### PR TITLE
fix: validate signed powershell packages in Azure and China Cloud

### DIFF
--- a/docs/topics/windows-provisioning-scripts.md
+++ b/docs/topics/windows-provisioning-scripts.md
@@ -20,7 +20,7 @@ Changes to the provisioning scripts packaged in the .zip can be tested by:
 - Check in script updates to [staging/provisioning/windows](../../staging/provisioning/windows).
 - Create a new **versioned** zip with the contents of [staging/provisioning/windows](../../staging/provisioning/windows) and upload it to a storage account. (Versioning ensues compatability with file caching mecanisms used by aks-engine VHD backed installs)
   - Optional - First sign the powershell scripts (out-of-scope for this documentation).
-- Update `DefaultWindowsProvisioningScriptsPackageURL` in [pkg/api/const.go](../../pkg/api/const.go) with new URL.
+- Update `DefaultWindowsProvisioningScriptsPackageVersion` in [pkg/api/const.go](../../pkg/api/const.go) with new URL.
 - Add new URL to [/vhd/packer/configure-windows-vhd.ps1::Get-FilesToCacheOnVHD](../../vhd/packer/configure-windows-vhd.ps1).
 
 ## Validation

--- a/scripts/validate-windows-provisioning-scripts.sh
+++ b/scripts/validate-windows-provisioning-scripts.sh
@@ -4,24 +4,33 @@
 # Licensed under the MIT license.
 set -euo pipefail
 
-echo "Validating content of Windows provisioning scripts..."
-package_url=$(grep  "DefaultWindowsProvisioningScriptsPackageURL" ./pkg/api/const.go  | cut -d ' ' -f 3 | cut -d '"' -f2)
+function validate_package() {
+    local package_url=$1
 
-if [ -z "$package_url" ]; then
-    echo "Could not find value for 'DefaultWindowsProvisioningScriptsPackageURL' in /pkg/api/const.go"
+    temp_dir=$(mktemp -d -t aks-engine-XXXXXXXX)
+    echo "Downloading $package_version to $temp_dir/scripts.zip"
+    curl -L "$package_url" -o "$temp_dir/scripts.zip"
+
+    echo "Extracting files to $temp_dir/scripts"
+    unzip "$temp_dir/scripts.zip" -d "$temp_dir/scripts"
+
+    # Perform a recursive diff of the two directories but ignore comments since checked in powershell files
+    # will not container signature blocks at the end of the files.
+    diff -bBr --ignore-matching-lines='^#' "$temp_dir/scripts" "./staging/provisioning/windows/"
+
+    echo "Files match"
+}
+
+echo "Validating content of Windows provisioning scripts..."
+package_version=$(grep  "DefaultWindowsProvisioningScriptsPackageVersion" ./pkg/api/const.go  | cut -d ' ' -f 3 | cut -d '"' -f2)
+
+echo "Package version: $package_version"
+if [ -z "$package_version" ]; then
+    echo "Could not find value for 'DefaultWindowsProvisioningScriptsPackageVersion' in /pkg/api/const.go"
     exit 1
 fi
 
-temp_dir=$(mktemp -d -t aks-engine-XXXXXXXX)
+# urls from pkg/api/azenvtypes.go
+validate_package "https://kubernetesartifacts.azureedge.net/aks-engine/windows/provisioning/signedscripts-${package_version}.zip"
+validate_package "https://mirror.azk8s.cn/aks-engine/windows/provisioning/signedscripts-${package_version}.zip"
 
-echo "Downloading $package_url to $temp_dir/scripts.zip"
-curl -L "$package_url" -o "$temp_dir/scripts.zip"
-
-echo "Extracting files to $temp_dir/scripts"
-unzip "$temp_dir/scripts.zip" -d "$temp_dir/scripts"
-
-# Perform a recursive diff of the two directories but ignore comments since checked in powershell files
-# will not container signature blocks at the end of the files.
-diff -bBr --ignore-matching-lines='^#' "$temp_dir/scripts" "./staging/provisioning/windows/"
-
-echo "Files match"


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
The pr #3441 added signing of the powershell scripts for China Cloud but the validation script was not update to reflect the change.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
