### PR TITLE
ci: make sure sku is exact match when deciding to create or reuse sku  for publishing Windows VHDs

### DIFF
--- a/vhd/publishing/new-sku-and-add-image-version.sh
+++ b/vhd/publishing/new-sku-and-add-image-version.sh
@@ -43,7 +43,7 @@ echo "Checking if offer contains SKU: $sku_id"
 (set -x; hack/tools/bin/pub skus list -p $PUBLISHER -o $OFFER | jq ".[] | .planId" | tr -d '"' | tee skus.txt)
 echo ""
 
-if grep -q $sku_id skus.txt; then
+if grep -q "^$sku_id$" skus.txt; then
     echo "Offer already has SKU"
 else
     echo "Creating new SKU"


### PR DESCRIPTION

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

AKS publishes SKUs starting with aks- and if AKS publishes a SKU first the logic in this script will not create a new non-AKS sku so I'm fixing that.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
