### PR TITLE
fix: availabilityZones value in template to read from parameter

### DIFF
--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -85,7 +85,7 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 	addCustomTagsToVMScaleSets(cs.Properties.MasterProfile.CustomVMTags, &virtualMachine)
 
 	if hasAvailabilityZones {
-		virtualMachine.Zones = to.StringPtr("[parameters('availabilityZones')]")
+		virtualMachine.Zones = &[]string{"[parameters('availabilityZones')]"}
 	}
 
 	if userAssignedIDEnabled {
@@ -417,7 +417,7 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 	addCustomTagsToVMScaleSets(profile.CustomVMTags, &virtualMachineScaleSet)
 
 	if profile.HasAvailabilityZones() {
-		virtualMachineScaleSet.Zones = to.StringPtr(fmt.Sprintf("[parameters('%sAvailabilityZones')]", profile.Name))
+		virtualMachineScaleSet.Zones = &[]string{fmt.Sprintf("[parameters('%sAvailabilityZones')]", profile.Name)}
 	}
 
 	var useManagedIdentity bool

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -417,7 +417,11 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 	addCustomTagsToVMScaleSets(profile.CustomVMTags, &virtualMachineScaleSet)
 
 	if profile.HasAvailabilityZones() {
-		virtualMachineScaleSet.Zones = &[]string{fmt.Sprintf("[parameters('%sAvailabilityZones')]", profile.Name)}
+		zones := []string{}
+		for i := range profile.AvailabilityZones {
+			zones = append(zones, fmt.Sprintf("[parameters('%sAvailabilityZones')[%d]]", profile.Name, i))
+		}
+		virtualMachineScaleSet.Zones = &zones
 	}
 
 	var useManagedIdentity bool

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -85,7 +85,7 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 	addCustomTagsToVMScaleSets(cs.Properties.MasterProfile.CustomVMTags, &virtualMachine)
 
 	if hasAvailabilityZones {
-		virtualMachine.Zones = &masterProfile.AvailabilityZones
+		virtualMachine.Zones = to.StringPtr("[parameters('availabilityZones')]")
 	}
 
 	if userAssignedIDEnabled {
@@ -417,7 +417,7 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 	addCustomTagsToVMScaleSets(profile.CustomVMTags, &virtualMachineScaleSet)
 
 	if profile.HasAvailabilityZones() {
-		virtualMachineScaleSet.Zones = &profile.AvailabilityZones
+		virtualMachineScaleSet.Zones = to.StringPtr(fmt.Sprintf("[parameters('%sAvailabilityZones')]", profile.Name))
 	}
 
 	var useManagedIdentity bool

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute/models.go
@@ -2485,7 +2485,7 @@ type DedicatedHostGroup struct {
 	autorest.Response             `json:"-"`
 	*DedicatedHostGroupProperties `json:"properties,omitempty"`
 	// Zones - Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone.
-	Zones *string `json:"zones,omitempty"`
+	Zones *[]string `json:"zones,omitempty"`
 	// ID - READ-ONLY; Resource Id
 	ID *string `json:"id,omitempty"`
 	// Name - READ-ONLY; Resource name
@@ -10720,7 +10720,7 @@ func (vmss *VirtualMachineScaleSet) UnmarshalJSON(body []byte) error {
 			}
 		case "zones":
 			if v != nil {
-				var zones string
+				var zones []string
 				err = json.Unmarshal(*v, &zones)
 				if err != nil {
 					return err

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute/models.go
@@ -2485,7 +2485,7 @@ type DedicatedHostGroup struct {
 	autorest.Response             `json:"-"`
 	*DedicatedHostGroupProperties `json:"properties,omitempty"`
 	// Zones - Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *string `json:"zones,omitempty"`
 	// ID - READ-ONLY; Resource Id
 	ID *string `json:"id,omitempty"`
 	// Name - READ-ONLY; Resource name
@@ -10720,7 +10720,7 @@ func (vmss *VirtualMachineScaleSet) UnmarshalJSON(body []byte) error {
 			}
 		case "zones":
 			if v != nil {
-				var zones []string
+				var zones string
 				err = json.Unmarshal(*v, &zones)
 				if err != nil {
 					return err


### PR DESCRIPTION
 fix: Fix availabilityZones value in template to read from parameter

**Reason for Change**:
The availability zone of virtualMachineScaleSets is specified directly in the template file instead of reading from the parameter file.


**Issue Fixed**:
Fixes #3762 

fix: Bug Fixes 🐞

**Earlier:**
![grege4r](https://user-images.githubusercontent.com/22790904/91748662-f5103000-ebdd-11ea-933c-375de1c9e3e1.PNG)

**Now:**
![reef](https://user-images.githubusercontent.com/22790904/91748684-fb061100-ebdd-11ea-9442-10c17096ce1e.PNG)

