### PR TITLE
revert: "chore: targeting sept updates for Windows 2019 VHD"

### DIFF
--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -187,8 +187,9 @@ function Install-WindowsPatches {
     # Windows Server 2019 update history can be found at https://support.microsoft.com/en-us/help/4464619
     # then you can get download links by searching for specific KBs at http://www.catalog.update.microsoft.com/home.aspx
 
-    # https://www.catalog.update.microsoft.com/Search.aspx?q=KB4570333 - Sept 2020 updates for Windows Server 2019
-    $patchUrls = @("http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/09/windows10.0-kb4570333-x64_8c3c376b98addc84ef5c6c59de3b59cb33436fee.msu")
+    # KB4558998 contains August 11, 2020 cumulative updates for Windows Server 2019
+    # https://www.catalog.update.microsoft.com/Search.aspx?q=KB4565349
+    $patchUrls = @("http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/08/windows10.0-kb4565349-x64_919b9f31d4ccfa91183fbb9bab8c2975529e66b6.msu")
 
     foreach ($patchUrl in $patchUrls) {
         $pathOnly = $patchUrl.Split("?")[0]

--- a/vhd/packer/windows-vhd-builder.json
+++ b/vhd/packer/windows-vhd-builder.json
@@ -26,7 +26,7 @@
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",
             "image_sku": "2019-Datacenter-Core-smalldisk",
-            "image_version": "17763.1397.2008070242",
+            "image_version": "17763.1339.2007101755",
             "resource_group_name": "{{user `resource_group_name`}}",
             "capture_container_name": "aksengine-vhds-windows-ws2019",
             "capture_name_prefix": "aksengine-{{user `create_time`}}",


### PR DESCRIPTION
Reverts Azure/aks-engine#3801

We're seeing DNS failures after applying 9B / Sept 2020 updates on Windows Server 2019