### PR TITLE
fix: kube-proxy image on Azure Stack deployments

### DIFF
--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -1179,9 +1179,7 @@ func getCSISidecarComponent(csiDriverName, csiSidecarName string, k8sComponents 
 // Azure Stack needs the '-azs' suffix so kube-proxy's manifests uses the custom hyperkube image present in the VHD
 func kubeProxyImageSuffix(cs ContainerService) string {
 	if cs.Properties.IsAzureStackCloud() {
-		if !common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.16.0") {
-			return common.AzureStackSuffix
-		}
+		return common.AzureStackSuffix
 	}
 	return ""
 }

--- a/pkg/api/addons_test.go
+++ b/pkg/api/addons_test.go
@@ -5299,25 +5299,13 @@ func TestKubeProxyImageSuffix(t *testing.T) {
 	}{
 		{
 			name:       "return empty string if target cloud is NOT Azure Stack",
-			cs:         getMockBaseContainerService("1.15.0"),
+			cs:         getMockBaseContainerService("1.19.0"),
 			azurestack: false,
 			expected:   "",
 		},
 		{
-			name:       "return empty string if target cloud is NOT Azure Stack",
-			cs:         getMockBaseContainerService("1.16.0"),
-			azurestack: false,
-			expected:   "",
-		},
-		{
-			name:       "return empty string if target version is v1.16 or greater",
-			cs:         getMockBaseContainerService("1.16.0"),
-			azurestack: true,
-			expected:   "",
-		},
-		{
-			name:       "return '-azs' if target cloud is Azure Stack and K8s version lower than v1.16",
-			cs:         getMockBaseContainerService("1.15.0"),
+			name:       "return '-azs' if target cloud is Azure Stack",
+			cs:         getMockBaseContainerService("1.19.0"),
 			azurestack: true,
 			expected:   common.AzureStackSuffix,
 		},


### PR DESCRIPTION
**Reason for Change**:

Disconnected deployments on ASH using v0.61.0 fail as the kube-proxy manifest is referencing an image that is not present in the VHD. I suspect this was introduced by #4249.

As v1.16 is now unsupported, it should be safe to return how things were before #3529. 

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
