### PR TITLE
chore: ensure containerd has image cache on VHDs

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -675,12 +675,11 @@ cleanUpContainerImages() {
   {{- if NeedsContainerd}}
   docker rmi -f $(docker images -a -q) &
   {{else}}
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'hyperkube') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'cloud-controller-manager') &
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${ETCD_VERSION}$|${ETCD_VERSION}-|${ETCD_VERSION}_" | grep 'etcd') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'hcp-tunnel-front') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'kube-svc-redirect') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'nginx') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-proxy') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-controller-manager') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-apiserver') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-scheduler') &
   docker rmi registry:2.7.1 &
   ctr -n=k8s.io image rm $(ctr -n=k8s.io images ls -q) &
   {{- end}}

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -304,9 +304,10 @@ enableCRISystemdMonitor() {
 }
 {{- if NeedsContainerd}}
 installContainerd() {
+  removeMoby
   local v
   v=$(containerd -version | cut -d " " -f 3 | sed 's|v||')
-  if [[ $v != "${CONTAINERD_VERSION}" ]]; then
+  if [[ $v != "${CONTAINERD_VERSION}"* ]]; then
     os_lower=$(echo ${OS} | tr '[:upper:]' '[:lower:]')
     if [[ ${OS} == "${UBUNTU_OS_NAME}" ]]; then
       url_path="${os_lower}/${UBUNTU_RELEASE}/multiarch/prod"
@@ -315,12 +316,7 @@ installContainerd() {
     else
       exit 25
     fi
-    removeMoby
     removeContainerd
-    retrycmd_no_stats 120 5 25 curl ${MS_APT_REPO}/config/ubuntu/${UBUNTU_RELEASE}/prod.list >/tmp/microsoft-prod.list || exit 25
-    retrycmd 10 5 10 cp /tmp/microsoft-prod.list /etc/apt/sources.list.d/ || exit 25
-    retrycmd_no_stats 120 5 25 curl ${MS_APT_REPO}/keys/microsoft.asc | gpg --dearmor >/tmp/microsoft.gpg || exit 26
-    retrycmd 10 5 10 cp /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/ || exit 26
     apt_get_update || exit 99
     apt_get_install 20 30 120 moby-runc moby-containerd=${CONTAINERD_VERSION}* --allow-downgrades || exit 27
   fi
@@ -676,14 +672,18 @@ installSGXDrivers() {
 {{end}}
 {{- if HasVHDDistroNodes}}
 cleanUpContainerImages() {
+  {{- if NeedsContainerd}}
+  docker rmi -f $(docker images -a -q) &
+  {{else}}
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'hyperkube') &
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'cloud-controller-manager') &
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${ETCD_VERSION}$|${ETCD_VERSION}-|${ETCD_VERSION}_" | grep 'etcd') &
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'hcp-tunnel-front') &
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'kube-svc-redirect') &
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'nginx') &
-
   docker rmi registry:2.7.1 &
+  ctr -n=k8s.io image rm $(ctr -n=k8s.io images ls -q) &
+  {{- end}}
 }
 cleanUpGPUDrivers() {
   rm -Rf $GPU_DEST

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -233,8 +233,8 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  docker pull $1
-  docker save $1 | ctr -n=k8s.io images import -
+  docker pull $1 || exit 35
+  docker save $1 | ctr -n=k8s.io images import - || exit 35
 
 }
 overrideNetworkConfig() {

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -236,9 +236,9 @@ loadContainerImage() {
   local f
   f=$(echo $1 | tr /: _)
   mkdir -p /opt/azure/containers
+  docker pull $1
   docker save $1 -o /opt/azure/containers/$f.tar
   ctr -n=k8s.io images import /opt/azure/containers/$f.tar
-  docker load --input /opt/azure/containers/$f.tar
   rm -f /opt/azure/containers/$f.tar
 
 }

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -233,7 +233,8 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  local f=$(echo $1 | tr /: _)
+  local f
+  f=$(echo $1 | tr /: _)
   docker save $1 -o /opt/azure/containers/$f
   ctr -n=k8s.io images import /opt/azure/containers/$f
   docker load --input /opt/azure/containers/$f

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -233,7 +233,7 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  local f=echo $1 | tr /: _
+  local f=$(echo $1 | tr /: _)
   docker save $1 -o /opt/azure/containers/$f
   ctr -n=k8s.io images import /opt/azure/containers/$f
   docker load --input /opt/azure/containers/$f

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -235,6 +235,7 @@ pullContainerImage() {
 loadContainerImage() {
   local f
   f=$(echo $1 | tr /: _)
+  mkdir -p /opt/azure/containers
   docker save $1 -o /opt/azure/containers/$f
   ctr -n=k8s.io images import /opt/azure/containers/$f
   docker load --input /opt/azure/containers/$f

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -236,10 +236,10 @@ loadContainerImage() {
   local f
   f=$(echo $1 | tr /: _)
   mkdir -p /opt/azure/containers
-  docker save $1 -o /opt/azure/containers/$f
-  ctr -n=k8s.io images import /opt/azure/containers/$f
-  docker load --input /opt/azure/containers/$f
-  rm -f /opt/azure/containers/$f
+  docker save $1 -o /opt/azure/containers/$f.tar
+  ctr -n=k8s.io images import /opt/azure/containers/$f.tar
+  docker load --input /opt/azure/containers/$f.tar
+  rm -f /opt/azure/containers/$f.tar
 
 }
 overrideNetworkConfig() {

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -233,13 +233,8 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  local f
-  f=$(echo $1 | tr /: _)
-  mkdir -p /opt/azure/containers
   docker pull $1
-  docker save $1 -o /opt/azure/containers/$f.tar
-  ctr -n=k8s.io images import /opt/azure/containers/$f.tar
-  rm -f /opt/azure/containers/$f.tar
+  docker save $1 | ctr -n=k8s.io images import -
 
 }
 overrideNetworkConfig() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13468,10 +13468,10 @@ loadContainerImage() {
   local f
   f=$(echo $1 | tr /: _)
   mkdir -p /opt/azure/containers
-  docker save $1 -o /opt/azure/containers/$f
-  ctr -n=k8s.io images import /opt/azure/containers/$f
-  docker load --input /opt/azure/containers/$f
-  rm -f /opt/azure/containers/$f
+  docker save $1 -o /opt/azure/containers/$f.tar
+  ctr -n=k8s.io images import /opt/azure/containers/$f.tar
+  docker load --input /opt/azure/containers/$f.tar
+  rm -f /opt/azure/containers/$f.tar
 
 }
 overrideNetworkConfig() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13465,13 +13465,8 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  local f
-  f=$(echo $1 | tr /: _)
-  mkdir -p /opt/azure/containers
-  docker save $1 -o /opt/azure/containers/$f.tar
-  ctr -n=k8s.io images import /opt/azure/containers/$f.tar
-  docker load --input /opt/azure/containers/$f.tar
-  rm -f /opt/azure/containers/$f.tar
+  docker pull $1
+  docker save $1 | ctr -n=k8s.io images import -
 
 }
 overrideNetworkConfig() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12671,12 +12671,11 @@ cleanUpContainerImages() {
   {{- if NeedsContainerd}}
   docker rmi -f $(docker images -a -q) &
   {{else}}
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'hyperkube') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'cloud-controller-manager') &
   docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${ETCD_VERSION}$|${ETCD_VERSION}-|${ETCD_VERSION}_" | grep 'etcd') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'hcp-tunnel-front') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'kube-svc-redirect') &
-  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep 'nginx') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-proxy') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-controller-manager') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-apiserver') &
+  docker rmi $(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep 'kube-scheduler') &
   docker rmi registry:2.7.1 &
   ctr -n=k8s.io image rm $(ctr -n=k8s.io images ls -q) &
   {{- end}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13467,6 +13467,7 @@ pullContainerImage() {
 loadContainerImage() {
   local f
   f=$(echo $1 | tr /: _)
+  mkdir -p /opt/azure/containers
   docker save $1 -o /opt/azure/containers/$f
   ctr -n=k8s.io images import /opt/azure/containers/$f
   docker load --input /opt/azure/containers/$f

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13465,7 +13465,8 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  local f=$(echo $1 | tr /: _)
+  local f
+  f=$(echo $1 | tr /: _)
   docker save $1 -o /opt/azure/containers/$f
   ctr -n=k8s.io images import /opt/azure/containers/$f
   docker load --input /opt/azure/containers/$f

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13465,8 +13465,8 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  docker pull $1
-  docker save $1 | ctr -n=k8s.io images import -
+  docker pull $1 || exit 35
+  docker save $1 | ctr -n=k8s.io images import - || exit 35
 
 }
 overrideNetworkConfig() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13465,7 +13465,7 @@ pullContainerImage() {
   retrycmd 60 1 1200 $cli_tool pull $url || exit 35
 }
 loadContainerImage() {
-  local f=echo $1 | tr /: _
+  local f=$(echo $1 | tr /: _)
   docker save $1 -o /opt/azure/containers/$f
   ctr -n=k8s.io images import /opt/azure/containers/$f
   docker load --input /opt/azure/containers/$f

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -294,35 +294,13 @@ K8S_VERSIONS="
 1.17.16
 "
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
-  if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 17 )); then
-    HYPERKUBE_URL="mcr.microsoft.com/oss/kubernetes/hyperkube:v${KUBERNETES_VERSION}"
-    extractHyperkube "docker"
-    echo "  - ${HYPERKUBE_URL}" >> ${VHD_LOGS_FILEPATH}
-  else
-    for component in kube-apiserver kube-controller-manager kube-proxy kube-scheduler; do
-      CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/${component}:v${KUBERNETES_VERSION}"
-      loadContainerImage ${CONTAINER_IMAGE}
-      echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
-    done
-    KUBE_BINARY_URL="https://kubernetesartifacts.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/binaries/kubernetes-node-linux-amd64.tar.gz"
-    extractKubeBinaries
-  fi
-  if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 16 )) && [[ $KUBERNETES_VERSION != *"azs"* ]]; then
-    CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v${KUBERNETES_VERSION}"
+  for component in kube-apiserver kube-controller-manager kube-proxy kube-scheduler; do
+    CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/${component}:v${KUBERNETES_VERSION}"
     loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
-  fi
-done
-
-# Use kube-proxy image instead of hyperkube for kube-proxy container. Fixes #3529.
-KUBE_PROXY_VERSIONS="
-1.16.15
-1.16.14
-"
-for KUBE_PROXY_VERSION in ${KUBE_PROXY_VERSIONS}; do
-  CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/kube-proxy:v${KUBE_PROXY_VERSION}"
-  loadContainerImage ${CONTAINER_IMAGE}
-  echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+  done
+  KUBE_BINARY_URL="https://kubernetesartifacts.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/binaries/kubernetes-node-linux-amd64.tar.gz"
+  extractKubeBinaries
 done
 
 # Starting with 1.16 we pull cloud-controller-manager and cloud-node-manager

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -85,7 +85,7 @@ echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 MOBY_VERSION="19.03.14"
 CONTAINERD_VERSION="1.3.9"
 installMoby
-systemctl start docker
+systemctlEnableAndStart docker || exit 1
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
 downloadGPUDrivers
 echo "  - nvidia-docker2 nvidia-container-runtime" >> ${VHD_LOGS_FILEPATH}
@@ -126,6 +126,7 @@ done
 installImg
 echo "  - img" >> ${VHD_LOGS_FILEPATH}
 
+systemctl status docker --no-pager || exit 1
 echo "Docker images pre-pulled:" >> ${VHD_LOGS_FILEPATH}
 
 DASHBOARD_VERSIONS="
@@ -276,7 +277,7 @@ for KMS_PLUGIN_VERSION in ${KMS_PLUGIN_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
-pullContainerImage "docker" "busybox"
+loadContainerImage "busybox"
 echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -474,7 +474,7 @@ df -h
 
 # warn at 75% space taken
 [ -s $(df -P | grep '/dev/sda1' | awk '0+$5 >= 75 {print}') ] || echo "WARNING: 75% of /dev/sda1 is used" >> ${VHD_LOGS_FILEPATH}
-# error at 90% space taken
+# error at 95% space taken
 [ -s $(df -P | grep '/dev/sda1' | awk '0+$5 >= 95 {print}') ] || exit 1
 
 echo "Using kernel:" >> ${VHD_LOGS_FILEPATH}

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -133,7 +133,7 @@ DASHBOARD_VERSIONS="
 "
 for DASHBOARD_VERSION in ${DASHBOARD_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/dashboard:v${DASHBOARD_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -142,7 +142,7 @@ DASHBOARD_METRICS_SCRAPER_VERSIONS="
 "
 for DASHBOARD_METRICS_SCRAPER_VERSION in ${DASHBOARD_METRICS_SCRAPER_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/metrics-scraper:v${DASHBOARD_METRICS_SCRAPER_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -151,7 +151,7 @@ ADDON_RESIZER_VERSIONS="
 "
 for ADDON_RESIZER_VERSION in ${ADDON_RESIZER_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:${ADDON_RESIZER_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -160,7 +160,7 @@ METRICS_SERVER_VERSIONS="
 "
 for METRICS_SERVER_VERSION in ${METRICS_SERVER_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/metrics-server:v${METRICS_SERVER_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -169,7 +169,7 @@ KUBE_ADDON_MANAGER_VERSIONS="
 "
 for KUBE_ADDON_MANAGER_VERSION in ${KUBE_ADDON_MANAGER_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v${KUBE_ADDON_MANAGER_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -177,7 +177,7 @@ MCR_PAUSE_VERSIONS="1.4.0"
 for PAUSE_VERSION in ${MCR_PAUSE_VERSIONS}; do
     # Pull the arch independent MCR pause image which is built for Linux and Windows
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/pause:${PAUSE_VERSION}"
-    pullContainerImage "docker" "${CONTAINER_IMAGE}"
+    loadContainerImage "${CONTAINER_IMAGE}"
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -189,7 +189,7 @@ CLUSTER_AUTOSCALER_VERSIONS="
 "
 for CLUSTER_AUTOSCALER_VERSION in ${CLUSTER_AUTOSCALER_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-autoscaler:v${CLUSTER_AUTOSCALER_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -198,7 +198,7 @@ CORE_DNS_VERSIONS="
 "
 for CORE_DNS_VERSION in ${CORE_DNS_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/coredns:${CORE_DNS_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -207,14 +207,14 @@ RESCHEDULER_VERSIONS="
 "
 for RESCHEDULER_VERSION in ${RESCHEDULER_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/rescheduler:v${RESCHEDULER_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
 VIRTUAL_KUBELET_VERSIONS="1.2.1.2"
 for VIRTUAL_KUBELET_VERSION in ${VIRTUAL_KUBELET_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/virtual-kubelet/virtual-kubelet:${VIRTUAL_KUBELET_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -224,7 +224,7 @@ AZURE_CNI_NETWORKMONITOR_VERSIONS="
 "
 for AZURE_CNI_NETWORKMONITOR_VERSION in ${AZURE_CNI_NETWORKMONITOR_VERSIONS}; do
     CONTAINER_IMAGE="${AZURE_CNIIMAGEBASE}/networkmonitor:v${AZURE_CNI_NETWORKMONITOR_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -233,7 +233,7 @@ AZURE_NPM_VERSIONS="
 "
 for AZURE_NPM_VERSION in ${AZURE_NPM_VERSIONS}; do
     CONTAINER_IMAGE="${AZURE_CNIIMAGEBASE}/azure-npm:v${AZURE_NPM_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -242,21 +242,21 @@ NVIDIA_DEVICE_PLUGIN_VERSIONS="
 "
 for NVIDIA_DEVICE_PLUGIN_VERSION in ${NVIDIA_DEVICE_PLUGIN_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/nvidia/k8s-device-plugin:${NVIDIA_DEVICE_PLUGIN_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
 KV_FLEXVOLUME_VERSIONS="0.0.16"
 for KV_FLEXVOLUME_VERSION in ${KV_FLEXVOLUME_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v${KV_FLEXVOLUME_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
 BLOBFUSE_FLEXVOLUME_VERSIONS="1.0.8"
 for BLOBFUSE_FLEXVOLUME_VERSION in ${BLOBFUSE_FLEXVOLUME_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:${BLOBFUSE_FLEXVOLUME_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -265,14 +265,14 @@ IP_MASQ_AGENT_VERSIONS="
 "
 for IP_MASQ_AGENT_VERSION in ${IP_MASQ_AGENT_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/ip-masq-agent:v${IP_MASQ_AGENT_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
 KMS_PLUGIN_VERSIONS="0.0.10"
 for KMS_PLUGIN_VERSION in ${KMS_PLUGIN_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/k8s/kms/keyvault:v${KMS_PLUGIN_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -300,7 +300,7 @@ for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
   else
     for component in kube-apiserver kube-controller-manager kube-proxy kube-scheduler; do
       CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/${component}:v${KUBERNETES_VERSION}"
-      pullContainerImage "docker" ${CONTAINER_IMAGE}
+      loadContainerImage ${CONTAINER_IMAGE}
       echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
     done
     KUBE_BINARY_URL="https://kubernetesartifacts.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/binaries/kubernetes-node-linux-amd64.tar.gz"
@@ -308,7 +308,7 @@ for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
   fi
   if (( $(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 16 )) && [[ $KUBERNETES_VERSION != *"azs"* ]]; then
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/cloud-controller-manager:v${KUBERNETES_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
   fi
 done
@@ -320,7 +320,7 @@ KUBE_PROXY_VERSIONS="
 "
 for KUBE_PROXY_VERSION in ${KUBE_PROXY_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/kube-proxy:v${KUBE_PROXY_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -331,7 +331,7 @@ CLOUD_MANAGER_VERSIONS="
 for CLOUD_MANAGER_VERSION in ${CLOUD_MANAGER_VERSIONS}; do
   for COMPONENT in azure-cloud-controller-manager azure-cloud-node-manager; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/${COMPONENT}:v${CLOUD_MANAGER_VERSION}"
-    pullContainerImage "docker" ${CONTAINER_IMAGE}
+    loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
   done
 done
@@ -341,7 +341,7 @@ AZUREDISK_CSI_VERSIONS="
 "
 for AZUREDISK_CSI_VERSION in ${AZUREDISK_CSI_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/k8s/csi/azuredisk-csi:v${AZUREDISK_CSI_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -350,7 +350,7 @@ AZUREFILE_CSI_VERSIONS="
 "
 for AZUREFILE_CSI_VERSION in ${AZUREFILE_CSI_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/k8s/csi/azurefile-csi:v${AZUREFILE_CSI_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -359,7 +359,7 @@ CSI_ATTACHER_VERSIONS="
 "
 for CSI_ATTACHER_VERSION in ${CSI_ATTACHER_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v${CSI_ATTACHER_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -368,7 +368,7 @@ CSI_NODE_DRIVER_REGISTRAR_VERSIONS="
 "
 for CSI_NODE_DRIVER_REGISTRAR_VERSION in ${CSI_NODE_DRIVER_REGISTRAR_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v${CSI_NODE_DRIVER_REGISTRAR_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -378,7 +378,7 @@ CSI_PROVISIONER_VERSIONS="
 "
 for CSI_PROVISIONER_VERSION in ${CSI_PROVISIONER_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v${CSI_PROVISIONER_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -387,7 +387,7 @@ LIVENESSPROBE_VERSIONS="
 "
 for LIVENESSPROBE_VERSION in ${LIVENESSPROBE_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v${LIVENESSPROBE_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -396,7 +396,7 @@ CSI_RESIZER_VERSIONS="
 "
 for CSI_RESIZER_VERSION in ${CSI_RESIZER_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v${CSI_RESIZER_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -406,7 +406,7 @@ CSI_SNAPSHOTTER_VERSIONS="
 "
 for CSI_SNAPSHOTTER_VERSION in ${CSI_SNAPSHOTTER_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v${CSI_SNAPSHOTTER_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -415,7 +415,7 @@ SNAPSHOT_CONTROLLER_VERSIONS="
 "
 for SNAPSHOT_CONTROLLER_VERSION in ${SNAPSHOT_CONTROLLER_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v${SNAPSHOT_CONTROLLER_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -424,7 +424,7 @@ CSI_SECRETS_STORE_PROVIDER_AZURE_VERSIONS="
 "
 for CSI_SECRETS_STORE_PROVIDER_AZURE_VERSION in ${CSI_SECRETS_STORE_PROVIDER_AZURE_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/azure/secrets-store/provider-azure:${CSI_SECRETS_STORE_PROVIDER_AZURE_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -433,7 +433,7 @@ CSI_SECRETS_STORE_DRIVER_VERSIONS="
 "
 for CSI_SECRETS_STORE_DRIVER_VERSION in ${CSI_SECRETS_STORE_DRIVER_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v${CSI_SECRETS_STORE_DRIVER_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -442,7 +442,7 @@ AAD_POD_IDENTITY_MIC_VERSIONS="
 "
 for AAD_POD_IDENTITY_MIC_VERSION in ${AAD_POD_IDENTITY_MIC_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/k8s/aad-pod-identity/mic:${AAD_POD_IDENTITY_MIC_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -451,7 +451,7 @@ AAD_POD_IDENTITY_NMI_VERSIONS="
 "
 for AAD_POD_IDENTITY_NMI_VERSION in ${AAD_POD_IDENTITY_NMI_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/k8s/aad-pod-identity/nmi:${AAD_POD_IDENTITY_NMI_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
@@ -460,13 +460,13 @@ CLUSTER_PROPORTIONAL_AUTOSCALER_VERSIONS="
 "
 for CLUSTER_PROPORTIONAL_AUTOSCALER_VERSION in ${CLUSTER_PROPORTIONAL_AUTOSCALER_VERSIONS}; do
   CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-proportional-autoscaler:${CLUSTER_PROPORTIONAL_AUTOSCALER_VERSION}"
-  pullContainerImage "docker" ${CONTAINER_IMAGE}
+  loadContainerImage ${CONTAINER_IMAGE}
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
 # This is to accommodate air-gapped environments, e.g., Azure Stack
 CONTAINER_IMAGE="registry:2.7.1"
-pullContainerImage "docker" ${CONTAINER_IMAGE}
+loadContainerImage ${CONTAINER_IMAGE}
 echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 
 df -h

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -475,7 +475,7 @@ df -h
 # warn at 75% space taken
 [ -s $(df -P | grep '/dev/sda1' | awk '0+$5 >= 75 {print}') ] || echo "WARNING: 75% of /dev/sda1 is used" >> ${VHD_LOGS_FILEPATH}
 # error at 90% space taken
-[ -s $(df -P | grep '/dev/sda1' | awk '0+$5 >= 90 {print}') ] || exit 1
+[ -s $(df -P | grep '/dev/sda1' | awk '0+$5 >= 95 {print}') ] || exit 1
 
 echo "Using kernel:" >> ${VHD_LOGS_FILEPATH}
 tee -a ${VHD_LOGS_FILEPATH} < /proc/version

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -85,7 +85,7 @@ echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 MOBY_VERSION="19.03.14"
 CONTAINERD_VERSION="1.3.9"
 installMoby
-systemctlEnableAndStart docker || exit 1
+systemctl_restart 100 5 30 docker || exit 1
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
 downloadGPUDrivers
 echo "  - nvidia-docker2 nvidia-container-runtime" >> ${VHD_LOGS_FILEPATH}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR changes the way we pre-pull container images during VHD CI so that both docker (moby) and containerd runtime configurations can use them.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
