### PR TITLE
fix: rotate-certs on custom clouds

### DIFF
--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -141,14 +141,6 @@ func (rcc *rotateCertsCmd) validateArgs() (err error) {
 			Locale: locale,
 		},
 	}
-	if err = rcc.getAuthArgs().validateAuthArgs(); err != nil {
-		return errors.Wrap(err, "failed to get validate auth args")
-	}
-	armClient, err := rcc.authProvider.getClient()
-	if err != nil {
-		return errors.Wrap(err, "failed to get ARM client")
-	}
-	rcc.armClient = ops.NewARMClientWrapper(armClient, rotateCertsDefaultInterval, rotateCertsDefaultTimeout)
 	rcc.location = helpers.NormalizeAzureRegion(rcc.location)
 	if rcc.location == "" {
 		return errors.New("--location must be specified")
@@ -211,7 +203,14 @@ func (rcc *rotateCertsCmd) loadAPIModel() (err error) {
 	if rcc.cs.Properties.WindowsProfile != nil && !rcc.cs.Properties.WindowsProfile.GetSSHEnabled() {
 		return errors.New("SSH not enabled on Windows nodes. SSH is required in order to rotate agent nodes certificates")
 	}
-
+	if err = rcc.getAuthArgs().validateAuthArgs(); err != nil {
+		return errors.Wrap(err, "failed to get validate auth args")
+	}
+	armClient, err := rcc.authProvider.getClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get ARM client")
+	}
+	rcc.armClient = ops.NewARMClientWrapper(armClient, rotateCertsDefaultInterval, rotateCertsDefaultTimeout)
 	return
 }
 

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -17,6 +17,5 @@ require (
 	github.com/uber/jaeger-client-go v2.21.1+incompatible // indirect
 	go.opencensus.io v0.22.2 // indirect
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	google.golang.org/api v0.15.0 // indirect
 )


### PR DESCRIPTION
**Reason for Change**:

An `ARMClient` should be instantiated after `apimodel` is loaded.

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
