### PR TITLE
chore: faster rolling updates for daemonset addons

### DIFF
--- a/parts/k8s/addons/aad-pod-identity.yaml
+++ b/parts/k8s/addons/aad-pod-identity.yaml
@@ -124,6 +124,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       component: nmi

--- a/parts/k8s/addons/antrea.yaml
+++ b/parts/k8s/addons/antrea.yaml
@@ -718,3 +718,5 @@ spec:
         name: xtables-lock
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%

--- a/parts/k8s/addons/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/addons/azure-cni-networkmonitor.yaml
@@ -12,6 +12,8 @@ spec:
       k8s-app: azure-cnms
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   template:
     metadata:
       labels:

--- a/parts/k8s/addons/azure-network-policy.yaml
+++ b/parts/k8s/addons/azure-network-policy.yaml
@@ -63,6 +63,8 @@ spec:
       k8s-app: azure-npm
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   template:
     metadata:
       labels:

--- a/parts/k8s/addons/azuredisk-csi-driver-deployment.yaml
+++ b/parts/k8s/addons/azuredisk-csi-driver-deployment.yaml
@@ -296,6 +296,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azuredisk-node-windows
@@ -453,6 +457,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azuredisk-node

--- a/parts/k8s/addons/azurefile-csi-driver-deployment.yaml
+++ b/parts/k8s/addons/azurefile-csi-driver-deployment.yaml
@@ -337,6 +337,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azurefile-node-windows
@@ -484,6 +488,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azurefile-node

--- a/parts/k8s/addons/blobfuse-flexvolume.yaml
+++ b/parts/k8s/addons/blobfuse-flexvolume.yaml
@@ -7,6 +7,10 @@ metadata:
     k8s-app: blobfuse
     kubernetes.io/cluster-service: "true"
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       name: blobfuse

--- a/parts/k8s/addons/calico.yaml
+++ b/parts/k8s/addons/calico.yaml
@@ -437,7 +437,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 50%
   template:
     metadata:
       labels:

--- a/parts/k8s/addons/cilium.yaml
+++ b/parts/k8s/addons/cilium.yaml
@@ -353,7 +353,7 @@ spec:
           secretName: cilium-clustermesh
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 50%
     type: RollingUpdate
 ---
 apiVersion: apps/v1

--- a/parts/k8s/addons/cloud-node-manager.yaml
+++ b/parts/k8s/addons/cloud-node-manager.yaml
@@ -51,6 +51,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: cloud-node-manager
@@ -108,6 +112,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: cloud-node-manager-windows

--- a/parts/k8s/addons/container-monitoring.yaml
+++ b/parts/k8s/addons/container-monitoring.yaml
@@ -472,6 +472,8 @@ spec:
             optional: true
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -623,6 +625,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       component: oms-agent-win

--- a/parts/k8s/addons/flannel.yaml
+++ b/parts/k8s/addons/flannel.yaml
@@ -44,6 +44,10 @@ metadata:
     app: flannel
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       tier: node

--- a/parts/k8s/addons/ip-masq-agent.yaml
+++ b/parts/k8s/addons/ip-masq-agent.yaml
@@ -9,6 +9,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     tier: node
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: azure-ip-masq-agent

--- a/parts/k8s/addons/keyvault-flexvolume.yaml
+++ b/parts/k8s/addons/keyvault-flexvolume.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: keyvault-flexvolume

--- a/parts/k8s/addons/node-problem-detector.yaml
+++ b/parts/k8s/addons/node-problem-detector.yaml
@@ -34,6 +34,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: node-problem-detector

--- a/parts/k8s/addons/nvidia-device-plugin.yaml
+++ b/parts/k8s/addons/nvidia-device-plugin.yaml
@@ -13,6 +13,8 @@ spec:
       k8s-app: nvidia-device-plugin
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   template:
     metadata:
 {{- if IsKubernetesVersionGe "1.17.0"}}

--- a/parts/k8s/addons/scheduled-maintenance-deployment.yaml
+++ b/parts/k8s/addons/scheduled-maintenance-deployment.yaml
@@ -290,6 +290,10 @@ metadata:
   name: drainsafe-controller-scheduledevent-manager
   namespace: drainsafe-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -302,6 +302,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-secrets-store
@@ -455,6 +459,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-secrets-store-provider-azure

--- a/parts/k8s/addons/smb-flexvolume.yaml
+++ b/parts/k8s/addons/smb-flexvolume.yaml
@@ -7,6 +7,10 @@ metadata:
     k8s-app: smb
     kubernetes.io/cluster-service: "true"
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       name: smb

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -575,6 +575,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       component: nmi
@@ -1638,6 +1640,8 @@ spec:
         name: xtables-lock
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
 `)
 
 func k8sAddonsAntreaYamlBytes() ([]byte, error) {
@@ -2139,6 +2143,8 @@ spec:
       k8s-app: azure-cnms
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   template:
     metadata:
       labels:
@@ -2284,6 +2290,8 @@ spec:
       k8s-app: azure-npm
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   template:
     metadata:
       labels:
@@ -3369,6 +3377,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azuredisk-node-windows
@@ -3526,6 +3538,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azuredisk-node
@@ -4785,6 +4801,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azurefile-node-windows
@@ -4932,6 +4952,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-azurefile-node
@@ -5285,6 +5309,10 @@ metadata:
     k8s-app: blobfuse
     kubernetes.io/cluster-service: "true"
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       name: blobfuse
@@ -5789,7 +5817,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 50%
   template:
     metadata:
       labels:
@@ -6482,7 +6510,7 @@ spec:
           secretName: cilium-clustermesh
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 50%
     type: RollingUpdate
 ---
 apiVersion: apps/v1
@@ -7054,6 +7082,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: cloud-node-manager
@@ -7111,6 +7143,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: cloud-node-manager-windows
@@ -7944,6 +7980,8 @@ spec:
             optional: true
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -8095,6 +8133,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       component: oms-agent-win
@@ -8675,6 +8715,10 @@ metadata:
     app: flannel
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       tier: node
@@ -8815,6 +8859,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     tier: node
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: azure-ip-masq-agent
@@ -8919,6 +8967,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: keyvault-flexvolume
@@ -9926,6 +9976,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       k8s-app: node-problem-detector
@@ -10039,6 +10093,8 @@ spec:
       k8s-app: nvidia-device-plugin
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   template:
     metadata:
 {{- if IsKubernetesVersionGe "1.17.0"}}
@@ -10548,6 +10604,10 @@ metadata:
   name: drainsafe-controller-scheduledevent-manager
   namespace: drainsafe-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -10906,6 +10966,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-secrets-store
@@ -11059,6 +11123,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: csi-secrets-store-provider-azure
@@ -11129,6 +11195,10 @@ metadata:
     k8s-app: smb
     kubernetes.io/cluster-service: "true"
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
   selector:
     matchLabels:
       name: smb


### PR DESCRIPTION
**Reason for Change**:

Updating the `rollingUpdate` strategy of addon daemonsets to `maxUnavailable: 50%` in order to speed up `aks-engine rotate-certs`.

**Issue Fixed**:

Fixes #4088

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
