### PR TITLE
test: fix two UTs to work with "cli" auth

### DIFF
--- a/cmd/get_locations_test.go
+++ b/cmd/get_locations_test.go
@@ -24,7 +24,7 @@ func TestGetLocationsCmd(t *testing.T) {
 	g.Expect(command.Long).Should(Equal(locationsLongDescription))
 	g.Expect(command.Flags().Lookup("output")).NotTo(BeNil())
 
-	command.SetArgs([]string{})
+	command.SetArgs([]string{"--bogus"})
 	err := command.Execute()
 	g.Expect(err).To(HaveOccurred())
 }

--- a/cmd/get_skus_test.go
+++ b/cmd/get_skus_test.go
@@ -24,7 +24,7 @@ func TestGetSkusCmd(t *testing.T) {
 	g.Expect(command.Long).Should(Equal(skusLongDescription))
 	g.Expect(command.Flags().Lookup("output")).NotTo(BeNil())
 
-	command.SetArgs([]string{})
+	command.SetArgs([]string{"--bogus"})
 	err := command.Execute()
 	g.Expect(err).To(HaveOccurred())
 }


### PR DESCRIPTION
**Reason for Change**:

Locally we've noticed two test cases may fail. This seems to be because there are no required arguments to the `get-locations` and `get-skus` commands if `cli` auth is working.

To meet test expectations, I explicitly added a bogus command-line argument to ensure these tests see an expected error in any case.

**Issue Fixed**:

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
