### PR TITLE
chore: remove apiserver /etc/kubernetes/certs mount

### DIFF
--- a/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -18,8 +18,6 @@ spec:
       volumeMounts:
         - name: etc-kubernetes
           mountPath: /etc/kubernetes
-        - name: etc-kubernetes-certs
-          mountPath: /etc/kubernetes/certs
         - name: etc-ssl-certs
           mountPath: /etc/ssl/certs
         - name: var-lib-kubelet
@@ -35,9 +33,6 @@ spec:
     - name: etc-kubernetes
       hostPath:
         path: /etc/kubernetes
-    - name: etc-kubernetes-certs
-      hostPath:
-        path: /etc/kubernetes/certs
     - name: etc-ssl-certs
       hostPath:
         path: /etc/ssl/certs

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -24218,8 +24218,6 @@ spec:
       volumeMounts:
         - name: etc-kubernetes
           mountPath: /etc/kubernetes
-        - name: etc-kubernetes-certs
-          mountPath: /etc/kubernetes/certs
         - name: etc-ssl-certs
           mountPath: /etc/ssl/certs
         - name: var-lib-kubelet
@@ -24235,9 +24233,6 @@ spec:
     - name: etc-kubernetes
       hostPath:
         path: /etc/kubernetes
-    - name: etc-kubernetes-certs
-      hostPath:
-        path: /etc/kubernetes/certs
     - name: etc-ssl-certs
       hostPath:
         path: /etc/ssl/certs


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

In our haste to unblock AAD scenarios, we added an unnecessary `/etc/kubernetes/certs` `mountPath` to the apiserver spec. In fact, the needed mount was at `/etc/ssl/certs`, added in https://github.com/Azure/aks-engine/pull/3800.

We are already mounting `/etc/kubernetes`, and thus have access to `/etc/kubernetes/certs` recursively. E.g. from a cluster built with this changeset:

```
azureuser@k8s-master-20163450-0:~$ kubectl exec -it kube-apiserver-k8s-master-20163450-0 -n kube-system -- /bin/sh
# ls -la /etc/kubernetes/certs
total 80
drwxr-xr-x 2 root root 4096 Sep  9 16:50 .
drwxr-xr-x 6 root root 4096 Sep  9 16:50 ..
-rw-r--r-- 1 root root 6404 Sep  9 16:50 apiserver.crt
-rw------- 1 root root 3243 Sep  9 16:49 apiserver.key
-rw-r--r-- 1 root root 1720 Sep  9 16:48 ca.crt
-rw------- 1 root root 3243 Sep  9 16:49 ca.key
-rw-r--r-- 1 root root 1785 Sep  9 16:48 client.crt
-rw------- 1 root root 3243 Sep  9 16:50 client.key
-rw-r--r-- 1 root root 1818 Sep  9 16:49 etcdclient.crt
-rw------- 1 root root 3243 Sep  9 16:49 etcdclient.key
-rw-r--r-- 1 root root 1814 Sep  9 16:49 etcdpeer0.crt
-rw------- 1 1001 1001 3243 Sep  9 16:49 etcdpeer0.key
-rw-r--r-- 1 root root 1818 Sep  9 16:49 etcdserver.crt
-rw------- 1 1001 1001 3243 Sep  9 16:49 etcdserver.key
-rw-r--r-- 1 root root 1147 Sep  9 16:50 kubeletserver.crt
-rw------- 1 root root 1675 Sep  9 16:50 kubeletserver.key
-rw-r--r-- 1 root root 1123 Sep  9 16:50 proxy-ca.crt
-rw-r--r-- 1 root root 1005 Sep  9 16:50 proxy.crt
-rw------- 1 root root 1679 Sep  9 16:50 proxy.key
# cat /etc/kubernetes/manifests/kube-apiserver.yaml
apiVersion: v1
kind: Pod
metadata:
  name: kube-apiserver
  namespace: kube-system
  labels:
    tier: control-plane
    component: kube-apiserver
spec:
  priorityClassName: system-node-critical
  hostNetwork: true
  containers:
    - name: kube-apiserver
      image: mcr.microsoft.com/oss/kubernetes/kube-apiserver:v1.18.8
      imagePullPolicy: IfNotPresent
      command: ["kube-apiserver"]
      args: ["--advertise-address=10.255.255.5", "--allow-privileged=true", "--anonymous-auth=false", "--audit-log-maxage=30", "--audit-log-maxbackup=10", "--audit-log-maxsize=100", "--audit-log-path=/var/log/kubeaudit/audit.log", "--audit-policy-file=/etc/kubernetes/addons/audit-policy.yaml", "--authorization-mode=Node,RBAC", "--bind-address=0.0.0.0", "--client-ca-file=/etc/kubernetes/certs/ca.crt", "--cloud-config=/etc/kubernetes/azure.json", "--cloud-provider=azure", "--enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ValidatingAdmissionWebhook,ResourceQuota,ExtendedResourceToleration,PodSecurityPolicy", "--enable-bootstrap-token-auth=true", "--etcd-cafile=/etc/kubernetes/certs/ca.crt", "--etcd-certfile=/etc/kubernetes/certs/etcdclient.crt", "--etcd-keyfile=/etc/kubernetes/certs/etcdclient.key", "--etcd-servers=https://127.0.0.1:2379", "--insecure-port=0", "--kubelet-client-certificate=/etc/kubernetes/certs/client.crt", "--kubelet-client-key=/etc/kubernetes/certs/client.key", "--profiling=false", "--proxy-client-cert-file=/etc/kubernetes/certs/proxy.crt", "--proxy-client-key-file=/etc/kubernetes/certs/proxy.key", "--requestheader-allowed-names=", "--requestheader-client-ca-file=/etc/kubernetes/certs/proxy-ca.crt", "--requestheader-extra-headers-prefix=X-Remote-Extra-", "--requestheader-group-headers=X-Remote-Group", "--requestheader-username-headers=X-Remote-User", "--secure-port=443", "--service-account-key-file=/etc/kubernetes/certs/apiserver.key", "--service-account-lookup=true", "--service-cluster-ip-range=10.0.0.0/16", "--storage-backend=etcd3", "--tls-cert-file=/etc/kubernetes/certs/apiserver.crt", "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "--tls-private-key-file=/etc/kubernetes/certs/apiserver.key", "--v=4"]
      volumeMounts:
        - name: etc-kubernetes
          mountPath: /etc/kubernetes
        - name: etc-ssl-certs
          mountPath: /etc/ssl/certs
        - name: var-lib-kubelet
          mountPath: /var/lib/kubelet
        - name: msi
          mountPath: /var/lib/waagent/ManagedIdentity-Settings
          readOnly: true
        - name: sock
          mountPath: /opt
        - name: auditlog
          mountPath: /var/log/kubeaudit
  volumes:
    - name: etc-kubernetes
      hostPath:
        path: /etc/kubernetes
    - name: etc-ssl-certs
      hostPath:
        path: /etc/ssl/certs
    - name: var-lib-kubelet
      hostPath:
        path: /var/lib/kubelet
    - name: msi
      hostPath:
        path: /var/lib/waagent/ManagedIdentity-Settings
    - name: sock
      hostPath:
        path: /opt
    - name: auditlog
      hostPath:
        path: /var/log/kubeaudit
```

Observe above that we have local access from the apiserver container to `/etc/kubernetes/certs` without that explicit `mountPath`, because we inherit that access by having a `mountPath` to the parent directory.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
