### PR TITLE
chore: Update Windows VHD to 8B with hotfixes for Windows CPU metrics

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -184,9 +184,9 @@ var (
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019
 	AKSWindowsServer2019OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks-windows",
-		ImageSku:       "2019-datacenter-core-smalldisk-2007",
+		ImageSku:       "2019-datacenter-core-smalldisk-2008",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "17763.1339.200718",
+		ImageVersion:   "17763.1397.200820",
 	}
 
 	// WindowsServer2019OSImageConfig is the 'vanilla' Windows Server 2019 image

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -50,7 +50,7 @@ const (
 	// DockerCEDockerComposeVersion is the Docker Compose version
 	DockerCEDockerComposeVersion = "1.14.0"
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
-	KubernetesWindowsDockerVersion = "19.03.5"
+	KubernetesWindowsDockerVersion = "19.03.11"
 	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
 	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 )

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -187,15 +187,15 @@ func getVersionOverrides(v string) map[string]string {
 	case "1.18.2":
 		return map[string]string{"windowszip": "v1.18.2-hotfix.20200624/windowszip/v1.18.2-hotfix.20200624-1int.zip"}
 	case "1.17.9":
-		return map[string]string{"windowszip": "v1.17.9-hotfix.20200714/windowszip/v1.17.9-hotfix.20200714-1int.zip"}
+		return map[string]string{"windowszip": "v1.17.9-hotfix.20200817/windowszip/v1.17.9-hotfix.20200817-1int.zip"}
 	case "1.17.7":
-		return map[string]string{"windowszip": "v1.17.7-hotfix.20200714/windowszip/v1.17.7-hotfix.20200714-1int.zip"}
+		return map[string]string{"windowszip": "v1.17.7-hotfix.20200817/windowszip/v1.17.7-hotfix.20200817-1int.zip"}
 	case "1.16.13":
-		return map[string]string{"windowszip": "v1.16.13-hotfix.20200714/windowszip/v1.16.13-hotfix.20200714-1int.zip"}
+		return map[string]string{"windowszip": "v1.16.13-hotfix.20200817/windowszip/v1.16.13-hotfix.20200817-1int.zip"}
 	case "1.16.11":
 		return map[string]string{"windowszip": "v1.16.11-hotfix.20200617/windowszip/v1.16.11-hotfix.20200617-1int.zip"}
 	case "1.16.10":
-		return map[string]string{"windowszip": "v1.16.10-hotfix.20200714/windowszip/v1.16.10-hotfix.20200714-1int.zip"}
+		return map[string]string{"windowszip": "v1.16.10-hotfix.20200817/windowszip/v1.16.10-hotfix.20200817-1int.zip"}
 	case "1.15.12":
 		return map[string]string{"windowszip": "v1.15.12-hotfix.20200714/windowszip/v1.15.12-hotfix.20200714-1int.zip"}
 	case "1.15.11":

--- a/test/e2e/kubernetes/workloads/validate-windows-logging.yaml
+++ b/test/e2e/kubernetes/workloads/validate-windows-logging.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: validate-windows-logging
+  labels:
+    name: storage
+spec:
+  containers:
+    - image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
+      name: validate-windows-logging
+      command:
+        - powershell.exe
+        - -Command
+        - sleep 10; $a="1234567890"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a";
+          $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; $a="$a-$a";
+          $a="$a-$a"; $a="$a-$a"; $a="$a-$a"; do { write-host "DATE=$(date)-$a"; sleep 0.1;
+          } until($false)
+  nodeSelector:
+    kubernetes.io/os: windows
+
+

--- a/vhd/release-notes/aks-windows/2019-datacenter-core-smalldisk-17763.1397.200820.txt
+++ b/vhd/release-notes/aks-windows/2019-datacenter-core-smalldisk-17763.1397.200820.txt
@@ -1,0 +1,139 @@
+﻿Build Number: 20200820.1
+Build Id:     10572
+Build Repo:   https://github.com/Azure/aks-engine
+Build Branch: master
+Commit:       49236ab0c98a2f5d1d0652f4ec4f2d2808fc9540
+
+VHD ID:      5009479c-4266-4327-af48-12ccb32ad600
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.1397
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB4565625 : Update          : http://support.microsoft.com/?kbid=4565625
+	KB4558997 : Security Update : http://support.microsoft.com/?kbid=4558997
+	KB4565349 : Security Update : http://support.microsoft.com/?kbid=4565349
+
+Installed Updates
+	2020-07 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB4566516)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.321.1768.0)
+	2020-08 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB4565349)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+
+Docker Info
+Version: Docker version 19.03.11, build 0da829ac52
+
+Images:
+
+Repository                                                     Tag                               ID          
+----------                                                     ---                               --          
+mcr.microsoft.com/windows/servercore                           ltsc2019                          86eddd4761f5
+mcr.microsoft.com/windows/nanoserver                           1809                              9cf03161d226
+mcr.microsoft.com/oss/kubernetes/pause                         1.4.0                             23d55e3daca0
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v1.2.1-alpha.1-windows-1809-amd64 927caec05c10
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.0.1-alpha.1-windows-1809-amd64 7c4afdb7e0d6
+
+
+
+Cached Files:
+
+File                                                                             Sha256                                                           SizeBytes
+----                                                                             ------                                                           ---------
+c:\akse-cache\collect-windows-logs.ps1                                           8CCABC979D689753F1C92294A065953DB1CA3D2F5F714F928321B17276A4D3CD      3554
+c:\akse-cache\collectlogs.ps1                                                    F979A04A6907690681074937337FA3C3F93278DDC6152E4571D8F220FA0AA5E5      7950
+c:\akse-cache\dumpVfpPolicies.ps1                                                02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                        BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                           A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                         4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\portReservationTest.ps1                                            0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\signedscripts-v0.0.2.zip                                           72AB4989F1239533D99B7CBAD61CBD0FE1F6964294CD65C9A93C0B1C165B3388     44608
+c:\akse-cache\starthnstrace.cmd                                                  3A566462ADBD27A0DCAB4049EF4A1A3EE7AECF2FCFEC6ED8A1CAE305AE7EF562       408
+c:\akse-cache\startpacketcapture.cmd                                             3E31690E507C8B18AC5CC569C89B51CE1901630A501472DA1BC1FBF2737AA5BC       756
+c:\akse-cache\stoppacketcapture.cmd                                              BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                           3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                     CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\containerd\containerd-0.0.87-public.zip                            8A40E7ECE59C79D29E878F6F5CC4546E6D672844EC7CF958EF92710573B84106  80967297
+c:\akse-cache\win-k8s\v1.15.10-1int.zip                                          F8E1941625136C61FE3FE1193F4DB59953E615EBB27390968530F0756D54CAAD  99075694
+c:\akse-cache\win-k8s\v1.15.11-1int.zip                                          FD31594C5D6C3C0EDD97269FB09630EC751353894166521F919C48DB3F58ADD9  99122881
+c:\akse-cache\win-k8s\v1.15.11-azs-1int.zip                                      10576CBA08115EC246CAE44F6AD52ECB26EC88DBBF77A7571F79AD769B5E3B31  99130288
+c:\akse-cache\win-k8s\v1.15.11-hotfix.20200714-1int.zip                          059F6B853DF74BAE748BBDAE673643D5BA1147A19C7AA48C68EA836888A533AF  99148635
+c:\akse-cache\win-k8s\v1.15.11-hotfix.20200817-1int.zip                          C81065B896CE9E676A01208EC7FD2D34362009017EA18E90141E5A5B6C4B7411  99214657
+c:\akse-cache\win-k8s\v1.15.12-1int.zip                                          18E0124DEB357EE6E599DD583AD0B74E3DFBEF41C70E0E79EB1846C5839E5116  99183450
+c:\akse-cache\win-k8s\v1.15.12-azs-1int.zip                                      BC930FFAD50B823B0D15C3DBF21CC2D85CF9C84873C9852BA2F87968D298ECA8  99182019
+c:\akse-cache\win-k8s\v1.15.12-hotfix.20200623-1int.zip                          8DD2BD7B8FC854755083E2EF5633473AC418FBA2A960228EAFF6E118448583BA  99175484
+c:\akse-cache\win-k8s\v1.15.12-hotfix.20200714-1int.zip                          F0FBA9D6CA841EA50CAF93E31C15C83C3916B51BC7D2A7F95B578E856655F158  99168699
+c:\akse-cache\win-k8s\v1.15.12-hotfix.20200817-1int.zip                          8F415A1EBF160FBE9749D84860FC3CF92506D30524A6C74B13CC679D6ED227FA  99235761
+c:\akse-cache\win-k8s\v1.16.10-hotfix.20200817-1int.zip                          8851ED60FF208C46F7B3E9F3C4D800C448DBAAFE1BA461F44053EB279947423B  98084915
+c:\akse-cache\win-k8s\v1.16.12-1int.zip                                          FB09AA607A573F8AAEB5F8741DE8AEA7BED37F519C1A5B63C2622EEAFE61000A  98022544
+c:\akse-cache\win-k8s\v1.16.13-1int.zip                                          086E58BA1D8E70DC09B29042720FAE681C38CB567DE95056F67C02EF13C16E4C  98027419
+c:\akse-cache\win-k8s\v1.16.13-azs-1int.zip                                      FB55038317319DF38092F3A3855D88B5747D3E0D9E0BA9E4657A6F87BFE8AB15  98026968
+c:\akse-cache\win-k8s\v1.16.13-hotfix.20200714-1int.zip                          27B44A3168206C51B68452724F9E552D36245F8CFFB7782EFC07569842890AC0  98030575
+c:\akse-cache\win-k8s\v1.16.13-hotfix.20200817-1int.zip                          238479D233899DD7FDBA209CFCF143B82AE96A656CDB0D5BB44254F7EA3D3862  98096564
+c:\akse-cache\win-k8s\v1.16.14-1int.zip                                          EA52B63488F37AFF33C84B3B340E1ED199B1C3AEBB09971804BD4C892ED97B2B  98124258
+c:\akse-cache\win-k8s\v1.16.14-azs-1int.zip                                      5B6ACE2E73CB0AC922B476F980C1011BC6AA854336C04A9BBF22DBE6B80A522F  98130019
+c:\akse-cache\win-k8s\v1.17.11-1int.zip                                          A1E7049BEBAB5A2C7743D756FFC9394F734D9FA4E46A69D1872018C48DFDBB12  98387085
+c:\akse-cache\win-k8s\v1.17.11-azs-1int.zip                                      E523696263267E8290A877185B44E62260A93776D4D3820B3675CC658F6D36DC  98383690
+c:\akse-cache\win-k8s\v1.17.7-hotfix.20200817-1int.zip                           7823108C804EA27E3315E7DE7003C057635B57D54ECCA9FF24FFDC02F9454699  98365082
+c:\akse-cache\win-k8s\v1.17.8-1int.zip                                           0A4BE204E497458BAB2AD6F731DAB5698D0A5D900BF158A90E1F7291BEC3C199  57396574
+c:\akse-cache\win-k8s\v1.17.9-1int.zip                                           5FF882E96484918141C649BDB0914D644C7DA2F9AADD355EF0DF077500F063D7  57402965
+c:\akse-cache\win-k8s\v1.17.9-azs-1int.zip                                       F9F31C5416CADCFA2E8F82CC862039F05FD06F4347A4F5E30FF6C00FB23D8F89  98294032
+c:\akse-cache\win-k8s\v1.17.9-hotfix.20200714-1int.zip                           0B7BECAE4248B8F35594A80FA823347A246D92F732507C4E24A04C82DEDA298E  57407696
+c:\akse-cache\win-k8s\v1.17.9-hotfix.20200817-1int.zip                           BEF4526C36A96F004F661A166F50B4CF0C17E2A2A4B7E4AB9D04D1AA5699E7C1  98365281
+c:\akse-cache\win-k8s\v1.18.4-hotfix.20200626-1int.zip                           2F39F5E9EEEB9B5C2ED4063CC680D2D92BA714181635FB09C13EC72B51E5D32A  58027424
+c:\akse-cache\win-k8s\v1.18.5-1int.zip                                           D5C444B542865DEECB70BA876C24D9B8E43F4A4808004F390A57A678156D86AF  58022761
+c:\akse-cache\win-k8s\v1.18.6-1int.zip                                           201B61C5B9D3F5E6B8A43E29C0D43736E03AD71FF35FEB4E38146E3A0EB7DA93  58037009
+c:\akse-cache\win-k8s\v1.18.6-hotfix.20200723-1int.zip                           477FBB5C80AC088A574C5B7585E2C2520439E50DB9ED09CD68E068C785A21FAE  58037109
+c:\akse-cache\win-k8s\v1.18.8-1int.zip                                           1B2ED449DA428CFE32AD94B212641448AD75932A822E9E82AD2E92FC65E59433  99520042
+c:\akse-cache\win-k8s\v1.19.0-rc.4-1int.zip                                      322931267CE9B24BDC073EC426D41552124139DFD6803D8494CE5E387D93910B 102783925
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.1.2.zip 60F21CAD6439446FCBD1D9A634E7D739D3BF589D17D7D0EAF4A90A63B544466B  23792148
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip 1E660EC0A5923A3E9F62B81BBC5F21923DB82F4F61F06A8067C7E5EB7A549799  23790847
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.1.6.zip 1087FAC87BB88C83830BC59CD869574FAA3AB8F5A6F097E8B05C64CD2D440735  33472459
+
+
+
+


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
1. fix: update windows docker version to fix log rotation error (#3641) 
2. fix: Patch v1.16.10, v1.16.13, v1.17.7, v1.17.9 for Windows CPU metrics issues
3. Update Windows VHD to `17763.1397.200820`: 2020-08 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB4565349)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#3573: Docker log rotation stops after reaching limit on Windows nodes
[82195](https://github.com/kubernetes/kubernetes/issues/82195): CRI pod CPU metrics incorrect for pods with 20+ CPUs 
[83507](https://github.com/kubernetes/kubernetes/pull/83507): Prevent returning invalid usageNanoCores value when cpuacct is reset in a live container #83507

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
