### PR TITLE
fix: Azure Stack upgrade operations clear old MCR ImageBase

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -137,9 +137,13 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			}
 			o.KubernetesConfig.KubernetesImageBase = cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase
 			if !strings.EqualFold(o.KubernetesConfig.KubernetesImageBaseType, common.KubernetesImageBaseTypeMCR) {
-				log.Warnf("apimodel: orchestratorProfile.kubernetesConfig.KubernetesImageBaseType forced to \"%s\"\n", common.KubernetesImageBaseTypeMCR)
+				log.Warnf("apimodel: orchestratorProfile.kubernetesConfig.kubernetesImageBaseType forced to \"%s\"\n", common.KubernetesImageBaseTypeMCR)
 			}
 			o.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
+			if isUpgrade && strings.EqualFold(o.KubernetesConfig.MCRKubernetesImageBase, "mcr.microsoft.com/k8s/core/") {
+				log.Warn("apimodel: clearing deprecated orchestratorProfile.kubernetesConfig.mcrKubernetesImageBase value\n")
+				o.KubernetesConfig.MCRKubernetesImageBase = ""
+			}
 		}
 
 		if isUpgrade {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1209,20 +1209,27 @@ func TestKubernetesImageBase(t *testing.T) {
 }
 
 func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
-	mockCS := getMockBaseContainerService("1.15.7")
-	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
-	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/k8s/azurestack/core/"
-	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
-	properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase = "mcr.microsoft.com/k8s/core/"
-	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
-	properties.CustomCloudProfile = &CustomCloudProfile{}
-	properties.CustomCloudProfile.Environment = &azure.Environment{}
-	mockCS.setOrchestratorDefaults(true, true)
+	genMockCS := func() ContainerService {
+		mockCS := getMockBaseContainerService("1.15.7")
+		properties := mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/k8s/azurestack/core/"
+		properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
+		properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase = "mcr.microsoft.com/k8s/core/"
+		properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
+		properties.CustomCloudProfile = &CustomCloudProfile{}
+		properties.CustomCloudProfile.Environment = &azure.Environment{}
+		return mockCS
+	}
 
-	expectedImageBase := "mcr.microsoft.com/"
-	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != expectedImageBase {
-		t.Fatalf("setOrchestratorDefaults did not set KubernetesImageBase to its expect value (%s) for Azure Stack clouds", expectedImageBase)
+	overrideImageBase := "mcr.microsoft.com/"
+	inputImageBase := "mcr.microsoft.com/k8s/core/"
+
+	mockCS := genMockCS()
+	properties := mockCS.Properties
+	mockCS.setOrchestratorDefaults(false, false)
+	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != overrideImageBase {
+		t.Fatalf("setOrchestratorDefaults did not set KubernetesImageBase to its expect value (%s) for Azure Stack clouds", overrideImageBase)
 	}
 	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType != common.KubernetesImageBaseTypeMCR {
 		t.Fatalf("setOrchestratorDefaults did not set KubernetesImageBaseType to its expect value (%s) for Azure Stack clouds", common.KubernetesImageBaseTypeMCR)
@@ -1230,8 +1237,24 @@ func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != DefaultAzureStackLoadBalancerSku {
 		t.Fatalf("setOrchestratorDefaults did not set LoadBalancerSku to its expect value (%s) for Azure Stack clouds", DefaultAzureStackLoadBalancerSku)
 	}
-	if properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase != expectedImageBase {
-		t.Fatalf("setOrchestratorDefaults did not set MCRKubernetesImageBase to its expect value (%s) for Azure Stack clouds", expectedImageBase)
+	if properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase != inputImageBase {
+		t.Fatal("setOrchestratorDefaults should not override MCRKubernetesImageBase")
+	}
+
+	mockCS = genMockCS()
+	properties = mockCS.Properties
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != overrideImageBase {
+		t.Fatalf("setOrchestratorDefaults did not set KubernetesImageBase to its expect value (%s) for Azure Stack clouds", overrideImageBase)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType != common.KubernetesImageBaseTypeMCR {
+		t.Fatalf("setOrchestratorDefaults did not set KubernetesImageBaseType to its expect value (%s) for Azure Stack clouds", common.KubernetesImageBaseTypeMCR)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != DefaultAzureStackLoadBalancerSku {
+		t.Fatalf("setOrchestratorDefaults did not set LoadBalancerSku to its expect value (%s) for Azure Stack clouds", DefaultAzureStackLoadBalancerSku)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase != overrideImageBase {
+		t.Fatalf("setOrchestratorDefaults did not set MCRKubernetesImageBase to its expect value (%s) for Azure Stack clouds", overrideImageBase)
 	}
 }
 

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1214,6 +1214,7 @@ func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/k8s/azurestack/core/"
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
+	properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase = "mcr.microsoft.com/k8s/core/"
 	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 	properties.CustomCloudProfile = &CustomCloudProfile{}
 	properties.CustomCloudProfile.Environment = &azure.Environment{}
@@ -1228,6 +1229,9 @@ func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 	}
 	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != DefaultAzureStackLoadBalancerSku {
 		t.Fatalf("setOrchestratorDefaults did not set LoadBalancerSku to its expect value (%s) for Azure Stack clouds", DefaultAzureStackLoadBalancerSku)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase != expectedImageBase {
+		t.Fatalf("setOrchestratorDefaults did not set MCRKubernetesImageBase to its expect value (%s) for Azure Stack clouds", expectedImageBase)
 	}
 }
 


### PR DESCRIPTION
**Reason for Change**:

Clear the deprecated MCR image base if upgrading an Azure Stack cluster.

An AzureStack-specific MCR repository was referenced by clusters created using older AKS Engine releases. 
New pause images wont be pushed to that repo.

**Issue Fixed**:
Related work #3689

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
