### PR TITLE
fix: fix network cleanup code on windows for contianerd nodes

### DIFF
--- a/scripts/collect-windows-logs.ps1
+++ b/scripts/collect-windows-logs.ps1
@@ -24,6 +24,20 @@ $lockedFiles | Foreach-Object {
   }
 }
 
+# azure-cni logs currently end up in system32 when called by containerd so check there for logs too
+$lockedTemp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -Type Directory $lockedTemp
+$lockedFiles | Foreach-Object {
+  Write-Host "Copying $_ to temp"
+  $src = "c:\windows\system32\$_"
+  if (Test-Path $src) {
+    $tempfile = Copy-Item $src $lockedTemp -Passthru -ErrorAction Ignore
+    if ($tempFile) {
+      $paths += $tempFile
+    }
+  }
+}
+
 # Containerd log is outside the c:\k folder 
 $containerd = "C:\ProgramData\containerd\root\panic.log"
 if (Test-Path $containerd) {

--- a/staging/provisioning/windows/cleanupnetwork.ps1
+++ b/staging/provisioning/windows/cleanupnetwork.ps1
@@ -3,6 +3,7 @@ $Global:ClusterConfiguration = ConvertFrom-Json ((Get-Content "c:\k\kubeclusterc
 $global:NetworkMode = "L2Bridge"
 $global:ContainerRuntime = $Global:ClusterConfiguration.Cri.Name
 $global:NetworkPlugin = $Global:ClusterConfiguration.Cni.Name
+$global:HNSModule = "c:\k\hns.psm1"
 
 ipmo $global:HNSModule
 
@@ -49,6 +50,8 @@ if ($global:NetworkPlugin -eq "azure") {
     taskkill /IM azure-vnet.exe /f
     taskkill /IM azure-vnet-ipam.exe /f
 
+    # azure-cni logs currently end up in c:\windows\system32 when machines are configured with containerd.
+    # https://github.com/containerd/containerd/issues/4928
     $filesToRemove = @(
         "c:\k\azure-vnet.json",
         "c:\k\azure-vnet.json.lock",
@@ -56,6 +59,12 @@ if ($global:NetworkPlugin -eq "azure") {
         "c:\k\azure-vnet-ipam.json.lock"
         "c:\k\azure-vnet-ipamv6.json",
         "c:\k\azure-vnet-ipamv6.json.lock"
+        "c:\windows\system32\azure-vnet.json",
+        "c:\windows\system32\azure-vnet.json.lock",
+        "c:\windows\system32\azure-vnet-ipam.json",
+        "c:\windows\system32\azure-vnet-ipam.json.lock"
+        "c:\windows\system32\azure-vnet-ipamv6.json",
+        "c:\windows\system32\azure-vnet-ipamv6.json.lock"
     )
 
     foreach ($file in $filesToRemove) {

--- a/staging/provisioning/windows/kubeletstart.ps1
+++ b/staging/provisioning/windows/kubeletstart.ps1
@@ -227,7 +227,7 @@ if ($global:NetworkPlugin -eq "kubenet") {
             $process | Stop-Process | Out-Null
         }
 
-        ./cleanupnetwork.ps1 
+        & "c:\k\cleanupnetwork.ps1"
 
         Write-Host "Creating a new hns Network"
         $hnsNetwork = New-HNSNetwork -Type $global:NetworkMode -AddressPrefix $podCIDR -Gateway $masterSubnetGW -Name $global:NetworkMode.ToLower() -Verbose

--- a/staging/provisioning/windows/kubeletstart.ps1
+++ b/staging/provisioning/windows/kubeletstart.ps1
@@ -191,8 +191,8 @@ if ($global:NetworkPlugin -eq "azure") {
     # Find if network created by CNI exists, if yes, remove it
     # This is required to keep the network non-persistent behavior
     # Going forward, this would be done by HNS automatically during restart of the node
-    ./cleanupnetwork.ps1 
-    
+    & "c:\k\cleanupnetwork.ps1"
+
     # Restart Kubeproxy, which would wait, until the network is created
     # This was fixed in 1.15, workaround still needed for 1.14 https://github.com/kubernetes/kubernetes/pull/78612
     Restart-Service Kubeproxy

--- a/staging/provisioning/windows/windowsnodereset.ps1
+++ b/staging/provisioning/windows/windowsnodereset.ps1
@@ -49,7 +49,7 @@ if ($global:EnableHostsConfigAgent) {
 # Perform cleanup
 #
 
-./cleanupnetwork.ps1 
+& "c:\k\cleanupnetwork.ps1"
 
 #
 # Create required networks


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
* Fixes issue when calling cleanupnetwork.ps1 as a stand-alone script
* Fixes issue when running kubeletstart.ps1 from a directory other than c:\k
* Fixes issue where 'azure' network is not re-created after network cleanup because logs weren't deleted (logs ended up in c:\windows\system32 due to issue where containerd not setting working directory) 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
