### PR TITLE
chore: use transparent mode for Azure CNI

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -41,7 +41,7 @@
             "name": "coredns",
             "enabled": true,
             "config": {
-              "min-replicas": "1",
+              "min-replicas": "3",
               "nodes-per-replica": "10"
             }
           },

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -202,6 +202,8 @@ const (
 	NetworkPluginKubenet = "kubenet"
 	// NetworkPluginAzure is the string expression for Azure CNI plugin.
 	NetworkPluginAzure = "azure"
+	// NetworkModeTransparent is the string expression for transparent network mode config option
+	NetworkModeTransparent = "transparent"
 	// DefaultSinglePlacementGroup determines the aks-engine provided default for supporting large VMSS
 	// (true = single placement group 0-100 VMs, false = multiple placement group 0-1000 VMs)
 	DefaultSinglePlacementGroup = true

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -202,6 +202,12 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 				}
 			}
 		}
+
+		if o.KubernetesConfig.NetworkPlugin == NetworkPluginAzure {
+			if o.KubernetesConfig.NetworkMode == "" {
+				o.KubernetesConfig.NetworkMode = NetworkModeTransparent
+			}
+		}
 		if o.KubernetesConfig.ContainerRuntime == "" {
 			o.KubernetesConfig.ContainerRuntime = DefaultContainerRuntime
 		}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1093,6 +1093,16 @@ func TestNetworkPluginDefaults(t *testing.T) {
 		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, NetworkPluginFlannel)
 	}
+
+	mockCS = getMockBaseContainerService("1.19.2")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkMode != NetworkModeTransparent {
+		t.Fatalf("NetworkMode did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkMode, NetworkModeTransparent)
+	}
 }
 
 func TestKubernetesImageBaseAppendSlash(t *testing.T) {

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -62,7 +62,7 @@
 							"name": "coredns",
 							"enabled": true,
 							"config": {
-								"min-replicas": "1",
+								"min-replicas": "3",
 								"nodes-per-replica": "8"
 							}
 						},


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR changes the Azure CNI implementation to use "transparent" mode by default, rather than using a bridge interface. This change is due to an observed reduction in UDP edge cases, specifically intermittent high DNS lookup latency when the resolver is an IP address that sits in front of a distributed set of resolvers (DNAT). In the Kubernetes context, this is reproduced if there are more than one coredns pods in the cluster.

Fixes #3955

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
