### PR TITLE
feat: Updating kubelet/kube-proxy to run with as high priority processes

### DIFF
--- a/staging/provisioning/windows/kubeletstart.ps1
+++ b/staging/provisioning/windows/kubeletstart.ps1
@@ -250,11 +250,11 @@ if ($global:NetworkPlugin -eq "kubenet") {
     catch {
         Write-Error $_
     }
-
-    # Start the kubelet
-    # Use run-process.cs to set process priority class as 'High'
-    Add-Type -Path .\run-process.cs
-    $exe = "$global:KubeDir\kubelet.exe"
-    $args = ($KubeletArgList -join " ")
-    [RunProcess.exec]::RunProcess($exe, $args)
 }
+
+# Start the kubelet
+# Use run-process.cs to set process priority class as 'High'
+Add-Type -Path .\run-process.cs
+$exe = "$global:KubeDir\kubelet.exe"
+$args = ($KubeletArgList -join " ")
+[RunProcess.exec]::RunProcess($exe, $args)

--- a/staging/provisioning/windows/kubeletstart.ps1
+++ b/staging/provisioning/windows/kubeletstart.ps1
@@ -253,8 +253,14 @@ if ($global:NetworkPlugin -eq "kubenet") {
 }
 
 # Start the kubelet
-# Use run-process.cs to set process priority class as 'High'
-Add-Type -Path .\run-process.cs
+# Use run-process.cs to set process priority class as 'AboveNormal'
+# Load a signed version of runprocess.dll if it exists for Azure SysLock compliance
+# otherwise load class from cs file (for CI/testing)
+if (Test-Path "$global:KubeDir\runprocess.dll") {
+    [System.Reflection.Assembly]::LoadFrom("$global:KubeDir\runprocess.dll")
+} else {
+    Add-Type -Path "$global:KubeDir\run-process.cs"
+}
 $exe = "$global:KubeDir\kubelet.exe"
 $args = ($KubeletArgList -join " ")
-[RunProcess.exec]::RunProcess($exe, $args)
+[RunProcess.exec]::RunProcess($exe, $args, [System.Diagnostics.ProcessPriorityClass]::AboveNormal)

--- a/staging/provisioning/windows/kubeletstart.ps1
+++ b/staging/provisioning/windows/kubeletstart.ps1
@@ -197,9 +197,8 @@ if ($global:NetworkPlugin -eq "azure") {
     # This was fixed in 1.15, workaround still needed for 1.14 https://github.com/kubernetes/kubernetes/pull/78612
     Restart-Service Kubeproxy
 
-    # startup the service
+    # Set env file for Azure Stack
     $env:AZURE_ENVIRONMENT_FILEPATH = "c:\k\azurestackcloud.json"
-    Invoke-Expression $KubeletCommandLine
 }
 
 if ($global:NetworkPlugin -eq "kubenet") {
@@ -247,12 +246,15 @@ if ($global:NetworkPlugin -eq "kubenet") {
             # Add route to all other POD networks
             Update-CNIConfigKubenetDocker $podCIDR $masterSubnetGW
         }
-
-        # startup the service
-        Invoke-Expression $KubeletCommandLine
     }
     catch {
         Write-Error $_
     }
 
+    # Start the kubelet
+    # Use run-process.cs to set process priority class as 'High'
+    Add-Type -Path .\run-process.cs
+    $exe = "$global:KubeDir\kubelet.exe"
+    $args = ($KubeletArgList -join " ")
+    [RunProcess.exec]::RunProcess($exe, $args)
 }

--- a/staging/provisioning/windows/kubeproxystart.ps1
+++ b/staging/provisioning/windows/kubeproxystart.ps1
@@ -31,8 +31,14 @@ Import-Module $global:HNSModule
 # and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
 Get-HnsPolicyList | Remove-HnsPolicyList
 
-# Use run-process.cs to set process priority class as 'High'
-Add-Type -Path .\run-process.cs
+# Use run-process.cs to set process priority class as 'AboveNormal'
+# Load a signed version of runprocess.dll if it exists for Azure SysLock compliance
+# otherwise load class from cs file (for CI/testing)
+if (Test-Path "$global:KubeDir\runprocess.dll") {
+    [System.Reflection.Assembly]::LoadFrom("$global:KubeDir\runprocess.dll")
+} else {
+    Add-Type -Path "$global:KubeDir\run-process.cs"
+}
 $exe = "$global:KubeDir\kube-proxy.exe"
 $args = ($global:KubeproxyArgList -join " ")
-[RunProcess.exec]::RunProcess($exe, $args)
+[RunProcess.exec]::RunProcess($exe, $args, [System.Diagnostics.ProcessPriorityClass]::AboveNormal)

--- a/staging/provisioning/windows/kubeproxystart.ps1
+++ b/staging/provisioning/windows/kubeproxystart.ps1
@@ -31,5 +31,8 @@ Import-Module $global:HNSModule
 # and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
 Get-HnsPolicyList | Remove-HnsPolicyList
 
-$KubeproxyCmdline = "$global:KubeDir\kube-proxy.exe "+ ($global:KubeproxyArgList -join " ")
-Invoke-Expression $KubeproxyCmdline
+# Use run-process.cs to set process priority class as 'High'
+Add-Type -Path .\run-process.cs
+$exe = "$global:KubeDir\kube-proxy.exe"
+$args = ($global:KubeproxyArgList -join " ")
+[RunProcess.exec]::RunProcess($exe, $args)

--- a/staging/provisioning/windows/run-process.cs
+++ b/staging/provisioning/windows/run-process.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace RunProcess
+{
+    public static class exec
+    {
+        public static void StdOutHandler(object sender, DataReceivedEventArgs e) {
+            Console.WriteLine(e.Data);
+        }
+
+        public static void StdErrHandler(object sender, DataReceivedEventArgs e) {
+            Console.Error.WriteLine(e.Data);
+        }
+        
+        // RunProcess starts a process, sets the priority class of that process to 'High'
+        // and redirects all standard output / error for logging.
+        public static int RunProcess(string executable, string args = "") {
+            Process p = new Process();
+            p.StartInfo.FileName = executable;
+            p.StartInfo.WorkingDirectory = Path.GetDirectoryName(executable);
+            p.StartInfo.UseShellExecute = false;
+            p.StartInfo.CreateNoWindow = true;
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.RedirectStandardError = true;
+
+            if (!String.IsNullOrEmpty(args)) {
+                p.StartInfo.Arguments = args;
+            }
+
+            p.OutputDataReceived += new DataReceivedEventHandler(StdOutHandler);
+            p.ErrorDataReceived += new DataReceivedEventHandler(StdErrHandler);
+
+            p.Start();
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+
+            // I don't know why this sleep is needed but it is :-/
+            Thread.Sleep(2000);
+            p.PriorityClass = ProcessPriorityClass.High;
+            p.WaitForExit();
+
+            return p.ExitCode;
+        }
+    }
+}

--- a/staging/provisioning/windows/run-process.cs
+++ b/staging/provisioning/windows/run-process.cs
@@ -17,7 +17,7 @@ namespace RunProcess
         
         // RunProcess starts a process, sets the priority class of that process to 'High'
         // and redirects all standard output / error for logging.
-        public static int RunProcess(string executable, string args = "") {
+        public static int RunProcess(string executable, string args = "", ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal) {
             Process p = new Process();
             p.StartInfo.FileName = executable;
             p.StartInfo.WorkingDirectory = Path.GetDirectoryName(executable);
@@ -39,7 +39,7 @@ namespace RunProcess
 
             // I don't know why this sleep is needed but it is :-/
             Thread.Sleep(2000);
-            p.PriorityClass = ProcessPriorityClass.High;
+            p.PriorityClass = priorityClass;
             p.WaitForExit();
 
             return p.ExitCode;


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

This should help address many customer reported issues we have been seeing where kubelet get starved of CPU cycles when node is running under high CPU load.

I tried creating the Process object in native powershell but saw some pretty horrible lag processing the OutputDataReceived/ErrorDataReceived events so I think this is probably the most performant thing to do.

**Note**: Once kubelet/kube-proxy both have flags to set the process priority we can remove / undo this code.

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
