### PR TITLE
test: validate kubelet and docker systemd during E2E

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -34,6 +34,7 @@ jobs:
     ENABLE_KMS_ENCRYPTION: ${{ parameters.enableKMSEncryption }}
     SUBSCRIPTION_ID: '$(SUBSCRIPTION_ID_E2E_KUBERNETES)'
     MSI_USER_ASSIGNED_ID: '$(MSI_USER_ASSIGNED_ID_AKS_ENGINE_E2E)'
+    GINKGO_FOCUS: 'should have resilient kubelet and docker systemd services'
 
   steps:
     - template: e2e-step-template.yaml

--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -34,7 +34,6 @@ jobs:
     ENABLE_KMS_ENCRYPTION: ${{ parameters.enableKMSEncryption }}
     SUBSCRIPTION_ID: '$(SUBSCRIPTION_ID_E2E_KUBERNETES)'
     MSI_USER_ASSIGNED_ID: '$(MSI_USER_ASSIGNED_ID_AKS_ENGINE_E2E)'
-    GINKGO_FOCUS: 'should have resilient kubelet and docker systemd services'
 
   steps:
     - template: e2e-step-template.yaml

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2635,5 +2635,33 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("Onboarding connected cluster was not requested")
 			}
 		})
+
+		It("should have resilient kubelet and docker systemd services", func() {
+			if cfg.BlockSSHPort {
+				Skip("SSH port is blocked")
+			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
+				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				systemdValidateScript := "systemd-validate.sh"
+				err = sshConn.CopyTo(systemdValidateScript)
+				Expect(err).NotTo(HaveOccurred())
+				envString := fmt.Sprintf("MASTER_NODE=true")
+				systemdValidationCommand := fmt.Sprintf("%s /tmp/%s", envString, systemdValidateScript)
+				err = sshConn.Execute(systemdValidationCommand, false)
+				Expect(err).NotTo(HaveOccurred())
+				for _, n := range nodes {
+					if n.IsUbuntu() && !firstMasterRegexp.MatchString(n.Metadata.Name) {
+						err := sshConn.CopyToRemoteWithRetry(n.Metadata.Name, "/tmp/"+systemdValidateScript, sleepBetweenRetriesRemoteSSHCommand, cfg.Timeout)
+						Expect(err).NotTo(HaveOccurred())
+						envString = fmt.Sprintf("MASTER_NODE=%t", n.HasSubstring([]string{common.LegacyControlPlaneVMPrefix}))
+						systemdValidationCommand = fmt.Sprintf("%s /tmp/%s", envString, systemdValidateScript)
+						err = sshConn.ExecuteRemoteWithRetry(n.Metadata.Name, systemdValidationCommand, false, sleepBetweenRetriesRemoteSSHCommand, cfg.Timeout)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+			} else {
+				Skip("Skip per-node tests in low-priority VMSS cluster configuration scenario")
+			}
+		})
 	})
 })

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2645,16 +2645,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				systemdValidateScript := "systemd-validate.sh"
 				err = sshConn.CopyTo(systemdValidateScript)
 				Expect(err).NotTo(HaveOccurred())
-				envString := fmt.Sprintf("MASTER_NODE=true")
-				systemdValidationCommand := fmt.Sprintf("%s /tmp/%s", envString, systemdValidateScript)
+				systemdValidationCommand := fmt.Sprintf("/tmp/%s", systemdValidateScript)
 				err = sshConn.Execute(systemdValidationCommand, false)
 				Expect(err).NotTo(HaveOccurred())
 				for _, n := range nodes {
 					if n.IsUbuntu() && !firstMasterRegexp.MatchString(n.Metadata.Name) {
 						err := sshConn.CopyToRemoteWithRetry(n.Metadata.Name, "/tmp/"+systemdValidateScript, sleepBetweenRetriesRemoteSSHCommand, cfg.Timeout)
 						Expect(err).NotTo(HaveOccurred())
-						envString = fmt.Sprintf("MASTER_NODE=%t", n.HasSubstring([]string{common.LegacyControlPlaneVMPrefix}))
-						systemdValidationCommand = fmt.Sprintf("%s /tmp/%s", envString, systemdValidateScript)
+						systemdValidationCommand = fmt.Sprintf("/tmp/%s", systemdValidateScript)
 						err = sshConn.ExecuteRemoteWithRetry(n.Metadata.Name, systemdValidationCommand, false, sleepBetweenRetriesRemoteSSHCommand, cfg.Timeout)
 						Expect(err).NotTo(HaveOccurred())
 					}

--- a/test/e2e/kubernetes/scripts/systemd-validate.sh
+++ b/test/e2e/kubernetes/scripts/systemd-validate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+sudo kill $(pgrep dockerd)
+sleep 10
+if ! sudo systemctl is-active docker; then
+  exit 1
+fi
+sudo kill $(pgrep kubelet)
+sleep 10
+if ! sudo systemctl is-active kubelet; then
+  exit 1
+fi


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR adds a systemd validation test for kubelet and docker, to ensure that they are restarted after the processes are killed.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
