### PR TITLE
fix: use mcr.azk8s.cn for Azure CNI networkmonitor in China cloud

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -288,7 +288,7 @@ var (
 			TillerImageBase:        "mcr.microsoft.com/",
 			ACIConnectorImageBase:  "dockerhub.azk8s.cn/microsoft/",
 			NVIDIAImageBase:        "dockerhub.azk8s.cn/nvidia/",
-			AzureCNIImageBase:      "dockerhub.azk8s.cn/containernetworking/",
+			AzureCNIImageBase:      "mcr.azk8s.cn/containernetworking/",
 			MCRKubernetesImageBase: "mcr.microsoft.com/",
 			CalicoImageBase:        "dockerhub.azk8s.cn/calico/",
 			EtcdDownloadURLBase:    "mcr.microsoft.com/oss/etcd-io/",


### PR DESCRIPTION
**Reason for Change**:

Changes the base URL for the Azure CNI networkmonitor component to `mcr.azk8s.cn` from `dockerhub.azk8s.cn`.

**Issue Fixed**:

Fixes #3580

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
