### PR TITLE
fix: update the flag due to using higher version of csi livenessprobe

### DIFF
--- a/parts/k8s/addons/azuredisk-csi-driver-deployment.yaml
+++ b/parts/k8s/addons/azuredisk-csi-driver-deployment.yaml
@@ -476,7 +476,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29603
             - --v=5
           resources:
@@ -725,7 +725,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29602
             - --v=5
           volumeMounts:

--- a/parts/k8s/addons/azurefile-csi-driver-deployment.yaml
+++ b/parts/k8s/addons/azurefile-csi-driver-deployment.yaml
@@ -507,7 +507,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29613
             - --v=5
           resources:
@@ -738,7 +738,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29612
             - --v=5
           volumeMounts:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -10332,7 +10332,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29603
             - --v=5
           resources:
@@ -10581,7 +10581,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29602
             - --v=5
           volumeMounts:
@@ -11740,7 +11740,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29613
             - --v=5
           resources:
@@ -11971,7 +11971,7 @@ spec:
           image: {{ContainerImage "livenessprobe"}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29612
             - --v=5
           volumeMounts:


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
The version of CSI livenessprobe are different from AzureDiskFile CSI Drivers and Secret Store CSI Drivers currently. Tested the AzureDiskFile CSI Drivers with CSI livenessprobe v2.0.0. They worked well. So here make a change that has the minimum impact on the code. 
Later I will update the CSI livenessprobe version in AzureDiskFileCSI Drivers repo.
/cc @feiskyer  @andyzhangx 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
