### PR TITLE
feat: cluster upgrade operations upgrade pause image

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -136,6 +136,11 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		defaultKubeletConfig["--container-runtime-endpoint"] = "unix:///run/containerd/containerd.sock"
 	}
 
+	if isUpgrade {
+		// if upgrade, force default "--pod-infra-container-image" value
+		delete(o.KubernetesConfig.KubeletConfig, "--pod-infra-container-image")
+	}
+
 	// If no user-configurable kubelet config values exists, use the defaults
 	setMissingKubeletValues(o.KubernetesConfig, defaultKubeletConfig)
 	addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, minVersionRotateCerts, "RotateKubeletServerCertificate=true")

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -185,6 +185,10 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 			cs.Properties.MasterProfile.KubernetesConfig = &KubernetesConfig{}
 			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig = make(map[string]string)
 		}
+		if isUpgrade {
+			// if upgrade, force default "--pod-infra-container-image" value
+			delete(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, "--pod-infra-container-image")
+		}
 		setMissingKubeletValues(cs.Properties.MasterProfile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 		addDefaultFeatureGates(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "", "")
 
@@ -229,6 +233,11 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		if profile.KubernetesConfig == nil {
 			profile.KubernetesConfig = &KubernetesConfig{}
 			profile.KubernetesConfig.KubeletConfig = make(map[string]string)
+		}
+
+		if isUpgrade {
+			// if upgrade, force default "--pod-infra-container-image" value
+			delete(profile.KubernetesConfig.KubeletConfig, "--pod-infra-container-image")
 		}
 
 		if profile.IsWindows() {

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -138,7 +138,7 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 
 	if isUpgrade {
 		// if upgrade, force default "--pod-infra-container-image" value
-		delete(o.KubernetesConfig.KubeletConfig, "--pod-infra-container-image")
+		o.KubernetesConfig.KubeletConfig["--pod-infra-container-image"] = defaultKubeletConfig["--pod-infra-container-image"]
 	}
 
 	// If no user-configurable kubelet config values exists, use the defaults
@@ -187,7 +187,7 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		}
 		if isUpgrade {
 			// if upgrade, force default "--pod-infra-container-image" value
-			delete(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, "--pod-infra-container-image")
+			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--pod-infra-container-image"] = o.KubernetesConfig.KubeletConfig["--pod-infra-container-image"]
 		}
 		setMissingKubeletValues(cs.Properties.MasterProfile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 		addDefaultFeatureGates(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "", "")
@@ -237,7 +237,7 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 
 		if isUpgrade {
 			// if upgrade, force default "--pod-infra-container-image" value
-			delete(profile.KubernetesConfig.KubeletConfig, "--pod-infra-container-image")
+			profile.KubernetesConfig.KubeletConfig["--pod-infra-container-image"] = o.KubernetesConfig.KubeletConfig["--pod-infra-container-image"]
 		}
 
 		if profile.IsWindows() {

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -183,6 +183,8 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	if cs.Properties.MasterProfile != nil {
 		if cs.Properties.MasterProfile.KubernetesConfig == nil {
 			cs.Properties.MasterProfile.KubernetesConfig = &KubernetesConfig{}
+		}
+		if cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig == nil {
 			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig = make(map[string]string)
 		}
 		if isUpgrade {
@@ -232,6 +234,8 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	for _, profile := range cs.Properties.AgentPoolProfiles {
 		if profile.KubernetesConfig == nil {
 			profile.KubernetesConfig = &KubernetesConfig{}
+		}
+		if profile.KubernetesConfig.KubeletConfig == nil {
 			profile.KubernetesConfig.KubeletConfig = make(map[string]string)
 		}
 

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -136,13 +136,13 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		defaultKubeletConfig["--container-runtime-endpoint"] = "unix:///run/containerd/containerd.sock"
 	}
 
+	// If no user-configurable kubelet config values exists, use the defaults
+	setMissingKubeletValues(o.KubernetesConfig, defaultKubeletConfig)
 	if isUpgrade {
 		// if upgrade, force default "--pod-infra-container-image" value
 		o.KubernetesConfig.KubeletConfig["--pod-infra-container-image"] = defaultKubeletConfig["--pod-infra-container-image"]
 	}
 
-	// If no user-configurable kubelet config values exists, use the defaults
-	setMissingKubeletValues(o.KubernetesConfig, defaultKubeletConfig)
 	addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, minVersionRotateCerts, "RotateKubeletServerCertificate=true")
 
 	// Override default cloud-provider?

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -2361,47 +2361,26 @@ func TestInputOverridesDuringUpgrade(t *testing.T) {
 		},
 	}
 
+	assert := func(profile string, expected, actual map[string]string, t *testing.T) {
+		for ek, ev := range expected {
+			av, ok := actual[ek]
+			if !ok {
+				t.Fatalf("%s missing expected config %s", profile, ek)
+			}
+			if av != ev {
+				t.Fatalf("%s expected config %s to equal %s, got %s", profile, ek, ev, av)
+			}
+		}
+	}
+
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			c.cs.setKubeletConfig(c.isUpgrade)
-
-			for ek, ev := range c.expectedKubeletConfig {
-				v, ok := c.cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig[ek]
-				if !ok {
-					t.Fatalf("OrchestratorProfile missing expected config %s", ek)
-				}
-				if v != ev {
-					t.Fatalf("OrchestratorProfile expected config %s to equal %s, got %s", ek, ev, v)
-				}
-
-				v, ok = c.cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig[ek]
-				if !ok {
-					t.Fatalf("MasterProfile missing expected config %s", ek)
-				}
-				if v != ev {
-					t.Fatalf("MasterProfile expected config %s to equal %s, got %s", ek, ev, v)
-				}
-
-				pool := c.cs.Properties.AgentPoolProfiles[0]
-				v, ok = pool.KubernetesConfig.KubeletConfig[ek]
-				if !ok {
-					t.Fatalf("%s AgentPoolProfiles missing expected config %s", pool.OSType, ek)
-				}
-				if v != ev {
-					t.Fatalf("%s AgentPoolProfiles expected config %s to equal %s, got %s", pool.OSType, ek, ev, v)
-				}
-			}
-			for ek, ev := range c.expectedWinKubeletConfig {
-				pool := c.cs.Properties.AgentPoolProfiles[1]
-				v, ok := pool.KubernetesConfig.KubeletConfig[ek]
-				if !ok {
-					t.Fatalf("%s AgentPoolProfiles missing expected config %s", pool.OSType, ek)
-				}
-				if v != ev {
-					t.Fatalf("%s AgentPoolProfiles expected config %s to equal %s, got %s", pool.OSType, ek, ev, v)
-				}
-			}
+			assert("OrchestratorProfile", c.expectedKubeletConfig, c.cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig, t)
+			assert("MasterProfile", c.expectedKubeletConfig, c.cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, t)
+			assert("Linux AgentPoolProfile", c.expectedKubeletConfig, c.cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig, t)
+			assert("Windows AgentPoolProfile", c.expectedWinKubeletConfig, c.cs.Properties.AgentPoolProfiles[1].KubernetesConfig.KubeletConfig, t)
 		})
 	}
 }


### PR DESCRIPTION
**Reason for Change**:

Use latest `pod-infra-container-image` on both `deploy` and `upgrade` operations.

**Issue Fixed**:

Fixes #3686

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

WIP while running validations.