### PR TITLE
fix: use correct VMSS name comparison during Windows scale

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -391,7 +391,12 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			for _, vmss := range vmssListPage.Values() {
 				vmssName := *vmss.Name
 				if sc.agentPool.OSType == api.Windows {
-					if !(sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, sc.agentPoolIndex) == vmssName) {
+					winPoolIndexStr := vmssName[len(vmssName)-2:]
+					var err error
+					winPoolIndex, err = strconv.Atoi(winPoolIndexStr)
+					if err != nil {
+						return errors.Wrap(err, "failed to get Windows pool index from VMSS name")
+					if !(sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, winPoolIndex) == vmssName) {
 						continue
 					}
 				} else {

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -396,6 +397,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					winPoolIndex, err = strconv.Atoi(winPoolIndexStr)
 					if err != nil {
 						return errors.Wrap(err, "failed to get Windows pool index from VMSS name")
+					}
 					if !(sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, winPoolIndex) == vmssName) {
 						continue
 					}

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -392,15 +392,14 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			for _, vmss := range vmssListPage.Values() {
 				vmssName := *vmss.Name
 				if sc.agentPool.OSType == api.Windows {
-					winPoolIndexStr := vmssName[len(vmssName)-2:]
-					var err error
-					winPoolIndex, err = strconv.Atoi(winPoolIndexStr)
+					possibleIndex, err := strconv.Atoi(vmssName[len(vmssName)-2:])
 					if err != nil {
-						return errors.Wrap(err, "failed to get Windows pool index from VMSS name")
-					}
-					if !(sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, winPoolIndex) == vmssName) {
 						continue
 					}
+					if !(sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, possibleIndex) == vmssName) {
+						continue
+					}
+					winPoolIndex = possibleIndex
 				} else {
 					if !sc.vmInAgentPool(vmssName, vmss.Tags) {
 						continue


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR updates the "does this VMSS name correlate with my Windows node pool?" implementation so it actually does that correctly. The prior implementation was using tags, and then falling back to a VMAS-specific string comparison for Windows. This change simply compares the VMSS name using the canonical string munging foo that converts friendly node pool strings down to the concise (unfriendly) VMSS name for Windows pools.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3522

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
