### PR TITLE
chore: Update VHD 2021.01.06 and k8s patch versions

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -144,9 +144,9 @@ var (
 	//Ubuntu1804Gen2OSImageConfig is Gen2 flavor the Ubunutu 18.04-LTS Linux distribution.
 	Ubuntu1804Gen2OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
-		ImageSku:       "aks-ubuntu-1804-gen2-2020-q4",
+		ImageSku:       "aks-ubuntu-1804-gen2-2021-q1",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.12.15",
+		ImageVersion:   "2021.01.06",
 	}
 
 	//RHELOSImageConfig is the RHEL Linux distribution.
@@ -168,17 +168,17 @@ var (
 	// AKSUbuntu1604OSImageConfig is the AKS image based on Ubuntu 16.04-LTS.
 	AKSUbuntu1604OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
-		ImageSku:       "aks-ubuntu-1604-2020-q4",
+		ImageSku:       "aks-ubuntu-1604-2021-q1",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.12.15",
+		ImageVersion:   "2021.01.06",
 	}
 
 	// AKSUbuntu1804OSImageConfig is the AKS image based on Ubuntu 18.04-LTS.
 	AKSUbuntu1804OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
-		ImageSku:       "aks-ubuntu-1804-2020-q4",
+		ImageSku:       "aks-ubuntu-1804-2021-q1",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2020.12.15",
+		ImageVersion:   "2021.01.06",
 	}
 
 	// AKSWindowsServer2019OSImageConfig is the AKS image based on Windows Server 2019

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -190,6 +190,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.17.11":        true,
 	"1.17.12":        true,
 	"1.17.13":        true,
+	"1.17.16":        true,
 	"1.18.0":         false,
 	"1.18.1":         true,
 	"1.18.2":         true,
@@ -199,9 +200,11 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.18.8":         true,
 	"1.18.9":         true,
 	"1.18.10":        true,
+	"1.18.14":        true,
 	"1.19.0":         true,
 	"1.19.1":         true,
 	"1.19.3":         true,
+	"1.19.6":         true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
Update new VHD and k8s patch versions