### PR TITLE
fix: fix that kubeproxy cannot parse featuregates

### DIFF
--- a/staging/provisioning/windows/kubeproxystart.ps1
+++ b/staging/provisioning/windows/kubeproxystart.ps1
@@ -24,7 +24,7 @@ if ($KubeproxyFeatureGates -contains "WinDSR=true") {
 }
 
 if ($KubeproxyFeatureGates.Count -ne 0) {
-    $global:KubeproxyArgList += @("--feature-gates='" + ($KubeproxyFeatureGates -join "','") + "'")
+    $global:KubeproxyArgList += @("--feature-gates=" + ($KubeproxyFeatureGates -join ","))
 }
 
 #
@@ -44,5 +44,5 @@ if (Test-Path "$global:KubeDir\runprocess.dll") {
     Add-Type -Path "$global:KubeDir\run-process.cs"
 }
 $exe = "$global:KubeDir\kube-proxy.exe"
-$args = ($global:KubeproxyArgList -join " ")
+$args = $global:KubeproxyArgList -join " "
 [RunProcess.exec]::RunProcess($exe, $args, [System.Diagnostics.ProcessPriorityClass]::AboveNormal)


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
fix that kubeproxy cannot parse featuregates

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I set `provisioningScriptsPackageURL` in `examples/windows/kubernetes-windsr.json` to `https://testxx3e.blob.core.windows.net/akswindows/signedscripts-v0.0.7.zip` and below test passed.
```
CLUSTER_DEFINITION="examples/windows/kubernetes-windsr.json" SUBSCRIPTION_ID="xxx" CLIENT_ID="xxx" CLIENT_SECRET="xxx" TENANT_ID="xxx" LOCATION="westus2" CLEANUP_ON_EXIT=false make test-kubernetes
```
Result
```
------------------------------

JUnit report was created: /aks-engine/test/e2e/kubernetes/junit.xml

Ran 45 of 65 Specs in 4174.634 seconds
SUCCESS! -- 45 Passed | 0 Failed | 0 Pending | 20 Skipped
PASS

Ginkgo ran 1 suite in 1h9m34.655119s
Test Suite Passed
```

