### PR TITLE
test: add E2E config for "control plane reboot" scenario

### DIFF
--- a/test/e2e/test_cluster_configs/control_plane_reboot.json
+++ b/test/e2e/test_cluster_configs/control_plane_reboot.json
@@ -1,5 +1,7 @@
 {
-	"env": {},
+	"env": {
+		"BLOCK_SSH": "true"
+	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {

--- a/test/e2e/test_cluster_configs/control_plane_reboot.json
+++ b/test/e2e/test_cluster_configs/control_plane_reboot.json
@@ -4,7 +4,10 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
+				"orchestratorType": "Kubernetes",
+				"kubernetesConfig": {
+					"networkPlugin": "kubenet"
+				}
 			},
 			"masterProfile": {
 				"count": 5,

--- a/test/e2e/test_cluster_configs/control_plane_reboot.json
+++ b/test/e2e/test_cluster_configs/control_plane_reboot.json
@@ -1,0 +1,40 @@
+{
+	"env": {},
+	"apiModel": {
+		"apiVersion": "vlabs",
+		"properties": {
+			"orchestratorProfile": {
+				"orchestratorType": "Kubernetes"
+			},
+			"masterProfile": {
+				"count": 5,
+				"dnsPrefix": "",
+				"vmSize": "Standard_D2_v3",
+				"distro": "ubuntu-18.04"
+			},
+			"agentPoolProfiles": [
+				{
+					"name": "agentpool1",
+					"count": 1,
+					"vmSize": "Standard_D2_v3",
+					"availabilityProfile": "VirtualMachineScaleSets",
+					"scalesetPriority": "Spot"
+				}
+			],
+			"linuxProfile": {
+				"adminUsername": "azureuser",
+				"ssh": {
+					"publicKeys": [
+						{
+							"keyData": ""
+						}
+					]
+				}
+			},
+			"servicePrincipalProfile": {
+				"clientId": "",
+				"secret": ""
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR adds an E2E test config for validating the health of cluster deployments when control plane VMs are rebooted immediately after provisioning.

In practice, we re-use the "ubuntu-18.04" distro to implement "requires reboot", as that distro includes known cloud-init-related reboot behavior.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
