### PR TITLE
test: use AZURE_CORE_ONLY_SHOW_ERRORS when running E2E

### DIFF
--- a/.pipelines/e2e-step-template.yaml
+++ b/.pipelines/e2e-step-template.yaml
@@ -17,6 +17,7 @@ steps:
       export CLIENT_ID=$(SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES)
       export CLIENT_SECRET=$(SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES)
       export CLIENT_OBJECTID=$(SERVICE_PRINCIPAL_OBJECT_ID_E2E_KUBERNETES)
+      export AZURE_CORE_ONLY_SHOW_ERRORS=True
       make test-kubernetes
     displayName: ginkgo k8s e2e tests
   - task: PublishPipelineArtifact@0

--- a/.pipelines/pr-windows-signed-scripts.yaml
+++ b/.pipelines/pr-windows-signed-scripts.yaml
@@ -63,6 +63,7 @@ jobs:
       -e TENANT_ID=${TENANT_ID} \
       -e WINDOWS_PROVISIONING_SCRIPTS_URL=${SCRIPT_PACKAGE_URL} \
       -e USE_MANAGED_IDENTITY="false" \
+      -e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
       ${DEIS_GO_DEV_IMAGE} make test-kubernetes
     displayName: Run e2e tests
     condition: succeeded()

--- a/.pipelines/vhd-builder-windows-template.yaml
+++ b/.pipelines/vhd-builder-windows-template.yaml
@@ -55,6 +55,7 @@ jobs:
       -e WINDOWS_NODE_VHD_URL=${OS_DISK_URI} \
       -e USE_MANAGED_IDENTITY="false" \
       -e CONTAINER_RUNTIME=${{ parameters.containerRuntime }} \
+      -e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
       ${DEIS_GO_DEV_IMAGE} make test-kubernetes
     displayName: run e2e tests
     condition: and(succeeded(), eq(variables.COPY_VHD, 'False'))

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -244,6 +244,7 @@ docker run --rm \
 -e CUSTOM_KUBE_SCHEDULER_IMAGE=${CUSTOM_KUBE_SCHEDULER_IMAGE} \
 -e CUSTOM_KUBE_CONTROLLER_MANAGER_IMAGE=${CUSTOM_KUBE_CONTROLLER_MANAGER_IMAGE} \
 -e CUSTOM_WINDOWS_PACKAGE_URL=${CUSTOM_WINDOWS_PACKAGE_URL} \
+-e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
 "${DEV_IMAGE}" make test-kubernetes || tryExit && renameResultsFile "deploy"
 
 if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n "$ADD_NODE_POOL_INPUT" ] || [ "${GET_CLUSTER_LOGS}" = "true" ] || [ "${ROTATE_CERTS}" = "true" ]; then
@@ -360,6 +361,7 @@ if [ "${ROTATE_CERTS}" = "true" ]; then
     -e ARC_SUBSCRIPTION_ID=${ARC_SUBSCRIPTION_ID:-$AZURE_SUBSCRIPTION_ID} \
     -e ARC_LOCATION=${ARC_LOCATION:-$LOCATION} \
     -e ARC_TENANT_ID=${ARC_TENANT_ID:-$AZURE_TENANT_ID} \
+    -e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
     ${DEV_IMAGE} make test-kubernetes || tryExit && renameResultsFile "rotate-certs"
 fi
 
@@ -440,6 +442,7 @@ if [ -n "$ADD_NODE_POOL_INPUT" ]; then
     -e ARC_SUBSCRIPTION_ID=${ARC_SUBSCRIPTION_ID:-$AZURE_SUBSCRIPTION_ID} \
     -e ARC_LOCATION=${ARC_LOCATION:-$LOCATION} \
     -e ARC_TENANT_ID=${ARC_TENANT_ID:-$AZURE_TENANT_ID} \
+    -e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
     ${DEV_IMAGE} make test-kubernetes || tryExit && renameResultsFile "add-node-pool"
 fi
 
@@ -554,6 +557,7 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -e ARC_SUBSCRIPTION_ID=${ARC_SUBSCRIPTION_ID:-$AZURE_SUBSCRIPTION_ID} \
     -e ARC_LOCATION=${ARC_LOCATION:-$LOCATION} \
     -e ARC_TENANT_ID=${ARC_TENANT_ID:-$AZURE_TENANT_ID} \
+    -e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
     ${DEV_IMAGE} make test-kubernetes || tryExit && renameResultsFile "scale-down"
 fi
 
@@ -643,6 +647,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ]; then
       -e ARC_SUBSCRIPTION_ID=${ARC_SUBSCRIPTION_ID:-$AZURE_SUBSCRIPTION_ID} \
       -e ARC_LOCATION=${ARC_LOCATION:-$LOCATION} \
       -e ARC_TENANT_ID=${ARC_TENANT_ID:-$AZURE_TENANT_ID} \
+      -e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
       ${DEV_IMAGE} make test-kubernetes || tryExit && renameResultsFile "upgrade"
   done
 fi
@@ -721,5 +726,6 @@ if [ "${SCALE_CLUSTER}" = "true" ]; then
     -e ARC_SUBSCRIPTION_ID=${ARC_SUBSCRIPTION_ID:-$AZURE_SUBSCRIPTION_ID} \
     -e ARC_LOCATION=${ARC_LOCATION:-$LOCATION} \
     -e ARC_TENANT_ID=${ARC_TENANT_ID:-$AZURE_TENANT_ID} \
+    -e AZURE_CORE_ONLY_SHOW_ERRORS="True" \
     ${DEV_IMAGE} make test-kubernetes || tryExit && renameResultsFile "scale-up"
 fi

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -82,6 +82,7 @@ type Config struct {
 	ArcSubscriptionID                string `envconfig:"ARC_SUBSCRIPTION_ID" default:""`
 	ArcLocation                      string `envconfig:"ARC_LOCATION" default:""`
 	ArcTenantID                      string `envconfig:"ARC_TENANT_ID" default:""`
+	RunVMSSNodePrototype             bool   `envconfig:"RUN_VMSS_NODE_PROTOTYPE" default:"false"`
 
 	ClusterDefinitionPath     string // The original template we want to use to build the cluster from.
 	ClusterDefinitionTemplate string // This is the template after we splice in the environment variables
@@ -179,6 +180,10 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetIDs []string, i
 			if prop.OrchestratorProfile.KubernetesConfig != nil && prop.OrchestratorProfile.KubernetesConfig.PrivateCluster != nil && prop.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil {
 				prop.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey = config.PublicSSHKey
 			}
+		}
+		if config.RunVMSSNodePrototype {
+			// In order to better determine the time it takes for nodes to come online let's eliminate any VM reboot considerations
+			prop.LinuxProfile.RunUnattendedUpgradesOnBootstrap = to.BoolPtr((false))
 		}
 	}
 

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2799,9 +2799,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if cfg.RunVMSSNodePrototype {
 				if eng.ExpandedDefinition.Properties.HasVMSSAgentPool() {
 					By("Installing kured with node annotations configuration")
-					cmd := exec.Command("k", "apply", "-f", filepath.Join(WorkloadDir, "kured-annotations.yaml"))
-					util.PrintCommand(cmd)
-					_, err := cmd.CombinedOutput()
+					_, err := daemonset.CreateDaemonsetFromFileWithRetry(filepath.Join(WorkloadDir, "kured-annotations.yaml"), "kured", "kube-system", 5*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
@@ -2901,7 +2899,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						timeToLargeContainerDaemonsetRunningBaseline = time.Since(start)
 						log.Printf("Took %s for large-container-daemonset pod to reach Running state on new node\n", timeToLargeContainerDaemonsetRunningBaseline)
 					}
-					cmd = exec.Command("helm", "status", "vmss-prototype")
+					cmd := exec.Command("helm", "status", "vmss-prototype")
 					out, err := cmd.CombinedOutput()
 					if err == nil {
 						By("Found pre-existing 'vmss-prototype' helm release, deleting it...")


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that any usage of the E2E test runner invoked `az` with the suppression of non-error output.

See:

https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/HISTORY.rst#230

Also, two tweaks to the vmss-prototype tests based on observations:

- If we're configured to test the vmss-prototype functionality, we automatically set `RunUnattendedUpgradesOnBootstrap` to false in the `LinuxProfile`
- retry the kured daemonset creation

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
