### PR TITLE
docs: fix misleading sysctldConfig examples

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -696,16 +696,35 @@ Custom YAML specifications can be configured for kube-scheduler, kube-controller
 
 #### sysctldConfig
 
-The `sysctldConfig` configuration interface allows generic Linux kernel runtime configuration that will be delivered to sysctl. Use at your own risk! It is a generic key/value object, and a child property of `masterProfile` and node pool configurations under `agentPoolProfiles`, for tuning the Linux kernel parameters on master and/or node pool VMs, respectively. An example custom sysctl config:
+The `sysctldConfig` configuration interface allows generic Linux kernel runtime configuration that will be delivered to sysctl. Use at your own risk! It is a generic key/value object, and a child property of both `masterProfile` and node pool configurations under `agentPoolProfiles`, for tuning the Linux kernel parameters on master and/or node pool VMs, respectively. An example custom sysctl config that tunes the control plane VMs:
 
 ```
-"kubernetesConfig": {
+"masterProfile": {
+    ...
     "sysctldConfig": {
         "net.ipv4.tcp_keepalive_time": "120",
         "net.ipv4.tcp_keepalive_intvl": "75",
         "net.ipv4.tcp_keepalive_probes": "9"
     }
+    ...
 }
+```
+
+And, here's that same config override example on a node pool named "my-custom-node-pool":
+
+```
+"agentPoolProfiles": [
+  {
+    "name": "my-custom-node-pool",
+    ...
+    "sysctldConfig": {
+        "net.ipv4.tcp_keepalive_time": "120",
+        "net.ipv4.tcp_keepalive_intvl": "75",
+        "net.ipv4.tcp_keepalive_probes": "9"
+    }
+    ...
+  }
+]
 ```
 
 Kubernetes kernel configuration varies by distro, so please validate that the kernel parameter and value works for the Linux flavor you are using in your cluster.


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR fixes documentation errata for the `sysctldConfig` interface.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3681

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
