### PR TITLE
test: Retry label when cluster first comes online

### DIFF
--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -224,7 +224,7 @@ func (n *Node) Describe() error {
 	return err
 }
 
-// Add Taint to node
+// AddLabel adds a label to a node
 func (n *Node) AddLabel(label string) error {
 	var commandTimeout time.Duration
 	cmd := exec.Command("k", "label", "node", n.Metadata.Name, label)
@@ -233,7 +233,37 @@ func (n *Node) AddLabel(label string) error {
 	return err
 }
 
-// Add Annotation to node
+// AddLabelWithRetry add label to a node until success or timeout
+func (n *Node) AddLabelWithRetry(sleep, timeout time.Duration, label string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ch := make(chan error)
+	var mostRecentRetryError error
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				ch <- n.AddLabel(label)
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case result := <-ch:
+			if result == nil {
+				return nil
+			}
+			mostRecentRetryError = result
+		case <-ctx.Done():
+			return errors.Errorf("AddLabelWithRetry timed out: %s\n", mostRecentRetryError)
+		}
+	}
+}
+
+// AddAnnotation adds an annotation to node
 func (n *Node) AddAnnotation(annotation string) error {
 	var commandTimeout time.Duration
 	cmd := exec.Command("k", "annotate", "nodes", n.Metadata.Name, annotation)
@@ -242,7 +272,37 @@ func (n *Node) AddAnnotation(annotation string) error {
 	return err
 }
 
-// Add taint to node
+// AddAnnotationWithRetry adds annotation to node trying until success or timeout
+func (n *Node) AddAnnotationWithRetry(sleep, timeout time.Duration, annotation string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ch := make(chan error)
+	var mostRecentRetryError error
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				ch <- n.AddAnnotation(annotation)
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case result := <-ch:
+			if result == nil {
+				return nil
+			}
+			mostRecentRetryError = result
+		case <-ctx.Done():
+			return errors.Errorf("AddAnnotationWithRetry timed out: %s\n", mostRecentRetryError)
+		}
+	}
+}
+
+// AddTaint adds a taint to node
 func (n *Node) AddTaint(taint Taint) error {
 	var commandTimeout time.Duration
 	cmd := exec.Command("k", "taint", "nodes", n.Metadata.Name, taint.Key+"="+taint.Value+":"+taint.Effect)
@@ -251,7 +311,7 @@ func (n *Node) AddTaint(taint Taint) error {
 	return err
 }
 
-// Remove taint to node
+// RemoveTaint removes a taint from a node
 func (n *Node) RemoveTaint(taint Taint) error {
 	var commandTimeout time.Duration
 	cmd := exec.Command("k", "taint", "nodes", n.Metadata.Name, taint.Key+":"+taint.Effect+"-")

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -224,6 +224,24 @@ func (n *Node) Describe() error {
 	return err
 }
 
+// Add Taint to node
+func (n *Node) AddLabel(label string) error {
+	var commandTimeout time.Duration
+	cmd := exec.Command("k", "label", "node", n.Metadata.Name, label)
+	out, err := util.RunAndLogCommand(cmd, commandTimeout)
+	log.Printf("\n%s\n", string(out))
+	return err
+}
+
+// Add Annotation to node
+func (n *Node) AddAnnotation(annotation string) error {
+	var commandTimeout time.Duration
+	cmd := exec.Command("k", "annotate", "nodes", n.Metadata.Name, annotation)
+	out, err := util.RunAndLogCommand(cmd, commandTimeout)
+	log.Printf("\n%s\n", string(out))
+	return err
+}
+
 // Add taint to node
 func (n *Node) AddTaint(taint Taint) error {
 	var commandTimeout time.Duration

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -357,11 +357,11 @@ func (cli *CLIProvisioner) waitForNodes() error {
 						return err
 					}
 					if !exp.MatchString(n.Metadata.Name) {
-						err = n.AddLabel("foo=bar")
+						err = n.AddLabelWithRetry(1*time.Second, cli.Config.Timeout, "foo=bar")
 						if err != nil {
 							return errors.Wrapf(err, "Unable to assign label to node %s", n.Metadata.Name)
 						}
-						err = n.AddAnnotation("foo=bar")
+						err = n.AddAnnotationWithRetry(1*time.Second, cli.Config.Timeout, "foo=bar")
 						if err != nil {
 							return errors.Wrapf(err, "Unable to add node annotation to node %s", n.Metadata.Name)
 						}

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -357,17 +357,11 @@ func (cli *CLIProvisioner) waitForNodes() error {
 						return err
 					}
 					if !exp.MatchString(n.Metadata.Name) {
-						cmd := exec.Command("k", "label", "node", n.Metadata.Name, "foo=bar")
-						util.PrintCommand(cmd)
-						out, err := cmd.CombinedOutput()
-						log.Printf("%s\n", out)
+						err = n.AddLabel("foo=bar")
 						if err != nil {
 							return errors.Wrapf(err, "Unable to assign label to node %s", n.Metadata.Name)
 						}
-						cmd = exec.Command("k", "annotate", "node", n.Metadata.Name, "foo=bar")
-						util.PrintCommand(cmd)
-						out, err = cmd.CombinedOutput()
-						log.Printf("%s\n", out)
+						err = n.AddAnnotation("foo=bar")
 						if err != nil {
 							return errors.Wrapf(err, "Unable to add node annotation to node %s", n.Metadata.Name)
 						}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
PR tests were failing occasionally #3974 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
