### PR TITLE
chore: deprecate orchestratorType

### DIFF
--- a/cmd/addpool.go
+++ b/cmd/addpool.go
@@ -267,27 +267,25 @@ func (apc *addPoolCmd) run(cmd *cobra.Command, args []string) error {
 		templateJSON["variables"].(map[string]interface{})[apc.nodePool.Name+"Index"] = winPoolIndex
 		templateJSON["variables"].(map[string]interface{})[apc.nodePool.Name+"VMNamePrefix"] = apc.containerService.Properties.GetAgentVMPrefix(apc.nodePool, winPoolIndex)
 	}
-	if orchestratorInfo.OrchestratorType == api.Kubernetes {
-		transformer := transform.Transformer{Translator: translator.Translator}
+	transformer := transform.Transformer{Translator: translator.Translator}
 
-		if orchestratorInfo.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
-			err = transformer.NormalizeForK8sSLBScalingOrUpgrade(apc.logger, templateJSON)
-			if err != nil {
-				return errors.Wrapf(err, "error transforming the template for scaling with SLB %s", apc.apiModelPath)
-			}
+	if orchestratorInfo.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
+		err = transformer.NormalizeForK8sSLBScalingOrUpgrade(apc.logger, templateJSON)
+		if err != nil {
+			return errors.Wrapf(err, "error transforming the template for scaling with SLB %s", apc.apiModelPath)
 		}
+	}
 
-		if apc.nodePool.IsVirtualMachineScaleSets() {
-			err = transformer.NormalizeForK8sVMASScalingUp(apc.logger, templateJSON)
-			if err != nil {
-				return errors.Wrapf(err, "error transforming the template for scaling template %s", apc.apiModelPath)
-			}
-			addValue(parametersJSON, apc.nodePool.Name+"Count", 0)
-		} else {
-			err = transformer.NormalizeForK8sAddVMASPool(apc.logger, templateJSON)
-			if err != nil {
-				return errors.Wrap(err, "error transforming the template to add a VMAS node pool")
-			}
+	if apc.nodePool.IsVirtualMachineScaleSets() {
+		err = transformer.NormalizeForK8sVMASScalingUp(apc.logger, templateJSON)
+		if err != nil {
+			return errors.Wrapf(err, "error transforming the template for scaling template %s", apc.apiModelPath)
+		}
+		addValue(parametersJSON, apc.nodePool.Name+"Count", 0)
+	} else {
+		err = transformer.NormalizeForK8sAddVMASPool(apc.logger, templateJSON)
+		if err != nil {
+			return errors.Wrap(err, "error transforming the template to add a VMAS node pool")
 		}
 	}
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -255,7 +255,7 @@ func TestAPIModelWithoutServicePrincipalProfileAndWithoutClientIdAndSecretInGene
 	}
 
 	err = generateCmd.validateAPIModelAsVLabs()
-	expectedErr := errors.New("ServicePrincipalProfile must be specified with Orchestrator Kubernetes")
+	expectedErr := errors.New("ServicePrincipalProfile must be specified")
 
 	if err != nil && err.Error() != expectedErr.Error() {
 		t.Fatalf("expected validate generate command to return error %s, but instead got %s", expectedErr.Error(), err.Error())

--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -18,7 +18,7 @@ Here are the cluster definitions for apiVersion "vlabs":
 
 | Name                | Required | Description                                        |
 | ------------------- | -------- | -------------------------------------------------- |
-| orchestratorType    | yes      | Specifies the orchestrator type for the cluster    |
+| orchestratorType    | no       | Defaults to "Kubernetes"; a legacy property to accommodate previously supported orchestrators (e.g., DC/OS) |
 | orchestratorRelease | no       | Specifies the orchestrator release for the cluster |
 | orchestratorVersion | no       | Specifies the orchestrator version for the cluster |
 
@@ -578,7 +578,6 @@ Or perhaps you want to customize/override the set of admission-control flags pas
 
 ```json
 "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.8",
       "kubernetesConfig": {
         "apiServerConfig": {

--- a/docs/topics/features.md
+++ b/docs/topics/features.md
@@ -435,9 +435,6 @@ This is possible by specifying `imageReference` under `masterProfile`, or on a g
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "imageReference": {
         "name": "linuxvm",
@@ -534,7 +531,7 @@ These parameters are all required.
 ### Hyper-v support
 This feature in AKS-Engine is for testing the in-development versions of ContainerD and Kubernetes, and is not for production use. Be sure to review [open issues](https://github.com/azure/aks-engine/issues?q=containerd+label%3Awindows+is%3Aopen) if you want to test or contribute to this effort.
 
-The current default for a Hyper-V enabled containerD sets process isolated containers as default.  It is required to explicity set the [Build Numbers of the OS](https://kubernetes.io/docs/setup/production-environment/windows/user-guide-windows-containers/#handling-multiple-windows-versions-in-the-same-cluster) in the api models to add Hyper-V options to containerD.  For example, with the default settings, if your VM OS version is Windows Server 2004 (10.0.19041) and you apply a pod spec with no RuntimeClass setting, you will get a 2004 container running as a process isolated container.  
+The current default for a Hyper-V enabled containerD sets process isolated containers as default.  It is required to explicity set the [Build Numbers of the OS](https://kubernetes.io/docs/setup/production-environment/windows/user-guide-windows-containers/#handling-multiple-windows-versions-in-the-same-cluster) in the api models to add Hyper-V options to containerD.  For example, with the default settings, if your VM OS version is Windows Server 2004 (10.0.19041) and you apply a pod spec with no RuntimeClass setting, you will get a 2004 container running as a process isolated container.
 
 To Configure other OS as hyper-v containers in the containerD set the following on the WindowsProfile:
 
@@ -555,7 +552,7 @@ To Configure other OS as hyper-v containers in the containerD set the following 
     },
 ```
 
-Supported Hyperv OS build Id's are: 
+Supported Hyperv OS build Id's are:
 
 - 17763 - Windows Server 2019 (1809)
 - 18362 - Windows Server SAC 1903
@@ -564,7 +561,7 @@ Supported Hyperv OS build Id's are:
 
 If you wish to use an OS version for a container below your current Host OS version or explicitly run in a Hyper-v conatiners, you will need to create a RuntimeClass object and map the pod to the RuntimeClass.  Note that Hyper-V support is currently backwards compatible.  You have to have a Host OS that is the same version or newer than the version of the container you wish to run.  Multi-arch container images are not supported; You must have a single arch image if Hyper-V is enabled in containerd.
 
-For example, assuming a Windows Host OS of 2004 (10.0.19041), you can apply the following `RuntimeClass` 
+For example, assuming a Windows Host OS of 2004 (10.0.19041), you can apply the following `RuntimeClass`
 
 ```yaml
 apiVersion: node.k8s.io/v1beta1
@@ -632,8 +629,8 @@ The `handler` names for `RuntimeClass` will be dependent on the `hypervRuntimes`
 
 Current limitations:
 
-- Currently the Runtime handlers are not configurable.  
-- If you specify a handler that does not map the fields in [../../parts/k8s/containerdtemplate.toml](parts/k8s/containerdtemplate.toml), then the container will not start. 
+- Currently the Runtime handlers are not configurable.
+- If you specify a handler that does not map the fields in [../../parts/k8s/containerdtemplate.toml](parts/k8s/containerdtemplate.toml), then the container will not start.
 - If you map to a container version that is higher than your current OS image your container will not start.
 - Multi-arch container images are not supported
 

--- a/docs/topics/monitoring.md
+++ b/docs/topics/monitoring.md
@@ -55,7 +55,6 @@ The Dashboard addon is not enabled by default for an AKS Engine cluster. You mus
 
 ```json
 "orchestratorProfile": {
-  "orchestratorType": "Kubernetes",
   "kubernetesConfig": {
     "addons": [
       {

--- a/docs/tutorials/custom-vnet.md
+++ b/docs/tutorials/custom-vnet.md
@@ -98,9 +98,6 @@ In this case, we are going to use the following template (this creates a cluster
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/addons/aad-pod-identity/README.md
+++ b/examples/addons/aad-pod-identity/README.md
@@ -9,7 +9,6 @@ This is the AAD Pod Identity add-on.  Add this add-on to your json file as shown
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/aad-pod-identity/kubernetes-aad-pod-identity.json
+++ b/examples/addons/aad-pod-identity/kubernetes-aad-pod-identity.json
@@ -2,14 +2,13 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
-	        {
-	          "name": "aad-pod-identity",
-	          "enabled" : true
-	        }
-	      ]
+          {
+            "name": "aad-pod-identity",
+            "enabled": true
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/examples/addons/aci-connector/README.md
+++ b/examples/addons/aci-connector/README.md
@@ -8,7 +8,6 @@ This is the ACI Connector add-on.  Add this add-on to your json file as shown be
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "kubernetesConfig": {
           "addons": [
             {

--- a/examples/addons/aci-connector/kubernetes-aci-connector.json
+++ b/examples/addons/aci-connector/kubernetes-aci-connector.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/appgw-ingress/README.md
+++ b/examples/addons/appgw-ingress/README.md
@@ -27,7 +27,6 @@ Once, the infrastructure is deployed, please follow the instructions to deploy t
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "azure",
         "addons": [

--- a/examples/addons/appgw-ingress/kubernetes-appgw-ingress.json
+++ b/examples/addons/appgw-ingress/kubernetes-appgw-ingress.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "azure",
         "addons": [

--- a/examples/addons/azure-arc-onboarding/kubernetes-arc.json
+++ b/examples/addons/azure-arc-onboarding/kubernetes-arc.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "useManagedIdentity": true,
         "addons": [

--- a/examples/addons/azure-policy/README.md
+++ b/examples/addons/azure-policy/README.md
@@ -18,7 +18,6 @@ The following is a sample API definition with azure-policy addon.
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/azure-policy/azure-policy.json
+++ b/examples/addons/azure-policy/azure-policy.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/cluster-autoscaler/README.md
+++ b/examples/addons/cluster-autoscaler/README.md
@@ -20,7 +20,6 @@ Here's a simple example of a cluster configuration (API model) that includes the
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/cluster-autoscaler/kubernetes-cluster-autoscaler.json
+++ b/examples/addons/cluster-autoscaler/kubernetes-cluster-autoscaler.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "useManagedIdentity": true,
         "addons": [

--- a/examples/addons/container-monitoring/README.md
+++ b/examples/addons/container-monitoring/README.md
@@ -7,7 +7,6 @@ This is sample API definition with Container-monitoring addon.
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/container-monitoring/kubernetes-container-monitoring.json
+++ b/examples/addons/container-monitoring/kubernetes-container-monitoring.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/container-monitoring/kubernetes-container-monitoring_existing_log_analytics_workspace.json
+++ b/examples/addons/container-monitoring/kubernetes-container-monitoring_existing_log_analytics_workspace.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/container-monitoring/kubernetes-container-monitoring_existing_workspace_id_and_key.json
+++ b/examples/addons/container-monitoring/kubernetes-container-monitoring_existing_workspace_id_and_key.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/csi-secrets-store/kubernetes-csi-secrets-store.json
+++ b/examples/addons/csi-secrets-store/kubernetes-csi-secrets-store.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "addons": [

--- a/examples/addons/custom-manifests/kubernetes-custom-psp.json
+++ b/examples/addons/custom-manifests/kubernetes-custom-psp.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/keyvault-flexvolume/README.md
+++ b/examples/addons/keyvault-flexvolume/README.md
@@ -11,7 +11,6 @@ Add this add-on to your API model as shown below to automatically enable Key Vau
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "kubernetesConfig": {
           "addons": [
             {

--- a/examples/addons/keyvault-flexvolume/kubernetes-keyvault-flexvolume.json
+++ b/examples/addons/keyvault-flexvolume/kubernetes-keyvault-flexvolume.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/node-problem-detector/README.md
+++ b/examples/addons/node-problem-detector/README.md
@@ -11,7 +11,6 @@ The following is a sample API definition with the node-problem-detector addon en
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addons/node-problem-detector/node-problem-detector.json
+++ b/examples/addons/node-problem-detector/node-problem-detector.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "kubernetesConfig": {
           "addons": [
             {

--- a/examples/addons/nvidia-device-plugin/README.md
+++ b/examples/addons/nvidia-device-plugin/README.md
@@ -7,7 +7,6 @@ This is the [NVIDIA Device Plugin](https://github.com/NVIDIA/k8s-device-plugin) 
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "addons": [

--- a/examples/addons/nvidia-device-plugin/nvidia-device-plugin.json
+++ b/examples/addons/nvidia-device-plugin/nvidia-device-plugin.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/addpool/apimodel.json
+++ b/examples/addpool/apimodel.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/azure-stack/conformance/kubernetes1.17.json
+++ b/examples/azure-stack/conformance/kubernetes1.17.json
@@ -3,7 +3,6 @@
     "location": "",
     "properties": {
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.17",
             "kubernetesConfig": {
                 "useInstanceMetadata": false,

--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -3,7 +3,6 @@
     "location": "",
     "properties": {
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.17",
             "orchestratorVersion": "1.17.11",
             "kubernetesConfig": {

--- a/examples/azure-stack/kubernetes-windows.json
+++ b/examples/azure-stack/kubernetes-windows.json
@@ -3,7 +3,6 @@
     "location": "",
     "properties": {
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.17",
             "orchestratorVersion": "1.17.11",
             "kubernetesConfig": {

--- a/examples/cosmos-etcd/kubernetes-3-masters-cosmos.json
+++ b/examples/cosmos-etcd/kubernetes-3-masters-cosmos.json
@@ -2,16 +2,15 @@
     "apiVersion": "vlabs",
     "properties": {
         "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
             "kubernetesConfig": {
-            "useManagedIdentity": true
-          }
+                "useManagedIdentity": true
+            }
         },
         "masterProfile": {
             "count": 3,
             "dnsPrefix": "",
             "vmSize": "Standard_D2_v3",
-            "cosmosEtcd" : true
+            "cosmosEtcd": true
         },
         "agentPoolProfiles": [
             {
@@ -31,5 +30,5 @@
                 ]
             }
         }
-  }
+    }
 }

--- a/examples/custom-image.json
+++ b/examples/custom-image.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "imageReference": {
         "name": "stretch",

--- a/examples/custom-shared-image.json
+++ b/examples/custom-shared-image.json
@@ -1,9 +1,6 @@
 {
     "apiVersion": "vlabs",
     "properties": {
-      "orchestratorProfile": {
-        "orchestratorType": "Kubernetes"
-      },
       "masterProfile": {
         "imageReference": {
           "name": "linuxvm",

--- a/examples/customfiles/kubernetes-customfiles-podnodeselector.json
+++ b/examples/customfiles/kubernetes-customfiles-podnodeselector.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "orchestratorVersion": "1.16.14",
         "kubernetesConfig": {
           "enableRbac" : true,

--- a/examples/disks-ephemeral/ephemeral-disks.json
+++ b/examples/disks-ephemeral/ephemeral-disks.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/disks-ephemeral/kubernetes-vmas.json
+++ b/examples/disks-ephemeral/kubernetes-vmas.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/disks-managed/kubernetes-preAttachedDisks-vmas.json
+++ b/examples/disks-managed/kubernetes-preAttachedDisks-vmas.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/disks-managed/kubernetes-vmas.json
+++ b/examples/disks-managed/kubernetes-vmas.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/disks-storageaccount/kubernetes-master-sa.json
+++ b/examples/disks-storageaccount/kubernetes-master-sa.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/disks-storageaccount/kubernetes.json
+++ b/examples/disks-storageaccount/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/dualstack/kubernetes.json
+++ b/examples/dualstack/kubernetes.json
@@ -5,7 +5,6 @@
             "enableIPv6DualStack": true
         },
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.16",
             "kubernetesConfig": {
                 "clusterSubnet": "10.244.0.0/16,fc00::/8",

--- a/examples/e2e-tests/kubernetes/flatcar/flatcar.json
+++ b/examples/e2e-tests/kubernetes/flatcar/flatcar.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "clusterSubnet": "10.239.0.0/16",
         "addons": [

--- a/examples/e2e-tests/kubernetes/gpu-enabled/definition.json
+++ b/examples/e2e-tests/kubernetes/gpu-enabled/definition.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "orchestratorRelease": "1.16"
       },
       "masterProfile": {

--- a/examples/e2e-tests/kubernetes/kubernetes-config/addons-disabled.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/addons-disabled.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/e2e-tests/kubernetes/kubernetes-config/addons-enabled.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/addons-enabled.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "addons": [

--- a/examples/e2e-tests/kubernetes/kubernetes-config/network-plugin-kubenet.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/network-plugin-kubenet.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin":"kubenet"
       }

--- a/examples/e2e-tests/kubernetes/node-count/50-nodes/definition.json
+++ b/examples/e2e-tests/kubernetes/node-count/50-nodes/definition.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16"
     },
     "masterProfile": {

--- a/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "kubernetesConfig": {
                 "enableEncryptionWithExternalKms": true,
                 "useManagedIdentity": true,

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "enableEncryptionWithExternalKms": true,
         "useManagedIdentity": true,

--- a/examples/e2e-tests/kubernetes/windows/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/definition.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/e2e-tests/kubernetes/zones/definition.json
+++ b/examples/e2e-tests/kubernetes/zones/definition.json
@@ -1,10 +1,6 @@
 {
     "apiVersion": "vlabs",
     "properties": {
-        "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.16"
-        },
         "masterProfile": {
             "count": 5,
             "dnsPrefix": "",

--- a/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas-multimaster.json
+++ b/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas-multimaster.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useManagedIdentity": true,

--- a/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas.json
+++ b/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useManagedIdentity": true,

--- a/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
+++ b/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useManagedIdentity": true,

--- a/examples/extensions/kubernetes.json
+++ b/examples/extensions/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
@@ -12,7 +9,7 @@
         {
           "name": "hello-world-k8s"
         }
-     ]
+      ]
     },
     "agentPoolProfiles": [
       {

--- a/examples/extensions/kubernetes.oms.json
+++ b/examples/extensions/kubernetes.oms.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
@@ -12,7 +9,7 @@
         {
           "name": "microsoft-oms-agent-k8s"
         }
-     ]
+      ]
     },
     "agentPoolProfiles": [
       {

--- a/examples/extensions/kubernetes.preprovision.json
+++ b/examples/extensions/kubernetes.preprovision.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/extensions/prometheus-grafana-k8s.json
+++ b/examples/extensions/prometheus-grafana-k8s.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/feature-gates/kubernetes-featuresgates.json
+++ b/examples/feature-gates/kubernetes-featuresgates.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "kubeletConfig" : {

--- a/examples/flatcar/kubernetes-flatcar-hybrid.json
+++ b/examples/flatcar/kubernetes-flatcar-hybrid.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "kubenet"
       }

--- a/examples/flatcar/kubernetes-flatcar.json
+++ b/examples/flatcar/kubernetes-flatcar.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "kubenet"
       }

--- a/examples/ipv6/kubernetes.json
+++ b/examples/ipv6/kubernetes.json
@@ -5,7 +5,6 @@
             "enableIPv6Only": true
         },
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.18",
             "kubernetesConfig": {
                 "loadBalancerSku": "Standard",

--- a/examples/ipvs/kubernetes-msi.json
+++ b/examples/ipvs/kubernetes-msi.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useManagedIdentity": true,

--- a/examples/keyvault-params/kubernetes.json
+++ b/examples/keyvault-params/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/examples/keyvaultcerts/kubernetes.json
+++ b/examples/keyvaultcerts/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/kubernetes-D2.json
+++ b/examples/kubernetes-D2.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/kubernetes-config/kubernetes-accelerated-network.json
+++ b/examples/kubernetes-config/kubernetes-accelerated-network.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/kubernetes-config/kubernetes-cloud-controller-manager.json
+++ b/examples/kubernetes-config/kubernetes-cloud-controller-manager.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useCloudControllerManager": true

--- a/examples/kubernetes-config/kubernetes-clustersubnet.json
+++ b/examples/kubernetes-config/kubernetes-clustersubnet.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "clusterSubnet": "10.230.0.0/16"
       }

--- a/examples/kubernetes-config/kubernetes-containerd-tmpdir.json
+++ b/examples/kubernetes-config/kubernetes-containerd-tmpdir.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
         "networkPlugin": "kubenet",

--- a/examples/kubernetes-config/kubernetes-data-encryption-at-rest.json
+++ b/examples/kubernetes-config/kubernetes-data-encryption-at-rest.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "enableDataEncryptionAtRest": true
       }

--- a/examples/kubernetes-config/kubernetes-docker-tmpdir.json
+++ b/examples/kubernetes-config/kubernetes-docker-tmpdir.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
         "containerRuntime": "docker",

--- a/examples/kubernetes-config/kubernetes-dockerbridgesubnet.json
+++ b/examples/kubernetes-config/kubernetes-dockerbridgesubnet.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "dockerBridgeSubnet": "192.168.21.5/24"
       }

--- a/examples/kubernetes-config/kubernetes-etcd-storage-size.json
+++ b/examples/kubernetes-config/kubernetes-etcd-storage-size.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "etcdDiskSizeGB": "256"
       }

--- a/examples/kubernetes-config/kubernetes-gc.json
+++ b/examples/kubernetes-config/kubernetes-gc.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "gcHighThreshold":70,
         "gcLowThreshold": 60

--- a/examples/kubernetes-config/kubernetes-keyvault-encryption.json
+++ b/examples/kubernetes-config/kubernetes-keyvault-encryption.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "enableEncryptionWithExternalKms": true,

--- a/examples/kubernetes-config/kubernetes-kube-reserved.json
+++ b/examples/kubernetes-config/kubernetes-kube-reserved.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
         "loadBalancerSku": "Standard",

--- a/examples/kubernetes-config/kubernetes-maxpods.json
+++ b/examples/kubernetes-config/kubernetes-maxpods.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "kubeletConfig": {
           "--max-pods": "20"

--- a/examples/kubernetes-config/kubernetes-no-dashboard.json
+++ b/examples/kubernetes-config/kubernetes-no-dashboard.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/kubernetes-config/kubernetes-private-cluster-single-master.json
+++ b/examples/kubernetes-config/kubernetes-private-cluster-single-master.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "privateCluster": {
           "enabled": true,

--- a/examples/kubernetes-config/kubernetes-private-cluster.json
+++ b/examples/kubernetes-config/kubernetes-private-cluster.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "privateCluster": {
           "enabled": true,

--- a/examples/kubernetes-config/kubernetes-rescheduler.json
+++ b/examples/kubernetes-config/kubernetes-rescheduler.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "addons": [
           {

--- a/examples/kubernetes-config/kubernetes-standardlb.json
+++ b/examples/kubernetes-config/kubernetes-standardlb.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "loadBalancerSku": "Standard",

--- a/examples/kubernetes-containerd.json
+++ b/examples/kubernetes-containerd.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "networkPlugin": "flannel",

--- a/examples/kubernetes-gpu/kubernetes.json
+++ b/examples/kubernetes-gpu/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/kubernetes-kubenet-containerd.json
+++ b/examples/kubernetes-kubenet-containerd.json
@@ -2,7 +2,6 @@
 	"apiVersion": "vlabs",
 	"properties": {
 		"orchestratorProfile": {
-			"orchestratorType": "Kubernetes",
 			"orchestratorRelease": "1.16",
 			"kubernetesConfig": {
 				"networkPlugin": "kubenet",

--- a/examples/kubernetes-labels/kubernetes.json
+++ b/examples/kubernetes-labels/kubernetes.json
@@ -1,10 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.16"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "my-cluster",

--- a/examples/kubernetes-msi-userassigned/kube-vma.json
+++ b/examples/kubernetes-msi-userassigned/kube-vma.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "useManagedIdentity": true,
         "userAssignedID": "aksenginetestid"

--- a/examples/kubernetes-msi-userassigned/kube-vmss.json
+++ b/examples/kubernetes-msi-userassigned/kube-vmss.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "useManagedIdentity": true,
         "userAssignedID": "aksenginetestid"

--- a/examples/kubernetes-non-vhd-distros.json
+++ b/examples/kubernetes-non-vhd-distros.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/kubernetes-releases/kubernetes1.16.json
+++ b/examples/kubernetes-releases/kubernetes1.16.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16"
     },
     "masterProfile": {

--- a/examples/kubernetes-releases/kubernetes1.17.json
+++ b/examples/kubernetes-releases/kubernetes1.17.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17"
     },
     "masterProfile": {

--- a/examples/kubernetes-releases/kubernetes1.18.json
+++ b/examples/kubernetes-releases/kubernetes1.18.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.18"
     },
     "masterProfile": {

--- a/examples/kubernetes-releases/kubernetes1.19.json
+++ b/examples/kubernetes-releases/kubernetes1.19.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.19"
     },
     "masterProfile": {

--- a/examples/kubernetes-releases/kubernetes1.20.json
+++ b/examples/kubernetes-releases/kubernetes1.20.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.20"
     },
     "masterProfile": {

--- a/examples/kubernetes-vmss-master/customvnet.json
+++ b/examples/kubernetes-vmss-master/customvnet.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "kubernetesConfig": {
           "clusterSubnet": "10.239.0.0/16",
           "addons": [

--- a/examples/kubernetes-vmss-master/kubernetes.json
+++ b/examples/kubernetes-vmss-master/kubernetes.json
@@ -1,10 +1,6 @@
 {
     "apiVersion": "vlabs",
     "properties": {
-      "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
-        "orchestratorRelease": "1.16"
-      },
       "masterProfile": {
         "count": 1,
         "dnsPrefix": "",

--- a/examples/kubernetes-vmss-master/windows.json
+++ b/examples/kubernetes-vmss-master/windows.json
@@ -1,10 +1,6 @@
 {
     "apiVersion": "vlabs",
     "properties": {
-      "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
-        "orchestratorRelease": "1.16"
-      },
       "masterProfile": {
         "count": 1,
         "dnsPrefix": "",

--- a/examples/kubernetes-vmss-spot/kubernetes.json
+++ b/examples/kubernetes-vmss-spot/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useManagedIdentity": true

--- a/examples/kubernetes-vmss/kubernetes.json
+++ b/examples/kubernetes-vmss/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useManagedIdentity": true

--- a/examples/kubernetes-zones/README.md
+++ b/examples/kubernetes-zones/README.md
@@ -16,7 +16,6 @@ Here is an [example of a Kubernetes cluster with Availability Zones support](../
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "orchestratorRelease": "1.13"
       },
       "masterProfile": {

--- a/examples/kubernetes.json
+++ b/examples/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/largeclusters/kubernetes.json
+++ b/examples/largeclusters/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "cloudProviderBackoff": true,

--- a/examples/managed-identity/kubernetes-msi.json
+++ b/examples/managed-identity/kubernetes-msi.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useManagedIdentity": true

--- a/examples/multiple-masters/kubernetes-3-masters.json
+++ b/examples/multiple-masters/kubernetes-3-masters.json
@@ -1,9 +1,6 @@
 {
     "apiVersion": "vlabs",
     "properties": {
-        "orchestratorProfile": {
-            "orchestratorType": "Kubernetes"
-        },
         "masterProfile": {
             "count": 3,
             "dnsPrefix": "",

--- a/examples/multiple-masters/kubernetes-5-masters.json
+++ b/examples/multiple-masters/kubernetes-5-masters.json
@@ -1,9 +1,6 @@
 {
     "apiVersion": "vlabs",
     "properties": {
-        "orchestratorProfile": {
-            "orchestratorType": "Kubernetes"
-        },
         "masterProfile": {
             "count": 5,
             "dnsPrefix": "",

--- a/examples/multiple-nodepools/multipool.json
+++ b/examples/multiple-nodepools/multipool.json
@@ -1,10 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.16"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/networkplugin/README.md
+++ b/examples/networkplugin/README.md
@@ -18,12 +18,11 @@ If the container host VM has multiple network interfaces, the primary network in
 
 More detailed documentation can be found in [the Azure Container Networking Repository](https://github.com/Azure/azure-container-networking/tree/master/docs)
 
-Example of templates enabling CNI:
+Example of templates enabling Azure CNI:
 
 ```json
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "azure"
       }
@@ -32,12 +31,14 @@ Example of templates enabling CNI:
   }
 ```
 
-Or by not specifying any network policy, leaving the default :
+Or by not specifying any network plugin, you'll get Azure CNI by default:
 
 ```json
-    "properties": {
+  "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "kubernetesConfig": {
+        <other kubernetesConfig properties>
+      }
     }
     ...
   }
@@ -50,7 +51,6 @@ Also available is the Kubernetes-native kubenet implementation, which is declare
 ```json
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "kubenet"
       }

--- a/examples/networkplugin/kubernetes-azure.json
+++ b/examples/networkplugin/kubernetes-azure.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "azure"
       }

--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -17,7 +17,6 @@ The kubernetes-calico deployment template enables Calico networking and policies
 ```json
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "calico",
         "networkPlugin": "azure|kubenet"
@@ -43,7 +42,6 @@ The kubernetes-cilium deployment template enables Cilium networking and policies
 ```json
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "cilium"
       }
@@ -56,7 +54,6 @@ The kubernetes-cilium deployment template enables Cilium networking and policies
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.10",
       "kubernetesConfig": {
         "networkPlugin": "cilium",
@@ -81,7 +78,6 @@ The kubernetes-antrea deployment template enables Antrea networking and policies
 ```json
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "antrea",
         "networkPlugin": "antrea"
@@ -95,7 +91,6 @@ Antrea also supports `NetworkPolicyOnly` mode with Azure CNI. In this mode, Antr
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "antrea"
       }

--- a/examples/networkpolicy/kubernetes-antrea.json
+++ b/examples/networkpolicy/kubernetes-antrea.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "networkPolicy": "antrea"

--- a/examples/networkpolicy/kubernetes-calico-azure.json
+++ b/examples/networkpolicy/kubernetes-calico-azure.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "calico",
         "networkPlugin": "azure"

--- a/examples/networkpolicy/kubernetes-calico-kubenet.json
+++ b/examples/networkpolicy/kubernetes-calico-kubenet.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "calico",
         "networkPlugin": "kubenet"

--- a/examples/networkpolicy/kubernetes-cilium.json
+++ b/examples/networkpolicy/kubernetes-cilium.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "networkPolicy": "cilium"

--- a/examples/service-mesh/istio.json
+++ b/examples/service-mesh/istio.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
         "apiServerConfig": {

--- a/examples/ubuntu-1604/kubernetes.json
+++ b/examples/ubuntu-1604/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "kubenet"
       }

--- a/examples/ubuntu-1804/kubernetes.json
+++ b/examples/ubuntu-1804/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "kubenet"
       }

--- a/examples/vnet/kubernetes-master-vmss.json
+++ b/examples/vnet/kubernetes-master-vmss.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "kubernetesConfig": {
           "clusterSubnet": "10.239.0.0/16",
           "addons": [

--- a/examples/vnet/kubernetesvnet-azure-cni.json
+++ b/examples/vnet/kubernetesvnet-azure-cni.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "test",

--- a/examples/vnet/kubernetesvnet-customnodesdns.json
+++ b/examples/vnet/kubernetesvnet-customnodesdns.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPolicy": "calico"
       }

--- a/examples/vnet/kubernetesvnet-customsearchdomain.json
+++ b/examples/vnet/kubernetesvnet-customsearchdomain.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
       "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
         "kubernetesConfig": {
           "networkPolicy": "calico"
         }

--- a/examples/vnet/kubernetesvnet.json
+++ b/examples/vnet/kubernetesvnet.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "kubenet"
       }

--- a/examples/windows/kubernetes-D2.json
+++ b/examples/windows/kubernetes-D2.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-custom-image.json
+++ b/examples/windows/kubernetes-custom-image.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-custom-shared-image.json
+++ b/examples/windows/kubernetes-custom-shared-image.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-custom-vhd.json
+++ b/examples/windows/kubernetes-custom-vhd.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-hybrid.azure-containerd.json
+++ b/examples/windows/kubernetes-hybrid.azure-containerd.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.18",
       "kubernetesConfig": {
         "networkPlugin": "azure",

--- a/examples/windows/kubernetes-hybrid.json
+++ b/examples/windows/kubernetes-hybrid.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-hybrid.kubenet-containerd.json
+++ b/examples/windows/kubernetes-hybrid.kubenet-containerd.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.18",
       "kubernetesConfig": {
         "networkPlugin": "kubenet",

--- a/examples/windows/kubernetes-hyperv.json
+++ b/examples/windows/kubernetes-hyperv.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "networkPlugin": "azure",

--- a/examples/windows/kubernetes-manageddisks.json
+++ b/examples/windows/kubernetes-manageddisks.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-master-sa.json
+++ b/examples/windows/kubernetes-master-sa.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-pause-image.json
+++ b/examples/windows/kubernetes-pause-image.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "azure",
         "useManagedIdentity": false

--- a/examples/windows/kubernetes-sadisks.json
+++ b/examples/windows/kubernetes-sadisks.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-wincni.json
+++ b/examples/windows/kubernetes-wincni.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "networkPlugin": "kubenet"
       }

--- a/examples/windows/kubernetes-windows-1903.json
+++ b/examples/windows/kubernetes-windows-1903.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16"
     },
     "masterProfile": {

--- a/examples/windows/kubernetes-windows-1909.json
+++ b/examples/windows/kubernetes-windows-1909.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.18"
     },
     "masterProfile": {

--- a/examples/windows/kubernetes-windows-docker-version.json
+++ b/examples/windows/kubernetes-windows-docker-version.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes-windows-version.json
+++ b/examples/windows/kubernetes-windows-version.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/examples/windows/kubernetes.json
+++ b/examples/windows/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16"
     },
     "masterProfile": {

--- a/extensions/prometheus-grafana-k8s/README.md
+++ b/extensions/prometheus-grafana-k8s/README.md
@@ -7,9 +7,6 @@ This is the prometheus-grafana extension.  Add this extension to the API model y
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",

--- a/parts/agentoutputs.t
+++ b/parts/agentoutputs.t
@@ -1,11 +1,3 @@
-{{if IsPublic .Ports}}
-  {{ if not IsKubernetes }}
-    "{{.Name}}FQDN": {
-        "type": "string",
-        "value": "[reference(concat('Microsoft.Network/publicIPAddresses/', variables('{{.Name}}IPAddressName'))).dnsSettings.fqdn]"
-    },
-  {{end}}
-{{end}}
 {{if and .IsAvailabilitySets .IsStorageAccount}}
   "{{.Name}}StorageAccountOffset": {
       "type": "int",

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -1,4 +1,3 @@
- {{if IsKubernetes}}
     "kubeBinariesSASURL": {
       "metadata": {
         "description": "The download url for kubernetes windows binaries package"
@@ -41,7 +40,6 @@
       },
       "type": "string"
     },
- {{end}}
     "windowsAdminUsername": {
       "type": "string",
       "metadata": {

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -102,6 +102,9 @@ func (a *Apiloader) LoadContainerService(
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
+		if containerService.Properties.OrchestratorProfile == nil {
+			containerService.Properties.OrchestratorProfile = &vlabs.OrchestratorProfile{}
+		}
 		if e := checkJSONKeys(contents, reflect.TypeOf(*containerService), reflect.TypeOf(TypeMeta{})); e != nil {
 			return nil, e
 		}

--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -168,39 +168,6 @@ func TestLoadContainerServiceForAgentPoolOnlyCluster(t *testing.T) {
 	})
 }
 
-func TestLoadContainerServiceWithNilProperties(t *testing.T) {
-	jsonWithoutProperties := `{
-        "type": "Microsoft.ContainerService/managedClusters",
-        "name": "[parameters('clusterName')]",
-        "apiVersion": "vlabs",
-        "location": "[resourceGroup().location]"
-        }`
-
-	tmpFile, err := ioutil.TempFile("", "containerService-invalid")
-	if err != nil {
-		t.Error(err)
-	}
-	fileName := tmpFile.Name()
-	defer os.Remove(fileName)
-
-	err = ioutil.WriteFile(fileName, []byte(jsonWithoutProperties), os.ModeAppend)
-	if err != nil {
-		t.Error(err)
-	}
-
-	apiloader := &Apiloader{}
-	existingContainerService := &ContainerService{Name: "test",
-		Properties: &Properties{OrchestratorProfile: &OrchestratorProfile{OrchestratorType: Kubernetes, OrchestratorVersion: "1.7.16"}}}
-	_, _, err = apiloader.LoadContainerServiceFromFile(fileName, true, false, existingContainerService)
-	if err == nil {
-		t.Errorf("Expected error to be thrown")
-	}
-	expectedMsg := "missing ContainerService Properties"
-	if err.Error() != expectedMsg {
-		t.Errorf("Expected error with message %s but got %s", expectedMsg, err.Error())
-	}
-}
-
 func TestLoadContainerServiceWithEmptyLocationCustomCloud(t *testing.T) {
 	jsonWithoutlocationcustomcloud := `{
 		"apiVersion": "vlabs",
@@ -371,9 +338,6 @@ func TestDeserializeContainerService(t *testing.T) {
 	if version != vlabs.APIVersion {
 		t.Errorf("expected apiVersion %s, instead got: %s", vlabs.APIVersion, version)
 	}
-	if cs.Properties.OrchestratorProfile.OrchestratorType != Kubernetes {
-		t.Errorf("expected cs.Properties.OrchestratorProfile.OrchestratorType %s, instead got: %s", Kubernetes, cs.Properties.OrchestratorProfile.OrchestratorType)
-	}
 
 	// Test AKS api model
 	cs, version, err = apiloader.DeserializeContainerService([]byte(exampleAKSAPIModel), false, false, nil)
@@ -382,9 +346,6 @@ func TestDeserializeContainerService(t *testing.T) {
 	}
 	if version != v20180331.APIVersion {
 		t.Errorf("expected apiVersion %s, instead got: %s", v20180331.APIVersion, version)
-	}
-	if cs.Properties.OrchestratorProfile.OrchestratorType != Kubernetes {
-		t.Errorf("expected cs.Properties.OrchestratorProfile.OrchestratorType %s, instead got: %s", Kubernetes, cs.Properties.OrchestratorProfile.OrchestratorType)
 	}
 	if cs.Properties.MasterProfile != nil {
 		t.Errorf("expected nil MasterProfile for AKS container service object")

--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -331,7 +331,7 @@ func TestDeserializeContainerService(t *testing.T) {
 	}
 
 	// Test AKS Engine api model
-	cs, version, err := apiloader.DeserializeContainerService([]byte(exampleAPIModel), false, false, nil)
+	_, version, err := apiloader.DeserializeContainerService([]byte(exampleAPIModel), false, false, nil)
 	if err != nil {
 		t.Errorf("unexpected error deserializing the example apimodel: %s", err)
 	}
@@ -340,7 +340,7 @@ func TestDeserializeContainerService(t *testing.T) {
 	}
 
 	// Test AKS api model
-	cs, version, err = apiloader.DeserializeContainerService([]byte(exampleAKSAPIModel), false, false, nil)
+	cs, version, err := apiloader.DeserializeContainerService([]byte(exampleAKSAPIModel), false, false, nil)
 	if err != nil {
 		t.Errorf("unexpected error deserializing the example apimodel: %s", err)
 	}

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -512,6 +512,9 @@ func GetValidPatchVersion(orchType, orchVer string, isUpdate, hasWindows bool, i
 
 // RationalizeReleaseAndVersion return a version when it can be rationalized from the input, otherwise ""
 func RationalizeReleaseAndVersion(orchType, orchRel, orchVer string, isUpdate, hasWindows bool, isAzureStackCloud bool) (version string) {
+	if orchType == "" {
+		orchType = Kubernetes
+	}
 	// ignore "v" prefix in orchestrator version and release: "v1.8.0" is equivalent to "1.8.0", "v1.9" is equivalent to "1.9"
 	orchVer = strings.TrimPrefix(orchVer, "v")
 	orchRel = strings.TrimPrefix(orchRel, "v")

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -140,13 +140,6 @@ func convertVLabsAgentPoolOnlyProperties(vlabs *vlabs.Properties, api *Propertie
 	for _, p := range vlabs.AgentPoolProfiles {
 		apiProfile := &AgentPoolProfile{}
 		convertVLabsAgentPoolOnlyAgentPoolProfile(p, apiProfile)
-		// by default vlabs will use managed disks for all orchestrators but kubernetes as it has encryption at rest.
-		if !api.OrchestratorProfile.IsKubernetes() {
-			// by default vlabs will use managed disks for all orchestrators but kubernetes as it has encryption at rest.
-			if len(p.StorageProfile) == 0 {
-				apiProfile.StorageProfile = ManagedDisks
-			}
-		}
 		api.AgentPoolProfiles = append(api.AgentPoolProfiles, apiProfile)
 	}
 	if vlabs.LinuxProfile != nil {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -297,7 +297,6 @@ func TestAssignDefaultAddonImages(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			mockCS := getMockBaseContainerService(kubernetesVersion)
-			mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 			mockCS.Properties.OrchestratorProfile.KubernetesConfig.Addons = c.myAddons
 			mockCS.setOrchestratorDefaults(c.isUpdate, c.isUpdate)
 			resultAddons := mockCS.Properties.OrchestratorProfile.KubernetesConfig.Addons
@@ -524,7 +523,6 @@ func TestAssignDefaultAddonVals(t *testing.T) {
 
 func TestAcceleratedNetworking(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
 
@@ -547,7 +545,6 @@ func TestAcceleratedNetworking(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
 
@@ -570,7 +567,6 @@ func TestAcceleratedNetworking(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
 	mockCS.Properties.AgentPoolProfiles[0].VMSize = "Standard_D2_v2"
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
@@ -597,7 +593,6 @@ func TestAcceleratedNetworking(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
 	mockCS.Properties.AgentPoolProfiles[0].VMSize = "Standard_D666_v2"
 	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
@@ -624,7 +619,6 @@ func TestAcceleratedNetworking(t *testing.T) {
 
 func TestVMSSOverProvisioning(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = VirtualMachineScaleSets
 	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = nil
 	_, err := mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -642,7 +636,6 @@ func TestVMSSOverProvisioning(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = VirtualMachineScaleSets
 	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = nil
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -660,7 +653,6 @@ func TestVMSSOverProvisioning(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = VirtualMachineScaleSets
 	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = nil
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -679,7 +671,6 @@ func TestVMSSOverProvisioning(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = VirtualMachineScaleSets
 	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = to.BoolPtr(true)
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -697,7 +688,6 @@ func TestVMSSOverProvisioning(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = VirtualMachineScaleSets
 	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = to.BoolPtr(false)
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -717,7 +707,6 @@ func TestVMSSOverProvisioning(t *testing.T) {
 
 func TestAuditDEnabled(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.12.7")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	isUpgrade := true
 	mockCS.Properties.setAgentProfileDefaults(isUpgrade, false)
 
@@ -727,7 +716,6 @@ func TestAuditDEnabled(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.12.7")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	isScale := true
 	mockCS.Properties.setAgentProfileDefaults(false, isScale)
 
@@ -737,7 +725,6 @@ func TestAuditDEnabled(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.12.7")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.setAgentProfileDefaults(false, false)
 
 	// In create scenario, nil AuditDEnabled should be the defaults
@@ -747,7 +734,6 @@ func TestAuditDEnabled(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled = to.BoolPtr(true)
 	mockCS.Properties.setAgentProfileDefaults(false, false)
 
@@ -757,7 +743,6 @@ func TestAuditDEnabled(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.10.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled = to.BoolPtr(false)
 	mockCS.Properties.setAgentProfileDefaults(false, false)
 
@@ -769,7 +754,6 @@ func TestAuditDEnabled(t *testing.T) {
 
 func TestDiskCachingTypes(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.18.2")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	isUpgrade := false
 	isScale := false
 	mockCS.Properties.setAgentProfileDefaults(isUpgrade, isScale)
@@ -782,7 +766,6 @@ func TestDiskCachingTypes(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.18.2")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.AgentPoolProfiles[0].StorageProfile = Ephemeral
 	mockCS.Properties.setAgentProfileDefaults(isUpgrade, isScale)
 	if mockCS.Properties.AgentPoolProfiles[0].OSDiskCachingType != string(compute.CachingTypesReadOnly) {
@@ -792,7 +775,6 @@ func TestDiskCachingTypes(t *testing.T) {
 
 func TestDefaultUseManagedIdentity(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.18.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	isUpgrade := false
 	isScale := false
 	mockCS.setOrchestratorDefaults(isUpgrade, isScale)
@@ -800,7 +782,6 @@ func TestDefaultUseManagedIdentity(t *testing.T) {
 		t.Errorf("expected UseManagedIdentity to be true by default, instead got %t", to.Bool(mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity))
 	}
 	mockCS = getMockBaseContainerService("1.18.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
 		Environment: &azure.Environment{},
 	}
@@ -810,7 +791,6 @@ func TestDefaultUseManagedIdentity(t *testing.T) {
 	}
 
 	mockCS = getMockBaseContainerService("1.18.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.MasterProfile.AvailabilityProfile = VirtualMachineScaleSets
 	mockCS.setOrchestratorDefaults(isUpgrade, isScale)
 	if to.Bool(mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity) {
@@ -820,7 +800,6 @@ func TestDefaultUseManagedIdentity(t *testing.T) {
 	isUpgrade = true
 	isScale = false
 	mockCS = getMockBaseContainerService("1.18.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(isUpgrade, isScale)
 	if mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity != nil {
 		t.Errorf("expected UseManagedIdentity to be unchanged by default in upgrade context, instead got %t", to.Bool(mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity))
@@ -829,14 +808,12 @@ func TestDefaultUseManagedIdentity(t *testing.T) {
 	isUpgrade = false
 	isScale = true
 	mockCS = getMockBaseContainerService("1.18.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(isUpgrade, isScale)
 	if mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity != nil {
 		t.Errorf("expected UseManagedIdentity to be unchanged by default in scale context, instead got %t", to.Bool(mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity))
 	}
 
 	mockCS = getMockBaseContainerService("1.18.8")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = to.BoolPtr(false)
 	mockCS.setOrchestratorDefaults(isUpgrade, isScale)
 	if to.Bool(mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity) {
@@ -893,7 +870,6 @@ func TestKubeletFeatureGatesEnsureMasterAndAgentConfigUsedFor1_6_0(t *testing.T)
 func TestEtcdDiskSize(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.8.10")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != DefaultEtcdDiskSize {
@@ -903,7 +879,6 @@ func TestEtcdDiskSize(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.8.10")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 5
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != DefaultEtcdDiskSizeGT3Nodes {
@@ -913,7 +888,6 @@ func TestEtcdDiskSize(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.8.10")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 5
 	properties.AgentPoolProfiles[0].Count = 6
 	mockCS.setOrchestratorDefaults(true, true)
@@ -924,7 +898,6 @@ func TestEtcdDiskSize(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.8.10")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 5
 	properties.AgentPoolProfiles[0].Count = 16
 	mockCS.setOrchestratorDefaults(true, true)
@@ -935,7 +908,6 @@ func TestEtcdDiskSize(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.8.10")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 5
 	properties.AgentPoolProfiles[0].Count = 50
 	customEtcdDiskSize := "512"
@@ -950,7 +922,6 @@ func TestEtcdDiskSize(t *testing.T) {
 func TestEtcdStorageLimitGB(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.18.5")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	mockCS.setOrchestratorDefaults(false, false)
 	if properties.OrchestratorProfile.KubernetesConfig.EtcdStorageLimitGB != DefaultEtcdStorageLimitGB {
@@ -961,7 +932,6 @@ func TestEtcdStorageLimitGB(t *testing.T) {
 	// validate defaults doesn't override valid value
 	mockCS = getMockBaseContainerService("1.18.5")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.OrchestratorProfile.KubernetesConfig.EtcdStorageLimitGB = 3
 	mockCS.setOrchestratorDefaults(false, false)
@@ -974,7 +944,6 @@ func TestEtcdStorageLimitGB(t *testing.T) {
 func TestMicrosoftAptRepositoryURL(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.18.5")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	mockCS.setOrchestratorDefaults(false, false)
 	if properties.OrchestratorProfile.KubernetesConfig.MicrosoftAptRepositoryURL != DefaultMicrosoftAptRepositoryURL {
@@ -985,7 +954,6 @@ func TestMicrosoftAptRepositoryURL(t *testing.T) {
 	// validate defaults doesn't override valid value
 	mockCS = getMockBaseContainerService("1.18.5")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.OrchestratorProfile.KubernetesConfig.MicrosoftAptRepositoryURL = "custom.packages.com"
 	mockCS.setOrchestratorDefaults(false, false)
@@ -1012,7 +980,6 @@ func TestGenerateEtcdEncryptionKey(t *testing.T) {
 func TestNetworkPolicyDefaults(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.8.10")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyCalico
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != NetworkPluginKubenet {
@@ -1022,7 +989,6 @@ func TestNetworkPolicyDefaults(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.8.10")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyCilium
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != NetworkPluginCilium {
@@ -1032,7 +998,6 @@ func TestNetworkPolicyDefaults(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.15.7")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyAntrea
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != NetworkPluginAzure {
@@ -1042,7 +1007,6 @@ func TestNetworkPolicyDefaults(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.8.10")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyAzure
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != NetworkPluginAzure {
@@ -1056,7 +1020,6 @@ func TestNetworkPolicyDefaults(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.8.10")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyNone
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != NetworkPluginKubenet {
@@ -1072,7 +1035,6 @@ func TestNetworkPolicyDefaults(t *testing.T) {
 func TestNetworkPluginDefaults(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.15.7")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != DefaultNetworkPlugin {
 		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
@@ -1081,7 +1043,6 @@ func TestNetworkPluginDefaults(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.15.7")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.Addons = []KubernetesAddon{
 		{
 			Name:    common.FlannelAddonName,
@@ -1096,7 +1057,6 @@ func TestNetworkPluginDefaults(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.19.2")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.NetworkMode != NetworkModeTransparent {
@@ -1108,7 +1068,6 @@ func TestNetworkPluginDefaults(t *testing.T) {
 func TestKubernetesImageBaseAppendSlash(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.15.7")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com"
 	mockCS.setOrchestratorDefaults(true, true)
 	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != "mcr.microsoft.com/" {
@@ -1122,7 +1081,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig := mockCS.GetCloudSpecConfig()
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(false, false)
 	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase {
 		t.Fatalf("defaults flow did assign the expected KubernetesImageBase value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase, cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase)
@@ -1136,7 +1094,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "chinanorth"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(false, false)
 	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase {
 		t.Fatalf("defaults flow did assign the expected KubernetesImageBase value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase, cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase)
@@ -1150,7 +1107,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "my-custom-gcr/"
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
 	mockCS.setOrchestratorDefaults(false, false)
@@ -1166,7 +1122,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "my-custom-mcr/"
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeMCR
 	mockCS.setOrchestratorDefaults(false, false)
@@ -1182,7 +1137,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(true, false)
 	if properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase != cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase {
 		t.Fatalf("defaults flow did assign the expected KubernetesImageBase value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase, cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase)
@@ -1196,7 +1150,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
 	mockCS.setOrchestratorDefaults(true, false)
@@ -1212,7 +1165,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = ""
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = ""
 	mockCS.setOrchestratorDefaults(true, false)
@@ -1228,7 +1180,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = ""
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
 	mockCS.setOrchestratorDefaults(true, false)
@@ -1244,7 +1195,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "k8s.gcr.io/"
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = ""
 	mockCS.setOrchestratorDefaults(true, false)
@@ -1260,7 +1210,6 @@ func TestKubernetesImageBase(t *testing.T) {
 	mockCS.Location = "westus2"
 	cloudSpecConfig = mockCS.GetCloudSpecConfig()
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "my-custom-gcr/"
 	properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
 	mockCS.setOrchestratorDefaults(true, false)
@@ -1276,7 +1225,6 @@ func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 	genMockCS := func() ContainerService {
 		mockCS := getMockBaseContainerService("1.15.7")
 		properties := mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBase = "mcr.microsoft.com/k8s/azurestack/core/"
 		properties.OrchestratorProfile.KubernetesConfig.KubernetesImageBaseType = common.KubernetesImageBaseTypeGCR
 		properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase = "mcr.microsoft.com/k8s/core/"
@@ -1327,7 +1275,6 @@ func TestContainerRuntime(t *testing.T) {
 	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10", "19.03.11", "19.03.12"} {
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
 		mockCS.setOrchestratorDefaults(true, true)
 		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Docker {
@@ -1349,7 +1296,6 @@ func TestContainerRuntime(t *testing.T) {
 
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
 		mockCS.setOrchestratorDefaults(false, false)
 		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Docker {
@@ -1372,7 +1318,6 @@ func TestContainerRuntime(t *testing.T) {
 
 	mockCS := getMockBaseContainerService("1.10.13")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(false, false)
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Docker {
 		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
@@ -1393,7 +1338,6 @@ func TestContainerRuntime(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.10.13")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
 	mockCS.setOrchestratorDefaults(false, false)
 	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != Containerd {
@@ -1413,7 +1357,6 @@ func TestContainerRuntime(t *testing.T) {
 
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
 		properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = containerdVersion
 		mockCS.setOrchestratorDefaults(true, true)
@@ -1432,7 +1375,6 @@ func TestContainerRuntime(t *testing.T) {
 
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = Containerd
 		properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = containerdVersion
 		mockCS.setOrchestratorDefaults(false, false)
@@ -1458,7 +1400,6 @@ func TestEtcdVersion(t *testing.T) {
 		// This sort of artificial (upgrade scenario should always have value), but strictly speaking this is what we want to do
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(true, false)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != DefaultEtcdVersion {
@@ -1469,7 +1410,6 @@ func TestEtcdVersion(t *testing.T) {
 		// Create scenario should always accept the provided value
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(false, false)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != DefaultEtcdVersion {
@@ -1481,7 +1421,6 @@ func TestEtcdVersion(t *testing.T) {
 		// This sort of artificial (upgrade scenario should always have value), but strictly speaking this is what we want to do
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(false, true)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != DefaultEtcdVersion {
@@ -1495,7 +1434,6 @@ func TestEtcdVersion(t *testing.T) {
 		// Upgrade scenario should always upgrade to newer, default etcd version
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(true, false)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != DefaultEtcdVersion {
@@ -1506,7 +1444,6 @@ func TestEtcdVersion(t *testing.T) {
 		// Create scenario should always accept the provided value
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(false, false)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
@@ -1517,7 +1454,6 @@ func TestEtcdVersion(t *testing.T) {
 		// Scale scenario should always accept the provided value
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(false, true)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
@@ -1531,7 +1467,6 @@ func TestEtcdVersion(t *testing.T) {
 		// Upgrade scenario should always keep the user-configured etcd version if it is greater than default
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(true, false)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
@@ -1542,7 +1477,6 @@ func TestEtcdVersion(t *testing.T) {
 		// Create scenario should always accept the provided value
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(false, false)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
@@ -1553,7 +1487,6 @@ func TestEtcdVersion(t *testing.T) {
 		// Scale scenario should always accept the provided value
 		mockCS = getMockBaseContainerService("1.10.13")
 		properties = mockCS.Properties
-		properties.OrchestratorProfile.OrchestratorType = Kubernetes
 		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
 		mockCS.setOrchestratorDefaults(false, true)
 		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
@@ -1567,7 +1500,6 @@ func TestStorageProfile(t *testing.T) {
 	// Test ManagedDisks default configuration
 	mockCS := getMockBaseContainerService("1.13.12")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.OrchestratorProfile.KubernetesConfig.PrivateCluster = &PrivateCluster{
 		Enabled:                to.BoolPtr(true),
@@ -1610,7 +1542,6 @@ func TestStorageProfile(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.13.12")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -1632,11 +1563,11 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default masterProfile configuration
 	mockCS := getMockBaseContainerService("1.13.12")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
 	properties.MasterProfile.AvailabilityProfile = ""
 	properties.MasterProfile.Count = 3
+	properties.CertificateProfile = &CertificateProfile{}
 	mockCS.Properties = properties
 	_, err := mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -1674,7 +1605,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default VMSS masterProfile configuration
 	mockCS = getMockBaseContainerService("1.13.12")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
 	properties.MasterProfile.AvailabilityProfile = VirtualMachineScaleSets
@@ -1710,7 +1640,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default masterProfile configuration and kubenet
 	mockCS = getMockBaseContainerService("1.13.12")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
 	properties.MasterProfile.AvailabilityProfile = VirtualMachineScaleSets
@@ -1755,7 +1684,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default vmas masterProfile configuration, AzureCNI, and custom vnet
 	mockCS = getMockBaseContainerService("1.10.3")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.VnetSubnetID = "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/ExampleCustomVNET/subnets/ExampleMasterSubnet"
 	properties.MasterProfile.VnetCidr = "10.239.0.0/16"
 	properties.MasterProfile.FirstConsecutiveStaticIP = "10.239.255.239"
@@ -1779,7 +1707,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default VMSS masterProfile configuration, AzureCNI, and custom VNET
 	mockCS = getMockBaseContainerService("1.10.3")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.VnetSubnetID = "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/ExampleCustomVNET/subnets/ExampleMasterSubnet"
 	properties.MasterProfile.VnetCidr = "10.239.0.0/16"
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
@@ -1801,7 +1728,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default configurations for LoadBalancerSku and ExcludeMasterFromStandardLB
 	mockCS = getMockBaseContainerService("1.13.12")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -1820,7 +1746,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default configurations for MaximumLoadBalancerRuleCount.
 	mockCS = getMockBaseContainerService("1.13.12")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -1837,7 +1762,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for dual stack feature with 1.16
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -1856,7 +1780,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for dual stack feature in 1.16 when only ipv4 subnet provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -1875,7 +1798,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for dual stack feature.
 	mockCS = getMockBaseContainerService("1.17.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -1894,7 +1816,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for dual stack feature when only ipv4 subnet provided
 	mockCS = getMockBaseContainerService("1.17.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "10.244.0.0/16"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -1914,7 +1835,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for dual stack feature when only ipv6 subnet provided
 	mockCS = getMockBaseContainerService("1.17.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "ace:cab:deca::/8"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -1934,7 +1854,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for azure cni dual stack feature.
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -1954,7 +1873,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for azure cni dual stack feature when only ipv4 subnet provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "10.240.1.0/24"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
@@ -1975,7 +1893,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for azure cni dual stack feature when only ipv6 subnet provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "ace:cab:deca::/8"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
@@ -1996,7 +1913,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for azure cni dual stack feature when both ipv4 and ipv6 subnet provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "10.240.1.0/24,ace:cab:deca::/8"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
@@ -2017,7 +1933,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for azure cni dual stack feature for k8s 1.17 version
 	mockCS = getMockBaseContainerService("1.17.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -2037,7 +1952,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates service cidr default configuration for dual stack feature when both ipv4 and ipv6 subnet provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.OrchestratorProfile.KubernetesConfig.ServiceCIDR = "192.168.0.0/16,ace:cab:deca::/8"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
@@ -2058,7 +1972,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates service cidr default configuration for dual stack feature when ipv4 provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.OrchestratorProfile.KubernetesConfig.ServiceCIDR = "192.168.0.0/16"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
@@ -2079,7 +1992,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates service cidr default configuration for dual stack feature when ipv6 provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.OrchestratorProfile.KubernetesConfig.ServiceCIDR = "ace:cab:deca::/8"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
@@ -2100,7 +2012,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates service cidr default configuration for dual stack feature when servicecidr not provided
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = "azure"
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -2120,7 +2031,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates default configurations for OutboundRuleIdleTimeoutInMinutes.
 	mockCS = getMockBaseContainerService("1.18.2")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = StandardLoadBalancerSku
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -2138,7 +2048,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 	// this validates cluster subnet default configuration for single stack IPv6 only cluster
 	mockCS = getMockBaseContainerService("1.18.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.FeatureFlags = &FeatureFlags{EnableIPv6Only: true}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -2165,7 +2074,6 @@ func TestMasterProfileDefaults(t *testing.T) {
 func TestAgentPoolProfile(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	_, err := mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -3004,7 +2912,6 @@ func TestWindowsProfileDefaults(t *testing.T) {
 func TestIsAzureCNINetworkmonitorAddon(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.OrchestratorProfile.KubernetesConfig.Addons = []KubernetesAddon{
 		{
@@ -3030,7 +2937,6 @@ func TestIsAzureCNINetworkmonitorAddon(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.10.3")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
 	mockCS.setOrchestratorDefaults(true, true)
@@ -3046,7 +2952,6 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 	// masters with VMSS and no zones
 	mockCS := getMockBaseContainerService("1.12.0")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.AvailabilityProfile = VirtualMachineScaleSets
 	_, err := mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -3067,7 +2972,6 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 	// masters with VMSS and zones
 	mockCS = getMockBaseContainerService("1.12.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.AvailabilityProfile = VirtualMachineScaleSets
 	properties.MasterProfile.AvailabilityZones = []string{"1", "2"}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -3099,7 +3003,6 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 	// agents with VMSS and no zones
 	mockCS = getMockBaseContainerService("1.12.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.AgentPoolProfiles[0].Count = 4
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -3120,7 +3023,6 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 	// agents with VMSS and Standard LB (default) should have SinglePlacementGroup set to false
 	mockCS = getMockBaseContainerService("1.12.0")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.AgentPoolProfiles[0].Count = 4
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
 		IsScale:    false,
@@ -3143,7 +3045,6 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 	// agents with VMSS and zones
 	mockCS = getMockBaseContainerService("1.13.12")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.AgentPoolProfiles[0].Count = 4
 	properties.AgentPoolProfiles[0].AvailabilityZones = []string{"1", "2"}
 	_, err = mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
@@ -3201,7 +3102,6 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 func TestAzureCNIVersionString(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
 	mockCS.setOrchestratorDefaults(true, true)
@@ -3212,7 +3112,6 @@ func TestAzureCNIVersionString(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.10.3")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.AgentPoolProfiles[0].OSType = Windows
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginAzure
@@ -3224,7 +3123,6 @@ func TestAzureCNIVersionString(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.10.3")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
 	mockCS.setOrchestratorDefaults(true, true)
@@ -3237,7 +3135,6 @@ func TestAzureCNIVersionString(t *testing.T) {
 func TestEnableAggregatedAPIs(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(false)
 	mockCS.setOrchestratorDefaults(true, true)
 
@@ -3248,7 +3145,6 @@ func TestEnableAggregatedAPIs(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.10.3")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(true)
 	mockCS.setOrchestratorDefaults(true, true)
 
@@ -3277,7 +3173,6 @@ func TestCloudControllerManagerEnabled(t *testing.T) {
 func TestDefaultCloudProvider(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.10.3")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(true, true)
 
 	if to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff) {
@@ -3292,7 +3187,6 @@ func TestDefaultCloudProvider(t *testing.T) {
 
 	mockCS = getMockBaseContainerService("1.10.3")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff = to.BoolPtr(false)
 	properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimit = to.BoolPtr(false)
 	mockCS.setOrchestratorDefaults(true, true)
@@ -3548,7 +3442,6 @@ func TestProxyModeDefaults(t *testing.T) {
 	// Test that default is what we expect
 	mockCS := getMockBaseContainerService("1.10.12")
 	properties := mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.MasterProfile.Count = 1
 	mockCS.setOrchestratorDefaults(true, true)
 
@@ -3559,7 +3452,6 @@ func TestProxyModeDefaults(t *testing.T) {
 	// Test that default assignment flow doesn't overwrite a user-provided config
 	mockCS = getMockBaseContainerService("1.10.12")
 	properties = mockCS.Properties
-	properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ProxyMode = KubeProxyModeIPVS
 	properties.MasterProfile.Count = 1
 	mockCS.setOrchestratorDefaults(true, true)
@@ -4183,9 +4075,8 @@ func TestSetAgentProfileDefaultsOnAzureStack(t *testing.T) {
 func TestEtcdDiskSizeOnAzureStack(t *testing.T) {
 	location := "testlocation"
 	mockCS := getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CertificateProfile = &CertificateProfile{}
 	mockCS.Location = location
-	mockCS.Properties.MasterProfile.Count = 1
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
 		PortalURL: "https://portal.testlocation.contoso.com",
 	}
@@ -4214,8 +4105,8 @@ func TestEtcdDiskSizeOnAzureStack(t *testing.T) {
 
 	// Case where total node count is 5.
 	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CertificateProfile = &CertificateProfile{}
 	mockCS.Location = location
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.MasterProfile.Count = 5
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
 		PortalURL: "https://portal.testlocation.contoso.com",
@@ -4245,8 +4136,8 @@ func TestEtcdDiskSizeOnAzureStack(t *testing.T) {
 
 	// Case where total node count is 11.
 	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CertificateProfile = &CertificateProfile{}
 	mockCS.Location = location
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.MasterProfile.Count = 5
 	mockCS.Properties.AgentPoolProfiles[0].Count = 6
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -4277,8 +4168,8 @@ func TestEtcdDiskSizeOnAzureStack(t *testing.T) {
 
 	// Case where total node count is 21.
 	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CertificateProfile = &CertificateProfile{}
 	mockCS.Location = location
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.MasterProfile.Count = 5
 	mockCS.Properties.AgentPoolProfiles[0].Count = 16
 	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
@@ -4309,8 +4200,8 @@ func TestEtcdDiskSizeOnAzureStack(t *testing.T) {
 
 	// Case where total node count is 55 but EtcdDiskSizeGB size is passed
 	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CertificateProfile = &CertificateProfile{}
 	mockCS.Location = location
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.Properties.MasterProfile.Count = 5
 	mockCS.Properties.AgentPoolProfiles[0].Count = 50
 	customEtcdDiskSize := "512"
@@ -4439,16 +4330,36 @@ func getMockAPIProperties(orchestratorVersion string) Properties {
 	return Properties{
 		ProvisioningState: "",
 		OrchestratorProfile: &OrchestratorProfile{
+			OrchestratorType:    Kubernetes,
 			OrchestratorVersion: orchestratorVersion,
 			KubernetesConfig:    &KubernetesConfig{},
 		},
-		MasterProfile: &MasterProfile{},
+		MasterProfile: &MasterProfile{
+			Count: 1,
+		},
 		AgentPoolProfiles: []*AgentPoolProfile{
 			{},
 			{},
 			{},
 			{},
-		}}
+		},
+		CertificateProfile: &CertificateProfile{
+			APIServerCertificate:  "a",
+			APIServerPrivateKey:   "b",
+			CaCertificate:         "c",
+			CaPrivateKey:          "d",
+			ClientCertificate:     "e",
+			ClientPrivateKey:      "f",
+			KubeConfigCertificate: "g",
+			KubeConfigPrivateKey:  "h",
+			EtcdClientCertificate: "i",
+			EtcdClientPrivateKey:  "j",
+			EtcdServerCertificate: "k",
+			EtcdServerPrivateKey:  "l",
+			EtcdPeerCertificates:  []string{"0"},
+			EtcdPeerPrivateKeys:   []string{"0"},
+		},
+	}
 }
 
 func getKubernetesConfigWithFeatureGates(featureGates string) *KubernetesConfig {
@@ -5703,15 +5614,12 @@ func ExampleContainerService_setOrchestratorDefaults() {
 	})
 
 	mockCS := getMockBaseContainerService("1.19.2")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(true, false)
 
 	mockCS = getMockBaseContainerService("1.19.2")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(false, true)
 
 	mockCS = getMockBaseContainerService("1.19.2")
-	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
 	mockCS.setOrchestratorDefaults(false, false)
 
 	// Output:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -272,6 +272,7 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
+	// OrchestratorType is a legacy property, this should always be set to "Kubernetes"
 	OrchestratorType    string            `json:"orchestratorType"`
 	OrchestratorVersion string            `json:"orchestratorVersion"`
 	KubernetesConfig    *KubernetesConfig `json:"kubernetesConfig,omitempty"`
@@ -934,13 +935,10 @@ func (p *Properties) HasVMSSAgentPool() bool {
 
 // K8sOrchestratorName returns the 3 character orchestrator code for kubernetes-based clusters.
 func (p *Properties) K8sOrchestratorName() string {
-	if p.OrchestratorProfile.IsKubernetes() {
-		if p.HostedMasterProfile != nil {
-			return DefaultHostedProfileMasterName
-		}
-		return DefaultOrchestratorName
+	if p.HostedMasterProfile != nil {
+		return DefaultHostedProfileMasterName
 	}
-	return ""
+	return DefaultOrchestratorName
 }
 
 // GetAgentPoolByName returns the pool in the AgentPoolProfiles array that matches a name, nil if no match
@@ -1893,11 +1891,6 @@ func (l *LinuxProfile) HasCustomNodesDNS() bool {
 	return false
 }
 
-// IsKubernetes returns true if this template is for Kubernetes orchestrator
-func (o *OrchestratorProfile) IsKubernetes() bool {
-	return o.OrchestratorType == Kubernetes
-}
-
 // IsAzureCNI returns true if Azure CNI network plugin is enabled
 func (o *OrchestratorProfile) IsAzureCNI() bool {
 	if o.KubernetesConfig != nil {
@@ -1908,17 +1901,11 @@ func (o *OrchestratorProfile) IsAzureCNI() bool {
 
 // IsPrivateCluster returns true if this deployment is a private cluster
 func (o *OrchestratorProfile) IsPrivateCluster() bool {
-	if !o.IsKubernetes() {
-		return false
-	}
 	return o.KubernetesConfig != nil && o.KubernetesConfig.PrivateCluster != nil && to.Bool(o.KubernetesConfig.PrivateCluster.Enabled)
 }
 
 // IsHostsConfigAgentEnabled returns true if hosts config agent is enabled
 func (o *OrchestratorProfile) IsHostsConfigAgentEnabled() bool {
-	if !o.IsKubernetes() {
-		return false
-	}
 	return o.KubernetesConfig != nil && o.KubernetesConfig.PrivateCluster != nil && to.Bool(o.KubernetesConfig.PrivateCluster.EnableHostsConfigAgent)
 }
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -3444,28 +3444,6 @@ func TestIsHostsConfigAgentEnabled(t *testing.T) {
 	}
 }
 
-func TestOrchestrator(t *testing.T) {
-	cases := []struct {
-		p                    Properties
-		expectedIsKubernetes bool
-	}{
-		{
-			p: Properties{
-				OrchestratorProfile: &OrchestratorProfile{
-					OrchestratorType: Kubernetes,
-				},
-			},
-			expectedIsKubernetes: true,
-		},
-	}
-
-	for _, c := range cases {
-		if c.expectedIsKubernetes != c.p.OrchestratorProfile.IsKubernetes() {
-			t.Fatalf("Expected IsKubernetes() to be %t with OrchestratorType=%s", c.expectedIsKubernetes, c.p.OrchestratorProfile.OrchestratorType)
-		}
-	}
-}
-
 func TestWindowsProfile(t *testing.T) {
 	trueVar := true
 	w := WindowsProfile{}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -187,210 +187,196 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 	o := a.OrchestratorProfile
 	// On updates we only need to make sure there is a supported patch version for the minor version
 	if !isUpdate {
-		switch o.OrchestratorType {
-		case Kubernetes:
-			version := common.RationalizeReleaseAndVersion(
-				o.OrchestratorType,
-				o.OrchestratorRelease,
-				o.OrchestratorVersion,
-				isUpdate,
-				a.HasWindows(),
-				a.IsAzureStackCloud())
-			if a.IsAzureStackCloud() {
-				if version == "" && a.HasWindows() {
-					return errors.Errorf("the following OrchestratorProfile configuration is not supported on Azure Stack with OsType \"Windows\": OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, true, true))
-				} else if version == "" {
-					return errors.Errorf("the following OrchestratorProfile configuration is not supported on Azure Stack: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, false, true))
-				}
-			} else {
-				if version == "" && a.HasWindows() {
-					return errors.Errorf("the following OrchestratorProfile configuration is not supported with OsType \"Windows\": OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, true, false))
-				} else if version == "" {
-					return errors.Errorf("the following OrchestratorProfile configuration is not supported: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, false, false))
-				}
+		version := common.RationalizeReleaseAndVersion(
+			o.OrchestratorType,
+			o.OrchestratorRelease,
+			o.OrchestratorVersion,
+			isUpdate,
+			a.HasWindows(),
+			a.IsAzureStackCloud())
+		if a.IsAzureStackCloud() {
+			if version == "" && a.HasWindows() {
+				return errors.Errorf("the following OrchestratorProfile configuration is not supported on Azure Stack with OsType \"Windows\": OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, true, true))
+			} else if version == "" {
+				return errors.Errorf("the following OrchestratorProfile configuration is not supported on Azure Stack: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, false, true))
 			}
+		} else {
+			if version == "" && a.HasWindows() {
+				return errors.Errorf("the following OrchestratorProfile configuration is not supported with OsType \"Windows\": OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, true, false))
+			} else if version == "" {
+				return errors.Errorf("the following OrchestratorProfile configuration is not supported: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please use one of the following versions: %v", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion, common.GetAllSupportedKubernetesVersions(false, false, false))
+			}
+		}
 
-			sv, err := semver.Make(version)
+		sv, err := semver.Make(version)
+		if err != nil {
+			return errors.Errorf("could not validate version %s", version)
+		}
+
+		if a.HasAvailabilityZones() {
+			minVersion, err := semver.Make("1.12.0")
 			if err != nil {
-				return errors.Errorf("could not validate version %s", version)
+				return errors.New("could not validate version")
 			}
 
-			if a.HasAvailabilityZones() {
-				minVersion, err := semver.Make("1.12.0")
-				if err != nil {
-					return errors.New("could not validate version")
-				}
+			if sv.LT(minVersion) {
+				return errors.New("availabilityZone is only available in Kubernetes version 1.12 or greater")
+			}
+		}
 
+		if o.KubernetesConfig != nil {
+			err := o.KubernetesConfig.Validate(version, a.HasWindows(), a.FeatureFlags.IsIPv6DualStackEnabled(), a.FeatureFlags.IsIPv6OnlyEnabled())
+			if err != nil {
+				return err
+			}
+			minVersion, err := semver.Make("1.7.0")
+			if err != nil {
+				return errors.New("could not validate version")
+			}
+
+			if o.KubernetesConfig.EnableAggregatedAPIs {
+				if !o.KubernetesConfig.IsRBACEnabled() {
+					return errors.New("enableAggregatedAPIs requires the enableRbac feature as a prerequisite")
+				}
+			}
+
+			if to.Bool(o.KubernetesConfig.EnableDataEncryptionAtRest) {
 				if sv.LT(minVersion) {
-					return errors.New("availabilityZone is only available in Kubernetes version 1.12 or greater")
+					return errors.Errorf("enableDataEncryptionAtRest is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
+						minVersion.String(), o.OrchestratorVersion)
+				}
+				if o.KubernetesConfig.EtcdEncryptionKey != "" {
+					_, err = base64.StdEncoding.DecodeString(o.KubernetesConfig.EtcdEncryptionKey)
+					if err != nil {
+						return errors.New("etcdEncryptionKey must be base64 encoded. Please provide a valid base64 encoded value or leave the etcdEncryptionKey empty to auto-generate the value")
+					}
 				}
 			}
 
-			if o.KubernetesConfig != nil {
-				err := o.KubernetesConfig.Validate(version, a.HasWindows(), a.FeatureFlags.IsIPv6DualStackEnabled(), a.FeatureFlags.IsIPv6OnlyEnabled())
+			if to.Bool(o.KubernetesConfig.EnableEncryptionWithExternalKms) {
+				minVersion, err := semver.Make("1.10.0")
 				if err != nil {
-					return err
+					return errors.Errorf("could not validate version")
 				}
-				minVersion, err := semver.Make("1.7.0")
+				if sv.LT(minVersion) {
+					return errors.Errorf("enableEncryptionWithExternalKms is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
+						minVersion.String(), o.OrchestratorVersion)
+				}
+			}
+
+			if o.KubernetesConfig.EnableRbac != nil && !o.KubernetesConfig.IsRBACEnabled() {
+				minVersionNotAllowed, err := semver.Make("1.15.0")
 				if err != nil {
-					return errors.New("could not validate version")
+					return errors.Errorf("could not validate version")
 				}
-
-				if o.KubernetesConfig.EnableAggregatedAPIs {
-					if !o.KubernetesConfig.IsRBACEnabled() {
-						return errors.New("enableAggregatedAPIs requires the enableRbac feature as a prerequisite")
-					}
+				if !sv.LT(minVersionNotAllowed) {
+					return errors.Errorf("RBAC support is required for Kubernetes version %s or greater; unable to build Kubernetes v%s cluster with enableRbac=false",
+						minVersionNotAllowed.String(), o.OrchestratorVersion)
 				}
+			}
 
-				if to.Bool(o.KubernetesConfig.EnableDataEncryptionAtRest) {
-					if sv.LT(minVersion) {
-						return errors.Errorf("enableDataEncryptionAtRest is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
-							minVersion.String(), o.OrchestratorVersion)
-					}
-					if o.KubernetesConfig.EtcdEncryptionKey != "" {
-						_, err = base64.StdEncoding.DecodeString(o.KubernetesConfig.EtcdEncryptionKey)
-						if err != nil {
-							return errors.New("etcdEncryptionKey must be base64 encoded. Please provide a valid base64 encoded value or leave the etcdEncryptionKey empty to auto-generate the value")
-						}
-					}
+			if to.Bool(o.KubernetesConfig.EnablePodSecurityPolicy) {
+				log.Warnf("EnablePodSecurityPolicy is deprecated in favor of the addon pod-security-policy.")
+				if !o.KubernetesConfig.IsRBACEnabled() {
+					return errors.Errorf("enablePodSecurityPolicy requires the enableRbac feature as a prerequisite")
 				}
-
-				if to.Bool(o.KubernetesConfig.EnableEncryptionWithExternalKms) {
-					minVersion, err := semver.Make("1.10.0")
-					if err != nil {
-						return errors.Errorf("could not validate version")
-					}
-					if sv.LT(minVersion) {
-						return errors.Errorf("enableEncryptionWithExternalKms is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
-							minVersion.String(), o.OrchestratorVersion)
-					}
+				if len(o.KubernetesConfig.PodSecurityPolicyConfig) > 0 {
+					log.Warnf("Raw manifest for PodSecurityPolicy using PodSecurityPolicyConfig is deprecated in favor of the addon pod-security-policy. This will be ignored.")
 				}
+			}
 
-				if o.KubernetesConfig.EnableRbac != nil && !o.KubernetesConfig.IsRBACEnabled() {
-					minVersionNotAllowed, err := semver.Make("1.15.0")
-					if err != nil {
-						return errors.Errorf("could not validate version")
-					}
-					if !sv.LT(minVersionNotAllowed) {
-						return errors.Errorf("RBAC support is required for Kubernetes version %s or greater; unable to build Kubernetes v%s cluster with enableRbac=false",
-							minVersionNotAllowed.String(), o.OrchestratorVersion)
-					}
+			if o.KubernetesConfig.LoadBalancerSku != "" {
+				if !strings.EqualFold(o.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) && !strings.EqualFold(o.KubernetesConfig.LoadBalancerSku, BasicLoadBalancerSku) {
+					return errors.Errorf("Invalid value for loadBalancerSku, only %s and %s are supported", StandardLoadBalancerSku, BasicLoadBalancerSku)
 				}
+			}
 
-				if to.Bool(o.KubernetesConfig.EnablePodSecurityPolicy) {
-					log.Warnf("EnablePodSecurityPolicy is deprecated in favor of the addon pod-security-policy.")
-					if !o.KubernetesConfig.IsRBACEnabled() {
-						return errors.Errorf("enablePodSecurityPolicy requires the enableRbac feature as a prerequisite")
-					}
-					if len(o.KubernetesConfig.PodSecurityPolicyConfig) > 0 {
-						log.Warnf("Raw manifest for PodSecurityPolicy using PodSecurityPolicyConfig is deprecated in favor of the addon pod-security-policy. This will be ignored.")
-					}
+			if o.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku {
+				minVersion, err := semver.Make("1.11.0")
+				if err != nil {
+					return errors.Errorf("could not validate version")
 				}
-
-				if o.KubernetesConfig.LoadBalancerSku != "" {
-					if !strings.EqualFold(o.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) && !strings.EqualFold(o.KubernetesConfig.LoadBalancerSku, BasicLoadBalancerSku) {
-						return errors.Errorf("Invalid value for loadBalancerSku, only %s and %s are supported", StandardLoadBalancerSku, BasicLoadBalancerSku)
-					}
+				if sv.LT(minVersion) {
+					return errors.Errorf("loadBalancerSku is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
+						minVersion.String(), o.OrchestratorVersion)
 				}
-
-				if o.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku {
-					minVersion, err := semver.Make("1.11.0")
-					if err != nil {
-						return errors.Errorf("could not validate version")
-					}
-					if sv.LT(minVersion) {
-						return errors.Errorf("loadBalancerSku is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
-							minVersion.String(), o.OrchestratorVersion)
-					}
-					if !to.Bool(a.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB) {
-						return errors.Errorf("standard loadBalancerSku should exclude master nodes. Please set KubernetesConfig \"ExcludeMasterFromStandardLB\" to \"true\"")
-					}
+				if !to.Bool(a.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB) {
+					return errors.Errorf("standard loadBalancerSku should exclude master nodes. Please set KubernetesConfig \"ExcludeMasterFromStandardLB\" to \"true\"")
 				}
+			}
 
-				if o.KubernetesConfig.LoadBalancerSku == BasicLoadBalancerSku {
-					if o.KubernetesConfig.LoadBalancerOutboundIPs != nil {
-						return errors.Errorf("kubernetesConfig.loadBalancerOutboundIPs configuration only supported for Standard loadBalancerSku=Standard")
-					}
-				}
-
-				if o.KubernetesConfig.DockerEngineVersion != "" {
-					log.Warnf("docker-engine is deprecated in favor of moby, but you passed in a dockerEngineVersion configuration. This will be ignored.")
-				}
-
-				if o.KubernetesConfig.MaximumLoadBalancerRuleCount < 0 {
-					return errors.New("maximumLoadBalancerRuleCount shouldn't be less than 0")
-				}
-
+			if o.KubernetesConfig.LoadBalancerSku == BasicLoadBalancerSku {
 				if o.KubernetesConfig.LoadBalancerOutboundIPs != nil {
-					if to.Int(o.KubernetesConfig.LoadBalancerOutboundIPs) > common.MaxLoadBalancerOutboundIPs {
-						return errors.Errorf("kubernetesConfig.loadBalancerOutboundIPs was set to %d, the maximum allowed is %d", to.Int(o.KubernetesConfig.LoadBalancerOutboundIPs), common.MaxLoadBalancerOutboundIPs)
-					}
+					return errors.Errorf("kubernetesConfig.loadBalancerOutboundIPs configuration only supported for Standard loadBalancerSku=Standard")
+				}
+			}
+
+			if o.KubernetesConfig.DockerEngineVersion != "" {
+				log.Warnf("docker-engine is deprecated in favor of moby, but you passed in a dockerEngineVersion configuration. This will be ignored.")
+			}
+
+			if o.KubernetesConfig.MaximumLoadBalancerRuleCount < 0 {
+				return errors.New("maximumLoadBalancerRuleCount shouldn't be less than 0")
+			}
+
+			if o.KubernetesConfig.LoadBalancerOutboundIPs != nil {
+				if to.Int(o.KubernetesConfig.LoadBalancerOutboundIPs) > common.MaxLoadBalancerOutboundIPs {
+					return errors.Errorf("kubernetesConfig.loadBalancerOutboundIPs was set to %d, the maximum allowed is %d", to.Int(o.KubernetesConfig.LoadBalancerOutboundIPs), common.MaxLoadBalancerOutboundIPs)
+				}
+			}
+
+			// https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-rules-overview
+			if o.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku && o.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes != 0 && (o.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes < 4 || o.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes > 120) {
+				return errors.New("outboundRuleIdleTimeoutInMinutes shouldn't be less than 4 or greater than 120")
+			}
+
+			if a.IsAzureStackCloud() {
+				if to.Bool(o.KubernetesConfig.UseInstanceMetadata) {
+					return errors.New("useInstanceMetadata shouldn't be set to true as feature not yet supported on Azure Stack")
 				}
 
-				// https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-rules-overview
-				if o.KubernetesConfig.LoadBalancerSku == StandardLoadBalancerSku && o.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes != 0 && (o.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes < 4 || o.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes > 120) {
-					return errors.New("outboundRuleIdleTimeoutInMinutes shouldn't be less than 4 or greater than 120")
-				}
-
-				if a.IsAzureStackCloud() {
-					if to.Bool(o.KubernetesConfig.UseInstanceMetadata) {
-						return errors.New("useInstanceMetadata shouldn't be set to true as feature not yet supported on Azure Stack")
+				if o.KubernetesConfig.EtcdDiskSizeGB != "" {
+					etcdDiskSizeGB, err := strconv.Atoi(o.KubernetesConfig.EtcdDiskSizeGB)
+					if err != nil {
+						return errors.Errorf("could not convert EtcdDiskSizeGB to int")
 					}
-
-					if o.KubernetesConfig.EtcdDiskSizeGB != "" {
-						etcdDiskSizeGB, err := strconv.Atoi(o.KubernetesConfig.EtcdDiskSizeGB)
-						if err != nil {
-							return errors.Errorf("could not convert EtcdDiskSizeGB to int")
-						}
-						if etcdDiskSizeGB > MaxAzureStackManagedDiskSize {
-							return errors.Errorf("EtcdDiskSizeGB max size supported on Azure Stack is %d", MaxAzureStackManagedDiskSize)
-						}
-					}
-				}
-
-				if o.KubernetesConfig.EtcdStorageLimitGB != 0 {
-					if o.KubernetesConfig.EtcdStorageLimitGB > 8 {
-						log.Warnf("EtcdStorageLimitGB of %d is larger than the recommended maximum of 8", o.KubernetesConfig.EtcdStorageLimitGB)
-					}
-					if o.KubernetesConfig.EtcdStorageLimitGB < 2 {
-						return errors.Errorf("EtcdStorageLimitGB value of %d is too small, the minimum allowed is 2", o.KubernetesConfig.EtcdStorageLimitGB)
+					if etcdDiskSizeGB > MaxAzureStackManagedDiskSize {
+						return errors.Errorf("EtcdDiskSizeGB max size supported on Azure Stack is %d", MaxAzureStackManagedDiskSize)
 					}
 				}
 			}
-		default:
-			return errors.Errorf("OrchestratorProfile has unknown orchestrator: %s", o.OrchestratorType)
+
+			if o.KubernetesConfig.EtcdStorageLimitGB != 0 {
+				if o.KubernetesConfig.EtcdStorageLimitGB > 8 {
+					log.Warnf("EtcdStorageLimitGB of %d is larger than the recommended maximum of 8", o.KubernetesConfig.EtcdStorageLimitGB)
+				}
+				if o.KubernetesConfig.EtcdStorageLimitGB < 2 {
+					return errors.Errorf("EtcdStorageLimitGB value of %d is too small, the minimum allowed is 2", o.KubernetesConfig.EtcdStorageLimitGB)
+				}
+			}
 		}
 	} else {
-		switch o.OrchestratorType {
-		case Kubernetes:
-
-			version := common.RationalizeReleaseAndVersion(
-				o.OrchestratorType,
-				o.OrchestratorRelease,
-				o.OrchestratorVersion,
-				false,
-				a.HasWindows(),
-				a.IsAzureStackCloud())
-			if version == "" {
-				patchVersion := common.GetValidPatchVersion(o.OrchestratorType, o.OrchestratorVersion, isUpdate, a.HasWindows(), a.IsAzureStackCloud())
-				// if there isn't a supported patch version for this version fail
-				if patchVersion == "" {
-					if a.HasWindows() {
-						return errors.Errorf("the following OrchestratorProfile configuration is not supported with Windows agentpools: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please check supported Release or Version for this build of aks-engine", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion)
-					}
-					return errors.Errorf("the following OrchestratorProfile configuration is not supported: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please check supported Release or Version for this build of aks-engine", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion)
+		version := common.RationalizeReleaseAndVersion(
+			o.OrchestratorType,
+			o.OrchestratorRelease,
+			o.OrchestratorVersion,
+			false,
+			a.HasWindows(),
+			a.IsAzureStackCloud())
+		if version == "" {
+			patchVersion := common.GetValidPatchVersion(o.OrchestratorType, o.OrchestratorVersion, isUpdate, a.HasWindows(), a.IsAzureStackCloud())
+			// if there isn't a supported patch version for this version fail
+			if patchVersion == "" {
+				if a.HasWindows() {
+					return errors.Errorf("the following OrchestratorProfile configuration is not supported with Windows agentpools: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please check supported Release or Version for this build of aks-engine", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion)
 				}
+				return errors.Errorf("the following OrchestratorProfile configuration is not supported: OrchestratorType: \"%s\", OrchestratorRelease: \"%s\", OrchestratorVersion: \"%s\". Please check supported Release or Version for this build of aks-engine", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion)
 			}
-
 		}
 	}
 
 	if a.HasFlatcar() && o.KubernetesConfig.NetworkPlugin == "azure" && o.KubernetesConfig.NetworkMode == NetworkModeBridge {
 		return errors.Errorf("Flatcar node pools require 'transparent' networkMode with Azure CNI")
-	}
-
-	if o.OrchestratorType != Kubernetes && o.KubernetesConfig != nil {
-		return errors.Errorf("KubernetesConfig can be specified only when OrchestratorType is Kubernetes")
 	}
 
 	return a.validateContainerRuntime(isUpdate)
@@ -402,10 +388,8 @@ func (a *Properties) validateMasterProfile(isUpdate bool) error {
 	if m.Count == 1 {
 		log.Warnf("Running only 1 control plane VM not recommended for production clusters, use 3 or 5 for control plane redundancy")
 	}
-	if a.OrchestratorProfile.OrchestratorType == Kubernetes {
-		if m.IsVirtualMachineScaleSets() && m.VnetSubnetID != "" && m.FirstConsecutiveStaticIP != "" {
-			return errors.New("when masterProfile's availabilityProfile is VirtualMachineScaleSets and a vnetSubnetID is specified, the firstConsecutiveStaticIP should be empty and will be determined by an offset from the first IP in the vnetCidr")
-		}
+	if m.IsVirtualMachineScaleSets() && m.VnetSubnetID != "" && m.FirstConsecutiveStaticIP != "" {
+		return errors.New("when masterProfile's availabilityProfile is VirtualMachineScaleSets and a vnetSubnetID is specified, the firstConsecutiveStaticIP should be empty and will be determined by an offset from the first IP in the vnetCidr")
 	}
 
 	if m.ImageRef != nil {
@@ -414,7 +398,7 @@ func (a *Properties) validateMasterProfile(isUpdate bool) error {
 		}
 	}
 
-	if m.IsVirtualMachineScaleSets() && a.OrchestratorProfile.OrchestratorType == Kubernetes {
+	if m.IsVirtualMachineScaleSets() {
 		log.Warnf("Clusters with VMSS masters are not yet upgradable! You will not be able to upgrade your cluster until a future version of aks-engine!")
 		e := validateVMSS(a.OrchestratorProfile, false, m.StorageProfile)
 		if e != nil {
@@ -529,7 +513,7 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 			}
 		}
 
-		if e := agentPoolProfile.validateOrchestratorSpecificProperties(a.OrchestratorProfile.OrchestratorType); e != nil {
+		if e := agentPoolProfile.validateOrchestratorSpecificProperties(); e != nil {
 			return e
 		}
 
@@ -541,15 +525,11 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 			return e
 		}
 
-		if e := agentPoolProfile.validateRoles(a.OrchestratorProfile.OrchestratorType); e != nil {
+		if e := agentPoolProfile.validateRoles(); e != nil {
 			return e
 		}
 
-		if e := agentPoolProfile.validateStorageProfile(a.OrchestratorProfile.OrchestratorType); e != nil {
-			return e
-		}
-
-		if e := agentPoolProfile.validateCustomNodeLabels(a.OrchestratorProfile.OrchestratorType); e != nil {
+		if e := agentPoolProfile.validateCustomNodeLabels(); e != nil {
 			return e
 		}
 
@@ -560,28 +540,26 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 			}
 		}
 
-		if a.OrchestratorProfile.OrchestratorType == Kubernetes {
-			if a.AgentPoolProfiles[i].AvailabilityProfile != a.AgentPoolProfiles[0].AvailabilityProfile {
-				return errors.New("mixed mode availability profiles are not allowed. Please set either VirtualMachineScaleSets or AvailabilitySet in availabilityProfile for all agent pools")
-			}
+		if a.AgentPoolProfiles[i].AvailabilityProfile != a.AgentPoolProfiles[0].AvailabilityProfile {
+			return errors.New("mixed mode availability profiles are not allowed. Please set either VirtualMachineScaleSets or AvailabilitySet in availabilityProfile for all agent pools")
+		}
 
-			if a.AgentPoolProfiles[i].SinglePlacementGroup != nil && a.AgentPoolProfiles[i].AvailabilityProfile == AvailabilitySet {
-				return errors.New("singlePlacementGroup is only supported with VirtualMachineScaleSets")
-			}
+		if a.AgentPoolProfiles[i].SinglePlacementGroup != nil && a.AgentPoolProfiles[i].AvailabilityProfile == AvailabilitySet {
+			return errors.New("singlePlacementGroup is only supported with VirtualMachineScaleSets")
+		}
 
-			distroValues := DistroValues
-			if isUpdate {
-				distroValues = append(distroValues, AKSDockerEngine, AKS1604Deprecated, AKS1804Deprecated)
-			}
-			if !validateDistro(agentPoolProfile.Distro, distroValues) {
-				switch agentPoolProfile.Distro {
-				case AKSDockerEngine, AKS1604Deprecated:
-					return errors.Errorf("The %s distro is deprecated, please use %s instead", agentPoolProfile.Distro, AKSUbuntu1604)
-				case AKS1804Deprecated:
-					return errors.Errorf("The %s distro is deprecated, please use %s instead", agentPoolProfile.Distro, AKSUbuntu1804)
-				default:
-					return errors.Errorf("The %s distro is not supported", agentPoolProfile.Distro)
-				}
+		distroValues := DistroValues
+		if isUpdate {
+			distroValues = append(distroValues, AKSDockerEngine, AKS1604Deprecated, AKS1804Deprecated)
+		}
+		if !validateDistro(agentPoolProfile.Distro, distroValues) {
+			switch agentPoolProfile.Distro {
+			case AKSDockerEngine, AKS1604Deprecated:
+				return errors.Errorf("The %s distro is deprecated, please use %s instead", agentPoolProfile.Distro, AKSUbuntu1604)
+			case AKS1804Deprecated:
+				return errors.Errorf("The %s distro is deprecated, please use %s instead", agentPoolProfile.Distro, AKSUbuntu1804)
+			default:
+				return errors.Errorf("The %s distro is not supported", agentPoolProfile.Distro)
 			}
 		}
 
@@ -622,48 +600,46 @@ func (a *Properties) validateAgentPoolProfiles(isUpdate bool) error {
 }
 
 func (a *Properties) validateZones() error {
-	if a.OrchestratorProfile.OrchestratorType == Kubernetes {
-		if a.HasAvailabilityZones() {
-			var poolsWithZones, poolsWithoutZones []string
-			for _, pool := range a.AgentPoolProfiles {
-				if pool.HasAvailabilityZones() {
-					poolsWithZones = append(poolsWithZones, pool.Name)
-				} else {
-					poolsWithoutZones = append(poolsWithoutZones, pool.Name)
-				}
+	if a.HasAvailabilityZones() {
+		var poolsWithZones, poolsWithoutZones []string
+		for _, pool := range a.AgentPoolProfiles {
+			if pool.HasAvailabilityZones() {
+				poolsWithZones = append(poolsWithZones, pool.Name)
+			} else {
+				poolsWithoutZones = append(poolsWithoutZones, pool.Name)
 			}
-			if !a.MastersAndAgentsUseAvailabilityZones() {
-				poolsWithZonesPrefix := "pool"
-				poolsWithoutZonesPrefix := "pool"
-				if len(poolsWithZones) > 1 {
-					poolsWithZonesPrefix = "pools"
-				}
-				if len(poolsWithoutZones) > 1 {
-					poolsWithoutZonesPrefix = "pools"
-				}
-				poolsWithZonesString := helpers.GetEnglishOrderedQuotedListWithOxfordCommas(poolsWithZones)
-				poolsWithoutZonesString := helpers.GetEnglishOrderedQuotedListWithOxfordCommas(poolsWithoutZones)
-				if !a.MasterProfile.HasAvailabilityZones() {
-					if len(poolsWithZones) == len(a.AgentPoolProfiles) {
-						log.Warnf("This cluster is using Availability Zones for %s %s, but not for master VMs", poolsWithZonesPrefix, poolsWithZonesString)
-					} else {
-						log.Warnf("This cluster is using Availability Zones for %s %s, but not for %s %s, nor for master VMs", poolsWithZonesPrefix, poolsWithZonesString, poolsWithoutZonesPrefix, poolsWithoutZonesString)
-					}
+		}
+		if !a.MastersAndAgentsUseAvailabilityZones() {
+			poolsWithZonesPrefix := "pool"
+			poolsWithoutZonesPrefix := "pool"
+			if len(poolsWithZones) > 1 {
+				poolsWithZonesPrefix = "pools"
+			}
+			if len(poolsWithoutZones) > 1 {
+				poolsWithoutZonesPrefix = "pools"
+			}
+			poolsWithZonesString := helpers.GetEnglishOrderedQuotedListWithOxfordCommas(poolsWithZones)
+			poolsWithoutZonesString := helpers.GetEnglishOrderedQuotedListWithOxfordCommas(poolsWithoutZones)
+			if !a.MasterProfile.HasAvailabilityZones() {
+				if len(poolsWithZones) == len(a.AgentPoolProfiles) {
+					log.Warnf("This cluster is using Availability Zones for %s %s, but not for master VMs", poolsWithZonesPrefix, poolsWithZonesString)
 				} else {
-					if len(poolsWithoutZones) > 0 {
-						log.Warnf("This cluster is using Availability Zones for master VMs, but not for %s %s", poolsWithoutZonesPrefix, poolsWithoutZonesString)
-					}
+					log.Warnf("This cluster is using Availability Zones for %s %s, but not for %s %s, nor for master VMs", poolsWithZonesPrefix, poolsWithZonesString, poolsWithoutZonesPrefix, poolsWithoutZonesString)
 				}
 			} else {
-				// agent pool profiles
-				for _, agentPoolProfile := range a.AgentPoolProfiles {
-					if agentPoolProfile.AvailabilityProfile == AvailabilitySet {
-						return errors.New("Availability Zones are not supported with an AvailabilitySet. Please either remove availabilityProfile or set availabilityProfile to VirtualMachineScaleSets")
-					}
+				if len(poolsWithoutZones) > 0 {
+					log.Warnf("This cluster is using Availability Zones for master VMs, but not for %s %s", poolsWithoutZonesPrefix, poolsWithoutZonesString)
 				}
-				if a.OrchestratorProfile.KubernetesConfig != nil && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "" && !strings.EqualFold(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) {
-					return errors.New("Availability Zones requires Standard LoadBalancer. Please set KubernetesConfig \"LoadBalancerSku\" to \"Standard\"")
+			}
+		} else {
+			// agent pool profiles
+			for _, agentPoolProfile := range a.AgentPoolProfiles {
+				if agentPoolProfile.AvailabilityProfile == AvailabilitySet {
+					return errors.New("Availability Zones are not supported with an AvailabilitySet. Please either remove availabilityProfile or set availabilityProfile to VirtualMachineScaleSets")
 				}
+			}
+			if a.OrchestratorProfile.KubernetesConfig != nil && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "" && !strings.EqualFold(a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, StandardLoadBalancerSku) {
+				return errors.New("Availability Zones requires Standard LoadBalancer. Please set KubernetesConfig \"LoadBalancerSku\" to \"Standard\"")
 			}
 		}
 	}
@@ -940,36 +916,34 @@ func (a *Properties) validateVNET() error {
 }
 
 func (a *Properties) validateServicePrincipalProfile() error {
-	if a.OrchestratorProfile.OrchestratorType == Kubernetes {
-		useManagedIdentityDisabled := a.OrchestratorProfile.KubernetesConfig != nil &&
-			a.OrchestratorProfile.KubernetesConfig.UseManagedIdentity != nil && !to.Bool(a.OrchestratorProfile.KubernetesConfig.UseManagedIdentity)
+	useManagedIdentityDisabled := a.OrchestratorProfile.KubernetesConfig != nil &&
+		a.OrchestratorProfile.KubernetesConfig.UseManagedIdentity != nil && !to.Bool(a.OrchestratorProfile.KubernetesConfig.UseManagedIdentity)
 
-		if useManagedIdentityDisabled {
-			if a.ServicePrincipalProfile == nil {
-				return errors.Errorf("ServicePrincipalProfile must be specified with Orchestrator %s", a.OrchestratorProfile.OrchestratorType)
-			}
-			if e := validate.Var(a.ServicePrincipalProfile.ClientID, "required"); e != nil {
-				return errors.Errorf("the service principal client ID must be specified with Orchestrator %s", a.OrchestratorProfile.OrchestratorType)
-			}
-			if (len(a.ServicePrincipalProfile.Secret) == 0 && a.ServicePrincipalProfile.KeyvaultSecretRef == nil) ||
-				(len(a.ServicePrincipalProfile.Secret) != 0 && a.ServicePrincipalProfile.KeyvaultSecretRef != nil) {
-				return errors.Errorf("either the service principal client secret or keyvault secret reference must be specified with Orchestrator %s", a.OrchestratorProfile.OrchestratorType)
-			}
+	if useManagedIdentityDisabled {
+		if a.ServicePrincipalProfile == nil {
+			return errors.Errorf("ServicePrincipalProfile must be specified")
+		}
+		if e := validate.Var(a.ServicePrincipalProfile.ClientID, "required"); e != nil {
+			return errors.Errorf("the service principal client ID must be specified")
+		}
+		if (len(a.ServicePrincipalProfile.Secret) == 0 && a.ServicePrincipalProfile.KeyvaultSecretRef == nil) ||
+			(len(a.ServicePrincipalProfile.Secret) != 0 && a.ServicePrincipalProfile.KeyvaultSecretRef != nil) {
+			return errors.Errorf("either the service principal client secret or keyvault secret reference must be specified")
+		}
 
-			if a.OrchestratorProfile.KubernetesConfig != nil && to.Bool(a.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms) && len(a.ServicePrincipalProfile.ObjectID) == 0 {
-				return errors.Errorf("the service principal object ID must be specified with Orchestrator %s when enableEncryptionWithExternalKms is true", a.OrchestratorProfile.OrchestratorType)
-			}
+		if a.OrchestratorProfile.KubernetesConfig != nil && to.Bool(a.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms) && len(a.ServicePrincipalProfile.ObjectID) == 0 {
+			return errors.Errorf("the service principal object ID must be specified when enableEncryptionWithExternalKms is true")
+		}
 
-			if a.ServicePrincipalProfile.KeyvaultSecretRef != nil {
-				if e := validate.Var(a.ServicePrincipalProfile.KeyvaultSecretRef.VaultID, "required"); e != nil {
-					return errors.Errorf("the Keyvault ID must be specified for the Service Principle with Orchestrator %s", a.OrchestratorProfile.OrchestratorType)
-				}
-				if e := validate.Var(a.ServicePrincipalProfile.KeyvaultSecretRef.SecretName, "required"); e != nil {
-					return errors.Errorf("the Keyvault Secret must be specified for the Service Principle with Orchestrator %s", a.OrchestratorProfile.OrchestratorType)
-				}
-				if !keyvaultIDRegex.MatchString(a.ServicePrincipalProfile.KeyvaultSecretRef.VaultID) {
-					return errors.Errorf("service principal client keyvault secret reference is of incorrect format")
-				}
+		if a.ServicePrincipalProfile.KeyvaultSecretRef != nil {
+			if e := validate.Var(a.ServicePrincipalProfile.KeyvaultSecretRef.VaultID, "required"); e != nil {
+				return errors.Errorf("the Keyvault ID must be specified for the Service Principle")
+			}
+			if e := validate.Var(a.ServicePrincipalProfile.KeyvaultSecretRef.SecretName, "required"); e != nil {
+				return errors.Errorf("the Keyvault Secret must be specified for the Service Principle")
+			}
+			if !keyvaultIDRegex.MatchString(a.ServicePrincipalProfile.KeyvaultSecretRef.VaultID) {
+				return errors.Errorf("service principal client keyvault secret reference is of incorrect format")
 			}
 		}
 	}
@@ -978,9 +952,6 @@ func (a *Properties) validateServicePrincipalProfile() error {
 
 func (a *Properties) validateAADProfile() error {
 	if profile := a.AADProfile; profile != nil {
-		if a.OrchestratorProfile.OrchestratorType != Kubernetes {
-			return errors.Errorf("'aadProfile' is only supported by orchestrator '%v'", Kubernetes)
-		}
 		if _, err := uuid.Parse(profile.ClientAppID); err != nil {
 			return errors.Errorf("clientAppID '%v' is invalid", profile.ClientAppID)
 		}
@@ -1015,7 +986,7 @@ func (a *AgentPoolProfile) validateAvailabilityProfile() error {
 	return nil
 }
 
-func (a *AgentPoolProfile) validateRoles(orchestratorType string) error {
+func (a *AgentPoolProfile) validateRoles() error {
 	validRoles := []AgentPoolProfileRole{AgentPoolProfileRoleEmpty}
 	var found bool
 	for _, validRole := range validRoles {
@@ -1025,89 +996,60 @@ func (a *AgentPoolProfile) validateRoles(orchestratorType string) error {
 		}
 	}
 	if !found {
-		return errors.Errorf("Role %q is not supported for Orchestrator %s", a.Role, orchestratorType)
+		return errors.Errorf("Role %q is not supported", a.Role)
 	}
 	return nil
 }
 
-func (a *AgentPoolProfile) validateStorageProfile(orchestratorType string) error {
-	/* this switch statement is left to protect newly added orchestrators until they support Managed Disks*/
-	if a.StorageProfile == ManagedDisks {
-		switch orchestratorType {
-		case Kubernetes:
-		default:
-			return errors.Errorf("HA volumes are currently unsupported for Orchestrator %s", orchestratorType)
-		}
-	}
-
-	if a.StorageProfile == Ephemeral {
-		switch orchestratorType {
-		case Kubernetes:
-			break
-		default:
-			return errors.Errorf("Ephemeral volumes are currently unsupported for Orchestrator %s", orchestratorType)
-		}
-	}
-
-	return nil
-}
-
-func (a *AgentPoolProfile) validateCustomNodeLabels(orchestratorType string) error {
+func (a *AgentPoolProfile) validateCustomNodeLabels() error {
 	if len(a.CustomNodeLabels) > 0 {
-		switch orchestratorType {
-		case Kubernetes:
-			for k, v := range a.CustomNodeLabels {
-				if e := validateKubernetesLabelKey(k); e != nil {
-					return e
-				}
-				if e := validateKubernetesLabelValue(v); e != nil {
-					return e
-				}
+		for k, v := range a.CustomNodeLabels {
+			if e := validateKubernetesLabelKey(k); e != nil {
+				return e
 			}
-		default:
-			return errors.New("Agent CustomNodeLabels are only supported for Kubernetes")
+			if e := validateKubernetesLabelValue(v); e != nil {
+				return e
+			}
 		}
 	}
 	return nil
 }
 
 func validateVMSS(o *OrchestratorProfile, isUpdate bool, storageProfile string) error {
-	if o.OrchestratorType == Kubernetes {
-		version := common.RationalizeReleaseAndVersion(
-			o.OrchestratorType,
-			o.OrchestratorRelease,
-			o.OrchestratorVersion,
-			isUpdate,
-			false,
-			false)
-		if version == "" {
-			return errors.Errorf("the following OrchestratorProfile configuration is not supported: OrchestratorType: %s, OrchestratorRelease: %s, OrchestratorVersion: %s. Please check supported Release or Version for this build of aks-engine", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion)
-		}
+	version := common.RationalizeReleaseAndVersion(
+		o.OrchestratorType,
+		o.OrchestratorRelease,
+		o.OrchestratorVersion,
+		isUpdate,
+		false,
+		false)
+	if version == "" {
+		return errors.Errorf("the following OrchestratorProfile configuration is not supported: OrchestratorType: %s, OrchestratorRelease: %s, OrchestratorVersion: %s. Please check supported Release or Version for this build of aks-engine", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion)
+	}
 
-		sv, err := semver.Make(version)
-		if err != nil {
-			return errors.Errorf("could not validate version %s", version)
+	sv, err := semver.Make(version)
+	if err != nil {
+		return errors.Errorf("could not validate version %s", version)
+	}
+	minVersion, err := semver.Make("1.10.0")
+	if err != nil {
+		return errors.New("could not validate version")
+	}
+	if sv.LT(minVersion) {
+		return errors.Errorf("VirtualMachineScaleSets are only available in Kubernetes version %s or greater. Please set \"orchestratorVersion\" to %s or above", minVersion.String(), minVersion.String())
+	}
+	// validation for instanceMetadata using VMSS with Kubernetes
+	minVersion, err = semver.Make("1.10.2")
+	if err != nil {
+		return errors.New("could not validate version")
+	}
+	if o.KubernetesConfig != nil && o.KubernetesConfig.UseInstanceMetadata != nil {
+		if *o.KubernetesConfig.UseInstanceMetadata && sv.LT(minVersion) {
+			return errors.Errorf("VirtualMachineScaleSets with instance metadata is supported for Kubernetes version %s or greater. Please set \"useInstanceMetadata\": false in \"kubernetesConfig\" or set \"orchestratorVersion\" to %s or above", minVersion.String(), minVersion.String())
 		}
-		minVersion, err := semver.Make("1.10.0")
-		if err != nil {
-			return errors.New("could not validate version")
-		}
-		if sv.LT(minVersion) {
-			return errors.Errorf("VirtualMachineScaleSets are only available in Kubernetes version %s or greater. Please set \"orchestratorVersion\" to %s or above", minVersion.String(), minVersion.String())
-		}
-		// validation for instanceMetadata using VMSS with Kubernetes
-		minVersion, err = semver.Make("1.10.2")
-		if err != nil {
-			return errors.New("could not validate version")
-		}
-		if o.KubernetesConfig != nil && o.KubernetesConfig.UseInstanceMetadata != nil {
-			if *o.KubernetesConfig.UseInstanceMetadata && sv.LT(minVersion) {
-				return errors.Errorf("VirtualMachineScaleSets with instance metadata is supported for Kubernetes version %s or greater. Please set \"useInstanceMetadata\": false in \"kubernetesConfig\" or set \"orchestratorVersion\" to %s or above", minVersion.String(), minVersion.String())
-			}
-		}
-		if storageProfile == StorageAccount {
-			return errors.Errorf("VirtualMachineScaleSets does not support %s disks.  Please specify \"storageProfile\": \"%s\" (recommended) or \"availabilityProfile\": \"%s\"", StorageAccount, ManagedDisks, AvailabilitySet)
-		}
+	}
+	if storageProfile == StorageAccount {
+		return errors.Errorf("VirtualMachineScaleSets does not support %s disks.  Please specify \"storageProfile\": \"%s\" (recommended) or \"availabilityProfile\": \"%s\"", StorageAccount, ManagedDisks, AvailabilitySet)
 	}
 	return nil
 }
@@ -1126,25 +1068,16 @@ func (a *Properties) validateWindowsProfile(isUpdate bool) error {
 	}
 
 	o := a.OrchestratorProfile
-	version := ""
-	// This logic is broken because golang cases do not fallthrough by default.
-	// I am leaving this in because I cannot get a clear answer on if we need to continue supporting Swarm + Windows and
-	// RationalizeReleaseAndVersion does not properly handle Swarm.
-	switch o.OrchestratorType {
-	case Kubernetes:
-		version = common.RationalizeReleaseAndVersion(
-			o.OrchestratorType,
-			o.OrchestratorRelease,
-			o.OrchestratorVersion,
-			isUpdate,
-			true,
-			false)
+	version := common.RationalizeReleaseAndVersion(
+		o.OrchestratorType,
+		o.OrchestratorRelease,
+		o.OrchestratorVersion,
+		isUpdate,
+		true,
+		false)
 
-		if version == "" {
-			return errors.Errorf("Orchestrator %s version %s does not support Windows", o.OrchestratorType, o.OrchestratorVersion)
-		}
-	default:
-		return errors.Errorf("Orchestrator %v does not support Windows", o.OrchestratorType)
+	if version == "" {
+		return errors.Errorf("Orchestrator %s version %s does not support Windows", o.OrchestratorType, o.OrchestratorVersion)
 	}
 
 	w := a.WindowsProfile
@@ -1207,19 +1140,16 @@ func validateWindowsRuntimes(r *WindowsRuntimes) error {
 	return nil
 }
 
-func (a *AgentPoolProfile) validateOrchestratorSpecificProperties(orchestratorType string) error {
+func (a *AgentPoolProfile) validateOrchestratorSpecificProperties() error {
 
-	// for Kubernetes, we don't support AgentPoolProfile.DNSPrefix
-	if orchestratorType == Kubernetes {
-		if e := validate.Var(a.DNSPrefix, "len=0"); e != nil {
-			return errors.New("AgentPoolProfile.DNSPrefix must be empty for Kubernetes")
-		}
-		if e := validate.Var(a.Ports, "len=0"); e != nil {
-			return errors.New("AgentPoolProfile.Ports must be empty for Kubernetes")
-		}
-		if validate.Var(a.ScaleSetPriority, "eq=Regular") == nil && validate.Var(a.ScaleSetEvictionPolicy, "len=0") != nil {
-			return errors.New("property 'AgentPoolProfile.ScaleSetEvictionPolicy' must be empty for AgentPoolProfile.Priority of Regular")
-		}
+	if e := validate.Var(a.DNSPrefix, "len=0"); e != nil {
+		return errors.New("AgentPoolProfile.DNSPrefix must be empty for Kubernetes")
+	}
+	if e := validate.Var(a.Ports, "len=0"); e != nil {
+		return errors.New("AgentPoolProfile.Ports must be empty for Kubernetes")
+	}
+	if validate.Var(a.ScaleSetPriority, "eq=Regular") == nil && validate.Var(a.ScaleSetEvictionPolicy, "len=0") != nil {
+		return errors.New("property 'AgentPoolProfile.ScaleSetEvictionPolicy' must be empty for AgentPoolProfile.Priority of Regular")
 	}
 
 	if a.DNSPrefix != "" {
@@ -1234,7 +1164,7 @@ func (a *AgentPoolProfile) validateOrchestratorSpecificProperties(orchestratorTy
 			a.Ports = []int{80, 443, 8080}
 		}
 	} else if e := validate.Var(a.Ports, "len=0"); e != nil {
-		return errors.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty for Orchestrator: %s", orchestratorType)
+		return errors.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty")
 	}
 
 	if len(a.DiskSizesGB) > 0 {
@@ -1724,13 +1654,8 @@ func (k *KubernetesConfig) isUsingCustomKubeComponent() bool {
 func (a *Properties) validateContainerRuntime(isUpdate bool) error {
 	var containerRuntime string
 
-	switch a.OrchestratorProfile.OrchestratorType {
-	case Kubernetes:
-		if a.OrchestratorProfile.KubernetesConfig != nil {
-			containerRuntime = a.OrchestratorProfile.KubernetesConfig.ContainerRuntime
-		}
-	default:
-		return nil
+	if a.OrchestratorProfile.KubernetesConfig != nil {
+		containerRuntime = a.OrchestratorProfile.KubernetesConfig.ContainerRuntime
 	}
 
 	// Check for deprecated, non-back-compat
@@ -1976,7 +1901,7 @@ func validateDependenciesLocation(dependenciesLocation DependenciesLocation, dep
 
 // validateAzureStackSupport logs a warning if apimodel contains preview features and returns an error if a property is not supported on Azure Stack clouds
 func (a *Properties) validateAzureStackSupport() error {
-	if a.OrchestratorProfile.OrchestratorType == Kubernetes && a.IsAzureStackCloud() {
+	if a.IsAzureStackCloud() {
 		networkPlugin := a.OrchestratorProfile.KubernetesConfig.NetworkPlugin
 		if networkPlugin == "azure" || networkPlugin == "" {
 			log.Warnf("NetworkPlugin 'azure' is a private preview feature on Azure Stack clouds")

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -884,11 +884,9 @@ func getKubernetesPodStartIndex(properties *api.Properties) int {
 func getMasterLinkedTemplateText(orchestratorType string, extensionProfile *api.ExtensionProfile, singleOrAll string) (string, error) {
 	extTargetVMNamePrefix := "variables('masterVMNamePrefix')"
 
-	loopCount := "[variables('masterCount')]"
-	loopOffset := ""
 	// Due to upgrade k8s sometimes needs to install just some of the nodes.
-	loopCount = "[sub(variables('masterCount'), variables('masterOffset'))]"
-	loopOffset = "variables('masterOffset')"
+	loopCount := "[sub(variables('masterCount'), variables('masterOffset'))]"
+	loopOffset := "variables('masterOffset')"
 
 	if strings.EqualFold(singleOrAll, "single") {
 		loopCount = "1"

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -535,7 +535,7 @@ func getComponentFuncMap(component api.KubernetesComponent, cs *api.ContainerSer
 			return cs.Properties.IsAzureStackCloud()
 		},
 		"IsKubernetesVersionGe": func(version string) bool {
-			return cs.Properties.OrchestratorProfile.IsKubernetes() && common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, version)
+			return common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, version)
 		},
 	}
 	if component.Name == common.APIServerComponentName {
@@ -886,11 +886,9 @@ func getMasterLinkedTemplateText(orchestratorType string, extensionProfile *api.
 
 	loopCount := "[variables('masterCount')]"
 	loopOffset := ""
-	if orchestratorType == api.Kubernetes {
-		// Due to upgrade k8s sometimes needs to install just some of the nodes.
-		loopCount = "[sub(variables('masterCount'), variables('masterOffset'))]"
-		loopOffset = "variables('masterOffset')"
-	}
+	// Due to upgrade k8s sometimes needs to install just some of the nodes.
+	loopCount = "[sub(variables('masterCount'), variables('masterOffset'))]"
+	loopOffset = "variables('masterOffset')"
 
 	if strings.EqualFold(singleOrAll, "single") {
 		loopCount = "1"

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -106,141 +106,67 @@ func TestExpected(t *testing.T) {
 			continue
 		}
 
-		if containerService.Properties.OrchestratorProfile.OrchestratorType != Kubernetes {
-			// test the output container service 3 times:
-			// 1. first time tests loaded containerService
-			// 2. second time tests generated containerService
-			// 3. third time tests the generated containerService from the generated containerService
-			ctx := Context{
-				Translator: &i18n.Translator{
-					Locale: locale,
-				},
-			}
-			templateGenerator, e3 := InitializeTemplateGenerator(ctx)
-			if e3 != nil {
-				t.Error(e3.Error())
-				continue
-			}
+		if version != vlabs.APIVersion {
+			// Set CertificateProfile here to avoid a new one generated.
+			// Kubernetes template needs certificate profile to match expected template
+			// API versions other than vlabs don't expose CertificateProfile
+			containerService.Properties.CertificateProfile = &api.CertificateProfile{}
+			addTestCertificateProfile(containerService.Properties.CertificateProfile)
+		}
 
-			certsGenerated, _ := containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
-				IsScale:    false,
-				IsUpgrade:  false,
-				PkiKeySize: helpers.DefaultPkiKeySize,
-			})
-			if certsGenerated {
-				t.Errorf("cert generation unexpected for %s", containerService.Properties.OrchestratorProfile.OrchestratorType)
-			}
+		// test the output container service 3 times:
+		// 1. first time tests loaded containerService
+		// 2. second time tests generated containerService
+		// 3. third time tests the generated containerService from the generated containerService
+		ctx := Context{
+			Translator: &i18n.Translator{
+				Locale: locale,
+			},
+		}
+		templateGenerator, e3 := InitializeTemplateGenerator(ctx)
+		if e3 != nil {
+			t.Error(e3.Error())
+			continue
+		}
 
-			armTemplate, params, err := templateGenerator.GenerateTemplate(containerService, DefaultGeneratorCode, TestAKSEngineVersion)
-			if err != nil {
-				t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, err.Error()))
-				continue
-			}
+		certsGenerated, _ := containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+			IsScale:    false,
+			IsUpgrade:  false,
+			PkiKeySize: helpers.DefaultPkiKeySize,
+		})
+		if certsGenerated {
+			t.Errorf("cert generation unexpected for %s, apiversion: %s, path: %s ", containerService.Properties.OrchestratorProfile.OrchestratorType, version, tuple.APIModelFilename)
+		}
 
-			expectedPpArmTemplate, e1 := transform.PrettyPrintArmTemplate(armTemplate)
-			if e1 != nil {
-				t.Error(armTemplate)
-				t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e1.Error()))
-				break
-			}
+		armTemplate, params, err := templateGenerator.GenerateTemplateV2(containerService, DefaultGeneratorCode, TestAKSEngineVersion)
+		if err != nil {
+			t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, err.Error()))
+			continue
+		}
 
-			expectedPpParams, e2 := transform.PrettyPrintJSON(params)
-			if e2 != nil {
-				t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e2.Error()))
-				continue
-			}
+		expectedPpArmTemplate, e1 := transform.PrettyPrintArmTemplate(armTemplate)
+		if e1 != nil {
+			t.Error(armTemplate)
+			t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e1.Error()))
+			break
+		}
 
-			for i := 0; i < 3; i++ {
-				if i > 0 {
-					certsGenerated, _ = containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
-						IsScale:    false,
-						IsUpgrade:  false,
-						PkiKeySize: helpers.DefaultPkiKeySize,
-					})
-					if certsGenerated {
-						t.Errorf("cert generation unexpected for %s", containerService.Properties.OrchestratorProfile.OrchestratorType)
-					}
+		expectedPpParams, e2 := transform.PrettyPrintJSON(params)
+		if e2 != nil {
+			t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e2.Error()))
+			continue
+		}
+
+		for i := 0; i < 3; i++ {
+			if i > 0 {
+				certsGenerated, _ = containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+					IsScale:    false,
+					IsUpgrade:  false,
+					PkiKeySize: helpers.DefaultPkiKeySize,
+				})
+				if certsGenerated {
+					t.Errorf("cert generation unexpected for %s", containerService.Properties.OrchestratorProfile.OrchestratorType)
 				}
-				armTemplate, params, err := templateGenerator.GenerateTemplate(containerService, DefaultGeneratorCode, TestAKSEngineVersion)
-				if err != nil {
-					t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, err.Error()))
-					continue
-				}
-				generatedPpArmTemplate, e1 := transform.PrettyPrintArmTemplate(armTemplate)
-				if e1 != nil {
-					t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e1.Error()))
-					continue
-				}
-
-				generatedPpParams, e2 := transform.PrettyPrintJSON(params)
-				if e2 != nil {
-					t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e2.Error()))
-					continue
-				}
-
-				if !bytes.Equal([]byte(expectedPpArmTemplate), []byte(generatedPpArmTemplate)) {
-					diffstr, differr := tuple.WriteArmTemplateErrFilename([]byte(generatedPpArmTemplate))
-					if differr != nil {
-						diffstr += differr.Error()
-					}
-					t.Errorf("generated output different from expected for model %s: '%s'", tuple.APIModelFilename, diffstr)
-				}
-
-				if !bytes.Equal([]byte(expectedPpParams), []byte(generatedPpParams)) {
-					diffstr, differr := tuple.WriteArmTemplateParamsErrFilename([]byte(generatedPpParams))
-					if differr != nil {
-						diffstr += differr.Error()
-					}
-					t.Errorf("generated parameters different from expected for model %s: '%s'", tuple.APIModelFilename, diffstr)
-				}
-
-				b, err := apiloader.SerializeContainerService(containerService, version)
-				if err != nil {
-					t.Error(err)
-				}
-				containerService, version, err = apiloader.DeserializeContainerService(b, true, false, nil)
-				if err != nil {
-					t.Error(err)
-				}
-				if version != vlabs.APIVersion {
-					// Set CertificateProfile here to avoid a new one generated.
-					// Kubernetes template needs certificate profile to match expected template
-					// API versions other than vlabs don't expose CertificateProfile
-					containerService.Properties.CertificateProfile = &api.CertificateProfile{}
-					addTestCertificateProfile(containerService.Properties.CertificateProfile)
-				}
-			}
-		} else {
-			if version != vlabs.APIVersion {
-				// Set CertificateProfile here to avoid a new one generated.
-				// Kubernetes template needs certificate profile to match expected template
-				// API versions other than vlabs don't expose CertificateProfile
-				containerService.Properties.CertificateProfile = &api.CertificateProfile{}
-				addTestCertificateProfile(containerService.Properties.CertificateProfile)
-			}
-
-			// test the output container service 3 times:
-			// 1. first time tests loaded containerService
-			// 2. second time tests generated containerService
-			// 3. third time tests the generated containerService from the generated containerService
-			ctx := Context{
-				Translator: &i18n.Translator{
-					Locale: locale,
-				},
-			}
-			templateGenerator, e3 := InitializeTemplateGenerator(ctx)
-			if e3 != nil {
-				t.Error(e3.Error())
-				continue
-			}
-
-			certsGenerated, _ := containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
-				IsScale:    false,
-				IsUpgrade:  false,
-				PkiKeySize: helpers.DefaultPkiKeySize,
-			})
-			if certsGenerated {
-				t.Errorf("cert generation unexpected for %s, apiversion: %s, path: %s ", containerService.Properties.OrchestratorProfile.OrchestratorType, version, tuple.APIModelFilename)
 			}
 
 			armTemplate, params, err := templateGenerator.GenerateTemplateV2(containerService, DefaultGeneratorCode, TestAKSEngineVersion)
@@ -248,80 +174,48 @@ func TestExpected(t *testing.T) {
 				t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, err.Error()))
 				continue
 			}
-
-			expectedPpArmTemplate, e1 := transform.PrettyPrintArmTemplate(armTemplate)
+			generatedPpArmTemplate, e1 := transform.PrettyPrintArmTemplate(armTemplate)
 			if e1 != nil {
-				t.Error(armTemplate)
 				t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e1.Error()))
-				break
+				continue
 			}
 
-			expectedPpParams, e2 := transform.PrettyPrintJSON(params)
+			generatedPpParams, e2 := transform.PrettyPrintJSON(params)
 			if e2 != nil {
 				t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e2.Error()))
 				continue
 			}
 
-			for i := 0; i < 3; i++ {
-				if i > 0 {
-					certsGenerated, _ = containerService.SetPropertiesDefaults(api.PropertiesDefaultsParams{
-						IsScale:    false,
-						IsUpgrade:  false,
-						PkiKeySize: helpers.DefaultPkiKeySize,
-					})
-					if certsGenerated {
-						t.Errorf("cert generation unexpected for %s", containerService.Properties.OrchestratorProfile.OrchestratorType)
-					}
+			if !bytes.Equal([]byte(expectedPpArmTemplate), []byte(generatedPpArmTemplate)) {
+				diffstr, differr := tuple.WriteArmTemplateErrFilename([]byte(generatedPpArmTemplate))
+				if differr != nil {
+					diffstr += differr.Error()
 				}
+				t.Errorf("generated output different from expected for model %s: '%s'", tuple.APIModelFilename, diffstr)
+			}
 
-				armTemplate, params, err := templateGenerator.GenerateTemplateV2(containerService, DefaultGeneratorCode, TestAKSEngineVersion)
-				if err != nil {
-					t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, err.Error()))
-					continue
+			if !bytes.Equal([]byte(expectedPpParams), []byte(generatedPpParams)) {
+				diffstr, differr := tuple.WriteArmTemplateParamsErrFilename([]byte(generatedPpParams))
+				if differr != nil {
+					diffstr += differr.Error()
 				}
-				generatedPpArmTemplate, e1 := transform.PrettyPrintArmTemplate(armTemplate)
-				if e1 != nil {
-					t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e1.Error()))
-					continue
-				}
+				t.Errorf("generated parameters different from expected for model %s: '%s'", tuple.APIModelFilename, diffstr)
+			}
 
-				generatedPpParams, e2 := transform.PrettyPrintJSON(params)
-				if e2 != nil {
-					t.Error(errors.Errorf("error in file %s: %s", tuple.APIModelFilename, e2.Error()))
-					continue
-				}
-
-				if !bytes.Equal([]byte(expectedPpArmTemplate), []byte(generatedPpArmTemplate)) {
-					diffstr, differr := tuple.WriteArmTemplateErrFilename([]byte(generatedPpArmTemplate))
-					if differr != nil {
-						diffstr += differr.Error()
-					}
-					t.Errorf("generated output different from expected for model %s: '%s'", tuple.APIModelFilename, diffstr)
-				}
-
-				if !bytes.Equal([]byte(expectedPpParams), []byte(generatedPpParams)) {
-					diffstr, differr := tuple.WriteArmTemplateParamsErrFilename([]byte(generatedPpParams))
-					if differr != nil {
-						diffstr += differr.Error()
-					}
-					t.Errorf("generated parameters different from expected for model %s: '%s'", tuple.APIModelFilename, diffstr)
-				}
-
-				b, err := apiloader.SerializeContainerService(containerService, version)
-				if err != nil {
-					t.Error(err)
-				}
-				containerService, version, err = apiloader.DeserializeContainerService(b, true, false, nil)
-				if err != nil {
-					t.Error(err)
-				}
-				if version != vlabs.APIVersion {
-					// Set CertificateProfile here to avoid a new one generated.
-					// Kubernetes template needs certificate profile to match expected template
-					// API versions other than vlabs don't expose CertificateProfile
-					containerService.Properties.CertificateProfile = &api.CertificateProfile{}
-					addTestCertificateProfile(containerService.Properties.CertificateProfile)
-				}
+			b, err := apiloader.SerializeContainerService(containerService, version)
+			if err != nil {
+				t.Error(err)
+			}
+			containerService, version, err = apiloader.DeserializeContainerService(b, true, false, nil)
+			if err != nil {
+				t.Error(err)
+			}
+			if version != vlabs.APIVersion {
+				// Set CertificateProfile here to avoid a new one generated.
+				// Kubernetes template needs certificate profile to match expected template
+				// API versions other than vlabs don't expose CertificateProfile
+				containerService.Properties.CertificateProfile = &api.CertificateProfile{}
+				addTestCertificateProfile(containerService.Properties.CertificateProfile)
 			}
 		}
 	}

--- a/pkg/engine/output.go
+++ b/pkg/engine/output.go
@@ -61,73 +61,71 @@ func (w *ArtifactWriter) WriteTLSArtifacts(containerService *api.ContainerServic
 	}
 
 	properties := containerService.Properties
-	if properties.OrchestratorProfile.IsKubernetes() {
-		directory := path.Join(artifactsDir, "kubeconfig")
-		var locations []string
-		if containerService.Location != "" {
-			locations = []string{containerService.Location}
-		} else {
-			locations = helpers.GetAzureLocations()
-		}
+	directory := path.Join(artifactsDir, "kubeconfig")
+	var locations []string
+	if containerService.Location != "" {
+		locations = []string{containerService.Location}
+	} else {
+		locations = helpers.GetAzureLocations()
+	}
 
-		for _, location := range locations {
-			b, gkcerr := GenerateKubeConfig(properties, location)
-			if gkcerr != nil {
-				return gkcerr
-			}
-			if e := f.SaveFileString(directory, fmt.Sprintf("kubeconfig.%s.json", location), b); e != nil {
-				return e
-			}
+	for _, location := range locations {
+		b, gkcerr := GenerateKubeConfig(properties, location)
+		if gkcerr != nil {
+			return gkcerr
 		}
+		if e := f.SaveFileString(directory, fmt.Sprintf("kubeconfig.%s.json", location), b); e != nil {
+			return e
+		}
+	}
 
-		if e := f.SaveFileString(artifactsDir, "ca.key", properties.CertificateProfile.CaPrivateKey); e != nil {
+	if e := f.SaveFileString(artifactsDir, "ca.key", properties.CertificateProfile.CaPrivateKey); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "ca.crt", properties.CertificateProfile.CaCertificate); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "apiserver.key", properties.CertificateProfile.APIServerPrivateKey); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "apiserver.crt", properties.CertificateProfile.APIServerCertificate); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "client.key", properties.CertificateProfile.ClientPrivateKey); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "client.crt", properties.CertificateProfile.ClientCertificate); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "kubectlClient.key", properties.CertificateProfile.KubeConfigPrivateKey); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "kubectlClient.crt", properties.CertificateProfile.KubeConfigCertificate); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "etcdserver.key", properties.CertificateProfile.EtcdServerPrivateKey); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "etcdserver.crt", properties.CertificateProfile.EtcdServerCertificate); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "etcdclient.key", properties.CertificateProfile.EtcdClientPrivateKey); e != nil {
+		return e
+	}
+	if e := f.SaveFileString(artifactsDir, "etcdclient.crt", properties.CertificateProfile.EtcdClientCertificate); e != nil {
+		return e
+	}
+	for i := 0; i < properties.MasterProfile.Count; i++ {
+		if len(properties.CertificateProfile.EtcdPeerPrivateKeys) <= i || len(properties.CertificateProfile.EtcdPeerCertificates) <= i {
+			return errors.New("missing etcd peer certificate/key pair")
+		}
+		k := "etcdpeer" + strconv.Itoa(i) + ".key"
+		if e := f.SaveFileString(artifactsDir, k, properties.CertificateProfile.EtcdPeerPrivateKeys[i]); e != nil {
 			return e
 		}
-		if e := f.SaveFileString(artifactsDir, "ca.crt", properties.CertificateProfile.CaCertificate); e != nil {
+		c := "etcdpeer" + strconv.Itoa(i) + ".crt"
+		if e := f.SaveFileString(artifactsDir, c, properties.CertificateProfile.EtcdPeerCertificates[i]); e != nil {
 			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "apiserver.key", properties.CertificateProfile.APIServerPrivateKey); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "apiserver.crt", properties.CertificateProfile.APIServerCertificate); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "client.key", properties.CertificateProfile.ClientPrivateKey); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "client.crt", properties.CertificateProfile.ClientCertificate); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "kubectlClient.key", properties.CertificateProfile.KubeConfigPrivateKey); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "kubectlClient.crt", properties.CertificateProfile.KubeConfigCertificate); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "etcdserver.key", properties.CertificateProfile.EtcdServerPrivateKey); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "etcdserver.crt", properties.CertificateProfile.EtcdServerCertificate); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "etcdclient.key", properties.CertificateProfile.EtcdClientPrivateKey); e != nil {
-			return e
-		}
-		if e := f.SaveFileString(artifactsDir, "etcdclient.crt", properties.CertificateProfile.EtcdClientCertificate); e != nil {
-			return e
-		}
-		for i := 0; i < properties.MasterProfile.Count; i++ {
-			if len(properties.CertificateProfile.EtcdPeerPrivateKeys) <= i || len(properties.CertificateProfile.EtcdPeerCertificates) <= i {
-				return errors.New("missing etcd peer certificate/key pair")
-			}
-			k := "etcdpeer" + strconv.Itoa(i) + ".key"
-			if e := f.SaveFileString(artifactsDir, k, properties.CertificateProfile.EtcdPeerPrivateKeys[i]); e != nil {
-				return e
-			}
-			c := "etcdpeer" + strconv.Itoa(i) + ".crt"
-			if e := f.SaveFileString(artifactsDir, c, properties.CertificateProfile.EtcdPeerCertificates[i]); e != nil {
-				return e
-			}
 		}
 	}
 

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -57,7 +57,7 @@ func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVers
 			if properties.MasterProfile.IsVirtualMachineScaleSets() {
 				addValue(parametersMap, "agentVnetSubnetID", properties.MasterProfile.AgentVnetSubnetID)
 			}
-			if properties.OrchestratorProfile.IsKubernetes() && properties.MasterProfile.VnetCidr != "" {
+			if properties.MasterProfile.VnetCidr != "" {
 				addValue(parametersMap, "vnetCidr", properties.MasterProfile.VnetCidr)
 			}
 		} else {
@@ -96,9 +96,7 @@ func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVers
 	}
 
 	// Kubernetes Parameters
-	if properties.OrchestratorProfile.IsKubernetes() {
-		assignKubernetesParameters(properties, parametersMap, cloudSpecConfig, generatorCode)
-	}
+	assignKubernetesParameters(properties, parametersMap, cloudSpecConfig, generatorCode)
 
 	// Agent parameters
 	for _, agentProfile := range properties.AgentPoolProfiles {

--- a/pkg/engine/params_k8s.go
+++ b/pkg/engine/params_k8s.go
@@ -17,203 +17,199 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 	addValue(parametersMap, "generatorCode", generatorCode)
 
 	orchestratorProfile := properties.OrchestratorProfile
+	k8sVersion := orchestratorProfile.OrchestratorVersion
+	k8sComponents := api.GetK8sComponentsByVersionMap(properties.OrchestratorProfile.KubernetesConfig)[k8sVersion]
+	kubernetesConfig := orchestratorProfile.KubernetesConfig
 
-	if orchestratorProfile.IsKubernetes() {
-
-		k8sVersion := orchestratorProfile.OrchestratorVersion
-		k8sComponents := api.GetK8sComponentsByVersionMap(properties.OrchestratorProfile.KubernetesConfig)[k8sVersion]
-		kubernetesConfig := orchestratorProfile.KubernetesConfig
-
-		if kubernetesConfig != nil {
-			if kubernetesConfig.CustomKubeBinaryURL != "" {
-				addValue(parametersMap, "kubeBinaryURL", kubernetesConfig.CustomKubeBinaryURL)
-			}
-
-			addValue(parametersMap, "kubeDNSServiceIP", kubernetesConfig.DNSServiceIP)
-			if kubernetesConfig.IsAADPodIdentityEnabled() {
-				aadPodIdentityAddon := kubernetesConfig.GetAddonByName(common.AADPodIdentityAddonName)
-				aadIndex := aadPodIdentityAddon.GetAddonContainersIndexByName(common.AADPodIdentityAddonName)
-				if aadIndex > -1 {
-					addValue(parametersMap, "kubernetesAADPodIdentityEnabled", to.Bool(aadPodIdentityAddon.Enabled))
-				}
-			}
-			if kubernetesConfig.IsAddonEnabled(common.ACIConnectorAddonName) {
-				addValue(parametersMap, "kubernetesACIConnectorEnabled", true)
-			} else {
-				addValue(parametersMap, "kubernetesACIConnectorEnabled", false)
-			}
-			addValue(parametersMap, "cloudproviderConfig", api.CloudProviderConfig{
-				CloudProviderBackoffMode:          kubernetesConfig.CloudProviderBackoffMode,
-				CloudProviderBackoff:              kubernetesConfig.CloudProviderBackoff,
-				CloudProviderBackoffRetries:       kubernetesConfig.CloudProviderBackoffRetries,
-				CloudProviderBackoffJitter:        strconv.FormatFloat(kubernetesConfig.CloudProviderBackoffJitter, 'f', -1, 64),
-				CloudProviderBackoffDuration:      kubernetesConfig.CloudProviderBackoffDuration,
-				CloudProviderBackoffExponent:      strconv.FormatFloat(kubernetesConfig.CloudProviderBackoffExponent, 'f', -1, 64),
-				CloudProviderRateLimit:            kubernetesConfig.CloudProviderRateLimit,
-				CloudProviderRateLimitQPS:         strconv.FormatFloat(kubernetesConfig.CloudProviderRateLimitQPS, 'f', -1, 64),
-				CloudProviderRateLimitQPSWrite:    strconv.FormatFloat(kubernetesConfig.CloudProviderRateLimitQPSWrite, 'f', -1, 64),
-				CloudProviderRateLimitBucket:      kubernetesConfig.CloudProviderRateLimitBucket,
-				CloudProviderRateLimitBucketWrite: kubernetesConfig.CloudProviderRateLimitBucketWrite,
-				CloudProviderDisableOutboundSNAT:  kubernetesConfig.CloudProviderDisableOutboundSNAT,
-			})
-			addValue(parametersMap, "kubeClusterCidr", kubernetesConfig.ClusterSubnet)
-			addValue(parametersMap, "dockerBridgeCidr", kubernetesConfig.DockerBridgeSubnet)
-			addValue(parametersMap, "networkPolicy", kubernetesConfig.NetworkPolicy)
-			addValue(parametersMap, "networkPlugin", kubernetesConfig.NetworkPlugin)
-			addValue(parametersMap, "networkMode", kubernetesConfig.NetworkMode)
-			addValue(parametersMap, "containerRuntime", kubernetesConfig.ContainerRuntime)
-			addValue(parametersMap, "containerdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.ContainerdDownloadURLBase)
-			addValue(parametersMap, "cniPluginsURL", cloudSpecConfig.KubernetesSpecConfig.CNIPluginsDownloadURL)
-			addValue(parametersMap, "vnetCniLinuxPluginsURL", kubernetesConfig.GetAzureCNIURLLinux(cloudSpecConfig))
-			addValue(parametersMap, "vnetCniWindowsPluginsURL", kubernetesConfig.GetAzureCNIURLWindows(cloudSpecConfig))
-			addValue(parametersMap, "gchighthreshold", kubernetesConfig.GCHighThreshold)
-			addValue(parametersMap, "gclowthreshold", kubernetesConfig.GCLowThreshold)
-			addValue(parametersMap, "etcdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase)
-			addValue(parametersMap, "etcdVersion", kubernetesConfig.EtcdVersion)
-			addValue(parametersMap, "etcdDiskSizeGB", kubernetesConfig.EtcdDiskSizeGB)
-			addValue(parametersMap, "etcdEncryptionKey", kubernetesConfig.EtcdEncryptionKey)
-			if kubernetesConfig.PrivateJumpboxProvision() {
-				addValue(parametersMap, "jumpboxVMName", kubernetesConfig.PrivateCluster.JumpboxProfile.Name)
-				addValue(parametersMap, "jumpboxVMSize", kubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
-				addValue(parametersMap, "jumpboxUsername", kubernetesConfig.PrivateCluster.JumpboxProfile.Username)
-				addValue(parametersMap, "jumpboxOSDiskSizeGB", kubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
-				addValue(parametersMap, "jumpboxPublicKey", kubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey)
-				addValue(parametersMap, "jumpboxStorageProfile", kubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile)
-			}
-
-			addValue(parametersMap, "enableAggregatedAPIs", kubernetesConfig.EnableAggregatedAPIs)
-
-			if properties.HasWindows() {
-				// Kubernetes packages as zip file as created by Azure Pipelines
-				// will be removed in future release as if gets phased out (https://github.com/Azure/aks-engine/issues/3851)
-				kubeBinariesSASURL := kubernetesConfig.CustomWindowsPackageURL
-				if kubeBinariesSASURL == "" {
-					if properties.IsAzureStackCloud() {
-						kubeBinariesSASURL = cloudSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase + k8sComponents[common.WindowsArtifactAzureStackComponentName]
-					} else {
-						kubeBinariesSASURL = cloudSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase + k8sComponents[common.WindowsArtifactComponentName]
-					}
-				}
-				addValue(parametersMap, "kubeBinariesSASURL", kubeBinariesSASURL)
-
-				// Kubernetes node binaries as packaged by upstream kubernetes
-				// example at https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#node-binaries-1
-				addValue(parametersMap, "windowsKubeBinariesURL", kubernetesConfig.WindowsNodeBinariesURL)
-				addValue(parametersMap, "kubeServiceCidr", kubernetesConfig.ServiceCIDR)
-				addValue(parametersMap, "kubeBinariesVersion", k8sVersion)
-				addValue(parametersMap, "windowsTelemetryGUID", cloudSpecConfig.KubernetesSpecConfig.WindowsTelemetryGUID)
-				addValue(parametersMap, "windowsContainerdURL", kubernetesConfig.WindowsContainerdURL)
-				addValue(parametersMap, "windowsSdnPluginURL", kubernetesConfig.WindowsSdnPluginURL)
-			}
+	if kubernetesConfig != nil {
+		if kubernetesConfig.CustomKubeBinaryURL != "" {
+			addValue(parametersMap, "kubeBinaryURL", kubernetesConfig.CustomKubeBinaryURL)
 		}
 
-		if kubernetesConfig == nil ||
-			!to.Bool(kubernetesConfig.UseManagedIdentity) ||
-			properties.IsHostedMasterProfile() {
-			servicePrincipalProfile := properties.ServicePrincipalProfile
+		addValue(parametersMap, "kubeDNSServiceIP", kubernetesConfig.DNSServiceIP)
+		if kubernetesConfig.IsAADPodIdentityEnabled() {
+			aadPodIdentityAddon := kubernetesConfig.GetAddonByName(common.AADPodIdentityAddonName)
+			aadIndex := aadPodIdentityAddon.GetAddonContainersIndexByName(common.AADPodIdentityAddonName)
+			if aadIndex > -1 {
+				addValue(parametersMap, "kubernetesAADPodIdentityEnabled", to.Bool(aadPodIdentityAddon.Enabled))
+			}
+		}
+		if kubernetesConfig.IsAddonEnabled(common.ACIConnectorAddonName) {
+			addValue(parametersMap, "kubernetesACIConnectorEnabled", true)
+		} else {
+			addValue(parametersMap, "kubernetesACIConnectorEnabled", false)
+		}
+		addValue(parametersMap, "cloudproviderConfig", api.CloudProviderConfig{
+			CloudProviderBackoffMode:          kubernetesConfig.CloudProviderBackoffMode,
+			CloudProviderBackoff:              kubernetesConfig.CloudProviderBackoff,
+			CloudProviderBackoffRetries:       kubernetesConfig.CloudProviderBackoffRetries,
+			CloudProviderBackoffJitter:        strconv.FormatFloat(kubernetesConfig.CloudProviderBackoffJitter, 'f', -1, 64),
+			CloudProviderBackoffDuration:      kubernetesConfig.CloudProviderBackoffDuration,
+			CloudProviderBackoffExponent:      strconv.FormatFloat(kubernetesConfig.CloudProviderBackoffExponent, 'f', -1, 64),
+			CloudProviderRateLimit:            kubernetesConfig.CloudProviderRateLimit,
+			CloudProviderRateLimitQPS:         strconv.FormatFloat(kubernetesConfig.CloudProviderRateLimitQPS, 'f', -1, 64),
+			CloudProviderRateLimitQPSWrite:    strconv.FormatFloat(kubernetesConfig.CloudProviderRateLimitQPSWrite, 'f', -1, 64),
+			CloudProviderRateLimitBucket:      kubernetesConfig.CloudProviderRateLimitBucket,
+			CloudProviderRateLimitBucketWrite: kubernetesConfig.CloudProviderRateLimitBucketWrite,
+			CloudProviderDisableOutboundSNAT:  kubernetesConfig.CloudProviderDisableOutboundSNAT,
+		})
+		addValue(parametersMap, "kubeClusterCidr", kubernetesConfig.ClusterSubnet)
+		addValue(parametersMap, "dockerBridgeCidr", kubernetesConfig.DockerBridgeSubnet)
+		addValue(parametersMap, "networkPolicy", kubernetesConfig.NetworkPolicy)
+		addValue(parametersMap, "networkPlugin", kubernetesConfig.NetworkPlugin)
+		addValue(parametersMap, "networkMode", kubernetesConfig.NetworkMode)
+		addValue(parametersMap, "containerRuntime", kubernetesConfig.ContainerRuntime)
+		addValue(parametersMap, "containerdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.ContainerdDownloadURLBase)
+		addValue(parametersMap, "cniPluginsURL", cloudSpecConfig.KubernetesSpecConfig.CNIPluginsDownloadURL)
+		addValue(parametersMap, "vnetCniLinuxPluginsURL", kubernetesConfig.GetAzureCNIURLLinux(cloudSpecConfig))
+		addValue(parametersMap, "vnetCniWindowsPluginsURL", kubernetesConfig.GetAzureCNIURLWindows(cloudSpecConfig))
+		addValue(parametersMap, "gchighthreshold", kubernetesConfig.GCHighThreshold)
+		addValue(parametersMap, "gclowthreshold", kubernetesConfig.GCLowThreshold)
+		addValue(parametersMap, "etcdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase)
+		addValue(parametersMap, "etcdVersion", kubernetesConfig.EtcdVersion)
+		addValue(parametersMap, "etcdDiskSizeGB", kubernetesConfig.EtcdDiskSizeGB)
+		addValue(parametersMap, "etcdEncryptionKey", kubernetesConfig.EtcdEncryptionKey)
+		if kubernetesConfig.PrivateJumpboxProvision() {
+			addValue(parametersMap, "jumpboxVMName", kubernetesConfig.PrivateCluster.JumpboxProfile.Name)
+			addValue(parametersMap, "jumpboxVMSize", kubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
+			addValue(parametersMap, "jumpboxUsername", kubernetesConfig.PrivateCluster.JumpboxProfile.Username)
+			addValue(parametersMap, "jumpboxOSDiskSizeGB", kubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
+			addValue(parametersMap, "jumpboxPublicKey", kubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey)
+			addValue(parametersMap, "jumpboxStorageProfile", kubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile)
+		}
 
-			if servicePrincipalProfile != nil {
-				addValue(parametersMap, "servicePrincipalClientId", servicePrincipalProfile.ClientID)
-				keyVaultSecretRef := servicePrincipalProfile.KeyvaultSecretRef
-				if keyVaultSecretRef != nil {
-					addKeyvaultReference(parametersMap, "servicePrincipalClientSecret",
-						keyVaultSecretRef.VaultID,
-						keyVaultSecretRef.SecretName,
-						keyVaultSecretRef.SecretVersion)
+		addValue(parametersMap, "enableAggregatedAPIs", kubernetesConfig.EnableAggregatedAPIs)
+
+		if properties.HasWindows() {
+			// Kubernetes packages as zip file as created by Azure Pipelines
+			// will be removed in future release as if gets phased out (https://github.com/Azure/aks-engine/issues/3851)
+			kubeBinariesSASURL := kubernetesConfig.CustomWindowsPackageURL
+			if kubeBinariesSASURL == "" {
+				if properties.IsAzureStackCloud() {
+					kubeBinariesSASURL = cloudSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase + k8sComponents[common.WindowsArtifactAzureStackComponentName]
 				} else {
-					addValue(parametersMap, "servicePrincipalClientSecret", servicePrincipalProfile.Secret)
+					kubeBinariesSASURL = cloudSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase + k8sComponents[common.WindowsArtifactComponentName]
 				}
+			}
+			addValue(parametersMap, "kubeBinariesSASURL", kubeBinariesSASURL)
 
-				if kubernetesConfig != nil && to.Bool(kubernetesConfig.EnableEncryptionWithExternalKms) {
-					if kubernetesConfig.KeyVaultSku != "" {
-						addValue(parametersMap, "clusterKeyVaultSku", kubernetesConfig.KeyVaultSku)
-					}
-					if !to.Bool(kubernetesConfig.UseManagedIdentity) && servicePrincipalProfile.ObjectID != "" {
-						addValue(parametersMap, "servicePrincipalObjectId", servicePrincipalProfile.ObjectID)
-					}
+			// Kubernetes node binaries as packaged by upstream kubernetes
+			// example at https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#node-binaries-1
+			addValue(parametersMap, "windowsKubeBinariesURL", kubernetesConfig.WindowsNodeBinariesURL)
+			addValue(parametersMap, "kubeServiceCidr", kubernetesConfig.ServiceCIDR)
+			addValue(parametersMap, "kubeBinariesVersion", k8sVersion)
+			addValue(parametersMap, "windowsTelemetryGUID", cloudSpecConfig.KubernetesSpecConfig.WindowsTelemetryGUID)
+			addValue(parametersMap, "windowsContainerdURL", kubernetesConfig.WindowsContainerdURL)
+			addValue(parametersMap, "windowsSdnPluginURL", kubernetesConfig.WindowsSdnPluginURL)
+		}
+	}
+
+	if kubernetesConfig == nil ||
+		!to.Bool(kubernetesConfig.UseManagedIdentity) ||
+		properties.IsHostedMasterProfile() {
+		servicePrincipalProfile := properties.ServicePrincipalProfile
+
+		if servicePrincipalProfile != nil {
+			addValue(parametersMap, "servicePrincipalClientId", servicePrincipalProfile.ClientID)
+			keyVaultSecretRef := servicePrincipalProfile.KeyvaultSecretRef
+			if keyVaultSecretRef != nil {
+				addKeyvaultReference(parametersMap, "servicePrincipalClientSecret",
+					keyVaultSecretRef.VaultID,
+					keyVaultSecretRef.SecretName,
+					keyVaultSecretRef.SecretVersion)
+			} else {
+				addValue(parametersMap, "servicePrincipalClientSecret", servicePrincipalProfile.Secret)
+			}
+
+			if kubernetesConfig != nil && to.Bool(kubernetesConfig.EnableEncryptionWithExternalKms) {
+				if kubernetesConfig.KeyVaultSku != "" {
+					addValue(parametersMap, "clusterKeyVaultSku", kubernetesConfig.KeyVaultSku)
+				}
+				if !to.Bool(kubernetesConfig.UseManagedIdentity) && servicePrincipalProfile.ObjectID != "" {
+					addValue(parametersMap, "servicePrincipalObjectId", servicePrincipalProfile.ObjectID)
 				}
 			}
 		}
+	}
 
-		addValue(parametersMap, "orchestratorName", properties.K8sOrchestratorName())
+	addValue(parametersMap, "orchestratorName", properties.K8sOrchestratorName())
 
-		/**
-		 The following parameters could be either a plain text, or referenced to a secret in a keyvault:
-		 - apiServerCertificate
-		 - apiServerPrivateKey
-		 - caCertificate
-		 - clientCertificate
-		 - clientPrivateKey
-		 - kubeConfigCertificate
-		 - kubeConfigPrivateKey
-		 - servicePrincipalClientSecret
-		 - etcdClientCertificate
-		 - etcdClientPrivateKey
-		 - etcdServerCertificate
-		 - etcdServerPrivateKey
-		 - etcdPeerCertificates
-		 - etcdPeerPrivateKeys
+	/**
+	 The following parameters could be either a plain text, or referenced to a secret in a keyvault:
+	 - apiServerCertificate
+	 - apiServerPrivateKey
+	 - caCertificate
+	 - clientCertificate
+	 - clientPrivateKey
+	 - kubeConfigCertificate
+	 - kubeConfigPrivateKey
+	 - servicePrincipalClientSecret
+	 - etcdClientCertificate
+	 - etcdClientPrivateKey
+	 - etcdServerCertificate
+	 - etcdServerPrivateKey
+	 - etcdPeerCertificates
+	 - etcdPeerPrivateKeys
 
-		 To refer to a keyvault secret, the value of the parameter in the api model file should be formatted as:
+	 To refer to a keyvault secret, the value of the parameter in the api model file should be formatted as:
 
-		 "<PARAMETER>": "/subscriptions/<SUB_ID>/resourceGroups/<RG_NAME>/providers/Microsoft.KeyVault/vaults/<KV_NAME>/secrets/<NAME>[/<VERSION>]"
-		 where:
-		   <SUB_ID> is the subscription ID of the keyvault
-		   <RG_NAME> is the resource group of the keyvault
-		   <KV_NAME> is the name of the keyvault
-		   <NAME> is the name of the secret.
-		   <VERSION> (optional) is the version of the secret (default: the latest version)
+	 "<PARAMETER>": "/subscriptions/<SUB_ID>/resourceGroups/<RG_NAME>/providers/Microsoft.KeyVault/vaults/<KV_NAME>/secrets/<NAME>[/<VERSION>]"
+	 where:
+	   <SUB_ID> is the subscription ID of the keyvault
+	   <RG_NAME> is the resource group of the keyvault
+	   <KV_NAME> is the name of the keyvault
+	   <NAME> is the name of the secret.
+	   <VERSION> (optional) is the version of the secret (default: the latest version)
 
-		 This will generate a reference block in the parameters file:
+	 This will generate a reference block in the parameters file:
 
-		 "reference": {
-		   "keyVault": {
-		     "id": "/subscriptions/<SUB_ID>/resourceGroups/<RG_NAME>/providers/Microsoft.KeyVault/vaults/<KV_NAME>"
-		   },
-		   "secretName": "<NAME>"
-		   "secretVersion": "<VERSION>"
-		}
-		**/
+	 "reference": {
+	   "keyVault": {
+	     "id": "/subscriptions/<SUB_ID>/resourceGroups/<RG_NAME>/providers/Microsoft.KeyVault/vaults/<KV_NAME>"
+	   },
+	   "secretName": "<NAME>"
+	   "secretVersion": "<VERSION>"
+	}
+	**/
 
-		certificateProfile := properties.CertificateProfile
-		if certificateProfile != nil {
-			addSecret(parametersMap, "apiServerCertificate", certificateProfile.APIServerCertificate, true)
-			addSecret(parametersMap, "apiServerPrivateKey", certificateProfile.APIServerPrivateKey, true)
-			addSecret(parametersMap, "caCertificate", certificateProfile.CaCertificate, true)
-			addSecret(parametersMap, "caPrivateKey", certificateProfile.CaPrivateKey, true)
-			addSecret(parametersMap, "clientCertificate", certificateProfile.ClientCertificate, true)
-			addSecret(parametersMap, "clientPrivateKey", certificateProfile.ClientPrivateKey, true)
-			addSecret(parametersMap, "kubeConfigCertificate", certificateProfile.KubeConfigCertificate, true)
-			addSecret(parametersMap, "kubeConfigPrivateKey", certificateProfile.KubeConfigPrivateKey, true)
-			if properties.MasterProfile != nil {
-				addSecret(parametersMap, "etcdServerCertificate", certificateProfile.EtcdServerCertificate, true)
-				addSecret(parametersMap, "etcdServerPrivateKey", certificateProfile.EtcdServerPrivateKey, true)
-				addSecret(parametersMap, "etcdClientCertificate", certificateProfile.EtcdClientCertificate, true)
-				addSecret(parametersMap, "etcdClientPrivateKey", certificateProfile.EtcdClientPrivateKey, true)
-				for i, pc := range certificateProfile.EtcdPeerCertificates {
-					addSecret(parametersMap, "etcdPeerCertificate"+strconv.Itoa(i), pc, true)
-				}
-				for i, pk := range certificateProfile.EtcdPeerPrivateKeys {
-					addSecret(parametersMap, "etcdPeerPrivateKey"+strconv.Itoa(i), pk, true)
-				}
+	certificateProfile := properties.CertificateProfile
+	if certificateProfile != nil {
+		addSecret(parametersMap, "apiServerCertificate", certificateProfile.APIServerCertificate, true)
+		addSecret(parametersMap, "apiServerPrivateKey", certificateProfile.APIServerPrivateKey, true)
+		addSecret(parametersMap, "caCertificate", certificateProfile.CaCertificate, true)
+		addSecret(parametersMap, "caPrivateKey", certificateProfile.CaPrivateKey, true)
+		addSecret(parametersMap, "clientCertificate", certificateProfile.ClientCertificate, true)
+		addSecret(parametersMap, "clientPrivateKey", certificateProfile.ClientPrivateKey, true)
+		addSecret(parametersMap, "kubeConfigCertificate", certificateProfile.KubeConfigCertificate, true)
+		addSecret(parametersMap, "kubeConfigPrivateKey", certificateProfile.KubeConfigPrivateKey, true)
+		if properties.MasterProfile != nil {
+			addSecret(parametersMap, "etcdServerCertificate", certificateProfile.EtcdServerCertificate, true)
+			addSecret(parametersMap, "etcdServerPrivateKey", certificateProfile.EtcdServerPrivateKey, true)
+			addSecret(parametersMap, "etcdClientCertificate", certificateProfile.EtcdClientCertificate, true)
+			addSecret(parametersMap, "etcdClientPrivateKey", certificateProfile.EtcdClientPrivateKey, true)
+			for i, pc := range certificateProfile.EtcdPeerCertificates {
+				addSecret(parametersMap, "etcdPeerCertificate"+strconv.Itoa(i), pc, true)
+			}
+			for i, pk := range certificateProfile.EtcdPeerPrivateKeys {
+				addSecret(parametersMap, "etcdPeerPrivateKey"+strconv.Itoa(i), pk, true)
 			}
 		}
+	}
 
-		if properties.HostedMasterProfile != nil && properties.HostedMasterProfile.FQDN != "" {
-			addValue(parametersMap, "kubernetesEndpoint", properties.HostedMasterProfile.FQDN)
-		}
+	if properties.HostedMasterProfile != nil && properties.HostedMasterProfile.FQDN != "" {
+		addValue(parametersMap, "kubernetesEndpoint", properties.HostedMasterProfile.FQDN)
+	}
 
-		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
-			addValue(parametersMap, "mobyVersion", properties.OrchestratorProfile.KubernetesConfig.MobyVersion)
-		}
+	if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
+		addValue(parametersMap, "mobyVersion", properties.OrchestratorProfile.KubernetesConfig.MobyVersion)
+	}
 
-		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
-			addValue(parametersMap, "containerdVersion", properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion)
-		}
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
+		addValue(parametersMap, "containerdVersion", properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion)
+	}
 
-		if kubernetesConfig != nil && kubernetesConfig.IsAddonEnabled(common.AppGwIngressAddonName) {
-			addValue(parametersMap, "appGwSku", kubernetesConfig.GetAddonByName(common.AppGwIngressAddonName).Config["appgw-sku"])
-			addValue(parametersMap, "appGwSubnet", kubernetesConfig.GetAddonByName(common.AppGwIngressAddonName).Config["appgw-subnet"])
-		}
+	if kubernetesConfig != nil && kubernetesConfig.IsAddonEnabled(common.AppGwIngressAddonName) {
+		addValue(parametersMap, "appGwSku", kubernetesConfig.GetAddonByName(common.AppGwIngressAddonName).Config["appgw-sku"])
+		addValue(parametersMap, "appGwSubnet", kubernetesConfig.GetAddonByName(common.AppGwIngressAddonName).Config["appgw-subnet"])
 	}
 }

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -249,10 +249,10 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 			return cs.Properties.IsIPMasqAgentEnabled()
 		},
 		"IsKubernetesVersionGe": func(version string) bool {
-			return cs.Properties.OrchestratorProfile.IsKubernetes() && common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, version)
+			return common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, version)
 		},
 		"IsKubernetesVersionLt": func(version string) bool {
-			return cs.Properties.OrchestratorProfile.IsKubernetes() && !common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, version)
+			return !common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, version)
 		},
 		"GetMasterKubernetesLabels": func(rg string) string {
 			return common.GetMasterKubernetesLabels(rg, false)
@@ -301,9 +301,6 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 		},
 		"HasPrivateRegistry": func() bool {
 			return false
-		},
-		"IsKubernetes": func() bool {
-			return cs.Properties.OrchestratorProfile.IsKubernetes()
 		},
 		"IsPublic": func(ports []int) bool {
 			return common.SliceIntIsNonEmpty(ports)

--- a/pkg/engine/template_generator_test.go
+++ b/pkg/engine/template_generator_test.go
@@ -61,7 +61,6 @@ func TestGetTemplateFuncMap(t *testing.T) {
 		"GetKubeletConfigKeyValsPsh",
 		"GetK8sRuntimeConfigKeyVals",
 		"HasPrivateRegistry",
-		"IsKubernetes",
 		"IsPublic",
 		"IsAzureCNI",
 		"HasCosmosEtcd",

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -155,15 +155,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _agentoutputsT = []byte(`{{if IsPublic .Ports}}
-  {{ if not IsKubernetes }}
-    "{{.Name}}FQDN": {
-        "type": "string",
-        "value": "[reference(concat('Microsoft.Network/publicIPAddresses/', variables('{{.Name}}IPAddressName'))).dnsSettings.fqdn]"
-    },
-  {{end}}
-{{end}}
-{{if and .IsAvailabilitySets .IsStorageAccount}}
+var _agentoutputsT = []byte(`{{if and .IsAvailabilitySets .IsStorageAccount}}
   "{{.Name}}StorageAccountOffset": {
       "type": "int",
       "value": "[variables('{{.Name}}StorageAccountOffset')]"
@@ -176,7 +168,8 @@ var _agentoutputsT = []byte(`{{if IsPublic .Ports}}
       "type": "string",
       "value": "[variables('{{.Name}}SubnetName')]"
     },
-{{end}}`)
+{{end}}
+`)
 
 func agentoutputsTBytes() ([]byte, error) {
 	return _agentoutputsT, nil
@@ -19358,8 +19351,7 @@ func masterparamsT() (*asset, error) {
 	return a, nil
 }
 
-var _windowsparamsT = []byte(` {{if IsKubernetes}}
-    "kubeBinariesSASURL": {
+var _windowsparamsT = []byte(`    "kubeBinariesSASURL": {
       "metadata": {
         "description": "The download url for kubernetes windows binaries package"
       },
@@ -19401,7 +19393,6 @@ var _windowsparamsT = []byte(` {{if IsKubernetes}}
       },
       "type": "string"
     },
- {{end}}
     "windowsAdminUsername": {
       "type": "string",
       "metadata": {

--- a/pkg/engine/testdata/addons/kubernetes-custom-psp.json
+++ b/pkg/engine/testdata/addons/kubernetes-custom-psp.json
@@ -4,7 +4,6 @@
   "properties": {
     "provisioningState": "",
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "enablePodSecurityPolicy": true,

--- a/pkg/engine/testdata/addons/kubernetes-kube-proxy.json
+++ b/pkg/engine/testdata/addons/kubernetes-kube-proxy.json
@@ -4,7 +4,6 @@
   "properties": {
     "provisioningState": "",
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "addons": [

--- a/pkg/engine/testdata/addons/kubernetes.json
+++ b/pkg/engine/testdata/addons/kubernetes.json
@@ -4,7 +4,6 @@
   "properties": {
     "provisioningState": "",
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "addons": [

--- a/pkg/engine/testdata/azurestack/kubernetes.json
+++ b/pkg/engine/testdata/azurestack/kubernetes.json
@@ -3,7 +3,6 @@
     "location": "local",
     "properties": {
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.16",
             "kubernetesConfig": {
                 "kubernetesImageBase": "k8s.gcr.io/",

--- a/pkg/engine/testdata/customcloud/kubernetes.json
+++ b/pkg/engine/testdata/customcloud/kubernetes.json
@@ -3,7 +3,6 @@
     "location": "westus",
     "properties": {
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.16",
             "kubernetesConfig": {
                 "kubernetesImageBase": "k8s.gcr.io/",

--- a/pkg/engine/testdata/disks-managed/kubernetes-vmas.json
+++ b/pkg/engine/testdata/disks-managed/kubernetes-vmas.json
@@ -3,9 +3,6 @@
   "plan": {},
   "properties": {
     "provisioningState": "",
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/disks-managed/kubernetes-vmss.json
+++ b/pkg/engine/testdata/disks-managed/kubernetes-vmss.json
@@ -4,8 +4,7 @@
   "properties": {
     "provisioningState": "",
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-    "orchestratorRelease": "1.16"
+      "orchestratorRelease": "1.16"
     },
     "masterProfile": {
       "count": 1,
@@ -20,7 +19,12 @@
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "VirtualMachineScaleSets",
         "storageProfile": "ManagedDisks",
-        "diskSizesGB": [128, 128, 128, 128]
+        "diskSizesGB": [
+          128,
+          128,
+          128,
+          128
+        ]
       },
       {
         "name": "agentpool2",
@@ -28,7 +32,12 @@
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "VirtualMachineScaleSets",
         "storageProfile": "ManagedDisks",
-        "diskSizesGB": [10, 10, 10, 10]
+        "diskSizesGB": [
+          10,
+          10,
+          10,
+          10
+        ]
       }
     ],
     "linuxProfile": {
@@ -59,8 +68,12 @@
       "etcdClientPrivateKey": "etcdClientPrivateKey",
       "etcdServerCertificate": "etcdServerCertificate",
       "etcdServerPrivateKey": "etcdServerPrivateKey",
-      "etcdPeerCertificates": ["etcdPeerCertificate0"],
-      "etcdPeerPrivateKeys": ["etcdPeerPrivateKey0"]
+      "etcdPeerCertificates": [
+        "etcdPeerCertificate0"
+      ],
+      "etcdPeerPrivateKeys": [
+        "etcdPeerPrivateKey0"
+      ]
     }
   }
 }

--- a/pkg/engine/testdata/disks-storageaccount/kubernetes.json
+++ b/pkg/engine/testdata/disks-storageaccount/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/etcd-versions/kubernetes.json
+++ b/pkg/engine/testdata/etcd-versions/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "etcdVersion": "3.1.10"
       }

--- a/pkg/engine/testdata/extensions/kubernetes.json
+++ b/pkg/engine/testdata/extensions/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/key-vault-certs/kubernetes.json
+++ b/pkg/engine/testdata/key-vault-certs/kubernetes.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "orchestratorVersion": "1.16.14",
       "kubernetesConfig": {

--- a/pkg/engine/testdata/key-vault-params/kubernetes.json
+++ b/pkg/engine/testdata/key-vault-params/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/kubernetesversions/1.13.json
+++ b/pkg/engine/testdata/kubernetesversions/1.13.json
@@ -2,8 +2,7 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-       "orchestratorRelease": "1.16"
+      "orchestratorRelease": "1.16"
     },
     "masterProfile": {
       "count": 1,

--- a/pkg/engine/testdata/largeclusters/kubernetes-vmss.json
+++ b/pkg/engine/testdata/largeclusters/kubernetes-vmss.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16"
     },
     "masterProfile": {

--- a/pkg/engine/testdata/largeclusters/kubernetes.json
+++ b/pkg/engine/testdata/largeclusters/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/location/kubernetes.json
+++ b/pkg/engine/testdata/location/kubernetes.json
@@ -2,9 +2,6 @@
   "apiVersion": "vlabs",
   "location": "westus",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/mastersonly/mastersonly.json
+++ b/pkg/engine/testdata/mastersonly/mastersonly.json
@@ -2,7 +2,6 @@
     "apiVersion": "vlabs",
     "properties": {
         "orchestratorProfile": {
-            "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.16"
         },
         "masterProfile": {

--- a/pkg/engine/testdata/simple/kubernetes.json
+++ b/pkg/engine/testdata/simple/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/vnet/kubernetesvnet.json
+++ b/pkg/engine/testdata/vnet/kubernetesvnet.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "dnsServiceIP": "172.17.1.10",
         "serviceCidr": "172.16.0.0/14",

--- a/pkg/engine/testdata/windows/kubernetes-hybrid.json
+++ b/pkg/engine/testdata/windows/kubernetes-hybrid.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/pkg/engine/testdata/windows/kubernetes-kubernetesconfig.json
+++ b/pkg/engine/testdata/windows/kubernetes-kubernetesconfig.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useInstanceMetadata": false,

--- a/pkg/engine/testdata/windows/kubernetes-vmss.json
+++ b/pkg/engine/testdata/windows/kubernetes-vmss.json
@@ -2,7 +2,6 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "useInstanceMetadata": false

--- a/pkg/engine/testdata/windows/kubernetes.json
+++ b/pkg/engine/testdata/windows/kubernetes.json
@@ -1,9 +1,6 @@
 {
   "apiVersion": "vlabs",
   "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
-    },
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "masterdns1",

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -122,13 +122,8 @@ func ParseCustomCloudConfig() (*CustomCloudConfig, error) {
 
 // GetKubeConfig returns the absolute path to the kubeconfig for c.Location
 func (c *Config) GetKubeConfig() string {
-	var kubeconfigPath string
-
-	if c.IsKubernetes() {
-		file := fmt.Sprintf("kubeconfig.%s.json", c.Location)
-		kubeconfigPath = filepath.Join(c.CurrentWorkingDir, "_output", c.Name, "kubeconfig", file)
-	}
-	return kubeconfigPath
+	file := fmt.Sprintf("kubeconfig.%s.json", c.Location)
+	return filepath.Join(c.CurrentWorkingDir, "_output", c.Name, "kubeconfig", file)
 }
 
 // IsCustomCloudProfile returns true if the cloud is a custom cloud
@@ -329,11 +324,6 @@ func (c *Config) SetSSHKeyPermissions() error {
 		return err
 	}
 	return nil
-}
-
-// IsKubernetes will return true if the ORCHESTRATOR env var is set to kubernetes or not set at all
-func (c *Config) IsKubernetes() bool {
-	return c.Orchestrator == kubernetesOrchestrator
 }
 
 // SetRandomRegion sets Location to a random region

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -143,7 +143,11 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 		isAzureStackCloud = true
 	}
 
-	if prop.OrchestratorProfile.KubernetesConfig == nil {
+	if prop.OrchestratorProfile == nil {
+		prop.OrchestratorProfile = &vlabs.OrchestratorProfile{
+			KubernetesConfig: &vlabs.KubernetesConfig{},
+		}
+	} else if prop.OrchestratorProfile.KubernetesConfig == nil {
 		prop.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
 	}
 

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -169,12 +169,6 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 		prop.MasterProfile.DNSPrefix = config.MasterDNSPrefix
 	}
 
-	if !cfg.IsKubernetes() && config.AgentDNSPrefix != "" {
-		for idx, pool := range prop.AgentPoolProfiles {
-			pool.DNSPrefix = fmt.Sprintf("%v-%v", config.AgentDNSPrefix, idx)
-		}
-	}
-
 	if prop.LinuxProfile != nil {
 		if config.PublicSSHKey != "" {
 			prop.LinuxProfile.SSH.PublicKeys[0].KeyData = config.PublicSSHKey

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -262,7 +262,7 @@ func teardown() {
 		log.Printf("cannot create directory for logs: %s", err)
 	}
 
-	if cliProvisioner.Config.IsKubernetes() && cfg.SoakClusterName == "" && !cfg.SkipLogsCollection {
+	if cfg.SoakClusterName == "" && !cfg.SkipLogsCollection {
 		err = cliProvisioner.FetchProvisioningMetrics(logsPath, cfg, acct)
 		if err != nil {
 			log.Printf("cliProvisioner.FetchProvisioningMetrics error: %s\n", err)

--- a/test/e2e/runner/ginkgo.go
+++ b/test/e2e/runner/ginkgo.go
@@ -68,14 +68,12 @@ func (g *Ginkgo) Run() error {
 	err = cmd.Wait()
 	if err != nil {
 		g.Point.RecordTestError()
-		if g.Config.IsKubernetes() {
-			kubectl := exec.Command("k", "get", "all", "--all-namespaces", "-o", "wide")
-			util.PrintCommand(kubectl)
-			kubectl.CombinedOutput()
-			kubectl = exec.Command("k", "get", "nodes", "-o", "wide")
-			util.PrintCommand(kubectl)
-			kubectl.CombinedOutput()
-		}
+		kubectl := exec.Command("k", "get", "all", "--all-namespaces", "-o", "wide")
+		util.PrintCommand(kubectl)
+		kubectl.CombinedOutput()
+		kubectl = exec.Command("k", "get", "nodes", "-o", "wide")
+		util.PrintCommand(kubectl)
+		kubectl.CombinedOutput()
 		return err
 	}
 	g.Point.RecordTestSuccess()

--- a/test/e2e/test_cluster_configs/availabilityset-standard-lb.json
+++ b/test/e2e/test_cluster_configs/availabilityset-standard-lb.json
@@ -4,7 +4,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"loadBalancerSku": "Standard",
 					"excludeMasterFromStandardLB": true

--- a/test/e2e/test_cluster_configs/availabilityset.json
+++ b/test/e2e/test_cluster_configs/availabilityset.json
@@ -7,9 +7,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/base.json
+++ b/test/e2e/test_cluster_configs/base.json
@@ -15,9 +15,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/byo_infra.json
+++ b/test/e2e/test_cluster_configs/byo_infra.json
@@ -9,9 +9,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/cloud_controller_manager.json
+++ b/test/e2e/test_cluster_configs/cloud_controller_manager.json
@@ -9,7 +9,6 @@
         "apiVersion": "vlabs",
         "properties": {
             "orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
                 "kubernetesConfig": {
                     "useCloudControllerManager": true,
                     "useManagedIdentity": false

--- a/test/e2e/test_cluster_configs/cloud_controller_manager_zones.json
+++ b/test/e2e/test_cluster_configs/cloud_controller_manager_zones.json
@@ -6,7 +6,6 @@
         "apiVersion": "vlabs",
         "properties": {
             "orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
                 "kubernetesConfig": {
                     "useCloudControllerManager": true
                 }

--- a/test/e2e/test_cluster_configs/container_monitoring.json
+++ b/test/e2e/test_cluster_configs/container_monitoring.json
@@ -4,7 +4,6 @@
         "apiVersion": "vlabs",
         "properties": {
             "orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
                 "kubernetesConfig": {
                     "addons": [
                         {

--- a/test/e2e/test_cluster_configs/containerd.json
+++ b/test/e2e/test_cluster_configs/containerd.json
@@ -4,7 +4,6 @@
         "apiVersion": "vlabs",
         "properties": {
             "orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
                 "kubernetesConfig": {
                     "networkPlugin": "azure",
                     "containerRuntime": "containerd",

--- a/test/e2e/test_cluster_configs/custom_hyperkube.json
+++ b/test/e2e/test_cluster_configs/custom_hyperkube.json
@@ -8,7 +8,6 @@
         "apiVersion": "vlabs",
         "properties": {
             "orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
                 "kubernetesConfig": {
                     "customHyperkubeImage": "mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.0",
                     "customKubeProxyImage": "mcr.microsoft.com/oss/kubernetes/hyperkube:v1.16.0"

--- a/test/e2e/test_cluster_configs/dualstack.json
+++ b/test/e2e/test_cluster_configs/dualstack.json
@@ -12,7 +12,6 @@
                 "enableIPv6DualStack": true
             },
             "orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
                 "kubernetesConfig": {
                     "loadBalancerSku": "Standard",
                     "excludeMasterFromStandardLB": true,

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -13,7 +13,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"enableEncryptionWithExternalKms": true,
 					"useManagedIdentity": true,

--- a/test/e2e/test_cluster_configs/flannel/containerd.json
+++ b/test/e2e/test_cluster_configs/flannel/containerd.json
@@ -5,7 +5,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"containerRuntime": "containerd",
 					"addons": [

--- a/test/e2e/test_cluster_configs/flatcar/flatcar.json
+++ b/test/e2e/test_cluster_configs/flatcar/flatcar.json
@@ -3,7 +3,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPlugin": "azure",
 					"networkMode": "transparent",

--- a/test/e2e/test_cluster_configs/network/kubenet.json
+++ b/test/e2e/test_cluster_configs/network/kubenet.json
@@ -5,7 +5,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPlugin": "kubenet"
 				}

--- a/test/e2e/test_cluster_configs/network/kubenet_containerd.json
+++ b/test/e2e/test_cluster_configs/network/kubenet_containerd.json
@@ -4,7 +4,6 @@
         "apiVersion": "vlabs",
         "properties": {
             "orchestratorProfile": {
-                "orchestratorType": "Kubernetes",
                 "kubernetesConfig": {
                     "networkPlugin": "kubenet",
                     "containerRuntime": "containerd"

--- a/test/e2e/test_cluster_configs/network_policy/antrea.json
+++ b/test/e2e/test_cluster_configs/network_policy/antrea.json
@@ -8,7 +8,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPolicy": "antrea"
 				}

--- a/test/e2e/test_cluster_configs/network_policy/antrea_azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/antrea_azure.json
@@ -7,7 +7,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPolicy": "antrea",
 					"networkPlugin": "azure"

--- a/test/e2e/test_cluster_configs/network_policy/azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/azure.json
@@ -6,7 +6,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPlugin": "azure",
 					"networkPolicy": "azure"

--- a/test/e2e/test_cluster_configs/network_policy/calico.json
+++ b/test/e2e/test_cluster_configs/network_policy/calico.json
@@ -7,7 +7,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPolicy": "calico",
 					"networkPlugin": "kubenet",

--- a/test/e2e/test_cluster_configs/network_policy/calico_azure.json
+++ b/test/e2e/test_cluster_configs/network_policy/calico_azure.json
@@ -8,7 +8,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPolicy": "calico",
 					"networkPlugin": "azure",

--- a/test/e2e/test_cluster_configs/no_outbound.json
+++ b/test/e2e/test_cluster_configs/no_outbound.json
@@ -6,9 +6,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/private_cluster/basic_lb_1_master.json
+++ b/test/e2e/test_cluster_configs/private_cluster/basic_lb_1_master.json
@@ -6,7 +6,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"loadBalancerSku": "Basic",
 					"etcdVersion": "3.3.15",

--- a/test/e2e/test_cluster_configs/private_cluster/basic_lb_3_masters.json
+++ b/test/e2e/test_cluster_configs/private_cluster/basic_lb_3_masters.json
@@ -6,7 +6,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"loadBalancerSku": "Basic",
 					"etcdVersion": "3.3.15",

--- a/test/e2e/test_cluster_configs/private_cluster/standard_lb_1_master.json
+++ b/test/e2e/test_cluster_configs/private_cluster/standard_lb_1_master.json
@@ -6,7 +6,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"loadBalancerSku": "Standard",
 					"excludeMasterFromStandardLB": true,

--- a/test/e2e/test_cluster_configs/private_cluster/standard_lb_3_masters.json
+++ b/test/e2e/test_cluster_configs/private_cluster/standard_lb_3_masters.json
@@ -6,7 +6,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"loadBalancerSku": "Standard",
 					"excludeMasterFromStandardLB": true,

--- a/test/e2e/test_cluster_configs/sgx.json
+++ b/test/e2e/test_cluster_configs/sgx.json
@@ -6,9 +6,6 @@
     "apiModel": {
         "apiVersion": "vlabs",
         "properties": {
-            "orchestratorProfile": {
-                "orchestratorType": "Kubernetes"
-            },
             "masterProfile": {
                 "count": 1,
                 "vmSize": "Standard_D2s_v3",

--- a/test/e2e/test_cluster_configs/vmss_master.json
+++ b/test/e2e/test_cluster_configs/vmss_master.json
@@ -4,7 +4,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"useManagedIdentity": false
 				}

--- a/test/e2e/test_cluster_configs/windows/image_reference.json
+++ b/test/e2e/test_cluster_configs/windows/image_reference.json
@@ -11,9 +11,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/windows/network_plugin/kubenet.json
+++ b/test/e2e/test_cluster_configs/windows/network_plugin/kubenet.json
@@ -11,7 +11,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"networkPlugin": "kubenet"
 				}

--- a/test/e2e/test_cluster_configs/windows/reproductions/high-cpu.json
+++ b/test/e2e/test_cluster_configs/windows/reproductions/high-cpu.json
@@ -9,7 +9,6 @@
 		"apiVersion": "vlabs",
 		"properties": {
 			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes",
 				"kubernetesConfig": {
 					"useManagedIdentity": false
 				}

--- a/test/e2e/test_cluster_configs/windows/sac/sac-1903.json
+++ b/test/e2e/test_cluster_configs/windows/sac/sac-1903.json
@@ -6,9 +6,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/windows/sac/sac-1909.json
+++ b/test/e2e/test_cluster_configs/windows/sac/sac-1909.json
@@ -6,9 +6,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/windows/sac/sac-2004.json
+++ b/test/e2e/test_cluster_configs/windows/sac/sac-2004.json
@@ -6,9 +6,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
+++ b/test/e2e/test_cluster_configs/windows/shared_image_gallery.json
@@ -14,9 +14,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/windows/vhd_ahub.json
+++ b/test/e2e/test_cluster_configs/windows/vhd_ahub.json
@@ -12,9 +12,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",

--- a/test/e2e/test_cluster_configs/windows/vhd_url.json
+++ b/test/e2e/test_cluster_configs/windows/vhd_url.json
@@ -10,9 +10,6 @@
 	"apiModel": {
 		"apiVersion": "vlabs",
 		"properties": {
-			"orchestratorProfile": {
-				"orchestratorType": "Kubernetes"
-			},
 			"masterProfile": {
 				"count": 1,
 				"dnsPrefix": "",


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

With #4036 merging, we no longer nominally support any non-Kubernetes orchestrators in any code flows (🎉). This change means that the `orchestratorType` property has no semantic value.

This PR effectively "deprecates" the `orchestratorType` property in the `orchestratorProfile` configuration object:

- defaults to `Kubernetes` where appropriate, so that it no longer needs to be included in API model definitions
- removes several validations whose purpose was to ensure that "orchestratorType == Kubernetes"; because that is *always* true, those validations are superfluous
- updated documentation and example API models

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
