### PR TITLE
fix: don't wait for pod-security-policy spec if disabled

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -566,7 +566,7 @@ configAddons() {
   {{if IsAzurePolicyAddonEnabled}}
   configAzurePolicyAddon
   {{end}}
-  {{- if not HasCustomPodSecurityPolicy}}
+  {{- if and (not HasCustomPodSecurityPolicy) IsPodSecurityPolicyAddonEnabled}}
   wait_for_file 1200 1 $POD_SECURITY_POLICY_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
   mkdir -p $ADDONS_DIR/init && cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{- end}}

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -209,6 +209,10 @@ func TestK8sVars(t *testing.T) {
 			Name:    common.AADPodIdentityAddonName,
 			Enabled: to.BoolPtr(true),
 		},
+		{
+			Name:    common.PodSecurityPolicyAddonName,
+			Enabled: to.BoolPtr(true),
+		},
 	}
 	varMap, err = GetKubernetesVariables(cs)
 	if err != nil {
@@ -254,7 +258,12 @@ func TestK8sVars(t *testing.T) {
 	}
 
 	// Test with ubuntu 16.04 distro
-	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.PodSecurityPolicyAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+	}
 	cs.Properties.AgentPoolProfiles[0].Distro = api.Ubuntu
 	cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = false
 	varMap, err = GetKubernetesVariables(cs)
@@ -814,6 +823,10 @@ func TestK8sVars(t *testing.T) {
 			Config: map[string]string{
 				"appgw-sku": "WAF_v2",
 			},
+		},
+		{
+			Name:    common.PodSecurityPolicyAddonName,
+			Enabled: to.BoolPtr(true),
 		},
 	}
 

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -766,6 +766,9 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		"IsDashboardAddonEnabled": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.DashboardAddonName)
 		},
+		"IsPodSecurityPolicyAddonEnabled": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.PodSecurityPolicyAddonName)
+		},
 		"GetAADPodIdentityTaintKey": func() string {
 			return common.AADPodIdentityTaintKey
 		},

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18705,7 +18705,7 @@ configAddons() {
   {{if IsAzurePolicyAddonEnabled}}
   configAzurePolicyAddon
   {{end}}
-  {{- if not HasCustomPodSecurityPolicy}}
+  {{- if and (not HasCustomPodSecurityPolicy) IsPodSecurityPolicyAddonEnabled}}
   wait_for_file 1200 1 $POD_SECURITY_POLICY_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
   mkdir -p $ADDONS_DIR/init && cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{- end}}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that we don't wait for a pod-security-policy yaml spec during cluster bootstrapping if the pod-security-policy addon has been explicitly disabled.

To be clear, explicitly disabling that addon will result in a non-working cluster, as privileged escalation capabilities won't be allowed, which various kube-system components require. But this PR will allow folks to deliver their own equivalent PodSecurityPolicy configs if they wish and still return from CSE.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3656 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
