### PR TITLE
feat: Enable chrony and host-based time sync by default on Ubuntu 18.04

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -110,6 +110,13 @@ configureEtcd() {
 ensureNTP() {
   systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
+configureChrony() {
+  sed -i "s/makestep.*/makestep 1.0 -1/g" /etc/chrony/chrony.conf
+  echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> /etc/chrony/chrony.conf
+}
+ensureChrony() {
+  systemctlEnableAndStart chrony || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+}
 configPrivateClusterHosts() {
   systemctlEnableAndStart reconcile-private-hosts || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -107,9 +107,6 @@ configureEtcd() {
   done
   retrycmd 120 5 25 sudo -E etcdctl member update $MEMBER ${etcd_peer_url} || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
 }
-ensureNTP() {
-  systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-}
 configureChrony() {
   sed -i "s/makestep.*/makestep 1.0 -1/g" /etc/chrony/chrony.conf
   echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> /etc/chrony/chrony.conf

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -41,7 +41,7 @@ installDeps() {
     packages+=" cgroup-lite ceph-common glusterfs-client"
     if [[ $UBUNTU_RELEASE == "18.04" ]]; then
       disableTimeSyncd
-      packages+=" ntp ntpstat"
+      packages+=" ntp ntpstat chrony"
     fi
   elif [[ $OS == $DEBIAN_OS_NAME ]]; then
     packages+=" gpg cgroup-bin"

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -87,10 +87,12 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  if apt list --installed | grep 'chrony'; then
-    time_metric "configureChrony" configureChrony
-    time_metric "EnsureChrony" ensureChrony
-  fi
+  if [[ ! $(apt list --installed | grep 'chrony') ]]; then
+    apt_get_install 30 1 600 chrony || exit 9
+  fi;
+
+  time_metric "ConfigureChrony" configureChrony
+  time_metric "EnsureChrony" ensureChrony
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -87,10 +87,6 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  if [[ ! $(apt list --installed | grep 'chrony') ]]; then
-    apt_get_install 30 1 600 chrony || exit 9
-  fi;
-
   time_metric "ConfigureChrony" configureChrony
   time_metric "EnsureChrony" ensureChrony
 fi

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -87,8 +87,9 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  if apt list --installed | grep 'ntp'; then
-    time_metric "EnsureNTP" ensureNTP
+  if apt list --installed | grep 'chrony'; then
+    time_metric "Configurehrony" configureChrony
+    time_metric "EnsureChrony" ensureChrony
   fi
 fi
 

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -88,7 +88,7 @@ fi
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
   if apt list --installed | grep 'chrony'; then
-    time_metric "Configurehrony" configureChrony
+    time_metric "configureChrony" configureChrony
     time_metric "EnsureChrony" ensureChrony
   fi
 fi

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -87,8 +87,10 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  time_metric "ConfigureChrony" configureChrony
-  time_metric "EnsureChrony" ensureChrony
+  if apt list --installed | grep 'chrony'; then
+    time_metric "ConfigureChrony" configureChrony
+    time_metric "EnsureChrony" ensureChrony
+  fi
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13152,8 +13152,10 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  time_metric "ConfigureChrony" configureChrony
-  time_metric "EnsureChrony" ensureChrony
+  if apt list --installed | grep 'chrony'; then
+    time_metric "ConfigureChrony" configureChrony
+    time_metric "EnsureChrony" ensureChrony
+  fi
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -11698,6 +11698,13 @@ configureEtcd() {
 ensureNTP() {
   systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
+configureChrony() {
+  sed -i "s/makestep.*/makestep 1.0 -1/g" /etc/chrony/chrony.conf
+  echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> /etc/chrony/chrony.conf
+}
+ensureChrony() {
+  systemctlEnableAndStart chrony || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+}
 configPrivateClusterHosts() {
   systemctlEnableAndStart reconcile-private-hosts || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
@@ -12840,7 +12847,7 @@ installDeps() {
     packages+=" cgroup-lite ceph-common glusterfs-client"
     if [[ $UBUNTU_RELEASE == "18.04" ]]; then
       disableTimeSyncd
-      packages+=" ntp ntpstat"
+      packages+=" ntp ntpstat chrony"
     fi
   elif [[ $OS == $DEBIAN_OS_NAME ]]; then
     packages+=" gpg cgroup-bin"
@@ -13148,8 +13155,9 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  if apt list --installed | grep 'ntp'; then
-    time_metric "EnsureNTP" ensureNTP
+  if apt list --installed | grep 'chrony'; then
+    time_metric "Configurehrony" configureChrony
+    time_metric "EnsureChrony" ensureChrony
   fi
 fi
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13152,10 +13152,6 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  if [[ ! $(apt list --installed | grep 'chrony') ]]; then
-    apt_get_install 30 1 600 chrony || exit 9
-  fi;
-
   time_metric "ConfigureChrony" configureChrony
   time_metric "EnsureChrony" ensureChrony
 fi

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13155,10 +13155,12 @@ fi
 {{end}}
 
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  if apt list --installed | grep 'chrony'; then
-    time_metric "Configurehrony" configureChrony
-    time_metric "EnsureChrony" ensureChrony
-  fi
+  if [[ ! $(apt list --installed | grep 'chrony') ]]; then
+    apt_get_install 30 1 600 chrony || exit 9
+  fi;
+
+  time_metric "ConfigureChrony" configureChrony
+  time_metric "EnsureChrony" ensureChrony
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -11695,9 +11695,6 @@ configureEtcd() {
   done
   retrycmd 120 5 25 sudo -E etcdctl member update $MEMBER ${etcd_peer_url} || exit {{GetCSEErrorCode "ERR_ETCD_CONFIG_FAIL"}}
 }
-ensureNTP() {
-  systemctlEnableAndStart ntp || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-}
 configureChrony() {
   sed -i "s/makestep.*/makestep 1.0 -1/g" /etc/chrony/chrony.conf
   echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> /etc/chrony/chrony.conf

--- a/test/e2e/kubernetes/scripts/time-sync-validate.sh
+++ b/test/e2e/kubernetes/scripts/time-sync-validate.sh
@@ -16,7 +16,7 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
     sudo timedatectl status | grep 'Network time on: yes' || exit 1
     sudo timedatectl status | grep 'NTP synchronized: yes' || exit 1
   elif [[ $RELEASE == "18.04" ]]; then
-    sudo chronyc sources | grep '#* PHC' || exit 1 # Make sure chrony is running and synced with host-based PTP source clock
+    sudo chronyc sources | grep '#* PHC' || exit 1 # Make sure chrony is running and synced with host-based PTP source clock ('#' means local clock and '*' means synced)
     sudo timedatectl status | grep 'System clock synchronized: yes' || exit 1
   fi
 fi

--- a/test/e2e/kubernetes/scripts/time-sync-validate.sh
+++ b/test/e2e/kubernetes/scripts/time-sync-validate.sh
@@ -16,7 +16,11 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
     sudo timedatectl status | grep 'Network time on: yes' || exit 1
     sudo timedatectl status | grep 'NTP synchronized: yes' || exit 1
   elif [[ $RELEASE == "18.04" ]]; then
-    sudo chronyc sources | grep '#* PHC' || exit 1 # Make sure chrony is running and synced with host-based PTP source clock ('#' means local clock and '*' means synced)
+    if apt list --installed | grep 'chrony'; then
+      sudo chronyc sources | grep '#* PHC' || exit 1 # Make sure chrony is running and synced with host-based PTP source clock ('#' means local clock and '*' means synced)
+    else
+      sudo ntpstat | grep 'synchronised to NTP server' || exit 1
+    fi
     sudo timedatectl status | grep 'System clock synchronized: yes' || exit 1
   fi
 fi

--- a/test/e2e/kubernetes/scripts/time-sync-validate.sh
+++ b/test/e2e/kubernetes/scripts/time-sync-validate.sh
@@ -17,6 +17,7 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
     sudo timedatectl status | grep 'NTP synchronized: yes' || exit 1
   elif [[ $RELEASE == "18.04" ]]; then
     sudo ntpstat | grep 'synchronised to NTP server' || exit 1
+    sudo chronyc sources | grep '#* PHC' || exit 1 # Make sure chrony is running and synced with host-based PTP source clock
     sudo timedatectl status | grep 'System clock synchronized: yes' || exit 1
   fi
 fi

--- a/test/e2e/kubernetes/scripts/time-sync-validate.sh
+++ b/test/e2e/kubernetes/scripts/time-sync-validate.sh
@@ -16,7 +16,6 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
     sudo timedatectl status | grep 'Network time on: yes' || exit 1
     sudo timedatectl status | grep 'NTP synchronized: yes' || exit 1
   elif [[ $RELEASE == "18.04" ]]; then
-    sudo ntpstat | grep 'synchronised to NTP server' || exit 1
     sudo chronyc sources | grep '#* PHC' || exit 1 # Make sure chrony is running and synced with host-based PTP source clock
     sudo timedatectl status | grep 'System clock synchronized: yes' || exit 1
   fi

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -58,9 +58,11 @@ apt packages:
   - zip
 EOF
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
-  echo "  - ntp" >> ${VHD_LOGS_FILEPATH}
-  echo "  - ntpstat" >> ${VHD_LOGS_FILEPATH}
-  echo "  - chrony" >> ${VHD_LOGS_FILEPATH}
+{
+  echo "  - ntp"
+  echo "  - ntpstat"
+  echo "  - chrony"
+} >> ${VHD_LOGS_FILEPATH}
 fi
 
 chmod a-x /etc/update-motd.d/??-{motd-news,release-upgrade}

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -60,6 +60,7 @@ EOF
 if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
   echo "  - ntp" >> ${VHD_LOGS_FILEPATH}
   echo "  - ntpstat" >> ${VHD_LOGS_FILEPATH}
+  echo "  - chrony" >> ${VHD_LOGS_FILEPATH}
 fi
 
 chmod a-x /etc/update-motd.d/??-{motd-news,release-upgrade}


### PR DESCRIPTION
**Reason for Change**:
Use chrony + host-based time sync which is a recommended way and also work in airgap clouds.

All Azure Ubuntu 18.04 stock images already come with chrony enabled as well.

**Issue Fixed**:
https://github.com/Azure/aks-engine/issues/2552

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [X] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
Reference: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync