### PR TITLE
chore: remove no-op 1.15 version checks in templates

### DIFF
--- a/parts/k8s/addons/azure-cloud-provider.yaml
+++ b/parts/k8s/addons/azure-cloud-provider.yaml
@@ -53,7 +53,6 @@ subjects:
 - kind: ServiceAccount
   name: persistent-volume-binder
   namespace: kube-system
-{{- if IsKubernetesVersionGe "1.15.0"}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.16.0")}}beta1{{end}}
 kind: ClusterRole
@@ -81,7 +80,6 @@ subjects:
 - kind: ServiceAccount
   name: azure-cloud-provider
   namespace: kube-system
-{{- end}}
 {{- if UsesCloudControllerManager}}
 ---
 apiVersion: storage.k8s.io/v1
@@ -98,9 +96,7 @@ parameters:
   kind: managed
   cachingMode: ReadOnly
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -123,9 +119,7 @@ parameters:
   kind: managed
   cachingMode: ReadOnly
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -148,9 +142,7 @@ parameters:
   kind: managed
   cachingMode: ReadOnly
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -171,9 +163,7 @@ provisioner: file.csi.azure.com
 parameters:
   skuName: Standard_LRS
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
 volumeBindingMode: Immediate
 {{else}}
   {{- if NeedsStorageAccountStorageClasses}}

--- a/parts/k8s/addons/pod-security-policy.yaml
+++ b/parts/k8s/addons/pod-security-policy.yaml
@@ -114,12 +114,9 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{if IsKubernetesVersionGe "1.15.0"}}ClusterRoleBinding{{else}}RoleBinding{{end}}
+kind: ClusterRoleBinding
 metadata:
   name: default:privileged
-{{- if not (IsKubernetesVersionGe "1.15.0")}}
-  namespace: kube-system
-{{end}}
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
@@ -128,13 +125,8 @@ roleRef:
   name: psp:privileged
 subjects:
 - kind: Group
-  name: {{if IsKubernetesVersionGe "1.15.0"}}system:authenticated{{else}}system:masters{{end}}
+  name: system:authenticated
   apiGroup: rbac.authorization.k8s.io
-{{- if not (IsKubernetesVersionGe "1.15.0")}}
-- kind: Group
-  name: system:serviceaccounts:kube-system
-  apiGroup: rbac.authorization.k8s.io
-{{end}}
 - kind: Group
   name: system:nodes
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -8654,7 +8654,6 @@ subjects:
 - kind: ServiceAccount
   name: persistent-volume-binder
   namespace: kube-system
-{{- if IsKubernetesVersionGe "1.15.0"}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.16.0")}}beta1{{end}}
 kind: ClusterRole
@@ -8682,7 +8681,6 @@ subjects:
 - kind: ServiceAccount
   name: azure-cloud-provider
   namespace: kube-system
-{{- end}}
 {{- if UsesCloudControllerManager}}
 ---
 apiVersion: storage.k8s.io/v1
@@ -8699,9 +8697,7 @@ parameters:
   kind: managed
   cachingMode: ReadOnly
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -8724,9 +8720,7 @@ parameters:
   kind: managed
   cachingMode: ReadOnly
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -8749,9 +8743,7 @@ parameters:
   kind: managed
   cachingMode: ReadOnly
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
   {{- if HasAvailabilityZones}}
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
@@ -8772,9 +8764,7 @@ provisioner: file.csi.azure.com
 parameters:
   skuName: Standard_LRS
 reclaimPolicy: Delete
-  {{- if IsKubernetesVersionGe "1.15.0"}}
 allowVolumeExpansion: true
-  {{- end}}
 volumeBindingMode: Immediate
 {{else}}
   {{- if NeedsStorageAccountStorageClasses}}
@@ -17002,12 +16992,9 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{if IsKubernetesVersionGe "1.15.0"}}ClusterRoleBinding{{else}}RoleBinding{{end}}
+kind: ClusterRoleBinding
 metadata:
   name: default:privileged
-{{- if not (IsKubernetesVersionGe "1.15.0")}}
-  namespace: kube-system
-{{end}}
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
@@ -17016,13 +17003,8 @@ roleRef:
   name: psp:privileged
 subjects:
 - kind: Group
-  name: {{if IsKubernetesVersionGe "1.15.0"}}system:authenticated{{else}}system:masters{{end}}
+  name: system:authenticated
   apiGroup: rbac.authorization.k8s.io
-{{- if not (IsKubernetesVersionGe "1.15.0")}}
-- kind: Group
-  name: system:serviceaccounts:kube-system
-  apiGroup: rbac.authorization.k8s.io
-{{end}}
 - kind: Group
   name: system:nodes
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Reason for Change**:

Since AKS Engine already supports only Kubernetes v1.15.x or later, these template conditionals have no effect.

**Issue Fixed**:

Refs #3751 

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

Thanks to @jadarsie for noticing the off-by-one error in #3751, which implies this cleanup.