### PR TITLE
chore: create azure.json via CSE

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -147,9 +147,6 @@ configureKubeletServerCert() {
 }
 configureK8s() {
   local client_key="/etc/kubernetes/certs/client.key" apiserver_crt="/etc/kubernetes/certs/apiserver.crt" azure_json="/etc/kubernetes/azure.json"
-  touch $azure_json
-  chmod 0600 $azure_json
-  chown root:root $azure_json
   touch "${client_key}"
   chmod 0600 "${client_key}"
   chown root:root "${client_key}"
@@ -171,6 +168,9 @@ configureK8s() {
     wait_for_file 1 1 /opt/azure/needs_azure.json || return
   fi
 
+  touch $azure_json
+  chmod 0600 $azure_json
+  chown root:root $azure_json
   {{/* Perform the required JSON escaping */}}
   local sp_secret=${SERVICE_PRINCIPAL_CLIENT_SECRET//\\/\\\\}
   sp_secret=${SERVICE_PRINCIPAL_CLIENT_SECRET//\"/\\\"}

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -147,6 +147,9 @@ configureKubeletServerCert() {
 }
 configureK8s() {
   local client_key="/etc/kubernetes/certs/client.key" apiserver_crt="/etc/kubernetes/certs/apiserver.crt" azure_json="/etc/kubernetes/azure.json"
+  touch $azure_json
+  chmod 0600 $azure_json
+  chown root:root $azure_json
   touch "${client_key}"
   chmod 0600 "${client_key}"
   chown root:root "${client_key}"

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -167,8 +167,8 @@ configureK8s() {
       generateAggregatedAPICerts
     fi
   else
-    {{- /* If we are a node vm then we only proceed w/ local azure.json configuration if cloud-init has pre-paved that file */}}
-    wait_for_file 1 1 $azure_json || return
+    {{- /* If we are a node that does not need azure.json (cloud-init tells us), then return immediately */}}
+    wait_for_file 1 1 /opt/azure/needs_azure.json || return
   fi
 
   {{/* Perform the required JSON escaping */}}

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -1,14 +1,6 @@
 #cloud-config
 
 write_files:
-{{- if .RequiresCloudproviderConfig}}
-- path: /etc/kubernetes/azure.json
-  permissions: "0600"
-  owner: root
-  content: |
-    #EOF
-{{end}}
-
 - path: {{GetCSEHelpersScriptFilepath}}
   permissions: "0744"
   encoding: gzip

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -1,6 +1,14 @@
 #cloud-config
 
 write_files:
+{{- if .RequiresCloudproviderConfig}}
+- path: /opt/azure/needs_azure.json
+  permissions: "0644"
+  owner: root
+  content: |
+    #EOF
+{{end}}
+
 - path: {{GetCSEHelpersScriptFilepath}}
   permissions: "0744"
   encoding: gzip

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18490,8 +18490,8 @@ configureK8s() {
       generateAggregatedAPICerts
     fi
   else
-    {{- /* If we are a node vm then we only proceed w/ local azure.json configuration if cloud-init has pre-paved that file */}}
-    wait_for_file 1 1 $azure_json || return
+    {{- /* If we are a node that does not need azure.json (cloud-init tells us), then return immediately */}}
+    wait_for_file 1 1 /opt/azure/needs_azure.json || return
   fi
 
   {{/* Perform the required JSON escaping */}}
@@ -22020,6 +22020,14 @@ func k8sCloudInitMasternodecustomdataYml() (*asset, error) {
 var _k8sCloudInitNodecustomdataYml = []byte(`#cloud-config
 
 write_files:
+{{- if .RequiresCloudproviderConfig}}
+- path: /opt/azure/needs_azure.json
+  permissions: "0644"
+  owner: root
+  content: |
+    #EOF
+{{end}}
+
 - path: {{GetCSEHelpersScriptFilepath}}
   permissions: "0744"
   encoding: gzip

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18470,9 +18470,6 @@ configureKubeletServerCert() {
 }
 configureK8s() {
   local client_key="/etc/kubernetes/certs/client.key" apiserver_crt="/etc/kubernetes/certs/apiserver.crt" azure_json="/etc/kubernetes/azure.json"
-  touch $azure_json
-  chmod 0600 $azure_json
-  chown root:root $azure_json
   touch "${client_key}"
   chmod 0600 "${client_key}"
   chown root:root "${client_key}"
@@ -18494,6 +18491,9 @@ configureK8s() {
     wait_for_file 1 1 /opt/azure/needs_azure.json || return
   fi
 
+  touch $azure_json
+  chmod 0600 $azure_json
+  chown root:root $azure_json
   {{/* Perform the required JSON escaping */}}
   local sp_secret=${SERVICE_PRINCIPAL_CLIENT_SECRET//\\/\\\\}
   sp_secret=${SERVICE_PRINCIPAL_CLIENT_SECRET//\"/\\\"}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18470,6 +18470,9 @@ configureKubeletServerCert() {
 }
 configureK8s() {
   local client_key="/etc/kubernetes/certs/client.key" apiserver_crt="/etc/kubernetes/certs/apiserver.crt" azure_json="/etc/kubernetes/azure.json"
+  touch $azure_json
+  chmod 0600 $azure_json
+  chown root:root $azure_json
   touch "${client_key}"
   chmod 0600 "${client_key}"
   chown root:root "${client_key}"
@@ -22017,14 +22020,6 @@ func k8sCloudInitMasternodecustomdataYml() (*asset, error) {
 var _k8sCloudInitNodecustomdataYml = []byte(`#cloud-config
 
 write_files:
-{{- if .RequiresCloudproviderConfig}}
-- path: /etc/kubernetes/azure.json
-  permissions: "0600"
-  owner: root
-  content: |
-    #EOF
-{{end}}
-
 - path: {{GetCSEHelpersScriptFilepath}}
   permissions: "0744"
   encoding: gzip


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR moves the initial creation of `/etc/kubernetes/azure.json` entirely to CSE. This is to ensure that OS images derived from a running Kubernetes node can be re-used to create new nodes.

tl;dr

- CSE exits 0 immediately if it's already been run
- We don't want cloud-init to blow away stuff that's been mutated by CSE (`/etc/kubernetes/azure.json` is created by CSE)

See #2849 for the initial implementation of "no azure.json" functionality.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
