### PR TITLE
Set the csi-secrets-store to have a priority class

### DIFF
--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -290,6 +290,8 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: csi-secrets-store
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
 value: 1000
 globalDefault: false
 description: "This is the daemonset priority class for csi-secrets-store"

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -282,6 +282,18 @@ status:
   conditions: []
   storedVersions: []
 ---
+# A priority class for the daemonset such that they are not
+# frozen out of a node due to the node filling up with "normal"
+# pods before the daemonset controller can get the daemonset
+# pods to be scheduled.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: csi-secrets-store
+value: 1000
+globalDefault: false
+description: "This is the daemonset priority class for csi-secrets-store"
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -298,6 +310,7 @@ spec:
       labels:
         app: csi-secrets-store
     spec:
+      priorityClassName: csi-secrets-store
       serviceAccountName: secrets-store-csi-driver
       hostNetwork: true
       containers:
@@ -458,6 +471,7 @@ spec:
       labels:
         app: csi-secrets-store-provider-azure
     spec:
+      priorityClassName: csi-secrets-store
       serviceAccountName: csi-secrets-store-provider-azure
       hostNetwork: true
       containers:

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -282,10 +282,10 @@ status:
   conditions: []
   storedVersions: []
 ---
-# A priority class for the daemonset such that they are not
-# frozen out of a node due to the node filling up with "normal"
-# pods before the daemonset controller can get the daemonset
-# pods to be scheduled.
+{{/* A priority class for the daemonset such that they are not */}}
+{{/* frozen out of a node due to the node filling up with "normal" */}}
+{{/* pods before the daemonset controller can get the daemonset */}}
+{{/* pods to be scheduled. */}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -282,10 +282,10 @@ status:
   conditions: []
   storedVersions: []
 ---
-{{/* A priority class for the daemonset such that they are not */}}
-{{/* frozen out of a node due to the node filling up with "normal" */}}
-{{/* pods before the daemonset controller can get the daemonset */}}
-{{/* pods to be scheduled. */}}
+{{- /* A priority class for the daemonset such that they are not */}}
+{{- /* frozen out of a node due to the node filling up with "normal" */}}
+{{- /* pods before the daemonset controller can get the daemonset */}}
+{{- /* pods to be scheduled. */}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17665,6 +17665,8 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: csi-secrets-store
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
 value: 1000
 globalDefault: false
 description: "This is the daemonset priority class for csi-secrets-store"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17657,10 +17657,10 @@ status:
   conditions: []
   storedVersions: []
 ---
-{{/* A priority class for the daemonset such that they are not */}}
-{{/* frozen out of a node due to the node filling up with "normal" */}}
-{{/* pods before the daemonset controller can get the daemonset */}}
-{{/* pods to be scheduled. */}}
+{{- /* A priority class for the daemonset such that they are not */}}
+{{- /* frozen out of a node due to the node filling up with "normal" */}}
+{{- /* pods before the daemonset controller can get the daemonset */}}
+{{- /* pods to be scheduled. */}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17657,6 +17657,18 @@ status:
   conditions: []
   storedVersions: []
 ---
+{{/* A priority class for the daemonset such that they are not */}}
+{{/* frozen out of a node due to the node filling up with "normal" */}}
+{{/* pods before the daemonset controller can get the daemonset */}}
+{{/* pods to be scheduled. */}}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: csi-secrets-store
+value: 1000
+globalDefault: false
+description: "This is the daemonset priority class for csi-secrets-store"
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -17673,6 +17685,7 @@ spec:
       labels:
         app: csi-secrets-store
     spec:
+      priorityClassName: csi-secrets-store
       serviceAccountName: secrets-store-csi-driver
       hostNetwork: true
       containers:
@@ -17833,6 +17846,7 @@ spec:
       labels:
         app: csi-secrets-store-provider-azure
     spec:
+      priorityClassName: csi-secrets-store
       serviceAccountName: csi-secrets-store-provider-azure
       hostNetwork: true
       containers:


### PR DESCRIPTION
Daemonsets are needed to run on all nodes but in a busy cluster with dynamic scaling, it is possible to have enough pending pods from replica sets that a new node fills up before the daemonset pod is ready to be scheduled.  Without priority classes, this can cause daemonsets to be pending to the pod they are bound to and can not run elsewhere.

In this change I added a priority class and use it in the daemonsets.  We could look at using the priority class system-node-critical which is reserved for kubernetes system daemonsets.  I don't think it is valid to use that here.

Just having a priority higher than 0 will usually address this as 99.99% of all workload pods are 0 (or below zero for the easily evicted buffer pods and such)

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
