### PR TITLE
fix: Restart=always docker systemd service

### DIFF
--- a/parts/k8s/cloud-init/artifacts/health-monitor.sh
+++ b/parts/k8s/cloud-init/artifacts/health-monitor.sh
@@ -32,6 +32,9 @@ container_runtime_monitoring() {
       fi
       systemctl kill --kill-who=main "${container_runtime_name}"
       sleep 120
+      if ! systemctl is-active ${container_runtime_name}; then
+        systemctl start ${container_runtime_name}
+      fi
     else
       sleep "${SLEEP_SECONDS}"
     fi
@@ -49,6 +52,9 @@ kubelet_monitoring() {
       echo "Kubelet is unhealthy!"
       systemctl kill kubelet
       sleep 60
+      if ! systemctl is-active kubelet; then
+        systemctl start kubelet
+      fi
     else
       sleep "${SLEEP_SECONDS}"
     fi

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -230,6 +230,7 @@ write_files:
   owner: root
   content: |
     [Service]
+    Restart=always
     ExecStart=
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     ExecStartPost=/sbin/iptables -P FORWARD ACCEPT

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -214,6 +214,7 @@ write_files:
   owner: root
   content: |
     [Service]
+    Restart=always
     ExecStart=
     {{- if .IsFlatcar}}
     ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}} $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -20508,6 +20508,9 @@ container_runtime_monitoring() {
       fi
       systemctl kill --kill-who=main "${container_runtime_name}"
       sleep 120
+      if ! systemctl is-active ${container_runtime_name}; then
+        systemctl start ${container_runtime_name}
+      fi
     else
       sleep "${SLEEP_SECONDS}"
     fi
@@ -20525,6 +20528,9 @@ kubelet_monitoring() {
       echo "Kubelet is unhealthy!"
       systemctl kill kubelet
       sleep 60
+      if ! systemctl is-active kubelet; then
+        systemctl start kubelet
+      fi
     else
       sleep "${SLEEP_SECONDS}"
     fi

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -21692,6 +21692,7 @@ write_files:
   owner: root
   content: |
     [Service]
+    Restart=always
     ExecStart=
     ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}}
     ExecStartPost=/sbin/iptables -P FORWARD ACCEPT
@@ -22273,6 +22274,7 @@ write_files:
   owner: root
   content: |
     [Service]
+    Restart=always
     ExecStart=
     {{- if .IsFlatcar}}
     ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock --storage-driver=overlay2 --bip={{WrapAsParameter "dockerBridgeCidr"}} $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that Restart=always is configured for the docker systemd service, and that the included monitor script for both docker and kubelet has a fail-safe "start the systemd service" if the systemd job spec doesn't do so itself.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
