### PR TITLE
fix: always ensure etcd on control plane vms

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -230,9 +230,7 @@ if [[ -n ${MASTER_NODE} ]]; then
   time_metric "EnsureTaints" ensureTaints
 {{end}}
   if [[ -z ${COSMOS_URI} ]]; then
-    if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
-      time_metric "EnsureEtcd" ensureEtcd
-    fi
+    time_metric "EnsureEtcd" ensureEtcd
   fi
   time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
   if [ -f /var/run/reboot-required ]; then

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13291,9 +13291,7 @@ if [[ -n ${MASTER_NODE} ]]; then
   time_metric "EnsureTaints" ensureTaints
 {{end}}
   if [[ -z ${COSMOS_URI} ]]; then
-    if ! { [ "$FULL_INSTALL_REQUIRED" = "true" ] && [ ${UBUNTU_RELEASE} == "18.04" ]; }; then
-      time_metric "EnsureEtcd" ensureEtcd
-    fi
+    time_metric "EnsureEtcd" ensureEtcd
   fi
   time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
   if [ -f /var/run/reboot-required ]; then


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Perhaps in the past the `ensureEtcd` func was unnecessary and not reliable in the non-VHD 18.04 scenario, but without it we don't start the etcd-monitor systemd job, which we want to do always.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
