### PR TITLE
fix: update Azure Stack's Linux VHD to 2020.09.14

### DIFF
--- a/pkg/api/defaults-custom-cloud-profile.go
+++ b/pkg/api/defaults-custom-cloud-profile.go
@@ -219,6 +219,14 @@ func (p *Properties) SetCustomCloudSpec(params AzureCustomCloudSpecParams) error
 			p.CustomCloudProfile.AzureEnvironmentSpecConfig = &azureCustomCloudSpec
 		}
 
+		if p.IsAzureStackCloud() {
+			azureCustomCloudSpec.OSImageConfig[AKSUbuntu1604] = AzureOSImageConfig{
+				ImageOffer:     "aks",
+				ImageSku:       "aks-engine-ubuntu-1604-202007",
+				ImagePublisher: "microsoft-aks",
+				ImageVersion:   "2020.09.14",
+			}
+		}
 		// Kubernetes only understand AzureStackCloud environment (AzureCloudSpecEnvMap is only accessed using AzureStackCloud for custom clouds)
 		AzureCloudSpecEnvMap[AzureStackCloud] = azureCustomCloudSpec
 	}


### PR DESCRIPTION
**Reason for Change**:
Distributing a fix for #3817 to air-gapped Azure Stack Hub clusters requires a new Linux VHD.

The proposed solution is to force, for Azure Stack clouds only, a different Linux base OS that contains the patched cloud provider images. 

This PR is meant to serve as a one-time fix that specifically targets release v0.55.x. 

**Issue Fixed**:
Fixes #3817 

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
