### PR TITLE
chore: distribute apiserver.crt to control plane nodes only

### DIFF
--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -426,7 +426,7 @@ func (rcc *rotateCertsCmd) rotateApiserver() error {
 
 	for _, host := range rcc.agentNodes {
 		log.Debugf("Ranging over node: %s\n", host.Name)
-		for _, cmd := range []string{caCertificateCmd, apiServerCertificateCmd} {
+		for _, cmd := range []string{caCertificateCmd} {
 			out, err := rcc.sshCommandExecuter(cmd, rcc.masterFQDN, host.Name, "22", rcc.sshConfig)
 			if err != nil {
 				log.Printf("Command %s output: %s\n", cmd, out)

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -148,16 +148,18 @@ configureKubeletServerCert() {
 configureK8s() {
   local client_key="/etc/kubernetes/certs/client.key" apiserver_crt="/etc/kubernetes/certs/apiserver.crt" azure_json="/etc/kubernetes/azure.json"
   touch "${client_key}"
-  touch "${apiserver_crt}"
   chmod 0600 "${client_key}"
-  chmod 0644 "${apiserver_crt}"
-  chown root:root "${client_key}" "${apiserver_crt}"
-
+  chown root:root "${client_key}"
+  if [[ -n ${MASTER_NODE} ]]; then
+    touch "${apiserver_crt}"
+    chmod 0644 "${apiserver_crt}"
+    chown root:root "${apiserver_crt}"
+  fi
   set +x
   echo "${KUBELET_PRIVATE_KEY}" | base64 --decode >"${client_key}"
-  echo "${APISERVER_PUBLIC_KEY}" | base64 --decode >"${apiserver_crt}"
   configureKubeletServerCert
   if [[ -n ${MASTER_NODE} ]]; then
+    echo "${APISERVER_PUBLIC_KEY}" | base64 --decode >"${apiserver_crt}"
     if [[ ${ENABLE_AGGREGATED_APIS} == True ]]; then
       generateAggregatedAPICerts
     fi

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18471,16 +18471,18 @@ configureKubeletServerCert() {
 configureK8s() {
   local client_key="/etc/kubernetes/certs/client.key" apiserver_crt="/etc/kubernetes/certs/apiserver.crt" azure_json="/etc/kubernetes/azure.json"
   touch "${client_key}"
-  touch "${apiserver_crt}"
   chmod 0600 "${client_key}"
-  chmod 0644 "${apiserver_crt}"
-  chown root:root "${client_key}" "${apiserver_crt}"
-
+  chown root:root "${client_key}"
+  if [[ -n ${MASTER_NODE} ]]; then
+    touch "${apiserver_crt}"
+    chmod 0644 "${apiserver_crt}"
+    chown root:root "${apiserver_crt}"
+  fi
   set +x
   echo "${KUBELET_PRIVATE_KEY}" | base64 --decode >"${client_key}"
-  echo "${APISERVER_PUBLIC_KEY}" | base64 --decode >"${apiserver_crt}"
   configureKubeletServerCert
   if [[ -n ${MASTER_NODE} ]]; then
+    echo "${APISERVER_PUBLIC_KEY}" | base64 --decode >"${apiserver_crt}"
     if [[ ${ENABLE_AGGREGATED_APIS} == True ]]; then
       generateAggregatedAPICerts
     fi


### PR DESCRIPTION
**Reason for Change**:
`apiserver.crt` is distributed to agent nodes even though it is not needed by any agent node component or addon.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
