### PR TITLE
feat: add support for Kubernetes 1.19.0-rc.4

### DIFF
--- a/.pipelines/vhd-builder-windows.yaml
+++ b/.pipelines/vhd-builder-windows.yaml
@@ -18,7 +18,7 @@ pr: none
 
 jobs:
 - job: build_vhd_windows
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   strategy:
     maxParallel: 0
   pool:
@@ -130,5 +130,5 @@ jobs:
 
   - script: |
       sudo chown -R $USER:$USER .
-    displayName: cleanup - chown all files in work directory 
+    displayName: cleanup - chown all files in work directory
     condition: always()

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -208,6 +208,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.19.0-beta.1":  true,
 	"1.19.0-beta.2":  true,
 	"1.19.0-rc.3":    true,
+	"1.19.0-rc.4":    true,
 }
 
 // AllKubernetesSupportedVersionsAzureStack is a hash table of all supported Kubernetes version strings on Azure Stack

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -112,7 +112,7 @@ function Get-FilesToCacheOnVHD
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.4-hotfix.20200624/windowszip/v1.18.4-hotfix.20200624-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.5/windowszip/v1.18.5-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.6/windowszip/v1.18.6-1int.zip",
-            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.19.0-rc.3/windowszip/v1.19.0-rc.3-1int.zip"
+            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.19.0-rc.4/windowszip/v1.19.0-rc.4-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
             "https://kubernetesartifacts.azureedge.net/azure-cni/v1.1.2/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.2.zip",

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -350,7 +350,7 @@ pullContainerImage "docker" "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="
-1.19.0-rc.3
+1.19.0-rc.4
 1.18.6
 1.18.5
 1.17.9


### PR DESCRIPTION
**Reason for Change**:
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1190-rc3

**Issue Fixed**:

**Requirements**:

- [x] Kubernetes artifacts built and pushed by Azure Pipelines
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
The Azure k8s artifacts are still building, so this will fail at first.