### PR TITLE
feat: add ScaleCPULimitsToSandbox for hyperv runtimeclasses

### DIFF
--- a/parts/k8s/windowscontainerdfunc.ps1
+++ b/parts/k8s/windowscontainerdfunc.ps1
@@ -40,6 +40,7 @@ function CreateHypervisorRuntime {
             SandboxImage = "$image-windows-$version-amd64"
             SandboxPlatform = "windows/amd64"
             SandboxIsolation = 1
+            ScaleCPULimitsToSandbox = true
 "@
 }
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -25072,6 +25072,7 @@ function CreateHypervisorRuntime {
             SandboxImage = "$image-windows-$version-amd64"
             SandboxPlatform = "windows/amd64"
             SandboxIsolation = 1
+            ScaleCPULimitsToSandbox = true
 "@
 }
 


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
On Windows kubelet computes CPU shares based on number of CPUs available on the host and passes that to the container runtime. When using Hyper-V isolated VMs the UVM the containers run in may have a different number of CPUs. Adding this flag instructs containerd to inspect the host and UVM CPU count and scale CPU limit values appropriately.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [x] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
