### PR TITLE
fix: don't warn about CRI update on cluster create

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -210,9 +210,12 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			// For that case we'll need to specify the containerd version.
 			if versions.GreaterThanOrEqualTo(o.KubernetesConfig.MobyVersion, "19.03") && (o.KubernetesConfig.ContainerdVersion == "" || isUpdate) {
 				if o.KubernetesConfig.ContainerdVersion != DefaultContainerdVersion {
-					log.Warnf("containerd will be upgraded to version %s\n", DefaultContainerdVersion)
-				} else {
-					log.Warnf("Any new nodes will have containerd version %s\n", DefaultContainerdVersion)
+					if isUpgrade {
+						log.Warnf("containerd will be upgraded to version %s\n", DefaultContainerdVersion)
+					}
+					if isScale {
+						log.Warnf("Any new nodes will have containerd version %s\n", DefaultContainerdVersion)
+					}
 				}
 				o.KubernetesConfig.ContainerdVersion = DefaultContainerdVersion
 			}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/aks-engine/pkg/versions"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestCertsAlreadyPresent(t *testing.T) {
@@ -5653,4 +5655,30 @@ func TestSetCSIProxyDefaults(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ExampleContainerService_setOrchestratorDefaults() {
+	log.SetOutput(os.Stdout)
+	log.SetFormatter(&log.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	})
+
+	mockCS := getMockBaseContainerService("1.19.2")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.setOrchestratorDefaults(true, false)
+
+	mockCS = getMockBaseContainerService("1.19.2")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.setOrchestratorDefaults(false, true)
+
+	mockCS = getMockBaseContainerService("1.19.2")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.setOrchestratorDefaults(false, false)
+
+	// Output:
+	// level=warning msg="Moby will be upgraded to version 19.03.12\n"
+	// level=warning msg="containerd will be upgraded to version 1.3.7\n"
+	// level=warning msg="Any new nodes will have Moby version 19.03.12\n"
+	// level=warning msg="Any new nodes will have containerd version 1.3.7\n"
 }


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR changes the CRI update warning in docker config scenarios so that it only logs on scale or upgrade, matching the log implementation of the containerd flow.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
