### PR TITLE
chore: check VHD media name length before being published to Marketplace

### DIFF
--- a/vhd/publishing/add-image-version-to-sku.sh
+++ b/vhd/publishing/add-image-version-to-sku.sh
@@ -52,7 +52,7 @@ image_version="${vhd_version}.${version_date}"
 # generate media name
 # Media name must be under 63 characters
 sku_prefix=$(< $SKU_INFO jq -r ".sku_prefix")
-media_name="${sku_prefix}-${image_version}"
+media_name="aks-windows-${sku_prefix}-${image_version}"
 if [ "${#media_name}" -ge 63 ]; then
 	echo "$media_name should be under 63 characters"
 	exit 1
@@ -87,3 +87,4 @@ sku=$(< $SKU_INFO jq -r ".sku_id")
 
 # TODO: Update pub versions put to take in version.json as a file
 (set -x ; pub versions put corevm -p $publisher -o aks-windows -s $sku --version $image_version --vhd-uri $vhd_url --media-name $media_name --label "AKS Base Image for Windows" --desc "AKS Base Image for Windows" --published-date "$published_date")
+

--- a/vhd/publishing/add-image-version-to-sku.sh
+++ b/vhd/publishing/add-image-version-to-sku.sh
@@ -50,8 +50,13 @@ version_date=$(date +"%y%m%d")
 image_version="${vhd_version}.${version_date}"
 
 # generate media name
+# Media name must be under 63 characters
 sku_prefix=$(< $SKU_INFO jq -r ".sku_prefix")
-media_name="aks-windows-${sku_prefix}-${image_version}"
+media_name="${sku_prefix}-${image_version}"
+if [ "${#media_name}" -ge 63 ]; then
+	echo "$media_name should be under 63 characters"
+	exit 1
+fi
 
 # generate published date
 published_date=$(date +"%m/%d/%Y")


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Maketplace has a VHD media name length, which should be under 63 characters.
This change check the media name length before the vhd is published to Marketplace.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
