### PR TITLE
fix: update error code for vhd not found

### DIFF
--- a/pkg/engine/cse.go
+++ b/pkg/engine/cse.go
@@ -63,12 +63,11 @@ var cseErrorCodes = map[string]int{
 	"ERR_CIS_ASSIGN_FILE_PERMISSION":             112,
 	"ERR_PACKER_COPY_FILE":                       113,
 	"ERR_CIS_APPLY_PASSWORD_CONFIG":              115,
-	"ERR_VHD_FILE_NOT_FOUND":                     124,
-	"ERR_VHD_BUILD_ERROR":                        125, // Deprecated
 	"ERR_AZURE_STACK_GET_ARM_TOKEN":              120,
 	"ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION":  121,
 	"ERR_AZURE_STACK_GET_SUBNET_PREFIX":          122,
 	"ERR_AZURE_STACK_GET_SDN_INTERFACES":         123,
+	"ERR_VHD_BUILD_ERROR":                        125, // Deprecated
 	"ERR_IOVISOR_KEY_DOWNLOAD_TIMEOUT":           166,
 	"ERR_IOVISOR_APT_KEY_TIMEOUT":                167,
 	"ERR_BCC_INSTALL_TIMEOUT":                    168,
@@ -80,6 +79,7 @@ var cseErrorCodes = map[string]int{
 	"ERR_CRI_SLICE_SETUP_FAIL":                   183,
 	"ERR_DEB_DOWNLOAD_TIMEOUT":                   184,
 	"ERR_DEB_PKG_ADD_FAIL":                       185,
+	"ERR_VHD_FILE_NOT_FOUND":                     186,
 }
 
 func GetCSEErrorCode(errorType string) int {

--- a/pkg/engine/cse_test.go
+++ b/pkg/engine/cse_test.go
@@ -76,7 +76,7 @@ func TestGetCSEErrorCode(t *testing.T) {
 				"ERR_CIS_ASSIGN_FILE_PERMISSION":             112,
 				"ERR_PACKER_COPY_FILE":                       113,
 				"ERR_CIS_APPLY_PASSWORD_CONFIG":              115,
-				"ERR_VHD_FILE_NOT_FOUND":                     124,
+				"ERR_VHD_FILE_NOT_FOUND":                     186,
 				"ERR_VHD_BUILD_ERROR":                        125,
 				"ERR_AZURE_STACK_GET_ARM_TOKEN":              120,
 				"ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION":  121,


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
The prow jobs occasionally fail due to long provisioning times for Windows nodes.  In the prow jobs we use a [second Extension](https://github.com/kubernetes-sigs/windows-testing/blob/master/extensions/master_extension/v1/win-e2e-master-extension.sh) which in turn calls `timeout`. When a timeout occurs the return code is 124 (see `man timeout`).  

 The prow job https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-20-windows/1345819398920736768 is an example:

```
\\\"details\\\": [\\r\\n      {\\r\\n        \\\"code\\\": \\\"VMExtensionProvisioningError\\\",\\r\\n        
\\\"message\\\": \\\"VM has reported a failure when processing extension 'cse-master-0'. Error message: 
\\\\\\\"Enable failed: failed to execute command: command terminated with exit status=124
\\\\n[stdout]\\\\n\\\\n[stderr]\\\\n\\\\\\\"\\\\r\\\\n\\\\r\\\\n
More information on troubleshooting is available at https://aka.ms/VMExtensionCSELinuxTroubleshoot
```

This was a red herring until we noticed that it was not the AKS provisiong script that was failing but the secondary Extension required by the Windows testing framework.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
