### PR TITLE
test: E2E fix scale test indexing out of bounds

### DIFF
--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -328,8 +328,8 @@ if [ -n "$ADD_NODE_POOL_INPUT" ]; then
 fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
-  nodepools=$(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json)
-  for ((i = 0; i < ${#nodepools[@]}; ++i)); do
+  nodepoolcount=$(jq '.properties.agentPoolProfiles| length' < _output/$RESOURCE_GROUP/apimodel.json)
+  for ((i = 0; i < $nodepoolcount; ++i)); do
     nodepool=$(jq -r --arg i $i '. | .properties.agentPoolProfiles[$i | tonumber].name' < _output/$RESOURCE_GROUP/apimodel.json)
     if [ "${UPDATE_NODE_POOLS}" = "true" ]; then
       # modify the master VM SKU to simulate vertical vm scaling via upgrade

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -329,7 +329,7 @@ fi
 
 if [ "${SCALE_CLUSTER}" = "true" ]; then
   nodepools=$(jq -r  '.properties.agentPoolProfiles[].name' < _output/$RESOURCE_GROUP/apimodel.json)
-  for ((i = 0; i <= ${#nodepools[@]}; ++i)); do
+  for ((i = 0; i < ${#nodepools[@]}; ++i)); do
     nodepool=$(jq -r --arg i $i '. | .properties.agentPoolProfiles[$i | tonumber].name' < _output/$RESOURCE_GROUP/apimodel.json)
     if [ "${UPDATE_NODE_POOLS}" = "true" ]; then
       # modify the master VM SKU to simulate vertical vm scaling via upgrade


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Fixing a test issue on E2E scale tests, the loop iterating the node pools needs to stop when the index is less than the total of agent pool profiles; currently the fix causes an additional call to scale with node poll set to null

+ (( ++i ))

+ (( i <= 1 ))

++ jq -r --arg i 1 '. | .properties.agentPoolProfiles[$i | tonumber].name'

+ nodepool=null

+ '[' '' = true ']'


Related to changes made in this PR: https://github.com/Azure/aks-engine/pull/3830

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
