### PR TITLE
fix: typo in upgrade log message

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -496,7 +496,7 @@ loop:
 	}
 	// return error if more than 1 upgraded node is not ready
 	if upgradedNotReadyCount > 1 {
-		uc.Logger.Error("At least 2 of the previusly upgraded control plane nodes did not reach the NodeReady status")
+		uc.Logger.Error("At least 2 of the previously upgraded control plane nodes did not reach the NodeReady status")
 		return errors.New("too many upgraded nodes are not ready")
 	}
 	return nil


### PR DESCRIPTION
**Reason for Change**:

Corrects a typo I noticed while running upgrade unit tests.

**Issue Fixed**:

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
