### PR TITLE
fix: disable docker when containerD is specified

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -406,7 +406,8 @@ try
         New-ExternalHnsNetwork -IsDualStackEnabled $global:IsDualStackEnabled
 
         Install-KubernetesServices `
-            -KubeDir $global:KubeDir
+            -KubeDir $global:KubeDir `
+            -ContainerRuntime $global:ContainerRuntime
 
         Get-LogCollectionScripts
 

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -352,7 +352,9 @@ New-NSSMService {
     & "$KubeDir\nssm.exe" set Kubelet AppRotateBytes 10485760 | RemoveNulls
     # Do not use & when calling DependOnService since 'docker csi-proxy'
     # is parsed as a single string instead of two separate strings
-    Invoke-Expression "$KubeDir\nssm.exe set Kubelet DependOnService $kubeletDependOnServices | RemoveNulls"
+    if (-not [string]::IsNullOrEmpty($kubeletDependOnServices) {
+        Invoke-Expression "$KubeDir\nssm.exe set Kubelet DependOnService $kubeletDependOnServices | RemoveNulls"
+    }
 
     # setup kubeproxy
     & "$KubeDir\nssm.exe" install Kubeproxy C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe | RemoveNulls

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -316,9 +316,14 @@ New-NSSMService {
         [string]
         [Parameter(Mandatory = $true)]
         $KubeProxyStartFile
+        [Parameter(Mandatory = $false)][string]
+        $ContainerRuntime = "docker"
     )
 
-    $kubeletDependOnServices = "docker"
+    $kubeletDependOnServices = ""
+    if ($ContainerRuntime -eq "docker") {
+        $kubeletDependOnServices = "docker"
+    }
     if ($global:EnableCsiProxy) {
         $kubeletDependOnServices += " csi-proxy"
     }
@@ -374,6 +379,8 @@ Install-KubernetesServices {
     param(
         [Parameter(Mandatory = $true)][string]
         $KubeDir
+        [Parameter(Mandatory = $false)][string]
+        $ContainerRuntime = "docker"
     )
 
     # TODO ksbrmnn fix callers to this function
@@ -383,5 +390,6 @@ Install-KubernetesServices {
 
     New-NSSMService -KubeDir $KubeDir `
         -KubeletStartFile $KubeletStartFile `
-        -KubeProxyStartFile $KubeProxyStartFile
+        -KubeProxyStartFile $KubeProxyStartFile `
+        -ContainerRuntime $ContainerRuntime
 }

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -315,15 +315,12 @@ New-NSSMService {
         $KubeletStartFile,
         [string]
         [Parameter(Mandatory = $true)]
-        $KubeProxyStartFile
+        $KubeProxyStartFile,
         [Parameter(Mandatory = $false)][string]
         $ContainerRuntime = "docker"
     )
 
-    $kubeletDependOnServices = "docker"
-    if ($ContainerRuntime -eq "containerd") {
-        $kubeletDependOnServices = "containerd"
-    }
+    $kubeletDependOnServices = $ContainerRuntime
     if ($global:EnableCsiProxy) {
         $kubeletDependOnServices += " csi-proxy"
     }
@@ -378,7 +375,7 @@ function
 Install-KubernetesServices {
     param(
         [Parameter(Mandatory = $true)][string]
-        $KubeDir
+        $KubeDir,
         [Parameter(Mandatory = $false)][string]
         $ContainerRuntime = "docker"
     )

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -320,9 +320,9 @@ New-NSSMService {
         $ContainerRuntime = "docker"
     )
 
-    $kubeletDependOnServices = ""
-    if ($ContainerRuntime -eq "docker") {
-        $kubeletDependOnServices = "docker"
+    $kubeletDependOnServices = "docker"
+    if ($ContainerRuntime -eq "containerd") {
+        $kubeletDependOnServices = "containerd"
     }
     if ($global:EnableCsiProxy) {
         $kubeletDependOnServices += " csi-proxy"

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -352,9 +352,7 @@ New-NSSMService {
     & "$KubeDir\nssm.exe" set Kubelet AppRotateBytes 10485760 | RemoveNulls
     # Do not use & when calling DependOnService since 'docker csi-proxy'
     # is parsed as a single string instead of two separate strings
-    if (-not [string]::IsNullOrEmpty($kubeletDependOnServices) {
-        Invoke-Expression "$KubeDir\nssm.exe set Kubelet DependOnService $kubeletDependOnServices | RemoveNulls"
-    }
+    Invoke-Expression "$KubeDir\nssm.exe set Kubelet DependOnService $kubeletDependOnServices | RemoveNulls"
 
     # setup kubeproxy
     & "$KubeDir\nssm.exe" install Kubeproxy C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe | RemoveNulls

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19666,15 +19666,12 @@ New-NSSMService {
         $KubeletStartFile,
         [string]
         [Parameter(Mandatory = $true)]
-        $KubeProxyStartFile
+        $KubeProxyStartFile,
         [Parameter(Mandatory = $false)][string]
         $ContainerRuntime = "docker"
     )
 
-    $kubeletDependOnServices = "docker"
-    if ($ContainerRuntime -eq "containerd") {
-        $kubeletDependOnServices = "containerd"
-    }
+    $kubeletDependOnServices = $ContainerRuntime
     if ($global:EnableCsiProxy) {
         $kubeletDependOnServices += " csi-proxy"
     }
@@ -19729,7 +19726,7 @@ function
 Install-KubernetesServices {
     param(
         [Parameter(Mandatory = $true)][string]
-        $KubeDir
+        $KubeDir,
         [Parameter(Mandatory = $false)][string]
         $ContainerRuntime = "docker"
     )

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19671,9 +19671,9 @@ New-NSSMService {
         $ContainerRuntime = "docker"
     )
 
-    $kubeletDependOnServices = ""
-    if ($ContainerRuntime -eq "docker") {
-        $kubeletDependOnServices = "docker"
+    $kubeletDependOnServices = "docker"
+    if ($ContainerRuntime -eq "containerd") {
+        $kubeletDependOnServices = "containerd"
     }
     if ($global:EnableCsiProxy) {
         $kubeletDependOnServices += " csi-proxy"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -19703,9 +19703,7 @@ New-NSSMService {
     & "$KubeDir\nssm.exe" set Kubelet AppRotateBytes 10485760 | RemoveNulls
     # Do not use & when calling DependOnService since 'docker csi-proxy'
     # is parsed as a single string instead of two separate strings
-    if (-not [string]::IsNullOrEmpty($kubeletDependOnServices) {
-        Invoke-Expression "$KubeDir\nssm.exe set Kubelet DependOnService $kubeletDependOnServices | RemoveNulls"
-    }
+    Invoke-Expression "$KubeDir\nssm.exe set Kubelet DependOnService $kubeletDependOnServices | RemoveNulls"
 
     # setup kubeproxy
     & "$KubeDir\nssm.exe" install Kubeproxy C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe | RemoveNulls

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -319,10 +319,10 @@ switch ($env:ProvisioningPhase) {
     "2" {
         Write-Log "Performing actions for provisioning phase 2 for container runtime '$containerRuntime'"
         Set-WinRmServiceAutoStart
-        # TODO: make decision on if we want to install docker along with containerd (will need to update CSE too,)
-        Install-Docker
         if ($containerRuntime -eq 'containerd') {
             Install-ContainerD
+        } else {
+            Install-Docker
         }
         Get-ContainerImages -containerRuntime $containerRuntime -WindowsServerVersion $windowsServerVersion
         Get-FilesToCacheOnVHD


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

1. Remove docker as not used when containerD is used. Also mixing docker and containerD may hide potential errors of containerD by docker
2. cx may get confused by the docker CLI output on a containerD-enabled node for devops

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
