### PR TITLE
test: re-engage cluster-autoscaler tests if no ssh

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -146,18 +146,18 @@ var _ = BeforeSuite(func() {
 		Expect(success).To(BeTrue())
 		firstMasterRegexp, err = regexp.Compile(firstMasterRegexStr)
 		Expect(err).NotTo(HaveOccurred())
-		if hasAddon, addon := eng.HasAddon(common.ClusterAutoscalerAddonName); hasAddon {
-			clusterAutoscalerAddon = addon
-			if len(addon.Pools) > 0 {
-				for _, pool := range addon.Pools {
-					p := eng.ExpandedDefinition.Properties.GetAgentPoolIndexByName(pool.Name)
-					maxNodes, _ := strconv.Atoi(pool.Config["max-nodes"])
-					minNodes, _ := strconv.Atoi(pool.Config["min-nodes"])
-					if maxNodes > eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count &&
-						minNodes <= eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count {
-						clusterAutoscalerEngaged = true
-						break
-					}
+	}
+	if hasAddon, addon := eng.HasAddon(common.ClusterAutoscalerAddonName); hasAddon {
+		clusterAutoscalerAddon = addon
+		if len(addon.Pools) > 0 {
+			for _, pool := range addon.Pools {
+				p := eng.ExpandedDefinition.Properties.GetAgentPoolIndexByName(pool.Name)
+				maxNodes, _ := strconv.Atoi(pool.Config["max-nodes"])
+				minNodes, _ := strconv.Atoi(pool.Config["min-nodes"])
+				if maxNodes > eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count &&
+					minNodes <= eng.ExpandedDefinition.Properties.AgentPoolProfiles[p].Count {
+					clusterAutoscalerEngaged = true
+					break
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR disentangles the E2E test runner logic that determines whether or not cluster-autoscaler is engaged from the "skip ssh tests" context.

It's possible that there's a good reason for coupling those two config contexts, this PR E2E CI will tell us.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
