### PR TITLE
chore: specify containerd version to install with moby-engine package

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -92,21 +92,34 @@ removeMoby() {
 removeContainerd() {
   apt_get_purge moby-containerd || exit 27
 }
+mobyPkgVersion() {
+  dpkg -s "${1}" | grep "Version:" | awk '{ print $2 }' | cut -d '+' -f 1
+}
 installMoby() {
-  CURRENT_VERSION=$(dockerd --version | grep "Docker version" | cut -d "," -f 1 | cut -d " " -f 3 | cut -d "+" -f 1)
-  if [[ $CURRENT_VERSION != "${MOBY_VERSION}" ]]; then
-    removeContainerd
+  install_pkgs=""
+  CURRENT_CONTAINERD_VERSION="$(mobyPkgVersion moby-containerd)"
+  if [ -n "${CONTAINERD_VERSION}" ] && [ ! "${CURRENT_CONTAINERD_VERSION}" = "${CONTAINERD_VERSION}" ]; then
+    install_pkgs+=" moby-containerd=${CONTAINERD_VERSION}*"
     removeMoby
+    removeContainerd
+  fi
+  CURRENT_ENGINE_VERSION="$(mobyPkgVersion moby-engine)"
+  if [ ! "${CURRENT_ENGINE_VERSION}" = "${MOBY_VERSION}" ]; then
+    install_pkgs+=" moby-engine=${MOBY_VERSION}*"
+    MOBY_CLI="${MOBY_VERSION}"
+    if [ "${MOBY_CLI}" = "3.0.4" ]; then
+      MOBY_CLI="3.0.3"
+    fi
+    install_pkgs+=" moby-cli=${MOBY_CLI}*"
+    removeMoby
+  fi
+  if [ -n "${install_pkgs}" ]; then
     retrycmd_no_stats 120 5 25 curl ${MICROSOFT_APT_REPO}/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
     retrycmd 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
     retrycmd_no_stats 120 5 25 curl ${MICROSOFT_APT_REPO}/keys/microsoft.asc | gpg --dearmor >/tmp/microsoft.gpg || exit 26
     retrycmd 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
     apt_get_update || exit 99
-    MOBY_CLI=${MOBY_VERSION}
-    if [[ ${MOBY_CLI} == "3.0.4" ]]; then
-      MOBY_CLI="3.0.3"
-    fi
-    apt_get_install 20 30 120 moby-engine=${MOBY_VERSION}* moby-cli=${MOBY_CLI}* --allow-downgrades || exit 27
+    apt_get_install 20 30 120 ${install_pkgs} --allow-downgrades || exit 27
   fi
 }
 installBcc() {

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -245,12 +245,17 @@
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.3.2",
+      "defaultValue": "1.3.7",
       "metadata": {
         "description": "The Azure Moby build version"
       },
       "allowedValues": [
-         "1.3.2"
+         "1.3.2",
+         "1.3.3",
+         "1.3.4",
+         "1.3.5",
+         "1.3.6",
+         "1.3.7"
        ],
       "type": "string"
     },

--- a/pkg/api/components_test.go
+++ b/pkg/api/components_test.go
@@ -780,7 +780,6 @@ func TestSynthesizeComponentsConfig(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
 			synthesizeComponentsConfig(c.components, c.defaultComponent, c.isUpgrade)
 			i := GetComponentsIndexByName(c.components, common.ControllerManagerComponentName)
 			if !reflect.DeepEqual(c.components[i], c.expected) {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -477,7 +477,7 @@ const (
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
 	DefaultMobyVersion = "19.03.12"
 	// DefaultContainerdVersion specifies the default containerd version to install.
-	DefaultContainerdVersion = "1.3.2"
+	DefaultContainerdVersion = "1.3.7"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
 	DefaultDockerBridgeSubnet = "172.17.0.1/16"
 	// DefaultKubernetesMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/aks-engine/pkg/versions"
 )
 
 // DistroValues is a list of currently supported distros
@@ -203,6 +204,17 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 					}
 				}
 				o.KubernetesConfig.MobyVersion = DefaultMobyVersion
+			}
+
+			// Moby versions >= 19.03 depend on containerd packaging (instead of the moby packages supplying their own containerd)
+			// For that case we'll need to specify the containerd version.
+			if versions.GreaterThanOrEqualTo(o.KubernetesConfig.MobyVersion, "19.03") && (o.KubernetesConfig.ContainerdVersion == "" || isUpdate) {
+				if o.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
+					log.Warnf("containerd will be upgraded to version %s\n", DefaultContainerdVersion)
+				} else {
+					log.Warnf("Any new nodes will have containerd version %s\n", DefaultContainerdVersion)
+				}
+				o.KubernetesConfig.ContainerdVersion = DefaultContainerdVersion
 			}
 		case Containerd:
 			if o.KubernetesConfig.ContainerdVersion == "" || isUpdate {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/aks-engine/pkg/versions"
 )
 
 func TestCertsAlreadyPresent(t *testing.T) {
@@ -1230,7 +1231,7 @@ func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 
 func TestContainerRuntime(t *testing.T) {
 
-	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10"} {
+	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10", "19.03.11", "19.03.12"} {
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
 		properties.OrchestratorProfile.OrchestratorType = Kubernetes
@@ -1244,9 +1245,13 @@ func TestContainerRuntime(t *testing.T) {
 			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
 				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, DefaultMobyVersion)
 		}
-		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
+		expectedContainerdVersion := ""
+		if versions.GreaterThanOrEqualTo(properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "19.03") {
+			expectedContainerdVersion = DefaultContainerdVersion
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != expectedContainerdVersion {
 			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
-				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, expectedContainerdVersion)
 		}
 
 		mockCS = getMockBaseContainerService("1.10.13")
@@ -1262,9 +1267,13 @@ func TestContainerRuntime(t *testing.T) {
 			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
 				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, mobyVersion)
 		}
-		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
+		expectedContainerdVersion = ""
+		if versions.GreaterThanOrEqualTo(properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "19.03") {
+			expectedContainerdVersion = DefaultContainerdVersion
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != expectedContainerdVersion {
 			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
-				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, expectedContainerdVersion)
 		}
 	}
 
@@ -1280,9 +1289,13 @@ func TestContainerRuntime(t *testing.T) {
 		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, DefaultMobyVersion)
 	}
-	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
+	expectedContainerdVersion := ""
+	if versions.GreaterThanOrEqualTo(properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "19.03") {
+		expectedContainerdVersion = DefaultContainerdVersion
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != expectedContainerdVersion {
 		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
-			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
+			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, expectedContainerdVersion)
 	}
 
 	mockCS = getMockBaseContainerService("1.10.13")

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/aks-engine/pkg/versions"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/blang/semver"
@@ -1606,13 +1607,12 @@ func (k *KubernetesConfig) Validate(k8sVersion string, hasWindows, ipv6DualStack
 
 	// Validate containerd scenarios
 	if k.ContainerRuntime == Docker || k.ContainerRuntime == "" {
-		if k.ContainerdVersion != "" {
+		if k.MobyVersion != "" && k.ContainerdVersion != "" && versions.LessThan(k.MobyVersion, "19.03") {
 			return errors.Errorf("containerdVersion is only valid in a non-docker context, use %s containerRuntime value instead if you wish to provide a containerdVersion", Containerd)
 		}
-	} else {
-		if e := validateContainerdVersion(k.ContainerdVersion); e != nil {
-			return e
-		}
+	}
+	if e := validateContainerdVersion(k.ContainerdVersion); e != nil {
+		return e
 	}
 
 	if to.Bool(k.UseCloudControllerManager) || k.CustomCcmImage != "" {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -38,7 +38,7 @@ var (
 		"3.1.0", "3.1.1", "3.1.2", "3.1.2", "3.1.3", "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8", "3.1.9", "3.1.10",
 		"3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.8", "3.2.9", "3.2.11", "3.2.12",
 		"3.2.13", "3.2.14", "3.2.15", "3.2.16", "3.2.23", "3.2.24", "3.2.25", "3.2.26", "3.3.0", "3.3.1", "3.3.8", "3.3.9", "3.3.10", "3.3.13", "3.3.15", "3.3.18", "3.3.19", "3.3.22"}
-	containerdValidVersions              = [...]string{"1.3.2"}
+	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7"}
 	kubernetesImageBaseTypeValidVersions = [...]string{"", common.KubernetesImageBaseTypeGCR, common.KubernetesImageBaseTypeMCR}
 	cachingTypesValidValues              = [...]string{"", string(compute.CachingTypesNone), string(compute.CachingTypesReadWrite), string(compute.CachingTypesReadOnly)}
 	networkPluginPlusPolicyAllowed       = []k8sNetworkConfig{

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -75,7 +75,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2]",
+			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7]",
 		},
 		"should error when KubernetesConfig has containerdVersion value for docker container runtime": {
 			properties: &Properties{
@@ -83,18 +83,8 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 					OrchestratorType: "Kubernetes",
 					KubernetesConfig: &KubernetesConfig{
 						ContainerRuntime:  Docker,
-						ContainerdVersion: "1.0.0",
-					},
-				},
-			},
-			expectedError: fmt.Sprintf("containerdVersion is only valid in a non-docker context, use %s containerRuntime value instead if you wish to provide a containerdVersion", Containerd),
-		},
-		"should error when KubernetesConfig has containerdVersion value for default (empty string) container runtime": {
-			properties: &Properties{
-				OrchestratorProfile: &OrchestratorProfile{
-					OrchestratorType: "Kubernetes",
-					KubernetesConfig: &KubernetesConfig{
-						ContainerdVersion: "1.0.0",
+						MobyVersion:       "3.0.11",
+						ContainerdVersion: "1.3.2",
 					},
 				},
 			},
@@ -330,6 +320,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 
 	for testName, test := range tests {
 		test := test
+		testName := testName
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 			err := test.properties.ValidateOrchestratorProfile(test.isUpdate)

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -22778,12 +22778,17 @@ var _k8sKubernetesparamsT = []byte(`{{if IsHostedMaster}}
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.3.2",
+      "defaultValue": "1.3.7",
       "metadata": {
         "description": "The Azure Moby build version"
       },
       "allowedValues": [
-         "1.3.2"
+         "1.3.2",
+         "1.3.3",
+         "1.3.4",
+         "1.3.5",
+         "1.3.6",
+         "1.3.7"
        ],
       "type": "string"
     },

--- a/pkg/versions/compare.go
+++ b/pkg/versions/compare.go
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package versions
+
+import (
+	"strconv"
+	"strings"
+)
+
+// compare compares two version strings
+// returns -1 if v1 < v2, 1 if v1 > v2, 0 otherwise.
+//
+// This was mostly copied from https://github.com/moby/moby/tree/4f0d95fa6ee7f865597c03b9e63702cdcb0f7067/api/types/versions
+func compare(v1, v2 string) int {
+	var (
+		currTab  = strings.Split(v1, ".")
+		otherTab = strings.Split(v2, ".")
+	)
+
+	max := len(currTab)
+	if len(otherTab) > max {
+		max = len(otherTab)
+	}
+	for i := 0; i < max; i++ {
+		var currInt, otherInt int
+
+		if len(currTab) > i {
+			currInt, _ = strconv.Atoi(currTab[i])
+		}
+		if len(otherTab) > i {
+			otherInt, _ = strconv.Atoi(otherTab[i])
+		}
+		if currInt > otherInt {
+			return 1
+		}
+		if otherInt > currInt {
+			return -1
+		}
+	}
+	return 0
+}
+
+// LessThan checks if a version is less than another
+func LessThan(v, other string) bool {
+	return compare(v, other) == -1
+}
+
+// LessThanOrEqualTo checks if a version is less than or equal to another
+func LessThanOrEqualTo(v, other string) bool {
+	return compare(v, other) <= 0
+}
+
+// GreaterThan checks if a version is greater than another
+func GreaterThan(v, other string) bool {
+	return compare(v, other) == 1
+}
+
+// GreaterThanOrEqualTo checks if a version is greater than or equal to another
+func GreaterThanOrEqualTo(v, other string) bool {
+	return compare(v, other) >= 0
+}
+
+// Equal checks if a version is equal to another
+func Equal(v, other string) bool {
+	return compare(v, other) == 0
+}

--- a/pkg/versions/compare_test.go
+++ b/pkg/versions/compare_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package versions
+
+import (
+	"testing"
+)
+
+func assertVersion(t *testing.T, a, b string, result int) {
+	if r := compare(a, b); r != result {
+		t.Fatalf("Unexpected version comparison result. Found %d, expected %d", r, result)
+	}
+}
+
+func TestCompareVersion(t *testing.T) {
+	assertVersion(t, "1.12", "1.12", 0)
+	assertVersion(t, "1.0.0", "1", 0)
+	assertVersion(t, "1", "1.0.0", 0)
+	assertVersion(t, "1.05.00.0156", "1.0.221.9289", 1)
+	assertVersion(t, "1", "1.0.1", -1)
+	assertVersion(t, "1.0.1", "1", 1)
+	assertVersion(t, "1.0.1", "1.0.2", -1)
+	assertVersion(t, "1.0.2", "1.0.3", -1)
+	assertVersion(t, "1.0.3", "1.1", -1)
+	assertVersion(t, "1.1", "1.1.1", -1)
+	assertVersion(t, "1.1.1", "1.1.2", -1)
+	assertVersion(t, "1.1.2", "1.2", -1)
+	// Check CalVer
+	assertVersion(t, "19.03.12", "3.0.10", 1)
+	assertVersion(t, "3.0.10", "19.03.12", -1)
+	assertVersion(t, "19.03", "3.0.10", 1)
+	assertVersion(t, "19.03.12", "19.03", 1)
+	assertVersion(t, "19.03.12", "19.04", -1)
+}

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -80,7 +80,7 @@ installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
 MOBY_VERSION="19.03.12"
-CONTAINERD_VERSION="1.3.2"
+CONTAINERD_VERSION="1.3.7"
 installMoby
 systemctl start docker
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -80,6 +80,7 @@ installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
 MOBY_VERSION="19.03.12"
+CONTAINERD_VERSION="1.3.2"
 installMoby
 systemctl start docker
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Since moby packages now depend on a separate containerd package, we should specify which version of the containerd package should be picked up so that we don't accidentally introduce regressions for new installs/upgrades due to `apt-get` picking the latest containerd (which may include major version bumps).

This also enables testing aks-engine with different versions of containerd (such as the newly released 1.4) since the api model now allows specifying a containerd version when the moby version is >= 19.03.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

N/A

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
