### PR TITLE
fix: ensure we wait for the right CRI service name

### DIFF
--- a/parts/k8s/cloud-init/artifacts/docker-monitor.service
+++ b/parts/k8s/cloud-init/artifacts/docker-monitor.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=a script that checks docker health and restarts if needed
+{{- if NeedsContainerd}}
+After=containerd.service
+{{else}}
 After=docker.service
+{{- end}}
 [Service]
 Restart=always
 RestartSec=10

--- a/parts/k8s/cloud-init/artifacts/docker-monitor.service
+++ b/parts/k8s/cloud-init/artifacts/docker-monitor.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=a script that checks docker health and restarts if needed
 After={{GetContainerRuntime}}.service
-{{- end}}
 [Service]
 Restart=always
 RestartSec=10

--- a/parts/k8s/cloud-init/artifacts/docker-monitor.service
+++ b/parts/k8s/cloud-init/artifacts/docker-monitor.service
@@ -1,9 +1,6 @@
 [Unit]
 Description=a script that checks docker health and restarts if needed
-{{- if NeedsContainerd}}
-After=containerd.service
-{{else}}
-After=docker.service
+After={{GetContainerRuntime}}.service
 {{- end}}
 [Service]
 Restart=always

--- a/parts/k8s/cloud-init/artifacts/kubelet.service
+++ b/parts/k8s/cloud-init/artifacts/kubelet.service
@@ -1,11 +1,7 @@
 [Unit]
 Description=Kubelet
 ConditionPathExists=/usr/local/bin/kubelet
-{{- if NeedsContainerd}}
-Requires=containerd.service
-{{else}}
-Requires=docker.service
-{{- end}}
+Requires={{GetContainerRuntime}}.service
 
 [Service]
 Restart=always

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -97,6 +97,7 @@ write_files:
     [Service]
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
+{{- end}}
 
 - path: /usr/local/bin/health-monitor.sh
   permissions: "0544"

--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -90,24 +90,13 @@ write_files:
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
 
-  {{if NeedsContainerd}}
-- path: /etc/systemd/system/containerd.service.d/kubereserved-slice.conf
+- path: /etc/systemd/system/{{GetContainerRuntime}}.service.d/kubereserved-slice.conf
   permissions: "0644"
   owner: root
   content: |
     [Service]
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
-  {{else}}
-- path: /etc/systemd/system/docker.service.d/kubereserved-slice.conf
-  permissions: "0644"
-  owner: root
-  content: |
-    [Service]
-    Slice={{- GetKubeReservedCgroup -}}.slice
-    #EOF
-  {{end}}
-{{end}}
 
 - path: /usr/local/bin/health-monitor.sh
   permissions: "0544"
@@ -139,6 +128,7 @@ write_files:
   content: !!binary |
     {{CloudInitData "kubeletSystemdService"}}
 
+{{- /* for historical reasons, we overload the name "docker" here; in fact this monitor service supports both docker and containerd */}}
 - path: /etc/systemd/system/docker-monitor.service
   permissions: "0644"
   encoding: gzip

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -105,6 +105,7 @@ write_files:
     [Service]
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
+{{- end}}
 
 {{- if HasKubeletHealthZPort}}
 - path: /etc/systemd/system/kubelet-monitor.service

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -98,24 +98,13 @@ write_files:
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
 
-  {{if NeedsContainerd}}
-- path: /etc/systemd/system/containerd.service.d/kubereserved-slice.conf
+- path: /etc/systemd/system/{{GetContainerRuntime}}.service.d/kubereserved-slice.conf
   permissions: "0644"
   owner: root
   content: |
     [Service]
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
-  {{else}}
-- path: /etc/systemd/system/docker.service.d/kubereserved-slice.conf
-  permissions: "0644"
-  owner: root
-  content: |
-    [Service]
-    Slice={{- GetKubeReservedCgroup -}}.slice
-    #EOF
-  {{end}}
-{{end}}
 
 {{- if HasKubeletHealthZPort}}
 - path: /etc/systemd/system/kubelet-monitor.service
@@ -144,6 +133,7 @@ write_files:
   content: !!binary |
     {{CloudInitData "kubeletSystemdService"}}
 
+{{- /* for historical reasons, we overload the name "docker" here; in fact this monitor service supports both docker and containerd */}}
 - path: /etc/systemd/system/docker-monitor.service
   permissions: "0644"
   encoding: gzip
@@ -424,11 +414,7 @@ coreos:
       drop-ins:
         - name: "10-flatcar.conf"
           content: |
-  {{- if NeedsContainerd}}
-            After=containerd.service
-  {{else}}
-            After=docker.service
-  {{- end}}
+            After={{GetContainerRuntime}}.service
             [Service]
             ExecStart=
             ExecStart=/opt/bin/health-monitor.sh container-runtime

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -424,7 +424,11 @@ coreos:
       drop-ins:
         - name: "10-flatcar.conf"
           content: |
+  {{- if NeedsContainerd}}
+            After=containerd.service
+  {{else}}
             After=docker.service
+  {{- end}}
             [Service]
             ExecStart=
             ExecStart=/opt/bin/health-monitor.sh container-runtime

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13482,7 +13482,6 @@ func k8sCloudInitArtifactsDhcpv6Service() (*asset, error) {
 var _k8sCloudInitArtifactsDockerMonitorService = []byte(`[Unit]
 Description=a script that checks docker health and restarts if needed
 After={{GetContainerRuntime}}.service
-{{- end}}
 [Service]
 Restart=always
 RestartSec=10

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -14843,6 +14843,7 @@ write_files:
     [Service]
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
+{{- end}}
 
 - path: /usr/local/bin/health-monitor.sh
   permissions: "0544"
@@ -15411,6 +15412,7 @@ write_files:
     [Service]
     Slice={{- GetKubeReservedCgroup -}}.slice
     #EOF
+{{- end}}
 
 {{- if HasKubeletHealthZPort}}
 - path: /etc/systemd/system/kubelet-monitor.service

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13481,7 +13481,11 @@ func k8sCloudInitArtifactsDhcpv6Service() (*asset, error) {
 
 var _k8sCloudInitArtifactsDockerMonitorService = []byte(`[Unit]
 Description=a script that checks docker health and restarts if needed
+{{- if NeedsContainerd}}
+After=containerd.service
+{{else}}
 After=docker.service
+{{- end}}
 [Service]
 Restart=always
 RestartSec=10
@@ -15744,7 +15748,11 @@ coreos:
       drop-ins:
         - name: "10-flatcar.conf"
           content: |
+  {{- if NeedsContainerd}}
+            After=containerd.service
+  {{else}}
             After=docker.service
+  {{- end}}
             [Service]
             ExecStart=
             ExecStart=/opt/bin/health-monitor.sh container-runtime


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures we are waiting for the correctly named CRI service name in various systemd definitions.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
