### PR TITLE
fix: do not restart addon-manager if a reboot is required

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -392,8 +392,7 @@ ensureAddons() {
   retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   rm -Rf ${ADDONS_DIR}/init
 {{- end}}
-  wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
@@ -419,6 +418,10 @@ ensureAddons() {
     sleep 3
   done
   {{end}}
+}
+replaceAddonsInit() {
+  wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
 }
 ensureLabelNodes() {
   LABEL_NODES_SCRIPT_FILE=/opt/azure/containers/label-nodes.sh

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -226,7 +226,7 @@ if [[ -n ${MASTER_NODE} ]]; then
 {{if IsAzurePolicyAddonEnabled}}
   time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
 {{end}}
-  if [ -f /var/run/reboot-required ] || [ "$NO_OUTBOUND" = "true" ]; then
+  if [ -f /var/run/reboot-required ]; then
     time_metric "ReplaceAddonsInit" replaceAddonsInit
   else
     time_metric "EnsureAddons" ensureAddons

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -226,7 +226,11 @@ if [[ -n ${MASTER_NODE} ]]; then
 {{if IsAzurePolicyAddonEnabled}}
   time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
 {{end}}
-  time_metric "EnsureAddons" ensureAddons
+  if [ -f /var/run/reboot-required ] || [ "$NO_OUTBOUND" = "true" ]; then
+    time_metric "ReplaceAddonsInit" replaceAddonsInit
+  else
+    time_metric "EnsureAddons" ensureAddons
+  fi
 fi
 time_metric "EnsureJournal" ensureJournal
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19821,7 +19821,7 @@ if [[ -n ${MASTER_NODE} ]]; then
 {{if IsAzurePolicyAddonEnabled}}
   time_metric "EnsureLabelExclusionForAzurePolicyAddon" ensureLabelExclusionForAzurePolicyAddon
 {{end}}
-  if [ -f /var/run/reboot-required ] || [ "$NO_OUTBOUND" = "true" ]; then
+  if [ -f /var/run/reboot-required ]; then
     time_metric "ReplaceAddonsInit" replaceAddonsInit
   else
     time_metric "EnsureAddons" ensureAddons


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Related to https://github.com/Azure/aks-engine/issues/3668#issuecomment-674305778
Seeing some clusters fail with exit 36 recently where CSE failed to get the addon-manager pod as part of ensureAddons().

```
+ for i in $(seq 1 $retries)
+ timeout 30 /usr/local/bin/kubectl --kubeconfig=/home/azureuser/.kube/config get pods -l app=kube-addon-manager -n kube-system
+ '[' 120 -eq 120 ']'
+ echo Executed '"/usr/local/bin/kubectl' --kubeconfig=/home/azureuser/.kube/config get pods -l app=kube-addon-manager -n 'kube-system"' 120 times
Executed "/usr/local/bin/kubectl --kubeconfig=/home/azureuser/.kube/config get pods -l app=kube-addon-manager -n kube-system" 120 times
```

This PR might not fix the underlying root cause but we should not be getting/restarting pods when the vm is marked for reboot so this PR addresses that.

/cc @mboersma @Michael-Sinz

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
