### PR TITLE
fix: resource identifier not pass to custom cloud profile

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -719,6 +719,14 @@ func convertCloudProfileToVLabs(api *CustomCloudProfile, vlabsccp *vlabs.CustomC
 		vlabsccp.Environment.ResourceManagerVMDNSSuffix = api.Environment.ResourceManagerVMDNSSuffix
 		vlabsccp.Environment.ContainerRegistryDNSSuffix = api.Environment.ContainerRegistryDNSSuffix
 		vlabsccp.Environment.TokenAudience = api.Environment.TokenAudience
+		vlabsccp.Environment.ResourceIdentifiers = azure.ResourceIdentifier{
+			Graph:               api.Environment.ResourceIdentifiers.Graph,
+			KeyVault:            api.Environment.ResourceIdentifiers.KeyVault,
+			Datalake:            api.Environment.ResourceIdentifiers.Datalake,
+			Batch:               api.Environment.ResourceIdentifiers.Batch,
+			OperationalInsights: api.Environment.ResourceIdentifiers.OperationalInsights,
+			Storage:             api.Environment.ResourceIdentifiers.Storage,
+		}
 	}
 
 	if api.AzureEnvironmentSpecConfig != nil {

--- a/pkg/api/converterfromapi_test.go
+++ b/pkg/api/converterfromapi_test.go
@@ -19,26 +19,32 @@ const ValidSSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEApD8+lRvLtUcyfO8N2
 
 func TestConvertCloudProfileToVLabs(t *testing.T) {
 	const (
-		name                         = "AzureStackCloud"
-		managementPortalURL          = "https://management.local.azurestack.external/"
-		publishSettingsURL           = "https://management.local.azurestack.external/publishsettings/index"
-		serviceManagementEndpoint    = "https://management.azurestackci15.onmicrosoft.com/36f71706-54df-4305-9847-5b038a4cf189"
-		resourceManagerEndpoint      = "https://management.local.azurestack.external/"
-		activeDirectoryEndpoint      = "https://login.windows.net/"
-		galleryEndpoint              = "https://portal.local.azurestack.external=30015/"
-		keyVaultEndpoint             = "https://vault.azurestack.external/"
-		graphEndpoint                = "https://graph.windows.net/"
-		serviceBusEndpoint           = "https://servicebus.azurestack.external/"
-		batchManagementEndpoint      = "https://batch.azurestack.external/"
-		storageEndpointSuffix        = "core.azurestack.external"
-		sqlDatabaseDNSSuffix         = "database.azurestack.external"
-		trafficManagerDNSSuffix      = "trafficmanager.cn"
-		keyVaultDNSSuffix            = "vault.azurestack.external"
-		serviceBusEndpointSuffix     = "servicebus.azurestack.external"
-		serviceManagementVMDNSSuffix = "chinacloudapp.cn"
-		resourceManagerVMDNSSuffix   = "cloudapp.azurestack.external"
-		containerRegistryDNSSuffix   = "azurecr.io"
-		tokenAudience                = "https://management.azurestack.external/"
+		name                                  = "AzureStackCloud"
+		managementPortalURL                   = "https://management.local.azurestack.external/"
+		publishSettingsURL                    = "https://management.local.azurestack.external/publishsettings/index"
+		serviceManagementEndpoint             = "https://management.azurestackci15.onmicrosoft.com/36f71706-54df-4305-9847-5b038a4cf189"
+		resourceManagerEndpoint               = "https://management.local.azurestack.external/"
+		activeDirectoryEndpoint               = "https://login.windows.net/"
+		galleryEndpoint                       = "https://portal.local.azurestack.external=30015/"
+		keyVaultEndpoint                      = "https://vault.azurestack.external/"
+		graphEndpoint                         = "https://graph.windows.net/"
+		serviceBusEndpoint                    = "https://servicebus.azurestack.external/"
+		batchManagementEndpoint               = "https://batch.azurestack.external/"
+		storageEndpointSuffix                 = "core.azurestack.external"
+		sqlDatabaseDNSSuffix                  = "database.azurestack.external"
+		trafficManagerDNSSuffix               = "trafficmanager.cn"
+		keyVaultDNSSuffix                     = "vault.azurestack.external"
+		serviceBusEndpointSuffix              = "servicebus.azurestack.external"
+		serviceManagementVMDNSSuffix          = "chinacloudapp.cn"
+		resourceManagerVMDNSSuffix            = "cloudapp.azurestack.external"
+		containerRegistryDNSSuffix            = "azurecr.io"
+		tokenAudience                         = "https://management.azurestack.external/"
+		graphResourceIdentifier               = "https://graph.azurestack.external/"
+		keyVaultResourceIdentifier            = "https://keyvault.azurestack.external/"
+		datalakeResourceIdentifier            = "https://datalake.azurestack.external/"
+		batchResourceIdentifier               = "https://batch.azurestack.external/"
+		operationalInsightsResourceIdentifier = "https://operationalinsights.azurestack.external/"
+		storageResourceIdentifier             = "https://storage.azurestack.external/"
 	)
 
 	cs := &ContainerService{
@@ -67,6 +73,14 @@ func TestConvertCloudProfileToVLabs(t *testing.T) {
 					ResourceManagerVMDNSSuffix:   resourceManagerVMDNSSuffix,
 					ContainerRegistryDNSSuffix:   containerRegistryDNSSuffix,
 					TokenAudience:                tokenAudience,
+					ResourceIdentifiers: azure.ResourceIdentifier{
+						Graph:               graphResourceIdentifier,
+						KeyVault:            keyVaultResourceIdentifier,
+						Datalake:            datalakeResourceIdentifier,
+						Batch:               batchResourceIdentifier,
+						OperationalInsights: operationalInsightsResourceIdentifier,
+						Storage:             storageResourceIdentifier,
+					},
 				},
 			},
 		},
@@ -139,6 +153,24 @@ func TestConvertCloudProfileToVLabs(t *testing.T) {
 	}
 	if vlabscs.Properties.CustomCloudProfile.Environment.TokenAudience != tokenAudience {
 		t.Errorf("incorrect TokenAudience, expect: '%s', actual: '%s'", tokenAudience, vlabscs.Properties.CustomCloudProfile.Environment.TokenAudience)
+	}
+	if vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Graph != graphResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Graph, expect: '%s', actual: '%s'", graphResourceIdentifier, vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Graph)
+	}
+	if vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.KeyVault != keyVaultResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.KeyVault, expect: '%s', actual: '%s'", keyVaultResourceIdentifier, vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.KeyVault)
+	}
+	if vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Datalake != datalakeResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Datalake, expect: '%s', actual: '%s'", datalakeResourceIdentifier, vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Datalake)
+	}
+	if vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Batch != batchResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Batch, expect: '%s', actual: '%s'", batchResourceIdentifier, vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Batch)
+	}
+	if vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.OperationalInsights != operationalInsightsResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.OperationalInsights, expect: '%s', actual: '%s'", operationalInsightsResourceIdentifier, vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.OperationalInsights)
+	}
+	if vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Storage != storageResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Storage, expect: '%s', actual: '%s'", storageResourceIdentifier, vlabscs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Storage)
 	}
 }
 

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -796,6 +796,14 @@ func convertVLabsCustomCloudProfile(vlabs *vlabs.CustomCloudProfile, api *Custom
 		api.Environment.ResourceManagerVMDNSSuffix = vlabs.Environment.ResourceManagerVMDNSSuffix
 		api.Environment.ContainerRegistryDNSSuffix = vlabs.Environment.ContainerRegistryDNSSuffix
 		api.Environment.TokenAudience = vlabs.Environment.TokenAudience
+		api.Environment.ResourceIdentifiers = azure.ResourceIdentifier{
+			Graph:               vlabs.Environment.ResourceIdentifiers.Graph,
+			KeyVault:            vlabs.Environment.ResourceIdentifiers.KeyVault,
+			Datalake:            vlabs.Environment.ResourceIdentifiers.Datalake,
+			Batch:               vlabs.Environment.ResourceIdentifiers.Batch,
+			OperationalInsights: vlabs.Environment.ResourceIdentifiers.OperationalInsights,
+			Storage:             vlabs.Environment.ResourceIdentifiers.Storage,
+		}
 	}
 	if vlabs.AzureEnvironmentSpecConfig != nil {
 		api.AzureEnvironmentSpecConfig = &AzureEnvironmentSpecConfig{}

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -190,26 +190,32 @@ func TestConvertCustomFilesToAPI(t *testing.T) {
 
 func TestCustomCloudProfile(t *testing.T) {
 	const (
-		name                         = "AzureStackCloud"
-		managementPortalURL          = "https://management.local.azurestack.external/"
-		publishSettingsURL           = "https://management.local.azurestack.external/publishsettings/index"
-		serviceManagementEndpoint    = "https://management.azurestackci15.onmicrosoft.com/36f71706-54df-4305-9847-5b038a4cf189"
-		resourceManagerEndpoint      = "https://management.local.azurestack.external/"
-		activeDirectoryEndpoint      = "https://login.windows.net/"
-		galleryEndpoint              = "https://portal.local.azurestack.external=30015/"
-		keyVaultEndpoint             = "https://vault.azurestack.external/"
-		graphEndpoint                = "https://graph.windows.net/"
-		serviceBusEndpoint           = "https://servicebus.azurestack.external/"
-		batchManagementEndpoint      = "https://batch.azurestack.external/"
-		storageEndpointSuffix        = "core.azurestack.external"
-		sqlDatabaseDNSSuffix         = "database.azurestack.external"
-		trafficManagerDNSSuffix      = "trafficmanager.cn"
-		keyVaultDNSSuffix            = "vault.azurestack.external"
-		serviceBusEndpointSuffix     = "servicebus.azurestack.external"
-		serviceManagementVMDNSSuffix = "chinacloudapp.cn"
-		resourceManagerVMDNSSuffix   = "cloudapp.azurestack.external"
-		containerRegistryDNSSuffix   = "azurecr.io"
-		tokenAudience                = "https://management.azurestack.external/"
+		name                                  = "AzureStackCloud"
+		managementPortalURL                   = "https://management.local.azurestack.external/"
+		publishSettingsURL                    = "https://management.local.azurestack.external/publishsettings/index"
+		serviceManagementEndpoint             = "https://management.azurestackci15.onmicrosoft.com/36f71706-54df-4305-9847-5b038a4cf189"
+		resourceManagerEndpoint               = "https://management.local.azurestack.external/"
+		activeDirectoryEndpoint               = "https://login.windows.net/"
+		galleryEndpoint                       = "https://portal.local.azurestack.external=30015/"
+		keyVaultEndpoint                      = "https://vault.azurestack.external/"
+		graphEndpoint                         = "https://graph.windows.net/"
+		serviceBusEndpoint                    = "https://servicebus.azurestack.external/"
+		batchManagementEndpoint               = "https://batch.azurestack.external/"
+		storageEndpointSuffix                 = "core.azurestack.external"
+		sqlDatabaseDNSSuffix                  = "database.azurestack.external"
+		trafficManagerDNSSuffix               = "trafficmanager.cn"
+		keyVaultDNSSuffix                     = "vault.azurestack.external"
+		serviceBusEndpointSuffix              = "servicebus.azurestack.external"
+		serviceManagementVMDNSSuffix          = "chinacloudapp.cn"
+		resourceManagerVMDNSSuffix            = "cloudapp.azurestack.external"
+		containerRegistryDNSSuffix            = "azurecr.io"
+		tokenAudience                         = "https://management.azurestack.external/"
+		graphResourceIdentifier               = "https://graph.azurestack.external/"
+		keyVaultResourceIdentifier            = "https://keyvault.azurestack.external/"
+		datalakeResourceIdentifier            = "https://datalake.azurestack.external/"
+		batchResourceIdentifier               = "https://batch.azurestack.external/"
+		operationalInsightsResourceIdentifier = "https://operationalinsights.azurestack.external/"
+		storageResourceIdentifier             = "https://storage.azurestack.external/"
 	)
 
 	vlabscs := &vlabs.ContainerService{
@@ -238,6 +244,14 @@ func TestCustomCloudProfile(t *testing.T) {
 					ResourceManagerVMDNSSuffix:   resourceManagerVMDNSSuffix,
 					ContainerRegistryDNSSuffix:   containerRegistryDNSSuffix,
 					TokenAudience:                tokenAudience,
+					ResourceIdentifiers: azure.ResourceIdentifier{
+						Graph:               graphResourceIdentifier,
+						KeyVault:            keyVaultResourceIdentifier,
+						Datalake:            datalakeResourceIdentifier,
+						Batch:               batchResourceIdentifier,
+						OperationalInsights: operationalInsightsResourceIdentifier,
+						Storage:             storageResourceIdentifier,
+					},
 				},
 			},
 		},
@@ -312,6 +326,24 @@ func TestCustomCloudProfile(t *testing.T) {
 	}
 	if cs.Properties.CustomCloudProfile.Environment.TokenAudience != tokenAudience {
 		t.Errorf("incorrect TokenAudience, expect: '%s', actual: '%s'", tokenAudience, cs.Properties.CustomCloudProfile.Environment.TokenAudience)
+	}
+	if cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Graph != graphResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Graph, expect: '%s', actual: '%s'", graphResourceIdentifier, cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Graph)
+	}
+	if cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.KeyVault != keyVaultResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.KeyVault, expect: '%s', actual: '%s'", keyVaultResourceIdentifier, cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.KeyVault)
+	}
+	if cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Datalake != datalakeResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Datalake, expect: '%s', actual: '%s'", datalakeResourceIdentifier, cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Datalake)
+	}
+	if cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Batch != batchResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Batch, expect: '%s', actual: '%s'", batchResourceIdentifier, cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Batch)
+	}
+	if cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.OperationalInsights != operationalInsightsResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.OperationalInsights, expect: '%s', actual: '%s'", operationalInsightsResourceIdentifier, cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.OperationalInsights)
+	}
+	if cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Storage != storageResourceIdentifier {
+		t.Errorf("incorrect ResourceIdentifiers.Storage, expect: '%s', actual: '%s'", storageResourceIdentifier, cs.Properties.CustomCloudProfile.Environment.ResourceIdentifiers.Storage)
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Bug fix
Generated custom cloud profile does not contain resource identifiers even when set in API model.
It may cause unexpected application behavior for those programs relying on these values

**Issue Fixed**:

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [X] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
