### PR TITLE
fix: Re-ordering HNS policy removal due to 10c change in behavior and consolidating logic in Windows cleanup scripts 

### DIFF
--- a/.pipelines/pr-windows-signed-scripts.yaml
+++ b/.pipelines/pr-windows-signed-scripts.yaml
@@ -3,6 +3,7 @@ pr: none
 
 jobs:
 - job: test_staged_windows_provisioning_scripts
+  timeoutInMinutes: 150
   pool:
     name: $(BUILD_POOL)
   steps:

--- a/staging/provisioning/windows/cleanupnetwork.ps1
+++ b/staging/provisioning/windows/cleanupnetwork.ps1
@@ -1,0 +1,67 @@
+$Global:ClusterConfiguration = ConvertFrom-Json ((Get-Content "c:\k\kubeclusterconfig.json" -ErrorAction Stop) | out-string)
+
+$global:NetworkMode = "L2Bridge"
+$global:ContainerRuntime = $Global:ClusterConfiguration.Cri.Name
+$global:NetworkPlugin = $Global:ClusterConfiguration.Cni.Name
+
+ipmo $global:HNSModule
+
+$networkname = $global:NetworkMode.ToLower()
+if ($global:NetworkPlugin -eq "azure") {
+    $networkname = "azure"
+}
+
+$hnsNetwork = Get-HnsNetwork | ? Name -EQ $networkname
+if ($hnsNetwork) {
+    # Cleanup all containers
+    Write-Host "Cleaning up containers"
+    if ($global:ContainerRuntime -eq "containerd") {
+        ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io tasks kill $_ }
+        ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io c rm $_ }
+    }
+    else {
+        docker.exe ps -q | ForEach-Object { docker rm $_ -f }
+    }
+    
+    Write-Host "Cleaning up persisted HNS policy lists"
+    # Initially a workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
+    # and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
+    #
+    # October patch 10.0.17763.1554 introduced a breaking change 
+    # which requires the hns policy list to be removed before network if it gets into a bad state
+    # See https://github.com/Azure/aks-engine/pull/3956#issuecomment-720797433 for more info
+    # Kubeproxy doesn't fail becuase errors are not handled: 
+    # https://github.com/delulu/kubernetes/blob/524de768bb64b7adff76792ca3bf0f0ece1e849f/pkg/proxy/winkernel/proxier.go#L532
+    Get-HnsPolicyList | Remove-HnsPolicyList
+
+    Write-Host "Cleaning up old HNS network found"
+    Remove-HnsNetwork $hnsNetwork
+    Start-Sleep 10
+}
+
+
+if ($global:NetworkPlugin -eq "azure") {
+    Write-Host "NetworkPlugin azure, starting kubelet."
+
+    Write-Host "Cleaning stale CNI data"
+    # Kill all cni instances & stale data left by cni
+    # Cleanup all files related to cni
+    taskkill /IM azure-vnet.exe /f
+    taskkill /IM azure-vnet-ipam.exe /f
+
+    $filesToRemove = @(
+        "c:\k\azure-vnet.json",
+        "c:\k\azure-vnet.json.lock",
+        "c:\k\azure-vnet-ipam.json",
+        "c:\k\azure-vnet-ipam.json.lock"
+        "c:\k\azure-vnet-ipamv6.json",
+        "c:\k\azure-vnet-ipamv6.json.lock"
+    )
+
+    foreach ($file in $filesToRemove) {
+        if (Test-Path $file) {
+            Write-Host "Deleting stale file at $file"
+            Remove-Item $file
+        }
+    }
+}

--- a/staging/provisioning/windows/kubeletstart.ps1
+++ b/staging/provisioning/windows/kubeletstart.ps1
@@ -24,9 +24,6 @@ $global:CNIPath = [Io.path]::Combine("$global:KubeDir", "cni")
 $global:CNIConfig = [Io.path]::Combine($global:CNIPath, "config", "$global:NetworkMode.conf")
 $global:CNIConfigPath = [Io.path]::Combine("$global:CNIPath", "config")
 
-
-$UseContainerD = ($global:ContainerRuntime -eq "containerd")
-
 ipmo $global:HNSModule
 
 #TODO ksbrmnn refactor to be sensical instead of if if if ...
@@ -56,7 +53,7 @@ else {
 }
 
 # Update args to use ContainerD if needed
-if ($UseContainerD -eq $true) {
+if ($global:ContainerRuntime -eq "containerd") {
     $KubeletArgList += @("--container-runtime=remote", "--container-runtime-endpoint=npipe://./pipe/containerd-containerd")
 }
 
@@ -184,75 +181,17 @@ Update-CNIConfigKubenetContainerD($podCIDR, $masterSubnetGW) {
     Add-Content -Path $global:CNIConfig -Value (ConvertTo-Json $configJson -Depth 20)
 }
 
-function CleanUpNetwork($networkname) {
-    $hnsNetwork = Get-HnsNetwork | ? Name -EQ $networkname
-    if ($hnsNetwork) {
-        # Cleanup all containers
-        Write-Log "Cleaning up containers"
-        if ($UseContainerD -eq $true) {
-            ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io tasks kill $_ }
-            ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io c rm $_ }
-        }
-        else {
-            docker.exe ps -q | ForEach-Object { docker rm $_ -f }
-        }
-
-        #
-        # Stop services
-        #
-        Write-Log "Stopping kubeproxy service"
-        Stop-Service kubeproxy
-
-        Write-Log "Stopping kubelet service"
-        Stop-Service kubelet
-
-        Write-Log "Cleaning up persisted HNS policy lists"
-        # Workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
-        # and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
-        #
-        # October patch 10.0.17763.1554 introduced a breaking change 
-        # which requires the hns policy list to be removed before network if it gets into a bad state
-        # See https://github.com/Azure/aks-engine/pull/3956#issuecomment-720797433 for more info
-        # Kubeproxy doesn't fail becuase errors are not handled: 
-        # https://github.com/delulu/kubernetes/blob/524de768bb64b7adff76792ca3bf0f0ece1e849f/pkg/proxy/winkernel/proxier.go#L532
-        Get-HnsPolicyList | Remove-HnsPolicyList
-
-        Write-Host "Cleaning up old HNS network found"
-        Remove-HnsNetwork $hnsNetwork
-        Start-Sleep 10
-    }
-}
-
+# Required to clean up the HNS policy lists properly
+Write-Host "Stopping kubeproxy service"
+Stop-Service kubeproxy
 
 if ($global:NetworkPlugin -eq "azure") {
     Write-Host "NetworkPlugin azure, starting kubelet."
 
-    Write-Host "Cleaning stale CNI data"
-    # Kill all cni instances & stale data left by cni
-    # Cleanup all files related to cni
-    taskkill /IM azure-vnet.exe /f
-    taskkill /IM azure-vnet-ipam.exe /f
-
-    $filesToRemove = @(
-        "c:\k\azure-vnet.json",
-        "c:\k\azure-vnet.json.lock",
-        "c:\k\azure-vnet-ipam.json",
-        "c:\k\azure-vnet-ipam.json.lock"
-        "c:\k\azure-vnet-ipamv6.json",
-        "c:\k\azure-vnet-ipamv6.json.lock"
-    )
-
-    foreach ($file in $filesToRemove) {
-        if (Test-Path $file) {
-            Write-Log "Deleting stale file at $file"
-            Remove-Item $file
-        }
-    }
-
     # Find if network created by CNI exists, if yes, remove it
     # This is required to keep the network non-persistent behavior
     # Going forward, this would be done by HNS automatically during restart of the node
-    CleanUpNetwork("azure")
+    ./cleanupnetwork.ps1 
     
     # Restart Kubeproxy, which would wait, until the network is created
     # This was fixed in 1.15, workaround still needed for 1.14 https://github.com/kubernetes/kubernetes/pull/78612
@@ -263,57 +202,10 @@ if ($global:NetworkPlugin -eq "azure") {
     Invoke-Expression $KubeletCommandLine
 }
 
-if (($global:NetworkPlugin -eq "kubenet") -and ($global:ContainerRuntime -eq "docker")) {
+if ($global:NetworkPlugin -eq "kubenet") {
     try {
         $env:AZURE_ENVIRONMENT_FILEPATH = "c:\k\azurestackcloud.json"
 
-        $masterSubnetGW = Get-DefaultGateway $global:MasterSubnet
-        $podCIDR = Get-PodCIDR
-        $podCidrDiscovered = Test-PodCIDR($podCIDR)
-
-        # if the podCIDR has not yet been assigned to this node, start the kubelet process to get the podCIDR, and then promptly kill it.
-        if (-not $podCidrDiscovered) {
-            $argList = $KubeletArgListStr
-
-            $process = Start-Process -FilePath c:\k\kubelet.exe -PassThru -ArgumentList $kubeletArgList
-
-            # run kubelet until podCidr is discovered
-            Write-Host "waiting to discover pod CIDR"
-            while (-not $podCidrDiscovered) {
-                Write-Host "Sleeping for 10s, and then waiting to discover pod CIDR"
-                Start-Sleep 10
-
-                $podCIDR = Get-PodCIDR
-                $podCidrDiscovered = Test-PodCIDR($podCIDR)
-            }
-
-            # stop the kubelet process now that we have our CIDR, discard the process output
-            $process | Stop-Process | Out-Null
-        }
-
-        CleanUpNetwork($global:NetworkMode.ToLower())
-
-        Write-Host "Creating a new hns Network"
-        $hnsNetwork = New-HNSNetwork -Type $global:NetworkMode -AddressPrefix $podCIDR -Gateway $masterSubnetGW -Name $global:NetworkMode.ToLower() -Verbose
-        # New network has been created, Kubeproxy service has to be restarted
-        # This was fixed in 1.15, workaround still needed for 1.14 https://github.com/kubernetes/kubernetes/pull/78612
-        Restart-Service Kubeproxy
-
-        Start-Sleep 10
-        # Add route to all other POD networks
-        Update-CNIConfigKubenetDocker $podCIDR $masterSubnetGW
-
-        # startup the service
-        Invoke-Expression $KubeletCommandLine
-    }
-    catch {
-        Write-Error $_
-    }
-
-}
-
-if (($global:NetworkPlugin -eq "kubenet") -and ($global:ContainerRuntime -eq "containerd")) {
-    try {
         $masterSubnetGW = Get-DefaultGateway $global:MasterSubnet
         $podCIDR = Get-PodCIDR
         $podCidrDiscovered = Test-PodCIDR($podCIDR)
@@ -338,17 +230,25 @@ if (($global:NetworkPlugin -eq "kubenet") -and ($global:ContainerRuntime -eq "co
             $process | Stop-Process | Out-Null
         }
 
-        CleanUpNetwork($global:NetworkMode.ToLower())
-      
+        ./cleanupnetwork.ps1 
+
         Write-Host "Creating a new hns Network"
         $hnsNetwork = New-HNSNetwork -Type $global:NetworkMode -AddressPrefix $podCIDR -Gateway $masterSubnetGW -Name $global:NetworkMode.ToLower() -Verbose
         # New network has been created, Kubeproxy service has to be restarted
+        # This was fixed in 1.15, workaround still needed for 1.14 https://github.com/kubernetes/kubernetes/pull/78612
         Restart-Service Kubeproxy
 
         Start-Sleep 10
-        # Add route to all other POD networks
-        Write-Host "Updating CNI config"
-        Update-CNIConfigKubenetContainerD $podCIDR $masterSubnetGW
+
+        if  ($global:ContainerRuntime -eq "containerd") {
+            Write-Host "Updating CNI config"
+            Update-CNIConfigKubenetContainerD $podCIDR $masterSubnetGW
+        }
+
+        if  ($global:ContainerRuntime -eq "docker") {
+            # Add route to all other POD networks
+            Update-CNIConfigKubenetDocker $podCIDR $masterSubnetGW
+        }
 
         # startup the service
         Invoke-Expression $KubeletCommandLine
@@ -356,4 +256,5 @@ if (($global:NetworkPlugin -eq "kubenet") -and ($global:ContainerRuntime -eq "co
     catch {
         Write-Error $_
     }
+
 }

--- a/staging/provisioning/windows/windowsnodereset.ps1
+++ b/staging/provisioning/windows/windowsnodereset.ps1
@@ -49,52 +49,7 @@ if ($global:EnableHostsConfigAgent) {
 # Perform cleanup
 #
 
-Write-Log "Cleaning up persisted HNS policy lists"
-# Workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
-# and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
-#
-# October patch 10.0.17763.1554 introduced a breaking change 
-# which requires the hns policy list to be removed before network if it gets into a bad state
-# See https://github.com/Azure/aks-engine/pull/3956#issuecomment-720797433 for more info
-# Kubeproxy doesn't fail becuase errors are not handled: 
-# https://github.com/delulu/kubernetes/blob/524de768bb64b7adff76792ca3bf0f0ece1e849f/pkg/proxy/winkernel/proxier.go#L532
-Get-HnsPolicyList | Remove-HnsPolicyList
-
-$hnsNetwork = Get-HnsNetwork | Where-Object Name -EQ azure
-if ($hnsNetwork) {
-    Write-Log "Cleaning up containers"
-    if ($UseContainerD -eq $true) {
-        ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io tasks kill $_ }
-        ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io c rm $_ }
-    }
-    else {
-        docker.exe ps -q | ForEach-Object { docker rm $_ -f }
-    }
-
-    Write-Log "Removing old HNS network 'azure'"
-    Remove-HnsNetwork $hnsNetwork
-
-    taskkill /IM azure-vnet.exe /f
-    taskkill /IM azure-vnet-ipam.exe /f
-
-    $filesToRemove = @(
-        "c:\k\azure-vnet.json",
-        "c:\k\azure-vnet.json.lock",
-        "c:\k\azure-vnet-ipam.json",
-        "c:\k\azure-vnet-ipam.json.lock"
-        "c:\k\azure-vnet-ipamv6.json",
-        "c:\k\azure-vnet-ipamv6.json.lock"
-    )
-
-    foreach ($file in $filesToRemove) {
-        if (Test-Path $file) {
-            Write-Log "Deleting stale file at $file"
-            Remove-Item $file
-        }
-    }
-}
-
-
+./cleanupnetwork.ps1 
 
 #
 # Create required networks

--- a/staging/provisioning/windows/windowsnodereset.ps1
+++ b/staging/provisioning/windows/windowsnodereset.ps1
@@ -49,6 +49,17 @@ if ($global:EnableHostsConfigAgent) {
 # Perform cleanup
 #
 
+Write-Log "Cleaning up persisted HNS policy lists"
+# Workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
+# and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
+#
+# October patch 10.0.17763.1554 introduced a breaking change 
+# which requires the hns policy list to be removed before network if it gets into a bad state
+# See https://github.com/Azure/aks-engine/pull/3956#issuecomment-720797433 for more info
+# Kubeproxy doesn't fail becuase errors are not handled: 
+# https://github.com/delulu/kubernetes/blob/524de768bb64b7adff76792ca3bf0f0ece1e849f/pkg/proxy/winkernel/proxier.go#L532
+Get-HnsPolicyList | Remove-HnsPolicyList
+
 $hnsNetwork = Get-HnsNetwork | Where-Object Name -EQ azure
 if ($hnsNetwork) {
     Write-Log "Cleaning up containers"
@@ -83,10 +94,7 @@ if ($hnsNetwork) {
     }
 }
 
-Write-Log "Cleaning up persisted HNS policy lists"
-# Workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
-# and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
-Get-HnsPolicyList | Remove-HnsPolicyList
+
 
 #
 # Create required networks


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
First step in refactoring shared logic in startup and windows node reset.  We learned in 10c update (#3956) adds a breaking change  that requires `Get-HnsPolicyList | Remove-HnsPolicyList` to be removed before HNS-Network. We also need turn off kubeproxy while doing this.  

This also adds removed containerd images during the kubelet startup.

We should be able to have a follow up with a change that shares logic between startup and windowsnodereset.  This needs a little more consideration so is not included here.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Requires signed scripts before kicking off tests
/hold 
