### PR TITLE
fix: ensure cleanup scripts can login w/ sp

### DIFF
--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -26,13 +26,21 @@ if [ -z "$EXPIRATION_IN_HOURS" ]; then
     EXPIRATION_IN_HOURS=2
 fi
 
-az login --service-principal \
+if az login --service-principal \
 		--username "${SERVICE_PRINCIPAL_CLIENT_ID}" \
 		--password "${SERVICE_PRINCIPAL_CLIENT_SECRET}" \
-		--tenant "${TENANT_ID}" &>/dev/null
+		--tenant "${TENANT_ID}" &>/dev/null; then
+    echo "Successfully logged in using service principal"
+else
+    exit 1
+fi
 
 # set to the sub id we want to cleanup
-az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
+if az account set -s $SUBSCRIPTION_ID_TO_CLEANUP; then
+    echo "Successfully set subscription"
+else
+    exit 1
+fi
 
 # convert to seconds so we can compare it against the "tags.now" property in the resource group metadata
 (( expirationInSecs = ${EXPIRATION_IN_HOURS} * 60 * 60 ))

--- a/vhd/packer/vhd-rg-cleanup.sh
+++ b/vhd/packer/vhd-rg-cleanup.sh
@@ -31,13 +31,21 @@ if [ -z "$DRY_RUN" ]; then
     DRY_RUN=true
 fi
 
-az login --service-principal \
+if az login --service-principal \
 		--username "${SERVICE_PRINCIPAL_CLIENT_ID}" \
 		--password "${SERVICE_PRINCIPAL_CLIENT_SECRET}" \
-		--tenant "${TENANT_ID}" &>/dev/null
+		--tenant "${TENANT_ID}" &>/dev/null; then
+    echo "Successfully logged in using service principal"
+else
+    exit 1
+fi
 
 # set to the sub id we want to cleanup
-az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
+if az account set -s $SUBSCRIPTION_ID_TO_CLEANUP; then
+    echo "Successfully set subscription"
+else
+    exit 1
+fi
 
 # convert to seconds so we can compare it against the "tags.now" property in the resource group metadata
 (( expirationInSecs = ${EXPIRATION_IN_HOURS} * 60 * 60 ))


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that cleanup scripts are able to login, and if not, exits 1.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
