### PR TITLE
fix: mount /etc/ssl/certs for apiserver

### DIFF
--- a/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -20,6 +20,8 @@ spec:
           mountPath: /etc/kubernetes
         - name: etc-kubernetes-certs
           mountPath: /etc/kubernetes/certs
+        - name: etc-ssl-certs
+          mountPath: /etc/ssl/certs
         - name: var-lib-kubelet
           mountPath: /var/lib/kubelet
         - name: msi
@@ -36,6 +38,9 @@ spec:
     - name: etc-kubernetes-certs
       hostPath:
         path: /etc/kubernetes/certs
+    - name: etc-ssl-certs
+      hostPath:
+        path: /etc/ssl/certs
     - name: var-lib-kubelet
       hostPath:
         path: /var/lib/kubelet

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -24220,6 +24220,8 @@ spec:
           mountPath: /etc/kubernetes
         - name: etc-kubernetes-certs
           mountPath: /etc/kubernetes/certs
+        - name: etc-ssl-certs
+          mountPath: /etc/ssl/certs
         - name: var-lib-kubelet
           mountPath: /var/lib/kubelet
         - name: msi
@@ -24236,6 +24238,9 @@ spec:
     - name: etc-kubernetes-certs
       hostPath:
         path: /etc/kubernetes/certs
+    - name: etc-ssl-certs
+      hostPath:
+        path: /etc/ssl/certs
     - name: var-lib-kubelet
       hostPath:
         path: /var/lib/kubelet


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR mounts `/etc/ssl/certs` for the apiserver container so that it can access root CA certs.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

May fix #3637 #3042

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
