### PR TITLE
fix: persist VMSS name in API model

### DIFF
--- a/cmd/addpool.go
+++ b/cmd/addpool.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/aks-engine/pkg/i18n"
 	"github.com/Azure/aks-engine/pkg/operations"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/leonelquinteros/gotext"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -143,6 +144,12 @@ func (apc *addPoolCmd) load() error {
 		return errors.Wrap(err, "error parsing the agent pool")
 	}
 
+	if apc.nodePool.IsWindows() {
+		existingPools := len(apc.containerService.Properties.AgentPoolProfiles)
+		newIndex := existingPools + 1
+		apc.nodePool.VMSSName = apc.containerService.Properties.GetAgentVMPrefix(apc.nodePool, newIndex)
+	}
+
 	if apc.containerService.Properties.IsCustomCloudProfile() {
 		if err = writeCustomCloudProfile(apc.containerService); err != nil {
 			return errors.Wrap(err, "error writing custom cloud profile")
@@ -210,12 +217,8 @@ func (apc *addPoolCmd) run(cmd *cobra.Command, args []string) error {
 				return errors.Wrap(err, "failed to get VMSS list in the resource group")
 			}
 			for _, vmss := range vmssListPage.Values() {
-				segments := strings.Split(*vmss.Name, "-")
-				if len(segments) == 4 && segments[0] == "k8s" {
-					vmssName := segments[1]
-					if apc.nodePool.Name == vmssName {
-						return errors.New("An agent pool with the given name already exists in the cluster")
-					}
+				if apc.nodePool.VMSSName == to.String(vmss.Name) {
+					return errors.New("A VMSS node pool with the given name already exists in the cluster")
 				}
 			}
 		}

--- a/cmd/addpool.go
+++ b/cmd/addpool.go
@@ -144,7 +144,8 @@ func (apc *addPoolCmd) load() error {
 		return errors.Wrap(err, "error parsing the agent pool")
 	}
 
-	if apc.nodePool.IsWindows() {
+	// Back-compat logic to populate the VMSSName property for clusters built prior to VMSSName being a part of the API model spec
+	if apc.nodePool.IsVirtualMachineScaleSets() && apc.nodePool.VMSSName == "" {
 		existingPools := len(apc.containerService.Properties.AgentPoolProfiles)
 		newIndex := existingPools + 1
 		apc.nodePool.VMSSName = apc.containerService.Properties.GetAgentVMPrefix(apc.nodePool, newIndex)

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -226,6 +226,11 @@ func (sc *scaleCmd) load() error {
 		}
 	}
 
+	// Back-compat logic to populate the VMSSName property for clusters built prior to VMSSName being a part of the API model spec
+	if sc.agentPool.IsVirtualMachineScaleSets() && sc.agentPool.VMSSName == "" {
+		sc.agentPool.VMSSName = sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, sc.agentPoolIndex)
+	}
+
 	//allows to identify VMs in the resource group that belong to this cluster.
 	sc.nameSuffix = sc.containerService.Properties.GetClusterID()
 	log.Debugf("Cluster ID used in all agent pools: %s", sc.nameSuffix)

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -436,6 +436,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 
 				currentNodeCount = int(*vmss.Sku.Capacity)
 				highestUsedIndex = 0
+				break
 			}
 		}
 	}

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -608,6 +608,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	}
 	p.OSDiskCachingType = api.OSDiskCachingType
 	p.DataDiskCachingType = api.DataDiskCachingType
+	p.VMSSName = api.VMSSName
 }
 
 func convertServicePrincipalProfileToVLabs(api *ServicePrincipalProfile, v *vlabs.ServicePrincipalProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -647,6 +647,7 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 	}
 	api.OSDiskCachingType = vlabs.OSDiskCachingType
 	api.DataDiskCachingType = vlabs.DataDiskCachingType
+	api.VMSSName = vlabs.VMSSName
 }
 
 func convertVLabsKeyVaultSecrets(vlabs *vlabs.KeyVaultSecrets, api *KeyVaultSecrets) {

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -695,7 +695,7 @@ func (p *Properties) setMasterProfileDefaults() {
 }
 
 func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
-	for _, profile := range p.AgentPoolProfiles {
+	for i, profile := range p.AgentPoolProfiles {
 		if profile.AvailabilityProfile == "" {
 			profile.AvailabilityProfile = VirtualMachineScaleSets
 		}
@@ -712,6 +712,8 @@ func (p *Properties) setAgentProfileDefaults(isUpgrade, isScale bool) {
 			if profile.VMSSOverProvisioningEnabled == nil {
 				profile.VMSSOverProvisioningEnabled = to.BoolPtr(DefaultVMSSOverProvisioningEnabled && !isUpgrade && !isScale)
 			}
+
+			profile.VMSSName = p.GetAgentVMPrefix(profile, i)
 		}
 		// set default OSType to Linux
 		if profile.OSType == "" {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -705,6 +705,26 @@ func TestVMSSOverProvisioning(t *testing.T) {
 	}
 }
 
+func TestVMSSDefaultsVMSSName(t *testing.T) {
+	poolName := "foo"
+	mockCS := getMockBaseContainerService("1.18.10")
+	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = VirtualMachineScaleSets
+	mockCS.Properties.AgentPoolProfiles[0].Name = poolName
+	expectedVMSSName := mockCS.Properties.GetAgentVMPrefix(mockCS.Properties.AgentPoolProfiles[0], 0)
+	_, err := mockCS.SetPropertiesDefaults(PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if err != nil {
+		t.Errorf("expected no error from SetPropertiesDefaults, instead got %s", err)
+	}
+
+	if mockCS.Properties.AgentPoolProfiles[0].VMSSName != expectedVMSSName {
+		t.Errorf("expected VMSSName to be %s, instead got %s", expectedVMSSName, mockCS.Properties.AgentPoolProfiles[0].VMSSName)
+	}
+}
+
 func TestAuditDEnabled(t *testing.T) {
 	mockCS := getMockBaseContainerService("1.12.7")
 	isUpgrade := true

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -656,6 +656,7 @@ type AgentPoolProfile struct {
 	SinglePlacementGroup                *bool                `json:"singlePlacementGroup,omitempty"`
 	VnetCidrs                           []string             `json:"vnetCidrs,omitempty"`
 	PreserveNodesProperties             *bool                `json:"preserveNodesProperties,omitempty"`
+	VMSSName                            string               `json:"vmssName,omitempty"`
 	WindowsNameVersion                  string               `json:"windowsNameVersion,omitempty"`
 	EnableVMSSNodePublicIP              *bool                `json:"enableVMSSNodePublicIP,omitempty"`
 	LoadBalancerBackendAddressPoolIDs   []string             `json:"loadBalancerBackendAddressPoolIDs,omitempty"`
@@ -927,6 +928,9 @@ func (p *Properties) GetAgentPoolIndexByName(name string) int {
 
 // GetAgentVMPrefix returns the VM prefix for an agentpool.
 func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile, index int) string {
+	if a.IsVirtualMachineScaleSets() && a.VMSSName != "" {
+		return a.VMSSName
+	}
 	nameSuffix := p.GetClusterID()
 	vmPrefix := ""
 	if index != -1 {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -668,7 +668,8 @@ type AgentPoolProfile struct {
 	ProximityPlacementGroupID           string               `json:"proximityPlacementGroupID,omitempty"`
 	OSDiskCachingType                   string               `json:"osDiskCachingType,omitempty"`
 	DataDiskCachingType                 string               `json:"dataDiskCachingType,omitempty"`
-	VMSSName                            string               `json:"vmssName,omitempty"`
+	// VMSSName is a read-only field; its value will be computed during template generation
+	VMSSName string `json:"vmssName,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -656,7 +656,6 @@ type AgentPoolProfile struct {
 	SinglePlacementGroup                *bool                `json:"singlePlacementGroup,omitempty"`
 	VnetCidrs                           []string             `json:"vnetCidrs,omitempty"`
 	PreserveNodesProperties             *bool                `json:"preserveNodesProperties,omitempty"`
-	VMSSName                            string               `json:"vmssName,omitempty"`
 	WindowsNameVersion                  string               `json:"windowsNameVersion,omitempty"`
 	EnableVMSSNodePublicIP              *bool                `json:"enableVMSSNodePublicIP,omitempty"`
 	LoadBalancerBackendAddressPoolIDs   []string             `json:"loadBalancerBackendAddressPoolIDs,omitempty"`
@@ -669,6 +668,7 @@ type AgentPoolProfile struct {
 	ProximityPlacementGroupID           string               `json:"proximityPlacementGroupID,omitempty"`
 	OSDiskCachingType                   string               `json:"osDiskCachingType,omitempty"`
 	DataDiskCachingType                 string               `json:"dataDiskCachingType,omitempty"`
+	VMSSName                            string               `json:"vmssName,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -5511,6 +5511,38 @@ func TestGetAgentVMPrefix(t *testing.T) {
 			expectedVMPrefix: "k8s-agentpool-30819786-vmss",
 		},
 		{
+			name: "Linux VMSS agent pool profile with VMSSName",
+			profile: &AgentPoolProfile{
+				Name:                "agentpool",
+				VMSize:              "Standard_D2_v2",
+				Count:               1,
+				AvailabilityProfile: "VirtualMachineScaleSets",
+				OSType:              Linux,
+				VMSSName:            "foo",
+			},
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Count:     1,
+					DNSPrefix: "myprefix1",
+					VMSize:    "Standard_DS2_v2",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:                "agentpool",
+						VMSize:              "Standard_D2_v2",
+						Count:               1,
+						AvailabilityProfile: "VirtualMachineScaleSets",
+						OSType:              Linux,
+						VMSSName:            "foo",
+					},
+				},
+			},
+			expectedVMPrefix: "foo",
+		},
+		{
 			name: "Windows agent pool profile",
 			profile: &AgentPoolProfile{
 				Name:   "agentpool",

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -543,6 +543,7 @@ type AgentPoolProfile struct {
 	ProximityPlacementGroupID         string            `json:"proximityPlacementGroupID,omitempty"`
 	OSDiskCachingType                 string            `json:"osDiskCachingType,omitempty"`
 	DataDiskCachingType               string            `json:"dataDiskCachingType,omitempty"`
+	VMSSName                          string            `json:"vmssName,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -543,7 +543,8 @@ type AgentPoolProfile struct {
 	ProximityPlacementGroupID         string            `json:"proximityPlacementGroupID,omitempty"`
 	OSDiskCachingType                 string            `json:"osDiskCachingType,omitempty"`
 	DataDiskCachingType               string            `json:"dataDiskCachingType,omitempty"`
-	VMSSName                          string            `json:"vmssName,omitempty"`
+	// VMSSName is a read-only field; its value will be computed during template generation
+	VMSSName string `json:"vmssName,omitempty"`
 }
 
 // AgentPoolProfileRole represents an agent role

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -252,7 +252,7 @@ fi
 
 if [ -n "$ADD_NODE_POOL_INPUT" ]; then
   for pool in $(echo ${ADD_NODE_POOL_INPUT} | jq -c '.[]'); do
-    echo $pool > addpool-input.json
+    echo $pool > ${TMP_DIR}/addpool-input.json
     docker run --rm \
       -v $(pwd):${WORK_DIR} \
       -v /etc/ssl/certs:/etc/ssl/certs \

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -43,12 +43,6 @@ if [ "$STABILITY_TIMEOUT_SECONDS" == "" ]; then
   STABILITY_TIMEOUT_SECONDS=5
 fi
 
-if [ -n "$ADD_NODE_POOL_INPUT" ]; then
-  cat > ${TMP_DIR}/addpool-input.json <<END
-${ADD_NODE_POOL_INPUT}
-END
-fi
-
 if [ -n "$PRIVATE_SSH_KEY_FILE" ]; then
   PRIVATE_SSH_KEY_FILE=$(realpath --relative-to=$(pwd) ${PRIVATE_SSH_KEY_FILE})
 fi
@@ -257,23 +251,26 @@ else
 fi
 
 if [ -n "$ADD_NODE_POOL_INPUT" ]; then
-  docker run --rm \
-    -v $(pwd):${WORK_DIR} \
-    -v /etc/ssl/certs:/etc/ssl/certs \
-    -w ${WORK_DIR} \
-    -e RESOURCE_GROUP=$RESOURCE_GROUP \
-    -e REGION=$REGION \
-    ${DEV_IMAGE} \
-    ./bin/aks-engine addpool \
-    --azure-env ${AZURE_ENV} \
-    --subscription-id ${AZURE_SUBSCRIPTION_ID} \
-    --api-model _output/$RESOURCE_GROUP/apimodel.json \
-    --node-pool ${TMP_BASENAME}/addpool-input.json \
-    --location $REGION \
-    --resource-group $RESOURCE_GROUP \
-    --auth-method client_secret \
-    --client-id ${AZURE_CLIENT_ID} \
-    --client-secret ${AZURE_CLIENT_SECRET} || exit 1
+  for pool in $(echo ${ADD_NODE_POOL_INPUT} | jq -c '.[]'); do
+    echo $pool > addpool-input.json
+    docker run --rm \
+      -v $(pwd):${WORK_DIR} \
+      -v /etc/ssl/certs:/etc/ssl/certs \
+      -w ${WORK_DIR} \
+      -e RESOURCE_GROUP=$RESOURCE_GROUP \
+      -e REGION=$REGION \
+      ${DEV_IMAGE} \
+      ./bin/aks-engine addpool \
+      --azure-env ${AZURE_ENV} \
+      --subscription-id ${AZURE_SUBSCRIPTION_ID} \
+      --api-model _output/$RESOURCE_GROUP/apimodel.json \
+      --node-pool ${TMP_BASENAME}/addpool-input.json \
+      --location $REGION \
+      --resource-group $RESOURCE_GROUP \
+      --auth-method client_secret \
+      --client-id ${AZURE_CLIENT_ID} \
+      --client-secret ${AZURE_CLIENT_SECRET} || exit 1
+  done
 
   CLEANUP_AFTER_ADD_NODE_POOL=${CLEANUP_ON_EXIT}
   if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ]; then

--- a/test/e2e/test_cluster_configs/availabilityset.json
+++ b/test/e2e/test_cluster_configs/availabilityset.json
@@ -46,10 +46,19 @@
 			}
 		}
 	},
-	"addNodePool": {
-		"name": "pooladded",
-		"count": 1,
-		"vmSize": "Standard_D2_v3",
-		"availabilityProfile": "AvailabilitySet"
-	}
+	"addNodePool": [
+		{
+			"name": "pooladdedlinux",
+			"count": 1,
+			"vmSize": "Standard_D2_v3",
+			"availabilityProfile": "AvailabilitySet"
+		},
+		{
+			"name": "pooladdedwin",
+			"count": 1,
+			"vmSize": "Standard_D2_v3",
+			"osType": "Windows",
+			"availabilityProfile": "AvailabilitySet"
+		}
+	]
 }

--- a/test/e2e/test_cluster_configs/availabilityset.json
+++ b/test/e2e/test_cluster_configs/availabilityset.json
@@ -14,14 +14,14 @@
 			},
 			"agentPoolProfiles": [
 				{
-					"name": "agent1",
+					"name": "poollinux1",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"osType": "Linux",
 					"availabilityProfile": "AvailabilitySet"
 				},
 				{
-					"name": "poolwin",
+					"name": "poolwin1",
 					"count": 1,
 					"vmSize": "Standard_D2_v3",
 					"osType": "Windows",
@@ -48,13 +48,13 @@
 	},
 	"addNodePool": [
 		{
-			"name": "pooladdedlinux",
+			"name": "poollinux2",
 			"count": 1,
 			"vmSize": "Standard_D2_v3",
 			"availabilityProfile": "AvailabilitySet"
 		},
 		{
-			"name": "pooladdedwin",
+			"name": "poolwin2",
 			"count": 1,
 			"vmSize": "Standard_D2_v3",
 			"osType": "Windows",

--- a/test/e2e/test_cluster_configs/base.json
+++ b/test/e2e/test_cluster_configs/base.json
@@ -22,7 +22,7 @@
 			},
 			"agentPoolProfiles": [
 				{
-					"name": "poollinux",
+					"name": "poollinux1",
 					"count": 1,
 					"vmSize": "Standard_D2_v3"
 				},
@@ -53,7 +53,7 @@
 	},
 	"addNodePool": [
 		{
-			"name": "pooladdedlinux",
+			"name": "poollinux2",
 			"count": 1,
 			"vmSize": "Standard_D2_v3",
 			"availabilityProfile": "VirtualMachineScaleSets",
@@ -66,7 +66,7 @@
 			}
 		},
 		{
-			"name": "pooladdedwin",
+			"name": "poolwin2",
 			"count": 1,
 			"vmSize": "Standard_D2_v3",
 			"osType": "Windows"

--- a/test/e2e/test_cluster_configs/base.json
+++ b/test/e2e/test_cluster_configs/base.json
@@ -51,17 +51,25 @@
 			}
 		}
 	},
-	"addNodePool": {
-		"name": "pooladded",
-		"count": 1,
-		"vmSize": "Standard_D2_v3",
-		"availabilityProfile": "VirtualMachineScaleSets",
-		"kubernetesConfig": {
-			"kubeletConfig": {
-				"--cloud-provider": "",
-				"--cloud-config": "",
-				"--azure-container-registry-config": ""
+	"addNodePool": [
+		{
+			"name": "pooladdedlinux",
+			"count": 1,
+			"vmSize": "Standard_D2_v3",
+			"availabilityProfile": "VirtualMachineScaleSets",
+			"kubernetesConfig": {
+				"kubeletConfig": {
+					"--cloud-provider": "",
+					"--cloud-config": "",
+					"--azure-container-registry-config": ""
+				}
 			}
+		},
+		{
+			"name": "pooladdedwin",
+			"count": 1,
+			"vmSize": "Standard_D2_v3",
+			"osType": "Windows"
 		}
-	}
+	]
 }

--- a/test/e2e/test_cluster_configs/base.json
+++ b/test/e2e/test_cluster_configs/base.json
@@ -69,7 +69,8 @@
 			"name": "poolwin2",
 			"count": 1,
 			"vmSize": "Standard_D2_v3",
-			"osType": "Windows"
+			"osType": "Windows",
+			"availabilityProfile": "VirtualMachineScaleSets"
 		}
 	]
 }


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR adds a new `VMSSName` property to the `AgentPoolProfile` type struct, to persist the definitive VMSS name (when the node pool is VMSS) for future cluster operations.

The VMSS name is a computed property that depends in part upon the particular index value of the pool in the API model `agentPoolProfiles` array at the time of cluster creation; but over time that order may change (for example a pool may be removed, introducing a "hole" in the sequence, and effectively decrementing each pool's index by one). This solution continues to rely upon this undesirable solution (let's not throw away the baby with the bath water), but it does so only one time during a cluster operation when the API model data structure is stable, and once the property is computed it is persisted for all time in the API model to match the actual VMSS "name" property, which will remain stable and unique so long as the VMSS exists in the resource group.

This also fixes a particular edge case w/ respect to `aks-engine addpool` and Windows node pools (the `addpool` operation *always* operates against a single `AgentPoolProfile` (the new one), and thus the index is *always* zero: which means if the cluster was created with similarly named Windows pool at that index originally, the `addpool` command will produce an ARM template that actually modifies that existing pool, rather than adding an entirely new one.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #4055 

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
