### PR TITLE
ci: clarify apt packages installed during VHD CI

### DIFF
--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -571,8 +571,7 @@ df -h
 
 echo "Using kernel:" >> ${VHD_LOGS_FILEPATH}
 tee -a ${VHD_LOGS_FILEPATH} < /proc/version
-echo "Installed apt packages:" >> ${VHD_LOGS_FILEPATH}
-apt list --installed >> ${VHD_LOGS_FILEPATH}
+{ printf "Installed apt packages:\n"; apt list --installed | grep -v 'Listing...'; } >> ${VHD_LOGS_FILEPATH}
 {
   echo "Install completed successfully on " $(date)
   echo "VSTS Build NUMBER: ${BUILD_NUMBER}"

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -15,6 +15,7 @@ echo "Components downloaded in this VHD build (some of the below components migh
 AUDITD_ENABLED=true
 installDeps
 cat << EOF >> ${VHD_LOGS_FILEPATH}
+apt packages:
   - apache2-utils
   - apt-transport-https
   - auditd
@@ -33,7 +34,10 @@ cat << EOF >> ${VHD_LOGS_FILEPATH}
   - gcc
   - git
   - glusterfs-client
+  - htop
+  - iftop
   - init-system-helpers
+  - iotop
   - iproute2
   - ipset
   - iptables
@@ -44,7 +48,9 @@ cat << EOF >> ${VHD_LOGS_FILEPATH}
   - make
   - mount
   - nfs-common
-  - pigz socat
+  - pigz
+  - socat
+  - sysstat
   - traceroute
   - util-linux
   - xz-utils
@@ -60,6 +66,10 @@ chmod a-x /etc/update-motd.d/??-{motd-news,release-upgrade}
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
   overrideNetworkConfig
 fi
+
+cat << EOF >> ${VHD_LOGS_FILEPATH}
+Binaries:
+EOF
 
 apmz_version="v0.5.1"
 ensureAPMZ "${apmz_version}"
@@ -561,6 +571,8 @@ df -h
 
 echo "Using kernel:" >> ${VHD_LOGS_FILEPATH}
 tee -a ${VHD_LOGS_FILEPATH} < /proc/version
+echo "Installed apt packages:" >> ${VHD_LOGS_FILEPATH}
+apt list --installed >> ${VHD_LOGS_FILEPATH}
 {
   echo "Install completed successfully on " $(date)
   echo "VSTS Build NUMBER: ${BUILD_NUMBER}"


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR clarifies some errata in the manuallly curated list of CSE-installed apt packages during VHD CI output, and also adds a list of all apt packages installed.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
