### PR TITLE
Change iscustomvnet logic

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -643,6 +643,7 @@ type AgentPoolProfile struct {
 	StorageProfile                      string               `json:"storageProfile,omitempty"`
 	DiskSizesGB                         []int                `json:"diskSizesGB,omitempty"`
 	VnetSubnetID                        string               `json:"vnetSubnetID,omitempty"`
+	NodeResourceGroup                   string               `json:"nodeResourceGroup,omitempty"`
 	Subnet                              string               `json:"subnet"`
 	IPAddressCount                      int                  `json:"ipAddressCount,omitempty"`
 	Distro                              Distro               `json:"distro,omitempty"`
@@ -1554,7 +1555,7 @@ func (a *AgentPoolProfile) HasImageGallery() bool {
 
 // IsCustomVNET returns true if the customer brought their own VNET
 func (a *AgentPoolProfile) IsCustomVNET() bool {
-	return len(a.VnetSubnetID) > 0
+	return len(a.VnetSubnetID) > 0 && len(a.NodeResourceGroup) > 0 && !strings.Contains(a.VnetSubnetID, a.NodeResourceGroup)
 }
 
 // IsWindows returns true if the agent pool is windows

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1555,7 +1555,7 @@ func (a *AgentPoolProfile) HasImageGallery() bool {
 
 // IsCustomVNET returns true if the customer brought their own VNET
 func (a *AgentPoolProfile) IsCustomVNET() bool {
-	return len(a.VnetSubnetID) > 0 && !strings.Contains(a.VnetSubnetID, a.NodeResourceGroup)
+	return len(a.VnetSubnetID) > 0 && len(a.NodeResourceGroup) > 0 && !strings.Contains(a.VnetSubnetID, a.NodeResourceGroup)
 }
 
 // IsWindows returns true if the agent pool is windows

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1555,7 +1555,7 @@ func (a *AgentPoolProfile) HasImageGallery() bool {
 
 // IsCustomVNET returns true if the customer brought their own VNET
 func (a *AgentPoolProfile) IsCustomVNET() bool {
-	return len(a.VnetSubnetID) > 0 && len(a.NodeResourceGroup) > 0 && !strings.Contains(a.VnetSubnetID, a.NodeResourceGroup)
+	return len(a.VnetSubnetID) > 0 && !strings.Contains(a.VnetSubnetID, a.NodeResourceGroup)
 }
 
 // IsWindows returns true if the agent pool is windows


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Change iscustomvnet logic because I want to fill VnetSubnetID regardless if the subnet is custom or not

Related RP change:
https://msazure.visualstudio.com/CloudNativeCompute/_git/aks-rp/pullrequest/3583631

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
