### PR TITLE
test: go routine errata

### DIFF
--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -152,7 +152,8 @@ func (a *Account) CreateGroupWithRetry(name, location string, sleep, timeout tim
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- a.CreateGroup(name, location):
+			default:
+				ch <- a.CreateGroup(name, location)
 				time.Sleep(sleep)
 			}
 		}
@@ -200,7 +201,8 @@ func (a *Account) ShowGroupWithRetry(name string, sleep, timeout time.Duration) 
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- a.ShowGroup(name):
+			default:
+				ch <- a.ShowGroup(name)
 				time.Sleep(sleep)
 			}
 		}
@@ -387,7 +389,8 @@ func (a *Account) GetRGRouteTable(timeout time.Duration) (network.RouteTable, er
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- a.ListRGRouteTable():
+			default:
+				ch <- a.ListRGRouteTable()
 				time.Sleep(5 * time.Second)
 			}
 		}

--- a/test/e2e/remote/ssh.go
+++ b/test/e2e/remote/ssh.go
@@ -119,7 +119,8 @@ func NewConnectionWithRetry(host, port, user, keyPath string, sleep, timeout tim
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- NewConnectionAsync(host, port, user, keyPath):
+			default:
+				ch <- NewConnectionAsync(host, port, user, keyPath)
 				time.Sleep(sleep)
 			}
 		}
@@ -241,7 +242,8 @@ func (c *Connection) CopyToRemoteWithRetry(hostname, path string, sleep, timeout
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- c.CopyToRemote(hostname, path):
+			default:
+				ch <- c.CopyToRemote(hostname, path)
 				time.Sleep(sleep)
 			}
 		}
@@ -285,7 +287,8 @@ func (c *Connection) ExecuteRemoteWithRetry(node, command string, printStdout bo
 			select {
 			case <-ctx.Done():
 				return
-			case ch <- c.ExecuteRemote(node, command, printStdout):
+			default:
+				ch <- c.ExecuteRemote(node, command, printStdout)
 				time.Sleep(sleep)
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Whoops we were using the wrong select/case pattern to handle continual async message passing for a few go routines used by the E2E test runner. Specifically, we're doing a "run a command once then sleep" pattern, which in the context of a select/case that also handles messages from async channels means that after we return from sleep we want to process any messages first (because those messages tell us whether or not we need to actually re-run the command again).

The fix is to put the periodic command invocation in the `default` block, so that we will always "fall through" the case statements (order not guaranteed). In this case the only order we care about is invoking the command last, so doing it inside of `default` accomplishes that.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
