### PR TITLE
chore: mark Kubernetes 1.17.14 as disabled

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -195,6 +195,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.17.11":        false,
 	"1.17.12":        true,
 	"1.17.13":        true,
+	"1.17.14":        true, // disabled, see https://github.com/kubernetes/kubernetes/pull/96623
 	"1.18.0-alpha.1": false,
 	"1.18.0-alpha.2": false,
 	"1.18.0-alpha.3": false,

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -195,7 +195,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.17.11":        false,
 	"1.17.12":        true,
 	"1.17.13":        true,
-	"1.17.14":        true, // disabled, see https://github.com/kubernetes/kubernetes/pull/96623
+	"1.17.14":        false, // disabled, see https://github.com/kubernetes/kubernetes/pull/96623
 	"1.18.0-alpha.1": false,
 	"1.18.0-alpha.2": false,
 	"1.18.0-alpha.3": false,


### PR DESCRIPTION
**Reason for Change**:

We saw test failures with 1.17.14 and have a fix for the next patch release at kubernetes/kubernetes#96623.

See also https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#changelog-since-v11713

**Issue Fixed**:


**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [ ] Kubernetes artifacts built and pushed by Azure Pipelines
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

This PR contains a temporary testing commit that should be discarded before merging.

The Azure Pipeline for the 1.17.14 build has not completed successfully yet, so the artifacts are not published.
