### PR TITLE
ci: E2E fixes to allow more containerd tests

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -82,18 +82,18 @@ jobs:
   parameters:
     name: 'k8s_1_18_containerd_e2e'
     k8sRelease: '1.18'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
+    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json'
+    createVNET: false
     enableKMSEncryption: false
     containerRuntime: 'containerd'
-    runSSHTests: false
+    runSSHTests: true
 
 - template: e2e-job-template.yaml
   parameters:
     name: 'k8s_1_19_containerd_e2e'
     k8sRelease: '1.19'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
+    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json'
+    createVNET: false
     enableKMSEncryption: false
     containerRuntime: 'containerd'
-    runSSHTests: false
+    runSSHTests: true

--- a/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
@@ -1,0 +1,136 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "kubernetesConfig": {
+                "useManagedIdentity": true,
+                "addons": [
+                    {
+                        "name": "kubernetes-dashboard",
+                        "enabled": true
+                    },
+                    {
+                        "name": "rescheduler",
+                        "enabled": true
+                    },
+                    {
+                        "name": "cluster-autoscaler",
+                        "enabled": true,
+                        "pools": [
+                            {
+                                "name": "poollinux",
+                                "config": {
+                                    "min-nodes": "1",
+                                    "max-nodes": "3"
+                                }
+                            }
+                        ],
+                        "config": {
+                            "scan-interval": "1m",
+                            "scale-down-delay-after-add": "1m0s",
+                            "scale-down-unneeded-time": "2m0s"
+                        }
+                    },
+                    {
+                        "name": "aad-pod-identity",
+                        "enabled": true
+                    },
+                    {
+                        "name": "coredns",
+                        "enabled": true,
+                        "config": {
+                            "min-replicas": "1",
+                            "nodes-per-replica": "10"
+                        }
+                    },
+                    {
+                        "name": "azure-policy",
+                        "enabled": true
+                    },
+                    {
+                        "name": "node-problem-detector",
+                        "enabled": true
+                    }
+                ]
+            }
+        },
+        "masterProfile": {
+            "count": 3,
+            "dnsPrefix": "",
+            "vmSize": "Standard_D2_v3",
+            "OSDiskSizeGB": 200,
+            "availabilityZones": [
+                "1",
+                "2"
+            ]
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "poollinux",
+                "count": 1,
+                "vmSize": "Standard_D2_v3",
+                "OSDiskSizeGB": 200,
+                "storageProfile": "ManagedDisks",
+                "diskSizesGB": [
+                    128
+                ],
+                "availabilityProfile": "VirtualMachineScaleSets",
+                "osDiskCachingType": "ReadOnly",
+                "dataDiskCachingType": "ReadWrite"
+            },
+            {
+                "name": "poolwin",
+                "count": 1,
+                "vmSize": "Standard_D2s_v3",
+                "OSDiskSizeGB": 256,
+                "availabilityProfile": "VirtualMachineScaleSets",
+                "osType": "Windows"
+            },
+            {
+                "name": "pool1604vhd",
+                "count": 1,
+                "vmSize": "Standard_D2_v3",
+                "distro": "aks-ubuntu-16.04",
+                "availabilityProfile": "VirtualMachineScaleSets"
+            },
+            {
+                "name": "pool1604",
+                "count": 1,
+                "vmSize": "Standard_D2_v3",
+                "distro": "ubuntu",
+                "availabilityProfile": "VirtualMachineScaleSets"
+            },
+            {
+                "name": "pool1804",
+                "count": 1,
+                "vmSize": "Standard_D2_v3",
+                "distro": "ubuntu-18.04",
+                "availabilityProfile": "VirtualMachineScaleSets"
+            },
+            {
+                "name": "pool1804gen2",
+                "count": 1,
+                "vmSize": "Standard_D2s_v3",
+                "distro": "ubuntu-18.04-gen2",
+                "availabilityProfile": "VirtualMachineScaleSets"
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": ""
+                    }
+                ]
+            }
+        },
+        "windowsProfile": {
+            "adminUsername": "azureuser",
+            "adminPassword": "replacepassword1234$",
+            "sshEnabled": true,
+            "enableAutomaticUpdates": false
+        }
+    }
+}

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -235,14 +235,16 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 		if prop.OrchestratorProfile.KubernetesConfig.WindowsContainerdURL == "" {
 			prop.OrchestratorProfile.KubernetesConfig.WindowsContainerdURL = "https://github.com/containerd/containerd/releases/download/v1.4.0/containerd-1.4.0-windows-amd64.tar.gz"
 		}
-		if prop.WindowsProfile.WindowsPublisher == "" &&
-			prop.WindowsProfile.WindowsOffer == "" &&
-			prop.WindowsProfile.WindowsSku == "" &&
-			prop.WindowsProfile.ImageVersion == "" {
-			prop.WindowsProfile.WindowsPublisher = "microsoft-aks"
-			prop.WindowsProfile.WindowsOffer = "aks-windows"
-			prop.WindowsProfile.WindowsSku = "2019-datacenter-core-smalldisk-containerd-2005"
-			prop.WindowsProfile.ImageVersion = "latest"
+		if prop.WindowsProfile != nil {
+			if prop.WindowsProfile.WindowsPublisher == "" &&
+				prop.WindowsProfile.WindowsOffer == "" &&
+				prop.WindowsProfile.WindowsSku == "" &&
+				prop.WindowsProfile.ImageVersion == "" {
+				prop.WindowsProfile.WindowsPublisher = "microsoft-aks"
+				prop.WindowsProfile.WindowsOffer = "aks-windows"
+				prop.WindowsProfile.WindowsSku = "2019-datacenter-core-smalldisk-containerd-2005"
+				prop.WindowsProfile.ImageVersion = "latest"
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR removes the custom VNET configuration declarations from the PR-configured E2E jobs for containerd, and fixes a nil panic vector in the E2E runner API model injection logic.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
