### PR TITLE
fix: validate "basic" LB and fix related unit tests

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -545,7 +545,7 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 			if agentPoolProfile.AvailabilityProfile == AvailabilitySet {
 				return errors.Errorf("You have enabled VMSS node public IP in agent pool %s, but you did not specify VMSS", agentPoolProfile.Name)
 			}
-			if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != BasicLoadBalancerSku {
+			if !strings.EqualFold(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, BasicLoadBalancerSku) {
 				return errors.Errorf("You have enabled VMSS node public IP in agent pool %s, but you did not specify Basic Load Balancer SKU", agentPoolProfile.Name)
 			}
 		}


### PR DESCRIPTION
**Reason for Change**:

Makes load balancer type validation agree that "basic" and "Basic" are both ok.

In making this trivial fix, I noticed there was already a test case that specified "basic", but that was passing. It turns out that set of tests was ignoring any `err` return, so I fixed that so the UT will actually prevent this behavior from regressing.

**Issue Fixed**:

Fixes #3661

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
