### PR TITLE
chore: longer default cordonDrainTimeout for Azure Stack Cloud

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -170,6 +170,13 @@ func (uc *upgradeCmd) loadCluster() error {
 		return errors.Wrap(err, "error parsing the api model")
 	}
 
+	// Set 60 minutes cordonDrainTimeout for Azure Stack Cloud to give it enough time to move around resources during Node Drain,
+	// especially disk detach/attach operations. We still honor the user's input.
+	if uc.cordonDrainTimeout == nil && uc.containerService.Properties.IsAzureStackCloud() {
+		cordonDrainTimeout := time.Duration(60) * time.Minute
+		uc.cordonDrainTimeout = &cordonDrainTimeout
+	}
+
 	// Use the Windows VHD associated with the aks-engine version if upgradeWindowsVHD is set to "true"
 	if uc.upgradeWindowsVHD && uc.containerService.Properties.WindowsProfile != nil {
 		windowsProfile := uc.containerService.Properties.WindowsProfile


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [X] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Set 60 minutes cordonDrainTimeout for Azure Stack Cloud to give it enough time to move around resources during Node Drain, especially disk detach/attach operations.
We still honor the user's input.