### PR TITLE
fix: honor user-defined feature gates before applying defaults

### DIFF
--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -967,11 +967,11 @@ func TestKubeletConfigDefaultFeatureGates(t *testing.T) {
 	}
 
 	// test user-overrides
-	cs = CreateMockContainerService("testcluster", "1.18.2", 3, 2, false)
+	cs = CreateMockContainerService("testcluster", "1.20.0", 3, 2, false)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	k["--feature-gates"] = "DynamicKubeletConfig=true"
+	k["--feature-gates"] = "DynamicKubeletConfig=true,ExecProbeTimeout=true"
 	cs.setKubeletConfig(false)
-	if k["--feature-gates"] != "DynamicKubeletConfig=true,RotateKubeletServerCertificate=true" {
+	if k["--feature-gates"] != "DynamicKubeletConfig=true,ExecProbeTimeout=true,RotateKubeletServerCertificate=true" {
 		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
 			k["--feature-gates"])
 	}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -5629,3 +5629,38 @@ func ExampleContainerService_setOrchestratorDefaults() {
 	// level=warning msg="Any new nodes will have Moby version 19.03.12\n"
 	// level=warning msg="Any new nodes will have containerd version 1.3.7\n"
 }
+
+func TestCombineValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		inputs  []string
+		outputs string
+	}{
+		{
+			name:    "simple",
+			inputs:  []string{"foo=bar", ""},
+			outputs: "foo=bar",
+		},
+		{
+			name:    "get defaults",
+			inputs:  []string{"", "ExecProbeTimeout=false,RotateKubeletServerCertificate=true"},
+			outputs: "ExecProbeTimeout=false,RotateKubeletServerCertificate=true",
+		},
+		{
+			name:    "user overrides a default",
+			inputs:  []string{"ExecProbeTimeout=true", "ExecProbeTimeout=false"},
+			outputs: "ExecProbeTimeout=true",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			ret := combineValues(c.inputs...)
+			if ret != c.outputs {
+				t.Errorf("expected combineValues output to be %s, but got %s", c.outputs, ret)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

fixes #4112

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
