### PR TITLE
ci: reduce addons area for containerd config tests

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
@@ -7,14 +7,6 @@
                 "useManagedIdentity": true,
                 "addons": [
                     {
-                        "name": "kubernetes-dashboard",
-                        "enabled": true
-                    },
-                    {
-                        "name": "rescheduler",
-                        "enabled": true
-                    },
-                    {
                         "name": "cluster-autoscaler",
                         "enabled": true,
                         "pools": [
@@ -46,10 +38,6 @@
                     },
                     {
                         "name": "azure-policy",
-                        "enabled": true
-                    },
-                    {
-                        "name": "node-problem-detector",
                         "enabled": true
                     }
                 ]


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR removes some enabled addons from the containerd test configs, because the containerd cluster config carries a slightly higher cloud-init payload, and those addons are contributing to PR test errors due to too many bytes. :/

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
