### PR TITLE
test: e2e driver pass identity system to upgrade and scale commands

### DIFF
--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -282,6 +282,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
       --node-pool $nodepool \
       --new-node-count 1 \
       --auth-method client_secret \
+      --identity-system ${IDENTITY_SYSTEM}\
       --client-id ${AZURE_CLIENT_ID} \
       --client-secret ${AZURE_CLIENT_SECRET} || exit 1
   done
@@ -364,6 +365,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       --upgrade-version $ver_target \
       --vm-timeout 20 \
       --auth-method client_secret \
+      --identity-system ${IDENTITY_SYSTEM}\
       --client-id ${AZURE_CLIENT_ID} \
       --client-secret ${AZURE_CLIENT_SECRET} || exit 1
 
@@ -433,6 +435,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     --node-pool $nodepool \
     --new-node-count $NODE_COUNT \
     --auth-method client_secret \
+    --identity-system ${IDENTITY_SYSTEM}\
     --client-id ${AZURE_CLIENT_ID} \
     --client-secret ${AZURE_CLIENT_SECRET} || exit 1
   done


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
The previous e2e test was failing on Azure Stack ADFS environment, as there was no --identity-system parameter in the `aks-engine scale` and `aks-engine upgrade` commands.

BTW: the documentation about scale and upgrade may need an update as well.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
