### PR TITLE
feat: setting a default containerd package for Windows

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -459,6 +459,8 @@ const (
 	DefaultKubeProxyMode KubeProxyMode = KubeProxyModeIPTables
 	// DefaultWindowsSSHEnabled is the default windowsProfile.sshEnabled value
 	DefaultWindowsSSHEnabled = true
+	// DefaultWindowsContainerdURL is the URL for the default containerd package on Windows
+	DefaultWindowsContainerdURL = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.3+azure/windows/windows_amd64/moby-containerd-1.4.3+azure-1.amd64.zip"
 )
 
 // WindowsProfile defaults

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -242,6 +242,10 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 				}
 				o.KubernetesConfig.ContainerdVersion = DefaultContainerdVersion
 			}
+
+			if o.KubernetesConfig.WindowsContainerdURL == "" {
+				o.KubernetesConfig.WindowsContainerdURL = DefaultWindowsContainerdURL
+			}
 		}
 		if o.KubernetesConfig.ClusterSubnet == "" {
 			if o.IsAzureCNI() {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1683,10 +1683,6 @@ func (a *Properties) validateContainerRuntime(isUpdate bool) error {
 
 	// TODO: These validations should be relaxed once ContainerD and CNI plugins are more readily available
 	if containerRuntime == Containerd && a.HasWindows() {
-		if a.OrchestratorProfile.KubernetesConfig.WindowsContainerdURL == "" {
-			return errors.Errorf("WindowsContainerdURL must be provided when using Windows with ContainerRuntime=containerd")
-		}
-
 		if a.OrchestratorProfile.KubernetesConfig.NetworkPlugin == "kubenet" {
 			if a.OrchestratorProfile.KubernetesConfig.WindowsSdnPluginURL == "" {
 				return errors.Errorf("WindowsSdnPluginURL must be provided when using Windows with ContainerRuntime=containerd and networkPlugin=kubenet")

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1738,20 +1738,6 @@ func TestProperties_ValidateContainerRuntime_Windows(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "ContainerD-AzureCNI-NoWindowsContainerdURL",
-			p: &Properties{
-				OrchestratorProfile: &OrchestratorProfile{
-					OrchestratorType: Kubernetes,
-					KubernetesConfig: &KubernetesConfig{
-						ContainerRuntime:     Containerd,
-						NetworkPlugin:        "Azure",
-						WindowsContainerdURL: "",
-					},
-				},
-			},
-			expectedErr: errors.Errorf("WindowsContainerdURL must be provided when using Windows with ContainerRuntime=containerd"),
-		},
-		{
 			name: "ContainerD-kubenet",
 			p: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
@@ -1765,20 +1751,6 @@ func TestProperties_ValidateContainerRuntime_Windows(t *testing.T) {
 				},
 			},
 			expectedErr: nil,
-		},
-		{
-			name: "ContainerD-kubenet-NoWindowsContainerdURL",
-			p: &Properties{
-				OrchestratorProfile: &OrchestratorProfile{
-					OrchestratorType: Kubernetes,
-					KubernetesConfig: &KubernetesConfig{
-						ContainerRuntime:     Containerd,
-						NetworkPlugin:        "kubenet",
-						WindowsContainerdURL: "",
-					},
-				},
-			},
-			expectedErr: errors.Errorf("WindowsContainerdURL must be provided when using Windows with ContainerRuntime=containerd"),
 		},
 		{
 			name: "ContainerD-kubenet-NoWindowsSdnPluginURL",


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

We should be setting a default containerd package for Windows nodes if we plan on making containerd be the default container runtime for aks-engine.

This package contains **signed** versions of upstream containerd/containerd release binaries to comply with Azure SysLock policies.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
