### PR TITLE
chore: don't include auditd rules in Linux VHDs

### DIFF
--- a/parts/k8s/cloud-init/masternodecustomdata.yml
+++ b/parts/k8s/cloud-init/masternodecustomdata.yml
@@ -38,15 +38,13 @@ write_files:
     {{CloudInitData "provisionCIS"}}
 {{end}}
 
-{{- if not .MasterProfile.IsVHDDistro}}
-  {{- if .MasterProfile.IsAuditDEnabled}}
+{{- if .MasterProfile.IsAuditDEnabled}}
 - path: /etc/audit/rules.d/CIS.rules
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "auditdRules"}}
-  {{end}}
 {{end}}
 
 {{- if .MasterProfile.IsUbuntu1804}}

--- a/parts/k8s/cloud-init/nodecustomdata.yml
+++ b/parts/k8s/cloud-init/nodecustomdata.yml
@@ -46,15 +46,13 @@ write_files:
     {{CloudInitData "provisionCIS"}}
 {{end}}
 
-{{- if not .IsVHDDistro}}
-  {{- if .IsAuditDEnabled}}
+{{- if .IsAuditDEnabled}}
 - path: /etc/audit/rules.d/CIS.rules
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "auditdRules"}}
-  {{end}}
 {{end}}
 
 {{- if .IsUbuntu1804}}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1196,6 +1196,18 @@ func (p *Properties) GetAADAdminGroupID() string {
 	return ""
 }
 
+func (p *Properties) NeedsAuditdRules() bool {
+	if p.MasterProfile != nil && p.MasterProfile.IsAuditDEnabled() {
+		return true
+	}
+	for _, pool := range p.AgentPoolProfiles {
+		if pool.IsAuditDEnabled() {
+			return true
+		}
+	}
+	return false
+}
+
 // ShouldEnableAzureCloudAddon determines whether or not we should enable the following addons:
 // 1. cloud-node-manager,
 // 2. azuredisk-csi-driver,

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -320,6 +320,93 @@ func TestMasterProfileIsAuditDEnabled(t *testing.T) {
 	}
 }
 
+func TestNeedsAuditdRules(t *testing.T) {
+	cases := []struct {
+		name     string
+		p        *Properties
+		expected bool
+	}{
+		{
+			name: "enabled on control plane",
+			p: &Properties{
+				MasterProfile: &MasterProfile{
+					AuditDEnabled: to.BoolPtr(true),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "enabled on one node pool",
+			p: &Properties{
+				MasterProfile: &MasterProfile{
+					AuditDEnabled: nil,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						AuditDEnabled: nil,
+					},
+					{
+						AuditDEnabled: to.BoolPtr(true),
+					},
+					{
+						AuditDEnabled: to.BoolPtr(false),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "enabled",
+			p: &Properties{
+				MasterProfile: &MasterProfile{
+					AuditDEnabled: to.BoolPtr(true),
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						AuditDEnabled: to.BoolPtr(true),
+					},
+					{
+						AuditDEnabled: to.BoolPtr(true),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "disabled",
+			p: &Properties{
+				MasterProfile: &MasterProfile{
+					AuditDEnabled: nil,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						AuditDEnabled: nil,
+					},
+					{
+						AuditDEnabled: to.BoolPtr(false),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "nil",
+			p:        &Properties{},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if c.expected != c.p.NeedsAuditdRules() {
+				t.Fatalf("Got unexpected Properrties.NeedsAuditdRules() result. Expected: %t. Got: %t.", c.expected, c.p.NeedsAuditdRules())
+			}
+		})
+	}
+}
+
 func TestAgentPoolProfileIsUbuntuNonVHD(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/pkg/engine/armvariables.go
+++ b/pkg/engine/armvariables.go
@@ -170,13 +170,16 @@ func getK8sMasterVars(cs *api.ContainerService) (map[string]interface{}, error) 
 		cloudInitFiles["untaintNodesSystemdService"] = getBase64EncodedGzippedCustomScript(untaintNodesSystemdService, cs)
 	}
 
+	if cs.Properties.NeedsAuditdRules() {
+		cloudInitFiles["auditdRules"] = getBase64EncodedGzippedCustomScript(auditdRules, cs)
+	}
+
 	if !cs.Properties.IsVHDDistroForAllNodes() {
 		cloudInitFiles["provisionCIS"] = getBase64EncodedGzippedCustomScript(kubernetesCISScript, cs)
 		cloudInitFiles["labelNodesScript"] = getBase64EncodedGzippedCustomScript(labelNodesScript, cs)
 		cloudInitFiles["labelNodesSystemdService"] = getBase64EncodedGzippedCustomScript(labelNodesSystemdService, cs)
 		cloudInitFiles["aptPreferences"] = getBase64EncodedGzippedCustomScript(aptPreferences, cs)
 		cloudInitFiles["dockerClearMountPropagationFlags"] = getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags, cs)
-		cloudInitFiles["auditdRules"] = getBase64EncodedGzippedCustomScript(auditdRules, cs)
 		cloudInitFiles["generateProxyCertsScript"] = getBase64EncodedGzippedCustomScript(kubernetesMasterGenerateProxyCertsScript, cs)
 	}
 

--- a/pkg/engine/armvariables_test.go
+++ b/pkg/engine/armvariables_test.go
@@ -282,7 +282,6 @@ func TestK8sVars(t *testing.T) {
 		"labelNodesSystemdService":         getBase64EncodedGzippedCustomScript(labelNodesSystemdService, cs),
 		"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences, cs),
 		"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags, cs),
-		"auditdRules":                      getBase64EncodedGzippedCustomScript(auditdRules, cs),
 	}
 
 	diff = cmp.Diff(varMap, expectedMap)
@@ -428,7 +427,6 @@ func TestK8sVars(t *testing.T) {
 		"labelNodesSystemdService":         getBase64EncodedGzippedCustomScript(labelNodesSystemdService, cs),
 		"aptPreferences":                   getBase64EncodedGzippedCustomScript(aptPreferences, cs),
 		"dockerClearMountPropagationFlags": getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags, cs),
-		"auditdRules":                      getBase64EncodedGzippedCustomScript(auditdRules, cs),
 	}
 	diff = cmp.Diff(varMap, expectedMap)
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -15339,15 +15339,13 @@ write_files:
     {{CloudInitData "provisionCIS"}}
 {{end}}
 
-{{- if not .MasterProfile.IsVHDDistro}}
-  {{- if .MasterProfile.IsAuditDEnabled}}
+{{- if .MasterProfile.IsAuditDEnabled}}
 - path: /etc/audit/rules.d/CIS.rules
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "auditdRules"}}
-  {{end}}
 {{end}}
 
 {{- if .MasterProfile.IsUbuntu1804}}
@@ -15929,15 +15927,13 @@ write_files:
     {{CloudInitData "provisionCIS"}}
 {{end}}
 
-{{- if not .IsVHDDistro}}
-  {{- if .IsAuditDEnabled}}
+{{- if .IsAuditDEnabled}}
 - path: /etc/audit/rules.d/CIS.rules
   permissions: "0744"
   encoding: gzip
   owner: root
   content: !!binary |
     {{CloudInitData "auditdRules"}}
-  {{end}}
 {{end}}
 
 {{- if .IsUbuntu1804}}

--- a/test/e2e/test_cluster_configs/everything.json
+++ b/test/e2e/test_cluster_configs/everything.json
@@ -93,7 +93,6 @@
 				"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
 				"firstConsecutiveStaticIP": "10.239.255.239",
 				"vnetCidr": "10.239.0.0/16",
-				"auditDEnabled": true,
 				"availabilityZones": [
 					"1",
 					"2"
@@ -112,7 +111,6 @@
 					],
 					"vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
 					"scalesetPriority": "Spot",
-					"auditDEnabled": true,
 					"availabilityZones": [
 						"1",
 						"2"

--- a/vhd/packer/packer_source.sh
+++ b/vhd/packer/packer_source.sh
@@ -19,8 +19,6 @@ copyPackerFiles() {
   PAM_D_SU_DEST=/etc/pam.d/su
   PROFILE_D_CIS_SH_SRC=/home/packer/profile-d-cis.sh
   PROFILE_D_CIS_SH_DEST=/etc/profile.d/CIS.sh
-  AUDITD_RULES_SRC=/home/packer/auditd-rules
-  AUDITD_RULES_DEST=/etc/audit/rules.d/CIS.rules
   LABEL_NODES_SRC=/home/packer/label-nodes.sh
   LABEL_NODES_DEST=/opt/azure/containers/label-nodes.sh
   LABEL_NODES_SERVICE_SRC=/home/packer/label-nodes.service
@@ -51,7 +49,6 @@ copyPackerFiles() {
   cpAndMode $PWQUALITY_CONF_SRC $PWQUALITY_CONF_DEST 600
   cpAndMode $PAM_D_SU_SRC $PAM_D_SU_DEST 644
   cpAndMode $PROFILE_D_CIS_SH_SRC $PROFILE_D_CIS_SH_DEST 755
-  cpAndMode $AUDITD_RULES_SRC $AUDITD_RULES_DEST 640
   cpAndMode $LABEL_NODES_SRC $LABEL_NODES_DEST 744
   cpAndMode $LABEL_NODES_SERVICE_SRC $LABEL_NODES_SERVICE_DEST 644
   cpAndMode $CIS_SRC $CIS_DEST 744

--- a/vhd/packer/vhd-image-builder-ubuntu-gen2.json
+++ b/vhd/packer/vhd-image-builder-ubuntu-gen2.json
@@ -138,11 +138,6 @@
         },
         {
             "type": "file",
-            "source": "parts/k8s/cloud-init/artifacts/auditd-rules",
-            "destination": "/home/packer/auditd-rules"
-        },
-        {
-            "type": "file",
             "source": "parts/k8s/cloud-init/artifacts/label-nodes.sh",
             "destination": "/home/packer/label-nodes.sh"
         },

--- a/vhd/packer/vhd-image-builder.json
+++ b/vhd/packer/vhd-image-builder.json
@@ -138,11 +138,6 @@
         },
         {
             "type": "file",
-            "source": "parts/k8s/cloud-init/artifacts/auditd-rules",
-            "destination": "/home/packer/auditd-rules"
-        },
-        {
-            "type": "file",
             "source": "parts/k8s/cloud-init/artifacts/label-nodes.sh",
             "destination": "/home/packer/label-nodes.sh"
         },


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR changes the VHD configuration so that auditd rules are not put onto the VM filesystem as part of VHD creation. Also includes required ARM template composition changes due to the fact that there is no VHD context related to the need for these cloud-init requirements.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
