### PR TITLE
fix: ensure flatcar configs use transparent Azure CNI

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -406,6 +406,10 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 		}
 	}
 
+	if a.HasFlatcar() && o.KubernetesConfig.NetworkPlugin == "azure" && o.KubernetesConfig.NetworkMode == NetworkModeBridge {
+		return errors.Errorf("Flatcar node pools require 'transparent' networkMode with Azure CNI")
+	}
+
 	if o.OrchestratorType != Kubernetes && o.KubernetesConfig != nil {
 		return errors.Errorf("KubernetesConfig can be specified only when OrchestratorType is Kubernetes")
 	}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -316,6 +316,48 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 			},
 			expectedError: "EtcdStorageLimitGB value of 1 is too small, the minimum allowed is 2",
 		},
+		"should error when using flatcar + Azure CNI + bridge mode": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: "Kubernetes",
+					KubernetesConfig: &KubernetesConfig{
+						NetworkPlugin: "azure",
+						NetworkMode:   NetworkModeBridge,
+					},
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "flatcarpool",
+						Count:  10,
+						Distro: Flatcar,
+					},
+				},
+			},
+			expectedError: "Flatcar node pools require 'transparent' networkMode with Azure CNI",
+		},
+		"should not error when using Azure CNI + bridge mode + ubuntu": {
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: "Kubernetes",
+					KubernetesConfig: &KubernetesConfig{
+						NetworkPlugin: "azure",
+						NetworkMode:   NetworkModeBridge,
+					},
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "ubuntu1604pool",
+						Count:  10,
+						Distro: AKSUbuntu1604,
+					},
+					{
+						Name:   "ubuntu1804pool",
+						Count:  10,
+						Distro: AKSUbuntu1804,
+					},
+				},
+			},
+		},
 	}
 
 	for testName, test := range tests {

--- a/test/e2e/test_cluster_configs/flatcar/flatcar.json
+++ b/test/e2e/test_cluster_configs/flatcar/flatcar.json
@@ -1,13 +1,12 @@
 {
-	"env": {
-		"SKIP_TESTS": "true"
-	},
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
 				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
+					"networkPlugin": "azure",
+					"networkMode": "transparent",
 					"addons": [
 						{
 							"name": "cluster-autoscaler",


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that new flatcar node pool-enabled clusters use transparent mode if using Azure CNI, as that's proven to be the only working Azure CNI implementation w/ flatcar.

No upgrade foo added here; we'll see if folks desire that, but for now, this is a cleaner change that doesn't try to be too tricky in "converting" existing clusters that were built w/ bridge mode prior to the systemd change that broke it.

Fixes #3920 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
