### PR TITLE
ci: skip dns liveness test after upgrade

### DIFF
--- a/test/e2e/test_cluster_configs/availabilityset.json
+++ b/test/e2e/test_cluster_configs/availabilityset.json
@@ -2,7 +2,8 @@
 	"env": {
 		"UPGRADE_CLUSTER": true,
 		"SCALE_CLUSTER": true,
-		"STABILITY_ITERATIONS": "0"
+		"STABILITY_ITERATIONS": "0",
+		"GINKGO_SKIP_AFTER_UPGRADE": "dns-liveness pod"
 	},
 	"apiModel": {
 		"apiVersion": "vlabs",

--- a/test/e2e/test_cluster_configs/base.json
+++ b/test/e2e/test_cluster_configs/base.json
@@ -5,6 +5,7 @@
 		"UPGRADE_CLUSTER": true,
 		"GET_CLUSTER_LOGS": true,
 		"GINKGO_SKIP_AFTER_SCALE_DOWN": "should report all nodes in a Ready state",
+		"GINKGO_SKIP_AFTER_UPGRADE": "dns-liveness pod",
 		"SKIP_TESTS": "false",
 		"SKIP_TESTS_AFTER_ADD_POOL": "true",
 		"SKIP_TESTS_AFTER_SCALE_DOWN": "true",


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

We don't want to run the "DNS liveness" test on a long-lived cluster that has transitioned via an `aks-engine upgrade` operation as that can introduce temporarily downtime that can trigger a DNS liveness failure.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
