### PR TITLE
fix: use cached v1.15-azs kube-proxy on Azure Stack

### DIFF
--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -771,7 +771,7 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		Containers: []KubernetesContainerSpec{
 			{
 				Name:  common.KubeProxyAddonName,
-				Image: kubernetesImageBase + k8sComponents[common.KubeProxyAddonName],
+				Image: kubernetesImageBase + k8sComponents[common.KubeProxyAddonName] + kubeProxyImageSuffix(*cs),
 			},
 		},
 	}
@@ -1202,4 +1202,16 @@ func getCSISidecarComponent(csiDriverName, csiSidecarName string, k8sComponents 
 		}
 	}
 	return k8sComponents[csiSidecarName]
+}
+
+// kubeProxyImageSuffix returns '-azs' if target cloud is Azure Stack and Kubernetes version is lower than v1.16.0.
+// Otherwise, it returns empty string.
+// Azure Stack needs the '-azs' suffix so kube-proxy's manifests uses the custom hyperkube image present in the VHD
+func kubeProxyImageSuffix(cs ContainerService) string {
+	if cs.Properties.IsAzureStackCloud() {
+		if !common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.16.0") {
+			return common.AzureStackSuffix
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
**Reason for Change**:

Something like this #2806 is required again to successfully deploy K8s 1.15 on air-gapped Azure Stack environments.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
