### PR TITLE
chore: set go sdk log level for Azure Stack clusters

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -28,6 +28,9 @@ ensureCustomCloudRootCertificates() {
             sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
         fi
     fi
+
+    # remove the placeholder go sdk log level as it should be set for azure stack cloud only.
+    sed -i "/<gosdkloglevel>/d" $KUBE_CONTROLLER_MANAGER_FILE
 }
 
 ensureCustomCloudSourcesList() {
@@ -124,6 +127,9 @@ ensureAzureStackCertificates() {
       sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
     fi
   fi
+
+  # set the go sdk log level
+  sed -i "s|<gosdkloglevel>|- name: AZURE_GO_SDK_LOG_LEVEL\n        value: INFO|g" $KUBE_CONTROLLER_MANAGER_FILE
 
   # ensureAzureStackCertificates will be retried if the exit code is not 0
   curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT

--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -28,9 +28,6 @@ ensureCustomCloudRootCertificates() {
             sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
         fi
     fi
-
-    # remove the placeholder go sdk log level as it should be set for azure stack cloud only.
-    sed -i "/<gosdkloglevel>/d" $KUBE_CONTROLLER_MANAGER_FILE
 }
 
 ensureCustomCloudSourcesList() {
@@ -127,9 +124,6 @@ ensureAzureStackCertificates() {
       sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
     fi
   fi
-
-  # set the go sdk log level
-  sed -i "s|<gosdkloglevel>|- name: AZURE_GO_SDK_LOG_LEVEL\n        value: INFO|g" $KUBE_CONTROLLER_MANAGER_FILE
 
   # ensureAzureStackCertificates will be retried if the exit code is not 0
   curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT

--- a/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
@@ -19,6 +19,7 @@ spec:
       env:
       - name: AZURE_ENVIRONMENT_FILEPATH
         value: "/etc/kubernetes/azurestackcloud.json"
+      <gosdkloglevel>
 {{end}}
       volumeMounts:
         - name: etc-kubernetes

--- a/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
@@ -19,7 +19,10 @@ spec:
       env:
       - name: AZURE_ENVIRONMENT_FILEPATH
         value: "/etc/kubernetes/azurestackcloud.json"
-      <gosdkloglevel>
+  {{- if IsAzureStackCloud}}
+      - name: AZURE_GO_SDK_LOG_LEVEL
+        value: INFO
+  {{end}}
 {{end}}
       volumeMounts:
         - name: etc-kubernetes

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18292,9 +18292,6 @@ ensureCustomCloudRootCertificates() {
             sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
         fi
     fi
-
-    # remove the placeholder go sdk log level as it should be set for azure stack cloud only.
-    sed -i "/<gosdkloglevel>/d" $KUBE_CONTROLLER_MANAGER_FILE
 }
 
 ensureCustomCloudSourcesList() {
@@ -18391,9 +18388,6 @@ ensureAzureStackCertificates() {
       sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
     fi
   fi
-
-  # set the go sdk log level
-  sed -i "s|<gosdkloglevel>|- name: AZURE_GO_SDK_LOG_LEVEL\n        value: INFO|g" $KUBE_CONTROLLER_MANAGER_FILE
 
   # ensureAzureStackCertificates will be retried if the exit code is not 0
   curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
@@ -23528,7 +23522,10 @@ spec:
       env:
       - name: AZURE_ENVIRONMENT_FILEPATH
         value: "/etc/kubernetes/azurestackcloud.json"
-      <gosdkloglevel>
+  {{- if IsAzureStackCloud}}
+      - name: AZURE_GO_SDK_LOG_LEVEL
+        value: INFO
+  {{end}}
 {{end}}
       volumeMounts:
         - name: etc-kubernetes

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18292,6 +18292,9 @@ ensureCustomCloudRootCertificates() {
             sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
         fi
     fi
+
+    # remove the placeholder go sdk log level as it should be set for azure stack cloud only.
+    sed -i "/<gosdkloglevel>/d" $KUBE_CONTROLLER_MANAGER_FILE
 }
 
 ensureCustomCloudSourcesList() {
@@ -18388,6 +18391,9 @@ ensureAzureStackCertificates() {
       sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
     fi
   fi
+
+  # set the go sdk log level
+  sed -i "s|<gosdkloglevel>|- name: AZURE_GO_SDK_LOG_LEVEL\n        value: INFO|g" $KUBE_CONTROLLER_MANAGER_FILE
 
   # ensureAzureStackCertificates will be retried if the exit code is not 0
   curl $AZURESTACK_RESOURCE_METADATA_ENDPOINT
@@ -23522,6 +23528,7 @@ spec:
       env:
       - name: AZURE_ENVIRONMENT_FILEPATH
         value: "/etc/kubernetes/azurestackcloud.json"
+      <gosdkloglevel>
 {{end}}
       volumeMounts:
         - name: etc-kubernetes


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
This change sets the go sdk log level to INFO for clusters in Azure Stack. Info level logs request information made to ARM by the cloud provider; the extra info is needed to correlate cloud provider operations with Azure Stack service logs when investigating issues in cloud provider.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
