### PR TITLE
DONTMERGE: Add periodical task to update Windows node labels

### DIFF
--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -214,6 +214,16 @@ function Register-NodeResetScriptTask {
     Register-ScheduledTask -TaskName "k8s-restart-job" -InputObject $definition
 }
 
+function Register-NodeResetScriptTask {
+    Write-Log "Creating a startup task to run windowsnodelabelsync.ps1"
+
+    $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-File `"c:\k\windowsnodelabelsync.ps1`""
+    $principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest
+    $trigger = New-JobTrigger -AtStartup -RandomDelay 00:01:00  -RepetitionInterval 00:01:00
+    $definition = New-ScheduledTask -Action $action -Principal $principal -Trigger $trigger -Description "sync kubelet node labels"
+    Register-ScheduledTask -TaskName "sync-kubelet-node-label" -InputObject $definition
+}
+
 # TODO ksubrmnn parameterize this fully
 function Write-KubeClusterConfig {
     param(

--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -214,8 +214,8 @@ function Register-NodeResetScriptTask {
     Register-ScheduledTask -TaskName "k8s-restart-job" -InputObject $definition
 }
 
-function Register-NodeResetScriptTask {
-    Write-Log "Creating a startup task to run windowsnodelabelsync.ps1"
+function Register-NodeLabelSyncScriptTask {
+    Write-Log "Creating a periodical task to run windowsnodelabelsync.ps1"
 
     $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-File `"c:\k\windowsnodelabelsync.ps1`""
     $principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -425,6 +425,7 @@ try
         Adjust-DynamicPortRange
         Register-LogsCleanupScriptTask
         Register-NodeResetScriptTask
+        Register-NodeResetScriptTask
         Update-DefenderPreferences
 
         if (Test-Path $CacheDir)

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -425,7 +425,7 @@ try
         Adjust-DynamicPortRange
         Register-LogsCleanupScriptTask
         Register-NodeResetScriptTask
-        Register-NodeResetScriptTask
+        Register-NodeLabelSyncScriptTask
         Update-DefenderPreferences
 
         if (Test-Path $CacheDir)

--- a/staging/provisioning/windows/windowsnodelabelsync.ps1
+++ b/staging/provisioning/windows/windowsnodelabelsync.ps1
@@ -7,5 +7,5 @@ $global:KubeletNodeLabels = $Global:ClusterConfiguration.Kubernetes.Kubelet.Node
 
 $NodeLabels = $KubeletNodeLabels -split ","
 ForEach ($NodeLabel in $NodeLabels) {
-  c:\k\kubectl.exe --kubeconfig='c:\\k\\config' --overwrite $env:computername $HOSTNAME $NodeLabel
+  c:\k\kubectl.exe --kubeconfig='c:\\k\\config' --overwrite $env:computername.ToLower() $NodeLabel
 }

--- a/staging/provisioning/windows/windowsnodelabelsync.ps1
+++ b/staging/provisioning/windows/windowsnodelabelsync.ps1
@@ -1,0 +1,11 @@
+<#
+.DESCRIPTION
+    This script is intended to update Kubelet node labels.
+#>
+
+$global:KubeletNodeLabels = $Global:ClusterConfiguration.Kubernetes.Kubelet.NodeLabels
+
+$NodeLabels = $KubeletNodeLabels -split ","
+ForEach ($NodeLabel in $NodeLabels) {
+  c:\k\kubectl.exe --kubeconfig='c:\\k\\config' --overwrite $env:computername $HOSTNAME $NodeLabel
+}

--- a/staging/provisioning/windows/windowsnodelabelsync.ps1
+++ b/staging/provisioning/windows/windowsnodelabelsync.ps1
@@ -3,9 +3,10 @@
     This script is intended to update Kubelet node labels.
 #>
 
+$Global:ClusterConfiguration = ConvertFrom-Json ((Get-Content "c:\k\kubeclusterconfig.json" -ErrorAction Stop) | out-string)
 $global:KubeletNodeLabels = $Global:ClusterConfiguration.Kubernetes.Kubelet.NodeLabels
 
 $NodeLabels = $KubeletNodeLabels -split ","
 ForEach ($NodeLabel in $NodeLabels) {
-  c:\k\kubectl.exe --kubeconfig='c:\\k\\config' --overwrite $env:computername.ToLower() $NodeLabel
+  c:\k\kubectl.exe --kubeconfig=c:\k\config --overwrite $env:computername.ToLower() $NodeLabel
 }


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Currently, we use [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) to initialize the node label when registering the node, but Kubelet is not able to update the node label change.

The change shows us how to allow the user to update the customNodeLabels by running a periodical task to update the node labels. 

However this is not a complete change, to enable this periodical task, we need to:
  -  sign windowsnodelabelsync.ps1 , and I have a standalone PR [here](https://github.com/Azure/aks-engine/pull/4163) to include only this script
  -  build new VHD to have the new signed script
  -  register the task in k8s/kuberneteswindowsfunctions.ps1 as show in the change in this PR

Alternative:
we can also update the node labels once, and we need to wait until the update command is executed successfully

Note:
- This is for Windows only, to support fully updating customNodeLabels , we need additional work to update Linux Kubelet node labels.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
