### PR TITLE
fix: update windows docker version to fix log rotation error

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -48,7 +48,7 @@ const (
 	// DockerCEDockerComposeVersion is the Docker Compose version
 	DockerCEDockerComposeVersion = "1.14.0"
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
-	KubernetesWindowsDockerVersion = "19.03.5"
+	KubernetesWindowsDockerVersion = "19.03.11"
 	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
 	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 )

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2324,6 +2324,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		// verifies that the pod logs continue to flow even during rotation
+		// https://github.com/Azure/aks-engine/issues/3573
 		It("should be able to rotate docker logs", func() {
 			if !eng.HasWindowsAgents() {
 				Skip("No windows agent was provisioned for this Cluster Definition")
@@ -2334,7 +2336,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(err).NotTo(HaveOccurred())
 			defer os.Remove(loggingPodFile)
 
-			By("Launching an pod that logs too much")
+			By("launching a pod that logs too much")
 			podName := "validate-windows-logging" // should be the same as in iis-azurefile.yaml
 			loggingPod, err := pod.CreatePodFromFileWithRetry(loggingPodFile, podName, "default", 1*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
@@ -2342,8 +2344,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ready).To(Equal(true))
 
-			By("by validating the logs continues to flow")
-			logsRotated, err := loggingPod.ValidateLogsRotate(20 * time.Second, 2 * time.Minute)
+			By("validating the logs continue to flow")
+			logsRotated, err := loggingPod.ValidateLogsRotate(20*time.Second, 2*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(logsRotated).To(Equal(true))
 		})

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2323,6 +2323,30 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("No windows agent was provisioned for this Cluster Definition")
 			}
 		})
+
+		It("should be able to rotate docker logs", func() {
+			if !eng.HasWindowsAgents() {
+				Skip("No windows agent was provisioned for this Cluster Definition")
+			}
+
+			windowsImages, err := eng.GetWindowsTestImages()
+			loggingPodFile, err := pod.ReplaceContainerImageFromFile(filepath.Join(WorkloadDir, "validate-windows-logging.yaml"), windowsImages.ServerCore)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(loggingPodFile)
+
+			By("Launching an pod that logs too much")
+			podName := "validate-windows-logging" // should be the same as in iis-azurefile.yaml
+			loggingPod, err := pod.CreatePodFromFileWithRetry(loggingPodFile, podName, "default", 1*time.Second, cfg.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+			ready, err := loggingPod.WaitOnReady(sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(Equal(true))
+
+			By("by validating the logs continues to flow")
+			logsRotated, err := loggingPod.ValidateLogsRotate(20 * time.Second, 2 * time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logsRotated).To(Equal(true))
+		})
 	})
 
 	Describe("after the cluster has been up for awhile", func() {

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -1553,6 +1553,15 @@ func (p *Pod) Logs() error {
 	return nil
 }
 
+// CheckTailOfLogFor will get last line matched with grep filters
+func (p *Pod) checkTailOfLogFor(numberOflines, grepFromat string) (string, error) {
+	var commandTimeout time.Duration
+	piped := fmt.Sprintf("k logs %s -n %s --tail %s | grep %s | tail -n 1 | tr -d '\\n'", p.Metadata.Name, p.Metadata.Namespace, numberOflines, grepFromat)
+	cmd := exec.Command("bash","-c", piped)
+	out, err := util.RunAndLogCommand(cmd, commandTimeout)
+	return string(out), err
+}
+
 // Describe will describe a pod resource
 func (p *Pod) Describe() error {
 	var commandTimeout time.Duration
@@ -1595,6 +1604,65 @@ func (p *Pod) ValidateAzureFile(mountPath string, sleep, timeout time.Duration) 
 				log.Printf("Unable to describe pod\n: %s", err)
 			}
 			return false, errors.Errorf("ValidateAzureFile timed out: %s\n", mostRecentValidateAzureFileError)
+		}
+	}
+}
+
+// ValidateLogsRotate will keep retrying the check logs rotate over a given time
+func (p *Pod) ValidateLogsRotate(sleep, timeout time.Duration) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ch := make(chan string)
+	var previous time.Time
+	var current time.Time
+	var new string
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				output, err := p.checkTailOfLogFor("20", "-oP '(?<=DATE=)[^.-]*'")
+				if err != nil {
+					log.Printf("Unable to tail the log:\n %s \n", output)
+					time.Sleep(sleep)
+					continue
+				}
+				ch <- output
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case new = <-ch:
+			if new == "" {
+				// there is a chance the last few lines of the file might not contain search
+				continue
+			}
+			previous = current
+			newTime, err := time.Parse("01/02/2006 15:04:05", new)
+			if err != nil || new == "" {
+				log.Printf("Unable to convert time:\n %s", err)
+				continue
+			}
+			current = newTime
+		case <-ctx.Done():
+			log.Print("Finished waiting for logs to rotate")
+			if previous.Before(current) {
+				log.Printf("Time has continued to update. previous: %s current %s", previous, current)
+				return true, nil
+			}
+
+			err := p.Logs()
+			if err != nil {
+				log.Printf("Unable to print pod logs:\n %s", err)
+			}
+			err = p.Describe()
+			if err != nil {
+				log.Printf("Unable to describe pod:\n %s", err)
+			}
+			return false, errors.Errorf("ValidateLogsRotate did not see time stamp change: prior '%s' current '%s'\n", previous, current)
 		}
 	}
 }

--- a/test/e2e/kubernetes/workloads/validate-windows-logging.yaml
+++ b/test/e2e/kubernetes/workloads/validate-windows-logging.yaml
@@ -6,7 +6,7 @@ metadata:
     name: storage
 spec:
   containers:
-    - image: mcr.microsoft.com/windows/servercore:2004
+    - image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
       name: validate-windows-logging
       command:
         - powershell.exe

--- a/test/e2e/kubernetes/workloads/validate-windows-logging.yaml
+++ b/test/e2e/kubernetes/workloads/validate-windows-logging.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: validate-windows-logging
+  labels:
+    name: storage
+spec:
+  containers:
+    - image: mcr.microsoft.com/windows/servercore:2004
+      name: validate-windows-logging
+      command:
+        - powershell.exe
+        - -Command
+        - sleep 10; $a="1234567890"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a";
+          $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a";
+          $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; do { write-host "DATE=$(date)-$a"; sleep 0.1;
+          } until($false)
+  nodeSelector:
+    kubernetes.io/os: windows
+
+


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
This updates docker to 19.03.11 which has the fix for log rotation.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#3573

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds ~~unit tests~~ e2e tests
- [ ] tested upgrade from previous version

**Notes**:
I ran this test against 19.3.05 and if failed consistently.  It passed consistently on new docker version

I also evaluated creating this tests as an upstream test but the container runtime is outside the scope upstream k8s tests.