### PR TITLE
feat: add support for Kubernetes v1.20.4

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -246,7 +246,9 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.20.0-rc.0":    false,
 	"1.20.0":         false,
 	"1.20.1":         false,
-	"1.20.2":         true,
+	"1.20.2":         false,
+	"1.20.3":         false,
+	"1.20.4":         true,
 	"1.21.0-alpha.1": false,
 	"1.21.0-alpha.2": false, // disabled, see https://github.com/kubernetes/kubernetes/issues/98419
 	"1.21.0-alpha.3": true,

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -110,7 +110,7 @@ function Get-FilesToCacheOnVHD {
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.17.17/windowszip/v1.17.17-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.18.15/windowszip/v1.18.15-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.19.8/windowszip/v1.19.8-1int.zip",
-            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.20.2/windowszip/v1.20.2-1int.zip",
+            "https://kubernetesartifacts.azureedge.net/kubernetes/v1.20.4/windowszip/v1.20.4-1int.zip",
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.21.0-alpha.3/windowszip/v1.21.0-alpha.3-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -251,7 +251,7 @@ echo "  - busybox" >> ${VHD_LOGS_FILEPATH}
 
 K8S_VERSIONS="
 1.21.0-alpha.3
-1.20.2
+1.20.4
 1.19.8
 1.18.15
 1.18.15-azs


### PR DESCRIPTION
**Reason for Change**:

See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1203

**Issue Fixed**:


**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [ ] Kubernetes artifacts built and pushed by Azure Pipelines
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
~~This will fail for the time being, as we are still working out a build issue on the Azure Pipeline for k8s.~~
v1.20.3 was superceded by v1.20.4 due to a conformance test fix.