### PR TITLE
chore: validate Azure Stack's Linux VHD is in PIR

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -175,6 +175,14 @@ var (
 		ImageVersion:   "2020.08.24",
 	}
 
+	// AzureStackAKSUbuntu1604OSImageConfig is the AKS image based on Ubuntu 16.04-LTS.
+	AzureStackAKSUbuntu1604OSImageConfig = AzureOSImageConfig{
+		ImageOffer:     "aks",
+		ImageSku:       "aks-engine-ubuntu-1604-202007",
+		ImagePublisher: "microsoft-aks",
+		ImageVersion:   "2020.09.14",
+	}
+
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
 	AKSUbuntu1804OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",

--- a/pkg/api/defaults-custom-cloud-profile.go
+++ b/pkg/api/defaults-custom-cloud-profile.go
@@ -220,12 +220,7 @@ func (p *Properties) SetCustomCloudSpec(params AzureCustomCloudSpecParams) error
 		}
 
 		if p.IsAzureStackCloud() {
-			azureCustomCloudSpec.OSImageConfig[AKSUbuntu1604] = AzureOSImageConfig{
-				ImageOffer:     "aks",
-				ImageSku:       "aks-engine-ubuntu-1604-202007",
-				ImagePublisher: "microsoft-aks",
-				ImageVersion:   "2020.09.14",
-			}
+			azureCustomCloudSpec.OSImageConfig[AKSUbuntu1604] = AzureStackAKSUbuntu1604OSImageConfig
 		}
 		// Kubernetes only understand AzureStackCloud environment (AzureCloudSpecEnvMap is only accessed using AzureStackCloud for custom clouds)
 		AzureCloudSpecEnvMap[AzureStackCloud] = azureCustomCloudSpec

--- a/pkg/armhelpers/support_validator.go
+++ b/pkg/armhelpers/support_validator.go
@@ -85,7 +85,7 @@ func toImageConfig(distro api.Distro) api.AzureOSImageConfig {
 	case api.Flatcar:
 		return api.FlatcarImageConfig
 	case api.AKSUbuntu1604:
-		return api.AKSUbuntu1604OSImageConfig
+		return api.AzureStackAKSUbuntu1604OSImageConfig
 	case api.AKSUbuntu1804:
 		return api.AKSUbuntu1804OSImageConfig
 	case api.ACC1604:


### PR DESCRIPTION
**Reason for Change**:

Update an Azure Stack only validation that makes sure that the required OS images are in the Platform Images Repository (PIR). In this case, the Azure Stack only validation should look up `AzureStackAKSUbuntu1604OSImageConfig` instead of `AKSUbuntu1604OSImageConfig`.

This PR is meant to serve as a one-time fix that specifically targets release v0.55.x.

**Issue Fixed:**

Related to #3828

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
