### PR TITLE
fix: more resilient etcd systemd

### DIFF
--- a/parts/k8s/cloud-init/artifacts/etcd.service
+++ b/parts/k8s/cloud-init/artifacts/etcd.service
@@ -2,9 +2,8 @@
 Description=etcd - highly-available key value store
 Documentation=https://github.com/coreos/etcd
 Documentation=man:etcd
-After=network.target
-Wants=network-online.target
-RequiresMountsFor=/var/lib/etcddisk
+After=network.target var-lib-etcddisk.mount
+Wants=network-online.target var-lib-etcddisk.mount
 [Service]
 Environment=DAEMON_ARGS=
 Environment=ETCD_NAME=%H
@@ -13,6 +12,7 @@ EnvironmentFile=-/etc/default/%p
 Type=notify
 User=etcd
 PermissionsStartOnly=true
+ExecStartPre=/bin/mountpoint -q /var/lib/etcddisk
 ExecStart=/usr/bin/etcd $DAEMON_ARGS
 Restart=always
 [Install]

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -20374,9 +20374,8 @@ var _k8sCloudInitArtifactsEtcdService = []byte(`[Unit]
 Description=etcd - highly-available key value store
 Documentation=https://github.com/coreos/etcd
 Documentation=man:etcd
-After=network.target
-Wants=network-online.target
-RequiresMountsFor=/var/lib/etcddisk
+After=network.target var-lib-etcddisk.mount
+Wants=network-online.target var-lib-etcddisk.mount
 [Service]
 Environment=DAEMON_ARGS=
 Environment=ETCD_NAME=%H
@@ -20385,10 +20384,12 @@ EnvironmentFile=-/etc/default/%p
 Type=notify
 User=etcd
 PermissionsStartOnly=true
+ExecStartPre=/bin/mountpoint -q /var/lib/etcddisk
 ExecStart=/usr/bin/etcd $DAEMON_ARGS
 Restart=always
 [Install]
-WantedBy=multi-user.target`)
+WantedBy=multi-user.target
+`)
 
 func k8sCloudInitArtifactsEtcdServiceBytes() ([]byte, error) {
 	return _k8sCloudInitArtifactsEtcdService, nil


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR addresses observed systemd failures to guarantee the etcd mount dependency upon `/var/lib/etcddisk` via the `RequiresMountsFor` configuration option. In the real world, the systemd `RequiresMountsFor` implementation is unable to detect the specified mount points despite the volume being mounted on the host, and thus blocks the start operation of the service indefinitely.

All credit to @Michael-Sinz :)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3807

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
