### PR TITLE
docs: Remove double quotes(") at quickstart.md

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -81,7 +81,7 @@ $ aks-engine deploy --dns-prefix contoso-apple \
     --resource-group contoso-apple \
     --location westus2 \
     --api-model examples/kubernetes.json \
-    --auto-suffix"
+    --auto-suffix
 
 INFO[0000] No subscription provided, using selected subscription from azure CLI: 51ac25de-afdg-9201-d923-8d8e8e8e8e8e
 INFO[0003] Generated random suffix 5f776b0d, DNS Prefix is contoso-apple2-5f776b0d


### PR DESCRIPTION
-> run `aks-engine deploy` example script contains unwanted (") at Line number 84 of Quickstart.md, which causes syntax error. I have tried the script after truncating " and  it runs successfully.

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
 run `aks-engine deploy` example script contains unwanted (") at Line number 84 of Quickstart.md, which causes syntax error. I have tried the script after truncating " and  it runs successfully.


**Issue Fixed**:
Cosmetic changes in the Quickstart.md

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [X ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [X ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [ docs: Documentation 📘](https://www.conventionalcommits.org/)
- [ X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
