### PR TITLE
fix: ensure addon hostNetwork ports don't conflict

### DIFF
--- a/parts/k8s/addons/aad-pod-identity.yaml
+++ b/parts/k8s/addons/aad-pod-identity.yaml
@@ -155,6 +155,7 @@ spec:
         args:
           - "--host-ip=$(HOST_IP)"
           - "--node=$(NODE_NAME)"
+          - "--http-probe-port={{ContainerConfig "probePort"}}"
         env:
           - name: HOST_IP
             valueFrom:
@@ -182,7 +183,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: {{ContainerConfig "probePort"}}
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -343,7 +343,7 @@ spec:
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
             - "--grpc-supported-providers=azure"
-            - "--metrics-addr=:8080"
+            - "--metrics-addr=:{{ContainerConfig "metricsPort"}}"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -456,6 +456,9 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 	defaultsAADPodIdentityAddonsConfig := KubernetesAddon{
 		Name:    common.AADPodIdentityAddonName,
 		Enabled: to.BoolPtr(DefaultAADPodIdentityAddonEnabled && !cs.Properties.IsAzureStackCloud()),
+		Config: map[string]string{
+			"probePort": "8085",
+		},
 		Containers: []KubernetesContainerSpec{
 			{
 				Name:           common.NMIContainerName,
@@ -839,6 +842,9 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 
 	defaultSecretsStoreCSIDriverAddonsConfig := KubernetesAddon{
 		Name: common.SecretsStoreCSIDriverAddonName,
+		Config: map[string]string{
+			"metricsPort": "8095",
+		},
 		Enabled: to.BoolPtr(!o.KubernetesConfig.IsAddonEnabled(common.KeyVaultFlexVolumeAddonName) && DefaultSecretStoreCSIDriverAddonEnabled &&
 			common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0")),
 		Containers: []KubernetesContainerSpec{

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -1916,6 +1916,9 @@ func TestSetAddonsConfig(t *testing.T) {
 				{
 					Name:    common.AADPodIdentityAddonName,
 					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"probePort": "8085",
+					},
 					Containers: []KubernetesContainerSpec{
 						{
 							Name:           common.NMIContainerName,
@@ -5200,6 +5203,9 @@ func getDefaultAddons(version, kubernetesImageBase, kubernetesImageBaseType stri
 		addons = append(addons, KubernetesAddon{
 			Name:    common.SecretsStoreCSIDriverAddonName,
 			Enabled: to.BoolPtr(true),
+			Config: map[string]string{
+				"metricsPort": "8095",
+			},
 			Containers: []KubernetesContainerSpec{
 				{
 					Name:           common.CSILivenessProbeContainerName,

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -4428,6 +4428,9 @@ func TestSetAddonsConfig(t *testing.T) {
 				{
 					Name:    common.SecretsStoreCSIDriverAddonName,
 					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"metricsPort": "8095",
+					},
 				},
 			}, "1.15.4"),
 		},

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -7369,6 +7369,7 @@ spec:
         args:
           - "--host-ip=$(HOST_IP)"
           - "--node=$(NODE_NAME)"
+          - "--http-probe-port={{ContainerConfig "probePort"}}"
         env:
           - name: HOST_IP
             valueFrom:
@@ -7396,7 +7397,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: {{ContainerConfig "probePort"}}
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
@@ -17717,7 +17718,7 @@ spec:
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
             - "--grpc-supported-providers=azure"
-            - "--metrics-addr=:8080"
+            - "--metrics-addr=:{{ContainerConfig "metricsPort"}}"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that aad-pod-identity and csi-secrets-store-driver addons don't open up listeners on the same port, as both are hostNetwork daemonsets.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
