### PR TITLE
fix: use InternalIP for metrics-server DNS resolution

### DIFF
--- a/parts/k8s/addons/metrics-server.yaml
+++ b/parts/k8s/addons/metrics-server.yaml
@@ -129,6 +129,7 @@ spec:
         command:
         - /metrics-server
         - --kubelet-insecure-tls
+        - --kubelet-preferred-address-types=InternalIP
       nodeSelector:
         kubernetes.io/os: linux
 ---

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -15750,6 +15750,7 @@ spec:
         command:
         - /metrics-server
         - --kubelet-insecure-tls
+        - --kubelet-preferred-address-types=InternalIP
       nodeSelector:
         kubernetes.io/os: linux
 ---


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Following the guidance from this issue, setting metrics-server DNS resolution to `InternalIP`:

https://github.com/kubernetes-sigs/metrics-server/issues/131

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
