### PR TITLE
test: fix Azure Stack E2E cluster provisioner

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -191,16 +191,16 @@ func (ccc *CustomCloudConfig) SetEnvironment() error {
 	azsSelfSignedCaPath := "/aks-engine/Certificates.pem"
 	if _, err = os.Stat(azsSelfSignedCaPath); err == nil {
 		// latest dev_image has an azure-cli version that requires python3
-		devImagePython := "python3"
+		cert_command := fmt.Sprintf(`VER=$(python3 -V | grep -o [0-9].[0-9]*. | grep -o [0-9].[0-9]*);
+		CA=/usr/local/lib/python${VER}/dist-packages/certifi/cacert.pem;
+		if [ -f ${CA} ]; then cat %s >> ${CA}; fi;`, azsSelfSignedCaPath)
 		// include cacert.pem from python2.7 path for upgrade scenario
 		if _, err := os.Stat("/usr/local/lib/python2.7/dist-packages/certifi/cacert.pem"); err == nil {
-			devImagePython = "python"
+			cert_command = fmt.Sprintf(`CA=/usr/local/lib/python2.7/dist-packages/certifi/cacert.pem;
+			if [ -f ${CA} ]; then cat %s >> ${CA}; fi;`, azsSelfSignedCaPath)
 		}
 
-		cmd := exec.Command("/bin/bash", "-c",
-			fmt.Sprintf(`VER=$(%s -V | grep -o [0-9].[0-9]*. | grep -o [0-9].[0-9]*);
-		CA=/usr/local/lib/python${VER}/dist-packages/certifi/cacert.pem;
-		if [ -f ${CA} ]; then cat %s >> ${CA}; fi;`, devImagePython, azsSelfSignedCaPath))
+		cmd := exec.Command("/bin/bash", "-c", cert_command)
 
 		if out, err := cmd.CombinedOutput(); err != nil {
 			log.Printf("output:%s\n", out)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -803,7 +803,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				log.Printf("Image: %s", ds.Spec.Template.TemplateSpec.Containers[0].Image)
 				log.Printf("OrchestratorVersion: %s", eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion)
 				version := eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion
-				Expect(strings.HasSuffix(ds.Spec.Template.TemplateSpec.Containers[0].Image, version)).To(Equal(true))
+				Expect(strings.Contains(ds.Spec.Template.TemplateSpec.Containers[0].Image, version)).To(Equal(true))
 			} else {
 				Skip("Skipping as testing custom kube-proxy image")
 			}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
- E2E test for kube-proxy version validation failed for k8s 1.15 as the hyperkube image for Azure Stack have a different suffix
- E2E test for akse 0.48.0 upgrade scenario on Azure Stack hit certificate issue as `python -v` command didn't return the expected information for python 2

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
