### PR TITLE
chore: Only use Windows telemetry client when `enableTelemetry` is true

### DIFF
--- a/parts/k8s/windowsazurecnifunc.ps1
+++ b/parts/k8s/windowsazurecnifunc.ps1
@@ -76,10 +76,14 @@ Set-AzureCNIConfig
     # Fill in DNS information for kubernetes.
     if ($IsDualStackEnabled){
         $subnetToPass = $KubeClusterCIDR -split ","
-        $exceptionAddresses = @($subnetToPass[0], $MasterSubnet, $VNetCIDR)
+        $exceptionAddresses = @($subnetToPass[0], $MasterSubnet)
     }
     else {
-        $exceptionAddresses = @($KubeClusterCIDR, $MasterSubnet, $VNetCIDR)
+        $exceptionAddresses = @($KubeClusterCIDR, $MasterSubnet)
+    }
+    $vnetCIDRs = $VNetCIDR -split ","
+    foreach ($cidr in $vnetCIDRs) {
+        $exceptionAddresses += $cidr
     }
 
     $fileName  = [Io.path]::Combine("$AzureCNIConfDir", "10-azure.conflist")

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -24479,10 +24479,14 @@ Set-AzureCNIConfig
     # Fill in DNS information for kubernetes.
     if ($IsDualStackEnabled){
         $subnetToPass = $KubeClusterCIDR -split ","
-        $exceptionAddresses = @($subnetToPass[0], $MasterSubnet, $VNetCIDR)
+        $exceptionAddresses = @($subnetToPass[0], $MasterSubnet)
     }
     else {
-        $exceptionAddresses = @($KubeClusterCIDR, $MasterSubnet, $VNetCIDR)
+        $exceptionAddresses = @($KubeClusterCIDR, $MasterSubnet)
+    }
+    $vnetCIDRs = $VNetCIDR -split ","
+    foreach ($cidr in $vnetCIDRs) {
+        $exceptionAddresses += $cidr
     }
 
     $fileName  = [Io.path]::Combine("$AzureCNIConfDir", "10-azure.conflist")


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Only handle Windows telemetry when enableTelemetry is true

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
