### PR TITLE
ci: Windows VHD pipeline tests

### DIFF
--- a/.pipelines/vhd-builder-windows.yaml
+++ b/.pipelines/vhd-builder-windows.yaml
@@ -67,6 +67,7 @@ jobs:
       -e SUBSCRIPTION_ID=${SUBSCRIPTION_ID} \
       -e TENANT_ID=${TENANT_ID} \
       -e WINDOWS_NODE_VHD_URL=${OS_DISK_URI} \
+      -e USE_MANAGED_IDENTITY="false" \
       ${DEIS_GO_DEV_IMAGE} make test-kubernetes
     displayName: run e2e tests
     condition: and(succeeded(), eq(variables.COPY_VHD, 'False'))

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -35,7 +35,7 @@ type Config struct {
 	MasterDNSPrefix                string `envconfig:"DNS_PREFIX" default:""`
 	AgentDNSPrefix                 string `envconfig:"DNS_PREFIX" default:""`
 	MSIUserAssignedID              string `envconfig:"MSI_USER_ASSIGNED_ID" default:""`
-	UseManagedIdentity             bool   `envconfig:"USE_MANAGED_IDENTITY" default:""`
+	UseManagedIdentity             bool   `envconfig:"USE_MANAGED_IDENTITY" default:"true"`
 	PublicSSHKey                   string `envconfig:"PUBLIC_SSH_KEY" default:""`
 	WindowsAdminPasssword          string `envconfig:"WINDOWS_ADMIN_PASSWORD" default:""`
 	WindowsNodeImageGallery        string `envconfig:"WINDOWS_NODE_IMAGE_GALLERY" default:""`
@@ -151,9 +151,7 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 		prop.OrchestratorProfile.KubernetesConfig.UserAssignedID = config.MSIUserAssignedID
 	}
 
-	if config.UseManagedIdentity {
-		prop.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = to.BoolPtr(true)
-	}
+	prop.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = to.BoolPtr(config.UseManagedIdentity)
 
 	if config.ClientID != "" && config.ClientSecret != "" && !(prop.OrchestratorProfile.KubernetesConfig != nil && to.Bool(prop.OrchestratorProfile.KubernetesConfig.UseManagedIdentity)) {
 		if !prop.IsAzureStackCloud() {

--- a/vhd/packer/sysprep.ps1
+++ b/vhd/packer/sysprep.ps1
@@ -1,0 +1,36 @@
+# Stop and remove Azure Agents to enable use in Azure Stack
+# If deploying an Azure VM the agents will be re-added to the VMs at deployment time
+Stop-Service WindowsAzureGuestAgent
+Stop-Service WindowsAzureNetAgentSvc
+Stop-Service RdAgent
+& sc.exe delete WindowsAzureGuestAgent
+& sc.exe delete WindowsAzureNetAgentSvc
+& sc.exe delete RdAgent
+
+# Remove the WindowsAzureGuestAgent registry key for sysprep 
+# This removes AzureGuestAgent from participating in sysprep 
+# There was an update that is missing VMAgentDisabler.dll
+$path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize"
+$generalizeKey = Get-Item -Path $path
+$generalizeProperties = $generalizeKey | Select-Object -ExpandProperty property
+$values = $generalizeProperties | ForEach-Object {
+    New-Object psobject -Property @{"Name"=$_;
+    "Value" = (Get-ItemProperty -Path $path -Name $_).$_}
+}
+
+$values | ForEach-Object {
+    $item = $_;
+    if( $item.Value.Contains("VMAgentDisabler.dll")) {
+            Write-HOST "Removing " $item.Name - $item.Value;
+            Remove-ItemProperty -Path $path -Name $item.Name;
+    }
+}
+
+# run Sysprep
+if( Test-Path $Env:SystemRoot\\system32\\Sysprep\\unattend.xml ) {  Remove-Item $Env:SystemRoot\\system32\\Sysprep\\unattend.xml -Force }
+& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit
+
+# when done clean up
+while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }
+Get-ChildItem c:\\WindowsAzure -Force | Sort-Object -Property FullName -Descending | ForEach-Object { try { Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue; } catch { } }
+Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse

--- a/vhd/packer/windows-vhd-builder.json
+++ b/vhd/packer/windows-vhd-builder.json
@@ -115,21 +115,10 @@
             "destination": "release-notes.txt"
         },
         {
+            "elevated_user": "packer",
+            "elevated_password": "{{.WinRMPassword}}",
             "type": "powershell",
-            "inline": [
-                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
-                "Stop-Service WindowsAzureGuestAgent",
-                "Stop-Service WindowsAzureNetAgentSvc",
-                "Stop-Service RdAgent",
-                "Stop-Service WindowsAzureTelemetryService",
-                "& sc.exe delete WindowsAzureGuestAgent",
-                "& sc.exe delete WindowsAzureNetAgentSvc",
-                "& sc.exe delete RdAgent",
-                "& sc.exe delete WindowsAzureTelemetryService",
-                "Get-ChildItem c:\\WindowsAzure -Force | Sort-Object -Property FullName -Descending | ForEach-Object { try { Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue; } catch { } }",
-                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }",
-                "Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse"
-            ]
+            "script": "vhd/packer/sysprep.ps1"
         }
     ]
 }


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
This PR unblocks the Windows VHD scripts by doing two things:

- Removes Azure VM agents from the sysprep process 
  - this fixes an issue where there was a missing DLL on recent upgrade of the Azure VM agents that caused sysprep to fail: `azure-arm: IMAGE_STATE_UNDEPLOYABLE - missing VMAgentDisabler.dll.`  The VM agent doesn't do anything during sysprep so it is ok to remove it. If the image is deployed to Azure as a VM the agent will redeployed. 
- Fixes the e2e tests during the VHD build using `USE_MANAGED_IDENTITY=false`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
