### PR TITLE
feat: secrets store addon can pull from custom env

### DIFF
--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -365,8 +365,8 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
-            - name: providers-dir
-              mountPath: /etc/kubernetes/secrets-store-csi-providers
+            - name: etc-kubernetes
+              mountPath: /etc/kubernetes
           resources:
             limits:
               cpu: {{ContainerCPULimits "secrets-store"}}
@@ -405,9 +405,9 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-secrets-store/
             type: DirectoryOrCreate
-        - name: providers-dir
+        - name: etc-kubernetes
           hostPath:
-            path: /etc/kubernetes/secrets-store-csi-providers
+            path: /etc/kubernetes
             type: DirectoryOrCreate
       nodeSelector:
         kubernetes.io/os: linux

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -367,9 +367,11 @@ spec:
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: /etc/kubernetes/secrets-store-csi-providers
+{{- if IsCustomCloudProfile}}
             - name: custom-environment
               mountPath: /etc/kubernetes/azurestackcloud.json
               readOnly: true
+{{end}}
           resources:
             limits:
               cpu: {{ContainerCPULimits "secrets-store"}}
@@ -412,10 +414,12 @@ spec:
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
+{{- if IsCustomCloudProfile}}
         - name: custom-environment
           hostPath:
             path: /etc/kubernetes/azurestackcloud.json
             type: FileOrCreate
+{{end}}
       nodeSelector:
         kubernetes.io/os: linux
 ---

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -365,8 +365,11 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
-            - name: etc-kubernetes
-              mountPath: /etc/kubernetes
+            - name: providers-dir
+              mountPath: /etc/kubernetes/secrets-store-csi-providers
+            - name: custom-environment
+              mountPath: /etc/kubernetes/azurestackcloud.json
+              readOnly: true
           resources:
             limits:
               cpu: {{ContainerCPULimits "secrets-store"}}
@@ -405,10 +408,14 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-secrets-store/
             type: DirectoryOrCreate
-        - name: etc-kubernetes
+        - name: providers-dir
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
+        - name: custom-environment
+          hostPath:
+            path: /etc/kubernetes/azurestackcloud.json
+            type: FileOrCreate
       nodeSelector:
         kubernetes.io/os: linux
 ---

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17759,9 +17759,11 @@ spec:
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: /etc/kubernetes/secrets-store-csi-providers
+{{- if IsCustomCloudProfile}}
             - name: custom-environment
               mountPath: /etc/kubernetes/azurestackcloud.json
               readOnly: true
+{{end}}
           resources:
             limits:
               cpu: {{ContainerCPULimits "secrets-store"}}
@@ -17804,10 +17806,12 @@ spec:
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
+{{- if IsCustomCloudProfile}}
         - name: custom-environment
           hostPath:
             path: /etc/kubernetes/azurestackcloud.json
             type: FileOrCreate
+{{end}}
       nodeSelector:
         kubernetes.io/os: linux
 ---

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17757,8 +17757,8 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
-            - name: providers-dir
-              mountPath: /etc/kubernetes/secrets-store-csi-providers
+            - name: etc-kubernetes
+              mountPath: /etc/kubernetes
           resources:
             limits:
               cpu: {{ContainerCPULimits "secrets-store"}}
@@ -17797,9 +17797,9 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-secrets-store/
             type: DirectoryOrCreate
-        - name: providers-dir
+        - name: etc-kubernetes
           hostPath:
-            path: /etc/kubernetes/secrets-store-csi-providers
+            path: /etc/kubernetes
             type: DirectoryOrCreate
       nodeSelector:
         kubernetes.io/os: linux

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17757,8 +17757,11 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
-            - name: etc-kubernetes
-              mountPath: /etc/kubernetes
+            - name: providers-dir
+              mountPath: /etc/kubernetes/secrets-store-csi-providers
+            - name: custom-environment
+              mountPath: /etc/kubernetes/azurestackcloud.json
+              readOnly: true
           resources:
             limits:
               cpu: {{ContainerCPULimits "secrets-store"}}
@@ -17797,10 +17800,14 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-secrets-store/
             type: DirectoryOrCreate
-        - name: etc-kubernetes
+        - name: providers-dir
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
+        - name: custom-environment
+          hostPath:
+            path: /etc/kubernetes/azurestackcloud.json
+            type: FileOrCreate
       nodeSelector:
         kubernetes.io/os: linux
 ---


### PR DESCRIPTION
**Reason for Change**:

Make sure that the secrets store addon is able to pull Key Vault entries from air-gapped clouds. 

**Issue Fixed**:

Fixes #3786

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
