### PR TITLE
refactor: remove storage type from SKU lookup table

### DIFF
--- a/cmd/get_skus.go
+++ b/cmd/get_skus.go
@@ -178,13 +178,3 @@ var VMSkus = []VMSku{
 
 	return err
 }
-
-func storageAccountType(skuName string) string {
-	parts := strings.Split(skuName, "_")
-	if len(parts) > 1 {
-		if strings.Contains(strings.ToUpper(parts[1]), "S") {
-			return "Premium_LRS"
-		}
-	}
-	return "Standard_LRS"
-}

--- a/cmd/get_skus.go
+++ b/cmd/get_skus.go
@@ -121,7 +121,6 @@ func (vmc *SkusCmd) run(cmd *cobra.Command, args []string) error {
 				skus = append(skus, helpers.VMSku{
 					Name:                  name,
 					AcceleratedNetworking: acceleratedNetworking,
-					StorageAccountType:    storageAccountType(name),
 				})
 			}
 		}
@@ -155,23 +154,22 @@ package helpers
 
 type VMSku struct {
 	Name                  string
-	StorageAccountType    string
 	AcceleratedNetworking bool
 }
 
 var VMSkus = []VMSku{
 `)
-		formatStr := "\t{\n\t\tName:                  \"%s\",\n\t\tStorageAccountType:    \"%s\",\n\t\tAcceleratedNetworking: %t,\n\t},\n"
+		formatStr := "\t{\n\t\tName:                  \"%s\",\n\t\tAcceleratedNetworking: %t,\n\t},\n"
 		for _, s := range skus {
-			b.WriteString(fmt.Sprintf(formatStr, s.Name, s.StorageAccountType, s.AcceleratedNetworking))
+			b.WriteString(fmt.Sprintf(formatStr, s.Name, s.AcceleratedNetworking))
 		}
 		b.WriteString("}")
 		fmt.Println(b.String())
 	case "human":
 		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', tabwriter.FilterHTML)
-		fmt.Fprintln(w, "Name\tStorage Account Type\tAccelerated Networking Support")
+		fmt.Fprintln(w, "Name\tAccelerated Networking Support")
 		for _, sku := range skus {
-			fmt.Fprintf(w, "%s\t%s\t%t\n", sku.Name, sku.StorageAccountType, sku.AcceleratedNetworking)
+			fmt.Fprintf(w, "%s\t%t\n", sku.Name, sku.AcceleratedNetworking)
 		}
 		w.Flush()
 	}

--- a/cmd/get_skus_test.go
+++ b/cmd/get_skus_test.go
@@ -97,458 +97,458 @@ func ExampleSkusCmd_run_humanOutput() {
 	}
 
 	// Output:
-	// Name                    Storage Account Type  Accelerated Networking Support
-	// Standard_A0             Standard_LRS          false
-	// Standard_A1             Standard_LRS          false
-	// Standard_A10            Standard_LRS          false
-	// Standard_A11            Standard_LRS          false
-	// Standard_A1_v2          Standard_LRS          false
-	// Standard_A2             Standard_LRS          false
-	// Standard_A2_v2          Standard_LRS          false
-	// Standard_A2m_v2         Standard_LRS          false
-	// Standard_A3             Standard_LRS          false
-	// Standard_A4             Standard_LRS          false
-	// Standard_A4_v2          Standard_LRS          false
-	// Standard_A4m_v2         Standard_LRS          false
-	// Standard_A5             Standard_LRS          false
-	// Standard_A6             Standard_LRS          false
-	// Standard_A7             Standard_LRS          false
-	// Standard_A8             Standard_LRS          false
-	// Standard_A8_v2          Standard_LRS          false
-	// Standard_A8m_v2         Standard_LRS          false
-	// Standard_A9             Standard_LRS          false
-	// Standard_B12ms          Premium_LRS           true
-	// Standard_B16ms          Premium_LRS           true
-	// Standard_B1ls           Premium_LRS           false
-	// Standard_B1ms           Premium_LRS           false
-	// Standard_B1s            Premium_LRS           false
-	// Standard_B20ms          Premium_LRS           true
-	// Standard_B2ms           Premium_LRS           false
-	// Standard_B2s            Premium_LRS           false
-	// Standard_B4ms           Premium_LRS           false
-	// Standard_B8ms           Premium_LRS           false
-	// Standard_D1             Standard_LRS          false
-	// Standard_D11            Standard_LRS          false
-	// Standard_D11_v2         Standard_LRS          true
-	// Standard_D11_v2_Promo   Standard_LRS          true
-	// Standard_D12            Standard_LRS          false
-	// Standard_D12_v2         Standard_LRS          false
-	// Standard_D12_v2         Standard_LRS          true
-	// Standard_D12_v2_Promo   Standard_LRS          false
-	// Standard_D13            Standard_LRS          false
-	// Standard_D13_v2         Standard_LRS          true
-	// Standard_D13_v2_Promo   Standard_LRS          true
-	// Standard_D14            Standard_LRS          false
-	// Standard_D14_v2         Standard_LRS          true
-	// Standard_D14_v2_Promo   Standard_LRS          true
-	// Standard_D15_v2         Standard_LRS          true
-	// Standard_D16_v3         Standard_LRS          true
-	// Standard_D16_v4         Standard_LRS          true
-	// Standard_D16a_v3        Standard_LRS          false
-	// Standard_D16a_v4        Standard_LRS          true
-	// Standard_D16as_v3       Premium_LRS           false
-	// Standard_D16as_v4       Premium_LRS           true
-	// Standard_D16d_v4        Standard_LRS          true
-	// Standard_D16ds_v4       Premium_LRS           true
-	// Standard_D16s_v3        Premium_LRS           true
-	// Standard_D16s_v4        Premium_LRS           true
-	// Standard_D1_v2          Standard_LRS          false
-	// Standard_D2             Standard_LRS          false
-	// Standard_D2_v2          Standard_LRS          true
-	// Standard_D2_v2_Promo    Standard_LRS          true
-	// Standard_D2_v3          Standard_LRS          false
-	// Standard_D2_v4          Standard_LRS          false
-	// Standard_D2a_v3         Standard_LRS          false
-	// Standard_D2a_v4         Standard_LRS          false
-	// Standard_D2as_v3        Premium_LRS           false
-	// Standard_D2as_v4        Premium_LRS           false
-	// Standard_D2d_v4         Standard_LRS          false
-	// Standard_D2ds_v4        Premium_LRS           false
-	// Standard_D2s_v3         Premium_LRS           false
-	// Standard_D2s_v4         Premium_LRS           false
-	// Standard_D3             Standard_LRS          false
-	// Standard_D32_v3         Standard_LRS          true
-	// Standard_D32_v4         Standard_LRS          true
-	// Standard_D32a_v3        Standard_LRS          false
-	// Standard_D32a_v4        Standard_LRS          true
-	// Standard_D32as_v3       Premium_LRS           false
-	// Standard_D32as_v4       Premium_LRS           true
-	// Standard_D32d_v4        Standard_LRS          true
-	// Standard_D32ds_v4       Premium_LRS           true
-	// Standard_D32s_v3        Premium_LRS           true
-	// Standard_D32s_v4        Premium_LRS           true
-	// Standard_D3_v2          Standard_LRS          true
-	// Standard_D3_v2_Promo    Standard_LRS          true
-	// Standard_D4             Standard_LRS          false
-	// Standard_D48_v3         Standard_LRS          true
-	// Standard_D48_v4         Standard_LRS          true
-	// Standard_D48a_v3        Standard_LRS          false
-	// Standard_D48a_v4        Standard_LRS          true
-	// Standard_D48as_v3       Premium_LRS           false
-	// Standard_D48as_v4       Premium_LRS           true
-	// Standard_D48d_v4        Standard_LRS          true
-	// Standard_D48ds_v4       Premium_LRS           true
-	// Standard_D48s_v3        Premium_LRS           true
-	// Standard_D48s_v4        Premium_LRS           true
-	// Standard_D4_v2          Standard_LRS          true
-	// Standard_D4_v2_Promo    Standard_LRS          true
-	// Standard_D4_v3          Standard_LRS          true
-	// Standard_D4_v4          Standard_LRS          true
-	// Standard_D4a_v3         Standard_LRS          false
-	// Standard_D4a_v4         Standard_LRS          true
-	// Standard_D4as_v3        Premium_LRS           false
-	// Standard_D4as_v4        Premium_LRS           true
-	// Standard_D4d_v4         Standard_LRS          true
-	// Standard_D4ds_v4        Premium_LRS           true
-	// Standard_D4s_v3         Premium_LRS           true
-	// Standard_D4s_v4         Premium_LRS           true
-	// Standard_D5_v2          Standard_LRS          true
-	// Standard_D5_v2_Promo    Standard_LRS          true
-	// Standard_D64_v3         Standard_LRS          true
-	// Standard_D64_v4         Standard_LRS          true
-	// Standard_D64a_v3        Standard_LRS          false
-	// Standard_D64a_v4        Standard_LRS          true
-	// Standard_D64as_v3       Premium_LRS           false
-	// Standard_D64as_v4       Premium_LRS           true
-	// Standard_D64d_v4        Standard_LRS          true
-	// Standard_D64ds_v4       Premium_LRS           true
-	// Standard_D64s_v3        Premium_LRS           true
-	// Standard_D64s_v4        Premium_LRS           true
-	// Standard_D8_v3          Standard_LRS          true
-	// Standard_D8_v4          Standard_LRS          true
-	// Standard_D8a_v3         Standard_LRS          false
-	// Standard_D8a_v4         Standard_LRS          true
-	// Standard_D8as_v3        Premium_LRS           false
-	// Standard_D8as_v4        Premium_LRS           true
-	// Standard_D8d_v4         Standard_LRS          true
-	// Standard_D8ds_v4        Premium_LRS           true
-	// Standard_D8s_v3         Premium_LRS           true
-	// Standard_D8s_v4         Premium_LRS           true
-	// Standard_D96a_v3        Standard_LRS          false
-	// Standard_D96a_v4        Standard_LRS          true
-	// Standard_D96as_v3       Premium_LRS           false
-	// Standard_D96as_v4       Premium_LRS           true
-	// Standard_DC1s_v2        Premium_LRS           false
-	// Standard_DC2s           Premium_LRS           false
-	// Standard_DC2s_v2        Premium_LRS           true
-	// Standard_DC4s           Premium_LRS           false
-	// Standard_DC4s_v2        Premium_LRS           true
-	// Standard_DC8_v2         Standard_LRS          true
-	// Standard_DC8s           Premium_LRS           false
-	// Standard_DS1            Premium_LRS           false
-	// Standard_DS11           Premium_LRS           false
-	// Standard_DS11-1_v2      Premium_LRS           false
-	// Standard_DS11_v2        Premium_LRS           true
-	// Standard_DS11_v2_Promo  Premium_LRS           true
-	// Standard_DS12           Premium_LRS           false
-	// Standard_DS12-1_v2      Premium_LRS           true
-	// Standard_DS12-2_v2      Premium_LRS           true
-	// Standard_DS12_v2        Premium_LRS           true
-	// Standard_DS12_v2_Promo  Premium_LRS           true
-	// Standard_DS13           Premium_LRS           false
-	// Standard_DS13-2_v2      Premium_LRS           true
-	// Standard_DS13-4_v2      Premium_LRS           true
-	// Standard_DS13_v2        Premium_LRS           true
-	// Standard_DS13_v2_Promo  Premium_LRS           true
-	// Standard_DS14           Premium_LRS           false
-	// Standard_DS14-4_v2      Premium_LRS           true
-	// Standard_DS14-8_v2      Premium_LRS           true
-	// Standard_DS14_v2        Premium_LRS           true
-	// Standard_DS14_v2_Promo  Premium_LRS           true
-	// Standard_DS15_v2        Premium_LRS           true
-	// Standard_DS1_v2         Premium_LRS           false
-	// Standard_DS2            Premium_LRS           false
-	// Standard_DS2_v2         Premium_LRS           true
-	// Standard_DS2_v2_Promo   Premium_LRS           true
-	// Standard_DS3            Premium_LRS           false
-	// Standard_DS3_v2         Premium_LRS           true
-	// Standard_DS3_v2_Promo   Premium_LRS           true
-	// Standard_DS4            Premium_LRS           false
-	// Standard_DS4_v2         Premium_LRS           true
-	// Standard_DS4_v2_Promo   Premium_LRS           true
-	// Standard_DS5_v2         Premium_LRS           false
-	// Standard_DS5_v2_Promo   Premium_LRS           false
-	// Standard_E16-4as_v4     Premium_LRS           true
-	// Standard_E16-4ds_v4     Premium_LRS           true
-	// Standard_E16-4s_v3      Premium_LRS           true
-	// Standard_E16-4s_v4      Premium_LRS           true
-	// Standard_E16-8as_v4     Premium_LRS           false
-	// Standard_E16-8ds_v4     Premium_LRS           true
-	// Standard_E16-8s_v3      Premium_LRS           true
-	// Standard_E16-8s_v4      Premium_LRS           true
-	// Standard_E16_v3         Standard_LRS          true
-	// Standard_E16_v4         Standard_LRS          true
-	// Standard_E16a_v3        Standard_LRS          false
-	// Standard_E16a_v4        Standard_LRS          true
-	// Standard_E16as_v3       Premium_LRS           false
-	// Standard_E16as_v4       Premium_LRS           true
-	// Standard_E16d_v4        Standard_LRS          true
-	// Standard_E16ds_v4       Premium_LRS           true
-	// Standard_E16s_v3        Premium_LRS           true
-	// Standard_E16s_v4        Premium_LRS           true
-	// Standard_E20_v3         Standard_LRS          true
-	// Standard_E20_v4         Standard_LRS          true
-	// Standard_E20a_v4        Standard_LRS          true
-	// Standard_E20as_v4       Premium_LRS           true
-	// Standard_E20d_v4        Standard_LRS          true
-	// Standard_E20ds_v4       Premium_LRS           true
-	// Standard_E20s_v3        Premium_LRS           true
-	// Standard_E20s_v4        Premium_LRS           true
-	// Standard_E2_v3          Standard_LRS          false
-	// Standard_E2_v4          Standard_LRS          false
-	// Standard_E2a_v3         Standard_LRS          false
-	// Standard_E2a_v4         Standard_LRS          false
-	// Standard_E2as_v3        Premium_LRS           false
-	// Standard_E2as_v4        Premium_LRS           false
-	// Standard_E2d_v4         Standard_LRS          false
-	// Standard_E2ds_v4        Premium_LRS           false
-	// Standard_E2s_v3         Premium_LRS           false
-	// Standard_E2s_v4         Premium_LRS           false
-	// Standard_E32-16as_v4    Premium_LRS           true
-	// Standard_E32-16ds_v4    Premium_LRS           true
-	// Standard_E32-16s_v3     Premium_LRS           true
-	// Standard_E32-16s_v4     Premium_LRS           true
-	// Standard_E32-8as_v4     Premium_LRS           true
-	// Standard_E32-8ds_v4     Premium_LRS           true
-	// Standard_E32-8s_v3      Premium_LRS           true
-	// Standard_E32-8s_v4      Premium_LRS           true
-	// Standard_E32_v3         Standard_LRS          true
-	// Standard_E32_v4         Standard_LRS          true
-	// Standard_E32a_v3        Standard_LRS          false
-	// Standard_E32a_v4        Standard_LRS          true
-	// Standard_E32as_v3       Premium_LRS           false
-	// Standard_E32as_v4       Premium_LRS           true
-	// Standard_E32d_v4        Standard_LRS          true
-	// Standard_E32ds_v4       Premium_LRS           true
-	// Standard_E32s_v3        Premium_LRS           true
-	// Standard_E32s_v4        Premium_LRS           true
-	// Standard_E4-2as_v4      Premium_LRS           true
-	// Standard_E4-2ds_v4      Premium_LRS           true
-	// Standard_E4-2s_v3       Premium_LRS           true
-	// Standard_E4-2s_v4       Premium_LRS           true
-	// Standard_E48_v3         Standard_LRS          true
-	// Standard_E48_v4         Standard_LRS          true
-	// Standard_E48a_v3        Standard_LRS          false
-	// Standard_E48a_v4        Standard_LRS          true
-	// Standard_E48as_v3       Premium_LRS           false
-	// Standard_E48as_v4       Premium_LRS           true
-	// Standard_E48d_v4        Standard_LRS          true
-	// Standard_E48ds_v4       Premium_LRS           true
-	// Standard_E48s_v3        Premium_LRS           true
-	// Standard_E48s_v4        Premium_LRS           true
-	// Standard_E4_v3          Standard_LRS          true
-	// Standard_E4_v4          Standard_LRS          true
-	// Standard_E4a_v3         Standard_LRS          false
-	// Standard_E4a_v4         Standard_LRS          true
-	// Standard_E4as_v3        Premium_LRS           false
-	// Standard_E4as_v4        Premium_LRS           true
-	// Standard_E4d_v4         Standard_LRS          true
-	// Standard_E4ds_v4        Premium_LRS           true
-	// Standard_E4s_v3         Premium_LRS           true
-	// Standard_E4s_v4         Premium_LRS           true
-	// Standard_E64-16as_v4    Premium_LRS           true
-	// Standard_E64-16ds_v4    Premium_LRS           true
-	// Standard_E64-16s_v3     Premium_LRS           true
-	// Standard_E64-16s_v4     Premium_LRS           true
-	// Standard_E64-32as_v4    Premium_LRS           true
-	// Standard_E64-32ds_v4    Premium_LRS           true
-	// Standard_E64-32s_v3     Premium_LRS           true
-	// Standard_E64-32s_v4     Premium_LRS           true
-	// Standard_E64_v3         Standard_LRS          true
-	// Standard_E64_v4         Standard_LRS          true
-	// Standard_E64a_v3        Standard_LRS          false
-	// Standard_E64a_v4        Standard_LRS          true
-	// Standard_E64as_v3       Premium_LRS           false
-	// Standard_E64as_v4       Premium_LRS           true
-	// Standard_E64d_v4        Standard_LRS          true
-	// Standard_E64ds_v4       Premium_LRS           true
-	// Standard_E64i_v3        Standard_LRS          true
-	// Standard_E64is_v3       Premium_LRS           true
-	// Standard_E64s_v3        Premium_LRS           true
-	// Standard_E64s_v4        Premium_LRS           true
-	// Standard_E8-2as_v4      Premium_LRS           true
-	// Standard_E8-2ds_v4      Premium_LRS           true
-	// Standard_E8-2s_v3       Premium_LRS           true
-	// Standard_E8-2s_v4       Premium_LRS           true
-	// Standard_E8-4as_v4      Premium_LRS           true
-	// Standard_E8-4ds_v4      Premium_LRS           true
-	// Standard_E8-4s_v3       Premium_LRS           true
-	// Standard_E8-4s_v4       Premium_LRS           true
-	// Standard_E80ids_v4      Premium_LRS           true
-	// Standard_E80is_v4       Premium_LRS           true
-	// Standard_E8_v3          Standard_LRS          true
-	// Standard_E8_v4          Standard_LRS          true
-	// Standard_E8a_v3         Standard_LRS          false
-	// Standard_E8a_v4         Standard_LRS          true
-	// Standard_E8as_v3        Premium_LRS           false
-	// Standard_E8as_v4        Premium_LRS           true
-	// Standard_E8d_v4         Standard_LRS          true
-	// Standard_E8ds_v4        Premium_LRS           true
-	// Standard_E8s_v3         Premium_LRS           true
-	// Standard_E8s_v4         Premium_LRS           true
-	// Standard_E96-24as_v4    Premium_LRS           true
-	// Standard_E96-48as_v4    Premium_LRS           true
-	// Standard_E96a_v4        Standard_LRS          true
-	// Standard_E96as_v4       Premium_LRS           true
-	// Standard_F1             Standard_LRS          false
-	// Standard_F16            Standard_LRS          true
-	// Standard_F16s           Premium_LRS           true
-	// Standard_F16s_v2        Premium_LRS           true
-	// Standard_F1s            Premium_LRS           false
-	// Standard_F2             Standard_LRS          true
-	// Standard_F2s            Premium_LRS           true
-	// Standard_F2s_v2         Premium_LRS           false
-	// Standard_F32s_v2        Premium_LRS           true
-	// Standard_F4             Standard_LRS          true
-	// Standard_F48s_v2        Premium_LRS           true
-	// Standard_F4s            Premium_LRS           true
-	// Standard_F4s_v2         Premium_LRS           true
-	// Standard_F64s_v2        Premium_LRS           true
-	// Standard_F72s_v2        Premium_LRS           true
-	// Standard_F8             Standard_LRS          true
-	// Standard_F8s            Premium_LRS           true
-	// Standard_F8s_v2         Premium_LRS           true
-	// Standard_G1             Standard_LRS          false
-	// Standard_G2             Standard_LRS          false
-	// Standard_G3             Standard_LRS          false
-	// Standard_G4             Standard_LRS          false
-	// Standard_G5             Standard_LRS          false
-	// Standard_GS1            Premium_LRS           false
-	// Standard_GS2            Premium_LRS           false
-	// Standard_GS3            Premium_LRS           false
-	// Standard_GS4            Premium_LRS           false
-	// Standard_GS4-4          Premium_LRS           false
-	// Standard_GS4-8          Premium_LRS           false
-	// Standard_GS5            Premium_LRS           false
-	// Standard_GS5-16         Premium_LRS           false
-	// Standard_GS5-8          Premium_LRS           false
-	// Standard_H16            Standard_LRS          false
-	// Standard_H16_Promo      Standard_LRS          false
-	// Standard_H16m           Standard_LRS          false
-	// Standard_H16m_Promo     Standard_LRS          false
-	// Standard_H16mr          Standard_LRS          false
-	// Standard_H16mr_Promo    Standard_LRS          false
-	// Standard_H16r           Standard_LRS          false
-	// Standard_H16r_Promo     Standard_LRS          false
-	// Standard_H8             Standard_LRS          false
-	// Standard_H8_Promo       Standard_LRS          false
-	// Standard_H8m            Premium_LRS           false
-	// Standard_H8m_Promo      Standard_LRS          false
-	// Standard_HB120rs_v2     Premium_LRS           false
-	// Standard_HB60rs         Premium_LRS           false
-	// Standard_HC44rs         Standard_LRS          false
-	// Standard_L16s           Premium_LRS           false
-	// Standard_L16s_v2        Premium_LRS           true
-	// Standard_L32s           Premium_LRS           false
-	// Standard_L32s_v2        Premium_LRS           true
-	// Standard_L48s_v2        Premium_LRS           true
-	// Standard_L4s            Premium_LRS           false
-	// Standard_L64s_v2        Premium_LRS           true
-	// Standard_L80s_v2        Premium_LRS           true
-	// Standard_L8s            Premium_LRS           false
-	// Standard_L8s_v2         Premium_LRS           true
-	// Standard_LRS            Premium_LRS           false
-	// Standard_M128           Standard_LRS          true
-	// Standard_M128-32ms      Premium_LRS           true
-	// Standard_M128-64ms      Premium_LRS           true
-	// Standard_M128dms_v2     Premium_LRS           true
-	// Standard_M128ds_v2      Premium_LRS           true
-	// Standard_M128m          Standard_LRS          true
-	// Standard_M128ms         Premium_LRS           true
-	// Standard_M128ms_v2      Premium_LRS           true
-	// Standard_M128s          Premium_LRS           true
-	// Standard_M128s_v2       Premium_LRS           true
-	// Standard_M16-4ms        Premium_LRS           true
-	// Standard_M16-8ms        Premium_LRS           true
-	// Standard_M16ms          Premium_LRS           true
-	// Standard_M192idms_v2    Premium_LRS           true
-	// Standard_M192ids_v2     Premium_LRS           true
-	// Standard_M192ims_v2     Premium_LRS           true
-	// Standard_M192is_v2      Premium_LRS           true
-	// Standard_M192ms_v2      Premium_LRS           true
-	// Standard_M192s_v2       Premium_LRS           true
-	// Standard_M208ms_v2      Premium_LRS           true
-	// Standard_M208s_v2       Premium_LRS           true
-	// Standard_M24ms_v2       Premium_LRS           true
-	// Standard_M24s_v2        Premium_LRS           true
-	// Standard_M32-16ms       Premium_LRS           true
-	// Standard_M32-8ms        Premium_LRS           true
-	// Standard_M32dms_v2      Premium_LRS           true
-	// Standard_M32ls          Premium_LRS           true
-	// Standard_M32ms          Premium_LRS           true
-	// Standard_M32ms_v2       Premium_LRS           true
-	// Standard_M32ts          Premium_LRS           true
-	// Standard_M416-208ms_v2  Premium_LRS           true
-	// Standard_M416-208s_v2   Premium_LRS           true
-	// Standard_M416ms_v2      Premium_LRS           true
-	// Standard_M416s_v2       Premium_LRS           true
-	// Standard_M48ms_v2       Premium_LRS           true
-	// Standard_M48s_v2        Premium_LRS           true
-	// Standard_M64            Standard_LRS          true
-	// Standard_M64-16ms       Premium_LRS           true
-	// Standard_M64-32ms       Premium_LRS           true
-	// Standard_M64dms_v2      Premium_LRS           true
-	// Standard_M64ds_v2       Premium_LRS           true
-	// Standard_M64ls          Premium_LRS           true
-	// Standard_M64m           Standard_LRS          true
-	// Standard_M64ms          Premium_LRS           true
-	// Standard_M64ms_v2       Premium_LRS           true
-	// Standard_M64s           Premium_LRS           false
-	// Standard_M64s_v2        Premium_LRS           true
-	// Standard_M8-2ms         Premium_LRS           false
-	// Standard_M8-4ms         Premium_LRS           false
-	// Standard_M8ms           Premium_LRS           true
-	// Standard_M96ms_v2       Premium_LRS           true
-	// Standard_M96s_v2        Premium_LRS           true
-	// Standard_NC12           Standard_LRS          false
-	// Standard_NC12_Promo     Standard_LRS          false
-	// Standard_NC12s_v2       Premium_LRS           false
-	// Standard_NC12s_v3       Premium_LRS           false
-	// Standard_NC16as_T4_v3   Premium_LRS           true
-	// Standard_NC24           Standard_LRS          false
-	// Standard_NC24_Promo     Standard_LRS          false
-	// Standard_NC24r          Standard_LRS          false
-	// Standard_NC24r_Promo    Standard_LRS          false
-	// Standard_NC24rs_v2      Premium_LRS           false
-	// Standard_NC24rs_v3      Premium_LRS           false
-	// Standard_NC24s_v2       Premium_LRS           false
-	// Standard_NC24s_v3       Premium_LRS           false
-	// Standard_NC4as_T4_v3    Premium_LRS           true
-	// Standard_NC6            Standard_LRS          false
-	// Standard_NC64as_T4_v3   Premium_LRS           true
-	// Standard_NC6_Promo      Standard_LRS          false
-	// Standard_NC6s_v2        Premium_LRS           false
-	// Standard_NC6s_v3        Premium_LRS           false
-	// Standard_NC8as_T4_v3    Premium_LRS           true
-	// Standard_ND12s          Premium_LRS           false
-	// Standard_ND24rs         Premium_LRS           false
-	// Standard_ND24s          Premium_LRS           false
-	// Standard_ND40rs_v2      Premium_LRS           false
-	// Standard_ND40s_v3       Premium_LRS           true
-	// Standard_ND6s           Premium_LRS           false
-	// Standard_NP10s          Premium_LRS           false
-	// Standard_NP20s          Premium_LRS           false
-	// Standard_NP40s          Premium_LRS           false
-	// Standard_NV12           Standard_LRS          false
-	// Standard_NV12_Promo     Standard_LRS          false
-	// Standard_NV12s_v2       Premium_LRS           false
-	// Standard_NV12s_v3       Premium_LRS           false
-	// Standard_NV16as_v4      Premium_LRS           false
-	// Standard_NV24           Standard_LRS          false
-	// Standard_NV24_Promo     Standard_LRS          false
-	// Standard_NV24s_v2       Premium_LRS           false
-	// Standard_NV24s_v3       Premium_LRS           false
-	// Standard_NV32as_v4      Premium_LRS           false
-	// Standard_NV48s_v3       Premium_LRS           false
-	// Standard_NV4as_v4       Premium_LRS           false
-	// Standard_NV6            Standard_LRS          false
-	// Standard_NV6_Promo      Standard_LRS          false
-	// Standard_NV6s_v2        Premium_LRS           false
-	// Standard_NV8as_v4       Premium_LRS           false
-	// Standard_PB12s          Premium_LRS           false
-	// Standard_PB24s          Premium_LRS           false
-	// Standard_PB6s           Premium_LRS           false
-	// Standard_ZRS            Premium_LRS           false
+	// Name                    Accelerated Networking Support
+	// Standard_A0             false
+	// Standard_A1             false
+	// Standard_A10            false
+	// Standard_A11            false
+	// Standard_A1_v2          false
+	// Standard_A2             false
+	// Standard_A2_v2          false
+	// Standard_A2m_v2         false
+	// Standard_A3             false
+	// Standard_A4             false
+	// Standard_A4_v2          false
+	// Standard_A4m_v2         false
+	// Standard_A5             false
+	// Standard_A6             false
+	// Standard_A7             false
+	// Standard_A8             false
+	// Standard_A8_v2          false
+	// Standard_A8m_v2         false
+	// Standard_A9             false
+	// Standard_B12ms          true
+	// Standard_B16ms          true
+	// Standard_B1ls           false
+	// Standard_B1ms           false
+	// Standard_B1s            false
+	// Standard_B20ms          true
+	// Standard_B2ms           false
+	// Standard_B2s            false
+	// Standard_B4ms           false
+	// Standard_B8ms           false
+	// Standard_D1             false
+	// Standard_D11            false
+	// Standard_D11_v2         true
+	// Standard_D11_v2_Promo   true
+	// Standard_D12            false
+	// Standard_D12_v2         false
+	// Standard_D12_v2         true
+	// Standard_D12_v2_Promo   false
+	// Standard_D13            false
+	// Standard_D13_v2         true
+	// Standard_D13_v2_Promo   true
+	// Standard_D14            false
+	// Standard_D14_v2         true
+	// Standard_D14_v2_Promo   true
+	// Standard_D15_v2         true
+	// Standard_D16_v3         true
+	// Standard_D16_v4         true
+	// Standard_D16a_v3        false
+	// Standard_D16a_v4        true
+	// Standard_D16as_v3       false
+	// Standard_D16as_v4       true
+	// Standard_D16d_v4        true
+	// Standard_D16ds_v4       true
+	// Standard_D16s_v3        true
+	// Standard_D16s_v4        true
+	// Standard_D1_v2          false
+	// Standard_D2             false
+	// Standard_D2_v2          true
+	// Standard_D2_v2_Promo    true
+	// Standard_D2_v3          false
+	// Standard_D2_v4          false
+	// Standard_D2a_v3         false
+	// Standard_D2a_v4         false
+	// Standard_D2as_v3        false
+	// Standard_D2as_v4        false
+	// Standard_D2d_v4         false
+	// Standard_D2ds_v4        false
+	// Standard_D2s_v3         false
+	// Standard_D2s_v4         false
+	// Standard_D3             false
+	// Standard_D32_v3         true
+	// Standard_D32_v4         true
+	// Standard_D32a_v3        false
+	// Standard_D32a_v4        true
+	// Standard_D32as_v3       false
+	// Standard_D32as_v4       true
+	// Standard_D32d_v4        true
+	// Standard_D32ds_v4       true
+	// Standard_D32s_v3        true
+	// Standard_D32s_v4        true
+	// Standard_D3_v2          true
+	// Standard_D3_v2_Promo    true
+	// Standard_D4             false
+	// Standard_D48_v3         true
+	// Standard_D48_v4         true
+	// Standard_D48a_v3        false
+	// Standard_D48a_v4        true
+	// Standard_D48as_v3       false
+	// Standard_D48as_v4       true
+	// Standard_D48d_v4        true
+	// Standard_D48ds_v4       true
+	// Standard_D48s_v3        true
+	// Standard_D48s_v4        true
+	// Standard_D4_v2          true
+	// Standard_D4_v2_Promo    true
+	// Standard_D4_v3          true
+	// Standard_D4_v4          true
+	// Standard_D4a_v3         false
+	// Standard_D4a_v4         true
+	// Standard_D4as_v3        false
+	// Standard_D4as_v4        true
+	// Standard_D4d_v4         true
+	// Standard_D4ds_v4        true
+	// Standard_D4s_v3         true
+	// Standard_D4s_v4         true
+	// Standard_D5_v2          true
+	// Standard_D5_v2_Promo    true
+	// Standard_D64_v3         true
+	// Standard_D64_v4         true
+	// Standard_D64a_v3        false
+	// Standard_D64a_v4        true
+	// Standard_D64as_v3       false
+	// Standard_D64as_v4       true
+	// Standard_D64d_v4        true
+	// Standard_D64ds_v4       true
+	// Standard_D64s_v3        true
+	// Standard_D64s_v4        true
+	// Standard_D8_v3          true
+	// Standard_D8_v4          true
+	// Standard_D8a_v3         false
+	// Standard_D8a_v4         true
+	// Standard_D8as_v3        false
+	// Standard_D8as_v4        true
+	// Standard_D8d_v4         true
+	// Standard_D8ds_v4        true
+	// Standard_D8s_v3         true
+	// Standard_D8s_v4         true
+	// Standard_D96a_v3        false
+	// Standard_D96a_v4        true
+	// Standard_D96as_v3       false
+	// Standard_D96as_v4       true
+	// Standard_DC1s_v2        false
+	// Standard_DC2s           false
+	// Standard_DC2s_v2        true
+	// Standard_DC4s           false
+	// Standard_DC4s_v2        true
+	// Standard_DC8_v2         true
+	// Standard_DC8s           false
+	// Standard_DS1            false
+	// Standard_DS11           false
+	// Standard_DS11-1_v2      false
+	// Standard_DS11_v2        true
+	// Standard_DS11_v2_Promo  true
+	// Standard_DS12           false
+	// Standard_DS12-1_v2      true
+	// Standard_DS12-2_v2      true
+	// Standard_DS12_v2        true
+	// Standard_DS12_v2_Promo  true
+	// Standard_DS13           false
+	// Standard_DS13-2_v2      true
+	// Standard_DS13-4_v2      true
+	// Standard_DS13_v2        true
+	// Standard_DS13_v2_Promo  true
+	// Standard_DS14           false
+	// Standard_DS14-4_v2      true
+	// Standard_DS14-8_v2      true
+	// Standard_DS14_v2        true
+	// Standard_DS14_v2_Promo  true
+	// Standard_DS15_v2        true
+	// Standard_DS1_v2         false
+	// Standard_DS2            false
+	// Standard_DS2_v2         true
+	// Standard_DS2_v2_Promo   true
+	// Standard_DS3            false
+	// Standard_DS3_v2         true
+	// Standard_DS3_v2_Promo   true
+	// Standard_DS4            false
+	// Standard_DS4_v2         true
+	// Standard_DS4_v2_Promo   true
+	// Standard_DS5_v2         false
+	// Standard_DS5_v2_Promo   false
+	// Standard_E16-4as_v4     true
+	// Standard_E16-4ds_v4     true
+	// Standard_E16-4s_v3      true
+	// Standard_E16-4s_v4      true
+	// Standard_E16-8as_v4     false
+	// Standard_E16-8ds_v4     true
+	// Standard_E16-8s_v3      true
+	// Standard_E16-8s_v4      true
+	// Standard_E16_v3         true
+	// Standard_E16_v4         true
+	// Standard_E16a_v3        false
+	// Standard_E16a_v4        true
+	// Standard_E16as_v3       false
+	// Standard_E16as_v4       true
+	// Standard_E16d_v4        true
+	// Standard_E16ds_v4       true
+	// Standard_E16s_v3        true
+	// Standard_E16s_v4        true
+	// Standard_E20_v3         true
+	// Standard_E20_v4         true
+	// Standard_E20a_v4        true
+	// Standard_E20as_v4       true
+	// Standard_E20d_v4        true
+	// Standard_E20ds_v4       true
+	// Standard_E20s_v3        true
+	// Standard_E20s_v4        true
+	// Standard_E2_v3          false
+	// Standard_E2_v4          false
+	// Standard_E2a_v3         false
+	// Standard_E2a_v4         false
+	// Standard_E2as_v3        false
+	// Standard_E2as_v4        false
+	// Standard_E2d_v4         false
+	// Standard_E2ds_v4        false
+	// Standard_E2s_v3         false
+	// Standard_E2s_v4         false
+	// Standard_E32-16as_v4    true
+	// Standard_E32-16ds_v4    true
+	// Standard_E32-16s_v3     true
+	// Standard_E32-16s_v4     true
+	// Standard_E32-8as_v4     true
+	// Standard_E32-8ds_v4     true
+	// Standard_E32-8s_v3      true
+	// Standard_E32-8s_v4      true
+	// Standard_E32_v3         true
+	// Standard_E32_v4         true
+	// Standard_E32a_v3        false
+	// Standard_E32a_v4        true
+	// Standard_E32as_v3       false
+	// Standard_E32as_v4       true
+	// Standard_E32d_v4        true
+	// Standard_E32ds_v4       true
+	// Standard_E32s_v3        true
+	// Standard_E32s_v4        true
+	// Standard_E4-2as_v4      true
+	// Standard_E4-2ds_v4      true
+	// Standard_E4-2s_v3       true
+	// Standard_E4-2s_v4       true
+	// Standard_E48_v3         true
+	// Standard_E48_v4         true
+	// Standard_E48a_v3        false
+	// Standard_E48a_v4        true
+	// Standard_E48as_v3       false
+	// Standard_E48as_v4       true
+	// Standard_E48d_v4        true
+	// Standard_E48ds_v4       true
+	// Standard_E48s_v3        true
+	// Standard_E48s_v4        true
+	// Standard_E4_v3          true
+	// Standard_E4_v4          true
+	// Standard_E4a_v3         false
+	// Standard_E4a_v4         true
+	// Standard_E4as_v3        false
+	// Standard_E4as_v4        true
+	// Standard_E4d_v4         true
+	// Standard_E4ds_v4        true
+	// Standard_E4s_v3         true
+	// Standard_E4s_v4         true
+	// Standard_E64-16as_v4    true
+	// Standard_E64-16ds_v4    true
+	// Standard_E64-16s_v3     true
+	// Standard_E64-16s_v4     true
+	// Standard_E64-32as_v4    true
+	// Standard_E64-32ds_v4    true
+	// Standard_E64-32s_v3     true
+	// Standard_E64-32s_v4     true
+	// Standard_E64_v3         true
+	// Standard_E64_v4         true
+	// Standard_E64a_v3        false
+	// Standard_E64a_v4        true
+	// Standard_E64as_v3       false
+	// Standard_E64as_v4       true
+	// Standard_E64d_v4        true
+	// Standard_E64ds_v4       true
+	// Standard_E64i_v3        true
+	// Standard_E64is_v3       true
+	// Standard_E64s_v3        true
+	// Standard_E64s_v4        true
+	// Standard_E8-2as_v4      true
+	// Standard_E8-2ds_v4      true
+	// Standard_E8-2s_v3       true
+	// Standard_E8-2s_v4       true
+	// Standard_E8-4as_v4      true
+	// Standard_E8-4ds_v4      true
+	// Standard_E8-4s_v3       true
+	// Standard_E8-4s_v4       true
+	// Standard_E80ids_v4      true
+	// Standard_E80is_v4       true
+	// Standard_E8_v3          true
+	// Standard_E8_v4          true
+	// Standard_E8a_v3         false
+	// Standard_E8a_v4         true
+	// Standard_E8as_v3        false
+	// Standard_E8as_v4        true
+	// Standard_E8d_v4         true
+	// Standard_E8ds_v4        true
+	// Standard_E8s_v3         true
+	// Standard_E8s_v4         true
+	// Standard_E96-24as_v4    true
+	// Standard_E96-48as_v4    true
+	// Standard_E96a_v4        true
+	// Standard_E96as_v4       true
+	// Standard_F1             false
+	// Standard_F16            true
+	// Standard_F16s           true
+	// Standard_F16s_v2        true
+	// Standard_F1s            false
+	// Standard_F2             true
+	// Standard_F2s            true
+	// Standard_F2s_v2         false
+	// Standard_F32s_v2        true
+	// Standard_F4             true
+	// Standard_F48s_v2        true
+	// Standard_F4s            true
+	// Standard_F4s_v2         true
+	// Standard_F64s_v2        true
+	// Standard_F72s_v2        true
+	// Standard_F8             true
+	// Standard_F8s            true
+	// Standard_F8s_v2         true
+	// Standard_G1             false
+	// Standard_G2             false
+	// Standard_G3             false
+	// Standard_G4             false
+	// Standard_G5             false
+	// Standard_GS1            false
+	// Standard_GS2            false
+	// Standard_GS3            false
+	// Standard_GS4            false
+	// Standard_GS4-4          false
+	// Standard_GS4-8          false
+	// Standard_GS5            false
+	// Standard_GS5-16         false
+	// Standard_GS5-8          false
+	// Standard_H16            false
+	// Standard_H16_Promo      false
+	// Standard_H16m           false
+	// Standard_H16m_Promo     false
+	// Standard_H16mr          false
+	// Standard_H16mr_Promo    false
+	// Standard_H16r           false
+	// Standard_H16r_Promo     false
+	// Standard_H8             false
+	// Standard_H8_Promo       false
+	// Standard_H8m            false
+	// Standard_H8m_Promo      false
+	// Standard_HB120rs_v2     false
+	// Standard_HB60rs         false
+	// Standard_HC44rs         false
+	// Standard_L16s           false
+	// Standard_L16s_v2        true
+	// Standard_L32s           false
+	// Standard_L32s_v2        true
+	// Standard_L48s_v2        true
+	// Standard_L4s            false
+	// Standard_L64s_v2        true
+	// Standard_L80s_v2        true
+	// Standard_L8s            false
+	// Standard_L8s_v2         true
+	// Standard_LRS            false
+	// Standard_M128           true
+	// Standard_M128-32ms      true
+	// Standard_M128-64ms      true
+	// Standard_M128dms_v2     true
+	// Standard_M128ds_v2      true
+	// Standard_M128m          true
+	// Standard_M128ms         true
+	// Standard_M128ms_v2      true
+	// Standard_M128s          true
+	// Standard_M128s_v2       true
+	// Standard_M16-4ms        true
+	// Standard_M16-8ms        true
+	// Standard_M16ms          true
+	// Standard_M192idms_v2    true
+	// Standard_M192ids_v2     true
+	// Standard_M192ims_v2     true
+	// Standard_M192is_v2      true
+	// Standard_M192ms_v2      true
+	// Standard_M192s_v2       true
+	// Standard_M208ms_v2      true
+	// Standard_M208s_v2       true
+	// Standard_M24ms_v2       true
+	// Standard_M24s_v2        true
+	// Standard_M32-16ms       true
+	// Standard_M32-8ms        true
+	// Standard_M32dms_v2      true
+	// Standard_M32ls          true
+	// Standard_M32ms          true
+	// Standard_M32ms_v2       true
+	// Standard_M32ts          true
+	// Standard_M416-208ms_v2  true
+	// Standard_M416-208s_v2   true
+	// Standard_M416ms_v2      true
+	// Standard_M416s_v2       true
+	// Standard_M48ms_v2       true
+	// Standard_M48s_v2        true
+	// Standard_M64            true
+	// Standard_M64-16ms       true
+	// Standard_M64-32ms       true
+	// Standard_M64dms_v2      true
+	// Standard_M64ds_v2       true
+	// Standard_M64ls          true
+	// Standard_M64m           true
+	// Standard_M64ms          true
+	// Standard_M64ms_v2       true
+	// Standard_M64s           false
+	// Standard_M64s_v2        true
+	// Standard_M8-2ms         false
+	// Standard_M8-4ms         false
+	// Standard_M8ms           true
+	// Standard_M96ms_v2       true
+	// Standard_M96s_v2        true
+	// Standard_NC12           false
+	// Standard_NC12_Promo     false
+	// Standard_NC12s_v2       false
+	// Standard_NC12s_v3       false
+	// Standard_NC16as_T4_v3   true
+	// Standard_NC24           false
+	// Standard_NC24_Promo     false
+	// Standard_NC24r          false
+	// Standard_NC24r_Promo    false
+	// Standard_NC24rs_v2      false
+	// Standard_NC24rs_v3      false
+	// Standard_NC24s_v2       false
+	// Standard_NC24s_v3       false
+	// Standard_NC4as_T4_v3    true
+	// Standard_NC6            false
+	// Standard_NC64as_T4_v3   true
+	// Standard_NC6_Promo      false
+	// Standard_NC6s_v2        false
+	// Standard_NC6s_v3        false
+	// Standard_NC8as_T4_v3    true
+	// Standard_ND12s          false
+	// Standard_ND24rs         false
+	// Standard_ND24s          false
+	// Standard_ND40rs_v2      false
+	// Standard_ND40s_v3       true
+	// Standard_ND6s           false
+	// Standard_NP10s          false
+	// Standard_NP20s          false
+	// Standard_NP40s          false
+	// Standard_NV12           false
+	// Standard_NV12_Promo     false
+	// Standard_NV12s_v2       false
+	// Standard_NV12s_v3       false
+	// Standard_NV16as_v4      false
+	// Standard_NV24           false
+	// Standard_NV24_Promo     false
+	// Standard_NV24s_v2       false
+	// Standard_NV24s_v3       false
+	// Standard_NV32as_v4      false
+	// Standard_NV48s_v3       false
+	// Standard_NV4as_v4       false
+	// Standard_NV6            false
+	// Standard_NV6_Promo      false
+	// Standard_NV6s_v2        false
+	// Standard_NV8as_v4       false
+	// Standard_PB12s          false
+	// Standard_PB24s          false
+	// Standard_PB6s           false
+	// Standard_ZRS            false
 }
 
 func ExampleSkusCmd_run_jsonOutput() {
@@ -586,2257 +586,1806 @@ func ExampleSkusCmd_run_jsonOutput() {
 	// [
 	//   {
 	//     "Name": "Standard_A0",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A1",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A10",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A11",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A1_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A2_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A2m_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A4_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A4m_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A5",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A6",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A7",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A8",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A8_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A8m_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_A9",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_B12ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_B16ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_B1ls",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_B1ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_B1s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_B20ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_B2ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_B2s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_B4ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_B8ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D1",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D11",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D11_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D11_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D12",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D12_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D12_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D12_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D13",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D13_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D13_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D14",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D14_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D14_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D15_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D16a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D16as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D16s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D1_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D2_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D2_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D2s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D32_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D32_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D32a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D32a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D32as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D32as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D32d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D32ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D32s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D32s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D3_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D3_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D48_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D48_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D48a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D48a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D48as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D48as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D48d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D48ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D48s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D48s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D4a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D4as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D4s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D5_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D5_v2_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D64a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D64as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D64s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D8a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D8as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D8s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D96a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D96a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_D96as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_D96as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DC1s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DC2s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DC2s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DC4s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DC4s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DC8_v2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DC8s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS1",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS11",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS11-1_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS11_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS11_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS12",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS12-1_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS12-2_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS12_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS12_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS13",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS13-2_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS13-4_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS13_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS13_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS14",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS14-4_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS14-8_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS14_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS14_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS15_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS1_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS2_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS2_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS3_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS3_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS4_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS4_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_DS5_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_DS5_v2_Promo",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E16-4as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16-4ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16-4s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16-4s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16-8as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E16-8ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16-8s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16-8s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E16a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E16as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E16s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E20s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E2_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E2s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E32-16as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32-16ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32-16s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32-16s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32-8as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32-8ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32-8s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32-8s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E32a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E32as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E32s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4-2as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4-2ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4-2s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4-2s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E48a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E48as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E48s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E4a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E4as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E4s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-16as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-16ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-16s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-16s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-32as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-32ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-32s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64-32s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E64a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E64as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64i_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64is_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E64s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-2as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-2ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-2s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-2s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-4as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-4ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-4s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8-4s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E80ids_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E80is_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8a_v3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E8a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8as_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_E8as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8d_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8ds_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E8s_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E96-24as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E96-48as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E96a_v4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_E96as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F1",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_F16",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F16s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F16s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F1s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_F2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F2s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F2s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_F32s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F48s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F4s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F4s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F64s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F72s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F8",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F8s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_F8s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_G1",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_G2",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_G3",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_G4",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_G5",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS1",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS4-4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS4-8",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS5",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS5-16",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_GS5-8",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16m",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16m_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16mr",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16mr_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16r",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H16r_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H8",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H8_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H8m",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_H8m_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_HB120rs_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_HB60rs",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_HC44rs",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_L16s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_L16s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_L32s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_L32s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_L48s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_L4s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_L64s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_L80s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_L8s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_L8s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_LRS",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_M128",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128-32ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128-64ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128dms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128ds_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128m",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M128s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M16-4ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M16-8ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M16ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M192idms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M192ids_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M192ims_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M192is_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M192ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M192s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M208ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M208s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M24ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M24s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M32-16ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M32-8ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M32dms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M32ls",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M32ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M32ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M32ts",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M416-208ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M416-208s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M416ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M416s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M48ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M48s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64-16ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64-32ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64dms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64ds_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64ls",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64m",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M64s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_M64s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M8-2ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_M8-4ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_M8ms",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M96ms_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_M96s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_NC12",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC12_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC12s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC12s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC16as_T4_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_NC24",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC24_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC24r",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC24r_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC24rs_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC24rs_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC24s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC24s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC4as_T4_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_NC6",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC64as_T4_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_NC6_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC6s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC6s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NC8as_T4_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_ND12s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_ND24rs",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_ND24s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_ND40rs_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_ND40s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": true
 	//   },
 	//   {
 	//     "Name": "Standard_ND6s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NP10s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NP20s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NP40s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV12",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV12_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV12s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV12s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV16as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV24",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV24_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV24s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV24s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV32as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV48s_v3",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV4as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV6",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV6_Promo",
-	//     "StorageAccountType": "Standard_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV6s_v2",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_NV8as_v4",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_PB12s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_PB24s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_PB6s",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   },
 	//   {
 	//     "Name": "Standard_ZRS",
-	//     "StorageAccountType": "Premium_LRS",
 	//     "AcceleratedNetworking": false
 	//   }
 	// ]
@@ -2887,2109 +2436,1688 @@ func ExampleSkusCmd_run_codeOutput() {
 
 	// type VMSku struct {
 	// 	Name                  string
-	// 	StorageAccountType    string
 	// 	AcceleratedNetworking bool
 	// }
 
 	// var VMSkus = []VMSku{
 	// 	{
 	// 		Name:                  "Standard_A0",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A1",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A10",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A11",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A1_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A2_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A2m_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A4_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A4m_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A5",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A6",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A7",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A8",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A8_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A8m_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_A9",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B12ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B16ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B1ls",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B1ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B1s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B20ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B2ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B2s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B4ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_B8ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D1",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D11",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D11_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D11_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D12",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D12_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D12_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D12_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D13",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D13_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D13_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D14",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D14_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D14_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D15_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D16s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D1_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D2s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D32s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D3_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D3_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D48s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D4s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D5_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D5_v2_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D64s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D8s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D96a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D96a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D96as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_D96as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DC1s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DC2s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DC2s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DC4s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DC4s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DC8_v2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DC8s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS1",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS11",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS11-1_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS11_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS11_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS12",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS12-1_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS12-2_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS12_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS12_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS13",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS13-2_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS13-4_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS13_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS13_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS14",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS14-4_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS14-8_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS14_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS14_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS15_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS1_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS2_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS2_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS3_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS3_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS4_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS4_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS5_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_DS5_v2_Promo",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16-4ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16-4s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16-4s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16-8ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16-8s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16-8s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E16s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E20s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E2s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32-16ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32-16s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32-16s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32-8ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32-8s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32-8s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E32s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4-2ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4-2s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4-2s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E48s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E4s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64-16ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64-16s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64-16s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64-32ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64-32s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64-32s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64i_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64is_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E64s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8-2ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 			Name:                  "Standard_E8-2s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8-2s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8-4ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8-4s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8-4s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8a_v3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8as_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8d_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8ds_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E8s_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E96a_v4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_E96as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F1",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F16",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F16s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F16s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F1s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F2s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F2s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F32s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F48s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F4s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F4s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F64s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F72s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F8",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F8s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_F8s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_G1",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_G2",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_G3",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_G4",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_G5",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS1",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS4-4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS4-8",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS5",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS5-16",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_GS5-8",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16m",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16m_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16mr",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16mr_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16r",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H16r_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H8",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H8_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H8m",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_H8m_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_HB120rs_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_HB60rs",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_HC44rs",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L16s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L16s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L32s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L32s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L48s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L4s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L64s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L80s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L8s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_L8s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_LRS",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M128",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M128-32ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M128-64ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M128m",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M128ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M128s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M16-4ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M16-8ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M16ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M192ms_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M192s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M208ms_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M208s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M24ms_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M24s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M32-16ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M32-8ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M32ls",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M32ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M32ts",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M416-208ms_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M416-208s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M416ms_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M416s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M48ms_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M48s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M64",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M64-16ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M64-32ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M64ls",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M64m",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M64ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M64s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M8-2ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M8-4ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M8ms",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M96ms_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_M96s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC12",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC12_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC12s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC12s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24r",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24r_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24rs_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24rs_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC24s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC6",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC6_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC6s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NC6s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_ND12s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_ND24rs",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_ND24s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_ND40rs_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_ND40s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: true,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_ND6s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NP10s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NP20s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NP40s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV12",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV12_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV12s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV12s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV16as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV24",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV24_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV24s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV24s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV32as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV48s_v3",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV4as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV6",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV6_Promo",
-	// 		StorageAccountType:    "Standard_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV6s_v2",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_NV8as_v4",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_PB12s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_PB24s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_PB6s",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// 	{
 	// 		Name:                  "Standard_ZRS",
-	// 		StorageAccountType:    "Premium_LRS",
 	// 		AcceleratedNetworking: false,
 	// 	},
 	// }

--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -299,7 +299,7 @@ func GetMasterKubernetesLabels(rg string, deprecated bool) string {
 	return buf.String()
 }
 
-// GetStorageAccountType returns the support managed disk storage tier for a give VM size
+// GetStorageAccountType returns the managed disk storage tier for a given VM size.
 func GetStorageAccountType(sizeName string) (string, error) {
 	spl := strings.Split(sizeName, "_")
 	if len(spl) < 2 {

--- a/pkg/helpers/azure_skus.go
+++ b/pkg/helpers/azure_skus.go
@@ -6,6 +6,8 @@ package helpers
 import (
 	"fmt"
 	"strings"
+
+	"github.com/Azure/aks-engine/pkg/api/common"
 )
 
 // GetKubernetesAllowedVMSKUs returns the allowed sizes for Kubernetes agent
@@ -28,8 +30,12 @@ func GetSizeMap() string {
 	var b strings.Builder
 	b.WriteString("    \"vmSizesMap\": {\n")
 	for i, sku := range VMSkus {
+		storageType, err := common.GetStorageAccountType(sku.Name)
+		if err != nil {
+			storageType = err.Error()
+		}
 		fmt.Fprintf(&b, "    \"%s\": {\n      \"storageAccountType\": \"%s\"\n    }",
-			sku.Name, sku.StorageAccountType)
+			sku.Name, storageType)
 		if i < len(VMSkus)-1 {
 			b.WriteByte(',')
 		}

--- a/pkg/helpers/azure_skus_const.go
+++ b/pkg/helpers/azure_skus_const.go
@@ -12,2264 +12,1812 @@ package helpers
 
 type VMSku struct {
 	Name                  string
-	StorageAccountType    string
 	AcceleratedNetworking bool
 }
 
 var VMSkus = []VMSku{
 	{
 		Name:                  "Standard_A0",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A1",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A10",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A11",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A1_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A2_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A2m_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A4_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A4m_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A5",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A6",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A7",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A8",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A8_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A8m_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_A9",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_B12ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_B16ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_B1ls",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_B1ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_B1s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_B20ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_B2ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_B2s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_B4ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_B8ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D1",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D11",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D11_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D11_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D12",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D12_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D12_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D12_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D13",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D13_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D13_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D14",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D14_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D14_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D15_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D16a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D16as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D16s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D1_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D2_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D2_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D2s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D32_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D32_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D32a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D32a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D32as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D32as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D32d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D32ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D32s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D32s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D3_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D3_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D48_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D48_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D48a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D48a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D48as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D48as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D48d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D48ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D48s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D48s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D4a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D4as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D4s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D5_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D5_v2_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D64a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D64as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D64s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D8a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D8as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D8s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D96a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D96a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_D96as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_D96as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DC1s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DC2s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DC2s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DC4s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DC4s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DC8_v2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DC8s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS1",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS11",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS11-1_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS11_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS11_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS12",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS12-1_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS12-2_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS12_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS12_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS13",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS13-2_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS13-4_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS13_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS13_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS14",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS14-4_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS14-8_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS14_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS14_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS15_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS1_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS2_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS2_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS3_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS3_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS4_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS4_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_DS5_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_DS5_v2_Promo",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E16-4as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16-4ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16-4s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16-4s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16-8as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E16-8ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16-8s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16-8s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E16a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E16as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E16s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E20s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E2_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E2s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E32-16as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32-16ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32-16s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32-16s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32-8as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32-8ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32-8s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32-8s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E32a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E32as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E32s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4-2as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4-2ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4-2s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4-2s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E48a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E48as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E48s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E4a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E4as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E4s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-16as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-16ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-16s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-16s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-32as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-32ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-32s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64-32s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E64a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E64as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64i_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64is_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E64s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-2as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-2ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-2s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-2s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-4as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-4ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-4s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8-4s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E80ids_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E80is_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8a_v3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E8a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8as_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_E8as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8d_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8ds_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E8s_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E96-24as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E96-48as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E96a_v4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_E96as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F1",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_F16",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F16s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F16s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F1s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_F2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F2s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F2s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_F32s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F48s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F4s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F4s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F64s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F72s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F8",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F8s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_F8s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_G1",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_G2",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_G3",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_G4",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_G5",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS1",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS4-4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS4-8",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS5",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS5-16",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_GS5-8",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16m",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16m_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16mr",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16mr_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16r",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H16r_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H8",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H8_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H8m",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_H8m_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_HB120rs_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_HB60rs",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_HC44rs",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_L16s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_L16s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_L32s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_L32s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_L48s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_L4s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_L64s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_L80s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_L8s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_L8s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_LRS",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_M128",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128-32ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128-64ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128dms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128ds_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128m",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M128s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M16-4ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M16-8ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M16ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M192idms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M192ids_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M192ims_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M192is_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M192ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M192s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M208ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M208s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M24ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M24s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M32-16ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M32-8ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M32dms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M32ls",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M32ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M32ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M32ts",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M416-208ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M416-208s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M416ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M416s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M48ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M48s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64-16ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64-32ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64dms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64ds_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64ls",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64m",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M64s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_M64s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M8-2ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_M8-4ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_M8ms",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M96ms_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_M96s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_NC12",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC12_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC12s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC12s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC16as_T4_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_NC24",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC24_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC24r",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC24r_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC24rs_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC24rs_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC24s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC24s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC4as_T4_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_NC6",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC64as_T4_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_NC6_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC6s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC6s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NC8as_T4_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_ND12s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_ND24rs",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_ND24s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_ND40rs_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_ND40s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: true,
 	},
 	{
 		Name:                  "Standard_ND6s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NP10s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NP20s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NP40s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV12",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV12_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV12s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV12s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV16as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV24",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV24_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV24s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV24s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV32as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV48s_v3",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV4as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV6",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV6_Promo",
-		StorageAccountType:    "Standard_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV6s_v2",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_NV8as_v4",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_PB12s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_PB24s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_PB6s",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 	{
 		Name:                  "Standard_ZRS",
-		StorageAccountType:    "Premium_LRS",
 		AcceleratedNetworking: false,
 	},
 }


### PR DESCRIPTION
**Reason for Change**:

Since a VM's storage type is calculable from its name, there's no need to maintain a static lookup table. This is a minor simplification to ensure there's only one code path for finding storage type.

(This is also the only separable change that came out of my work on #4277 so far.)

**Issue Fixed**:

Refs #4277

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
