### PR TITLE
test: add dns-loop (actually curl) stress test

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -889,6 +889,16 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(ready).To(Equal(true))
 			}
 
+			By("Ensuring that we have stable and responsive DNS resolution")
+			p, err := pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "dns-loop.yaml"), "dns-loop", "default", 1*time.Second, cfg.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+			running, err := p.WaitOnReady(sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+			out, err := p.Exec("--", "dns-loop", "100", "google.com", "0.3", "5")
+			log.Printf("%s\n", string(out))
+			Expect(err).NotTo(HaveOccurred())
+
 			By("Ensuring that we have stable external DNS resolution as we recycle a bunch of pods")
 			name := fmt.Sprintf("alpine-%s", cfg.Name)
 			command := fmt.Sprintf("time nc -vz bbc.co.uk 80 || nc -vz google.com 443 || nc -vz microsoft.com 80")

--- a/test/e2e/kubernetes/workloads/dns-loop.yaml
+++ b/test/e2e/kubernetes/workloads/dns-loop.yaml
@@ -8,4 +8,6 @@ spec:
     image: sturrent/dns-loop
     command: ["/bin/sh"]
     args: ["-c", "while true; do sleep 1000; done"]
+  nodeSelector:
+    kubernetes.io/os: linux
 # See https://github.com/sturrent/dns-loop-container

--- a/test/e2e/kubernetes/workloads/dns-loop.yaml
+++ b/test/e2e/kubernetes/workloads/dns-loop.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dns-loop
+spec:
+  containers:
+  - name: dns-loop
+    image: sturrent/dns-loop
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do sleep 1000; done"]
+# See https://github.com/sturrent/dns-loop-container


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR adds a simple, one-time stress test to validate that a bunch of curls to a well-known external URL are responsive.

Nominally these checks actually do a curl, which relies upon the entire HTTP stack, but in practice they will surface high DNS lookups, which we've observed in the past.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
