### PR TITLE
fix: enable dhcpv6 only for ubuntu 16.04

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -354,10 +354,12 @@ ensureDocker() {
 {{end}}
 {{- if IsIPv6Enabled}}
 ensureDHCPv6() {
-  wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-  retrycmd 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  if [[ ${UBUNTU_RELEASE} == "16.04" ]]; then
+    wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+    wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+    systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+    retrycmd 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  fi
 }
 {{end}}
 ensureKubelet() {

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -202,7 +202,7 @@ write_files:
     APT::Periodic::AutocleanInterval "0";
     APT::Periodic::Unattended-Upgrade "0";
 
-{{- if IsIPv6Enabled}}
+{{- if and IsIPv6Enabled .MasterProfile.IsUbuntu1604}}
 - path: {{GetDHCPv6ServiceCSEScriptFilepath}}
   permissions: "0644"
   encoding: gzip

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -169,7 +169,7 @@ write_files:
     APT::Periodic::AutocleanInterval "0";
     APT::Periodic::Unattended-Upgrade "0";
 
-{{- if IsIPv6Enabled}}
+{{- if and IsIPv6Enabled .IsUbuntu1604}}
 - path: {{GetDHCPv6ServiceCSEScriptFilepath}}
   permissions: "0644"
   encoding: gzip

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17911,10 +17911,12 @@ ensureDocker() {
 {{end}}
 {{- if IsIPv6Enabled}}
 ensureDHCPv6() {
-  wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
-  retrycmd 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  if [[ ${UBUNTU_RELEASE} == "16.04" ]]; then
+    wait_for_file 3600 1 {{GetDHCPv6ServiceCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+    wait_for_file 3600 1 {{GetDHCPv6ConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+    systemctlEnableAndStart dhcpv6 || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
+    retrycmd 120 5 25 modprobe ip6_tables || exit {{GetCSEErrorCode "ERR_MODPROBE_FAIL"}}
+  fi
 }
 {{end}}
 ensureKubelet() {
@@ -20891,7 +20893,7 @@ write_files:
     APT::Periodic::AutocleanInterval "0";
     APT::Periodic::Unattended-Upgrade "0";
 
-{{- if IsIPv6Enabled}}
+{{- if and IsIPv6Enabled .MasterProfile.IsUbuntu1604}}
 - path: {{GetDHCPv6ServiceCSEScriptFilepath}}
   permissions: "0644"
   encoding: gzip
@@ -21428,7 +21430,7 @@ write_files:
     APT::Periodic::AutocleanInterval "0";
     APT::Periodic::Unattended-Upgrade "0";
 
-{{- if IsIPv6Enabled}}
+{{- if and IsIPv6Enabled .IsUbuntu1604}}
 - path: {{GetDHCPv6ServiceCSEScriptFilepath}}
   permissions: "0644"
   encoding: gzip

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -321,10 +321,11 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 		if prop.OrchestratorProfile.KubernetesConfig == nil {
 			prop.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
 		}
-		prop.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig = map[string]string{
-			"--horizontal-pod-autoscaler-downscale-stabilization":   "30s",
-			"--horizontal-pod-autoscaler-cpu-initialization-period": "30s",
+		if prop.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig == nil {
+			prop.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig = map[string]string{}
 		}
+		prop.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig["--horizontal-pod-autoscaler-downscale-stabilization"] = "30s"
+		prop.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig["--horizontal-pod-autoscaler-cpu-initialization-period"] = "30s"
 	}
 
 	if config.LogAnalyticsWorkspaceKey != "" && len(prop.OrchestratorProfile.KubernetesConfig.Addons) > 0 {

--- a/test/e2e/test_cluster_configs/dualstack.json
+++ b/test/e2e/test_cluster_configs/dualstack.json
@@ -2,7 +2,7 @@
     "env": {},
     "options": {
         "allowedOrchestratorVersions": [
-            "latestReleasedVersion"
+            "1.20"
         ]
     },
     "apiModel": {

--- a/test/e2e/test_cluster_configs/dualstack.json
+++ b/test/e2e/test_cluster_configs/dualstack.json
@@ -1,0 +1,59 @@
+{
+    "env": {},
+    "options": {
+        "allowedOrchestratorVersions": [
+            "latestReleasedVersion"
+        ]
+    },
+    "apiModel": {
+        "apiVersion": "vlabs",
+        "properties": {
+            "featureFlags": {
+                "enableIPv6DualStack": true
+            },
+            "orchestratorProfile": {
+                "orchestratorType": "Kubernetes",
+                "kubernetesConfig": {
+                    "loadBalancerSku": "Standard",
+                    "excludeMasterFromStandardLB": true,
+                    "clusterSubnet": "10.244.0.0/16,fc00::/48",
+                    "serviceCidr": "10.0.0.0/16,fd00::/108",
+                    "dnsServiceIP": "10.0.0.10",
+                    "kubeProxyMode": "iptables",
+                    "networkPlugin": "kubenet",
+                    "apiServerConfig": {
+                        "--feature-gates": "IPv6DualStack=true"
+                    },
+                    "kubeletConfig": {
+                        "--feature-gates": "IPv6DualStack=true"
+                    },
+                    "controllerManagerConfig": {
+                        "--feature-gates": "IPv6DualStack=true"
+                    }
+                }
+            },
+            "masterProfile": {
+                "count": 1,
+                "dnsPrefix": "",
+                "vmSize": "Standard_D2_v3"
+            },
+            "agentPoolProfiles": [
+                {
+                    "name": "agentpool1",
+                    "count": 2,
+                    "vmSize": "Standard_D2_v3"
+                }
+            ],
+            "linuxProfile": {
+                "adminUsername": "azureuser",
+                "ssh": {
+                    "publicKeys": [
+                        {
+                            "keyData": ""
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
- dhcpv6 systemd unit is only required for ubuntu `16.04`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
