### PR TITLE
fix: only remove CRI if re-installing

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -296,7 +296,6 @@ configureAzureCNI() {
 }
 {{- if NeedsContainerd}}
 installContainerd() {
-  removeMoby
   CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||')
   if [[ $CURRENT_VERSION != "${CONTAINERD_VERSION}" ]]; then
     os_lower=$(echo ${OS} | tr '[:upper:]' '[:lower:]')
@@ -307,6 +306,7 @@ installContainerd() {
     else
       exit 25
     fi
+    removeMoby
     removeContainerd
     retrycmd_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
     retrycmd 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
@@ -677,11 +677,5 @@ cleanUpContainerd() {
 {{end}}
 removeEtcd() {
   rm -rf /usr/bin/etcd
-}
-removeMoby() {
-  apt_get_purge moby-engine moby-cli || exit 27
-}
-removeContainerd() {
-  apt_get_purge moby-containerd || exit 27
 }
 #EOF

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -86,10 +86,16 @@ downloadGPUDrivers() {
     exit 85
   fi
 }
+removeMoby() {
+  apt_get_purge moby-engine moby-cli || exit 27
+}
+removeContainerd() {
+  apt_get_purge moby-containerd || exit 27
+}
 installMoby() {
-  removeContainerd
   CURRENT_VERSION=$(dockerd --version | grep "Docker version" | cut -d "," -f 1 | cut -d " " -f 3 | cut -d "+" -f 1)
   if [[ $CURRENT_VERSION != "${MOBY_VERSION}" ]]; then
+    removeContainerd
     removeMoby
     retrycmd_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
     retrycmd 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18314,7 +18314,6 @@ configureAzureCNI() {
 }
 {{- if NeedsContainerd}}
 installContainerd() {
-  removeMoby
   CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||')
   if [[ $CURRENT_VERSION != "${CONTAINERD_VERSION}" ]]; then
     os_lower=$(echo ${OS} | tr '[:upper:]' '[:lower:]')
@@ -18325,6 +18324,7 @@ installContainerd() {
     else
       exit 25
     fi
+    removeMoby
     removeContainerd
     retrycmd_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
     retrycmd 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
@@ -18695,12 +18695,6 @@ cleanUpContainerd() {
 {{end}}
 removeEtcd() {
   rm -rf /usr/bin/etcd
-}
-removeMoby() {
-  apt_get_purge moby-engine moby-cli || exit 27
-}
-removeContainerd() {
-  apt_get_purge moby-containerd || exit 27
 }
 #EOF
 `)
@@ -19300,10 +19294,16 @@ downloadGPUDrivers() {
     exit 85
   fi
 }
+removeMoby() {
+  apt_get_purge moby-engine moby-cli || exit 27
+}
+removeContainerd() {
+  apt_get_purge moby-containerd || exit 27
+}
 installMoby() {
-  removeContainerd
   CURRENT_VERSION=$(dockerd --version | grep "Docker version" | cut -d "," -f 1 | cut -d " " -f 3 | cut -d "+" -f 1)
   if [[ $CURRENT_VERSION != "${MOBY_VERSION}" ]]; then
+    removeContainerd
     removeMoby
     retrycmd_no_stats 120 5 25 curl https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
     retrycmd 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR changes the "install moby|containerd" CSE implementation so that we only do the "remove all other CRI" operations if we actually need to install either moby or containerd. In the event that we detect that the desired version is already installed, we can return immediately.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
