### PR TITLE
feat: allow setting read only cache

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -564,7 +564,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	p.EncryptionAtHost = api.EncryptionAtHost
 	p.ProximityPlacementGroupID = api.ProximityPlacementGroupID
 	if api.OSDiskCaching != nil {
-		caching := vlabs.CachingType(*api.OSDiskCaching)
+		caching := vlabs.DiskCachingType(*api.OSDiskCaching)
 		p.OSDiskCaching = &caching
 	}
 

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -563,6 +563,10 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	p.DiskEncryptionSetID = api.DiskEncryptionSetID
 	p.EncryptionAtHost = api.EncryptionAtHost
 	p.ProximityPlacementGroupID = api.ProximityPlacementGroupID
+	if api.OSDiskCaching != nil {
+		caching := vlabs.CachingType(*api.OSDiskCaching)
+		p.OSDiskCaching = &caching
+	}
 
 	for k, v := range api.CustomNodeLabels {
 		p.CustomNodeLabels[k] = v

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -610,7 +610,7 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 	api.EncryptionAtHost = vlabs.EncryptionAtHost
 	api.ProximityPlacementGroupID = vlabs.ProximityPlacementGroupID
 	if vlabs.OSDiskCaching != nil {
-		caching := CachingType(*vlabs.OSDiskCaching)
+		caching := DiskCachingType(*vlabs.OSDiskCaching)
 		api.OSDiskCaching = &caching
 	}
 

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -609,6 +609,10 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 	api.UltraSSDEnabled = vlabs.UltraSSDEnabled
 	api.EncryptionAtHost = vlabs.EncryptionAtHost
 	api.ProximityPlacementGroupID = vlabs.ProximityPlacementGroupID
+	if vlabs.OSDiskCaching != nil {
+		caching := CachingType(*vlabs.OSDiskCaching)
+		api.OSDiskCaching = &caching
+	}
 
 	api.CustomNodeLabels = map[string]string{}
 	for k, v := range vlabs.CustomNodeLabels {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1179,7 +1179,7 @@ func (p *Properties) AreAgentProfilesCustomVNET() bool {
 
 // GetClusterID creates a unique 8 string cluster ID.
 func (p *Properties) GetClusterID() string {
-	mutex := &sync.Mutex{}
+	var mutex = &sync.Mutex{}
 	if p.ClusterID == "" {
 		uniqueNameSuffixSize := 8
 		// the name suffix uniquely identifies the cluster and is generated off a hash
@@ -2230,7 +2230,7 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 // SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
-		agentPoolProfilesCount := len(p.AgentPoolProfiles)
+		var agentPoolProfilesCount = len(p.AgentPoolProfiles)
 		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
 		} else {
@@ -2245,7 +2245,7 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite == 0 {
-		agentPoolProfilesCount := len(p.AgentPoolProfiles)
+		var agentPoolProfilesCount = len(p.AgentPoolProfiles)
 		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = DefaultKubernetesCloudProviderRateLimitBucketWrite
 		} else {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -463,7 +463,7 @@ type KubernetesConfig struct {
 	ServiceCIDR                       string            `json:"serviceCidr,omitempty"`
 	UseManagedIdentity                bool              `json:"useManagedIdentity,omitempty"`
 	UserAssignedID                    string            `json:"userAssignedID,omitempty"`
-	UserAssignedClientID              string            `json:"userAssignedClientID,omitempty"` //Note: cannot be provided in config. Used *only* for transferring this to azure.json.
+	UserAssignedClientID              string            `json:"userAssignedClientID,omitempty"` // Note: cannot be provided in config. Used *only* for transferring this to azure.json.
 	CustomHyperkubeImage              string            `json:"customHyperkubeImage,omitempty"`
 	CustomKubeAPIServerImage          string            `json:"customKubeAPIServerImage,omitempty"`
 	CustomKubeControllerManagerImage  string            `json:"customKubeControllerManagerImage,omitempty"`
@@ -688,16 +688,16 @@ type AgentPoolProfile struct {
 	UltraSSDEnabled                     *bool                `json:"ultraSSDEnabled,omitempty"`
 	EncryptionAtHost                    *bool                `json:"encryptionAtHost,omitempty"`
 	ProximityPlacementGroupID           string               `json:"proximityPlacementGroupID,omitempty"`
-	OSDiskCaching                       *CachingType         `json:"osDiskCaching,omitempty"`
+	OSDiskCaching                       *DiskCachingType     `json:"osDiskCaching,omitempty"`
 }
 
-// CachingType determines the HostCache mode for an Azure VM Disk. Read more here:
+// DiskCachingType determines the HostCache mode for an Azure VM Disk. Read more here:
 // https://docs.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching
-type CachingType string
+type DiskCachingType string
 
 const (
-	CachingTypesReadOnly  CachingType = "ReadOnly"
-	CachingTypesReadWrite CachingType = "ReadWrite"
+	DiskCachingTypesReadOnly  DiskCachingType = "ReadOnly"
+	DiskCachingTypesReadWrite DiskCachingType = "ReadWrite"
 )
 
 // AgentPoolProfileRole represents an agent role
@@ -1051,7 +1051,6 @@ func (p *Properties) GetResourcePrefix() string {
 		return p.K8sOrchestratorName() + "-agentpool-" + p.GetClusterID() + "-"
 	}
 	return p.K8sOrchestratorName() + "-master-" + p.GetClusterID() + "-"
-
 }
 
 // GetRouteTableName returns the route table name of the cluster.
@@ -1180,7 +1179,7 @@ func (p *Properties) AreAgentProfilesCustomVNET() bool {
 
 // GetClusterID creates a unique 8 string cluster ID.
 func (p *Properties) GetClusterID() string {
-	var mutex = &sync.Mutex{}
+	mutex := &sync.Mutex{}
 	if p.ClusterID == "" {
 		uniqueNameSuffixSize := 8
 		// the name suffix uniquely identifies the cluster and is generated off a hash
@@ -2231,7 +2230,7 @@ func (p *Properties) IsNvidiaDevicePluginCapable() bool {
 // SetCloudProviderRateLimitDefaults sets default cloudprovider rate limiter config
 func (p *Properties) SetCloudProviderRateLimitDefaults() {
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket == 0 {
-		var agentPoolProfilesCount = len(p.AgentPoolProfiles)
+		agentPoolProfilesCount := len(p.AgentPoolProfiles)
 		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket = DefaultKubernetesCloudProviderRateLimitBucket
 		} else {
@@ -2246,7 +2245,7 @@ func (p *Properties) SetCloudProviderRateLimitDefaults() {
 		}
 	}
 	if p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite == 0 {
-		var agentPoolProfilesCount = len(p.AgentPoolProfiles)
+		agentPoolProfilesCount := len(p.AgentPoolProfiles)
 		if agentPoolProfilesCount == 0 {
 			p.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite = DefaultKubernetesCloudProviderRateLimitBucketWrite
 		} else {
@@ -2342,8 +2341,8 @@ func (f *FeatureFlags) IsFeatureEnabled(feature string) bool {
 }
 
 // GetCloudSpecConfig returns the Kubernetes container images URL configurations based on the deploy target environment.
-//for example: if the target is the public azure, then the default container image url should be k8s.gcr.io/...
-//if the target is azure china, then the default container image should be mirror.azure.cn:5000/google_container/...
+// for example: if the target is the public azure, then the default container image url should be k8s.gcr.io/...
+// if the target is azure china, then the default container image should be mirror.azure.cn:5000/google_container/...
 func (cs *ContainerService) GetCloudSpecConfig() AzureEnvironmentSpecConfig {
 	targetEnv := helpers.GetTargetEnv(cs.Location, cs.Properties.GetCustomCloudName())
 	return AzureCloudSpecEnvMap[targetEnv]

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -688,7 +688,17 @@ type AgentPoolProfile struct {
 	UltraSSDEnabled                     *bool                `json:"ultraSSDEnabled,omitempty"`
 	EncryptionAtHost                    *bool                `json:"encryptionAtHost,omitempty"`
 	ProximityPlacementGroupID           string               `json:"proximityPlacementGroupID,omitempty"`
+	OSDiskCaching                       *CachingType         `json:"osDiskCaching,omitempty"`
 }
+
+// CachingType determines the HostCache mode for an Azure VM Disk. Read more here:
+// https://docs.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching
+type CachingType string
+
+const (
+	CachingTypesReadOnly  CachingType = "ReadOnly"
+	CachingTypesReadWrite CachingType = "ReadWrite"
+)
 
 // AgentPoolProfileRole represents an agent role
 type AgentPoolProfileRole string

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -696,7 +696,7 @@ func TestHasStorageProfile(t *testing.T) {
 		expectedPrivateJB        bool
 		expectedHasDisks         bool
 		expectedDesID            string
-                expectedEncryptionAtHost bool
+		expectedEncryptionAtHost bool
 	}{
 		{
 			name: "Storage Account",

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -321,7 +321,7 @@ type KubernetesConfig struct {
 	DockerBridgeSubnet                string            `json:"dockerBridgeSubnet,omitempty"`
 	UseManagedIdentity                bool              `json:"useManagedIdentity,omitempty"`
 	UserAssignedID                    string            `json:"userAssignedID,omitempty"`
-	UserAssignedClientID              string            `json:"userAssignedClientID,omitempty"` //Note: cannot be provided in config. Used *only* for transferring this to azure.json.
+	UserAssignedClientID              string            `json:"userAssignedClientID,omitempty"` // Note: cannot be provided in config. Used *only* for transferring this to azure.json.
 	CustomHyperkubeImage              string            `json:"customHyperkubeImage,omitempty"`
 	CustomKubeAPIServerImage          string            `json:"customKubeAPIServerImage,omitempty"`
 	CustomKubeControllerManagerImage  string            `json:"customKubeControllerManagerImage,omitempty"`
@@ -531,16 +531,16 @@ type AgentPoolProfile struct {
 	SysctlDConfig                     map[string]string `json:"sysctldConfig,omitempty"`
 	UltraSSDEnabled                   *bool             `json:"ultraSSDEnabled,omitempty"`
 	ProximityPlacementGroupID         string            `json:"proximityPlacementGroupID,omitempty"`
-	OSDiskCaching                     *CachingType      `json:"osDiskCaching,omitempty"`
+	OSDiskCaching                     *DiskCachingType  `json:"osDiskCaching,omitempty"`
 }
 
-// CachingType determines the HostCache mode for an Azure VM Disk. Read more here:
+// DiskCachingType determines the HostCache mode for an Azure VM Disk. Read more here:
 // https://docs.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching
-type CachingType string
+type DiskCachingType string
 
 const (
-	CachingTypesReadOnly  CachingType = "ReadOnly"
-	CachingTypesReadWrite CachingType = "ReadWrite"
+	DiskCachingTypesReadOnly  DiskCachingType = "ReadOnly"
+	DiskCachingTypesReadWrite DiskCachingType = "ReadWrite"
 )
 
 // AgentPoolProfileRole represents an agent role

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -531,7 +531,17 @@ type AgentPoolProfile struct {
 	SysctlDConfig                     map[string]string `json:"sysctldConfig,omitempty"`
 	UltraSSDEnabled                   *bool             `json:"ultraSSDEnabled,omitempty"`
 	ProximityPlacementGroupID         string            `json:"proximityPlacementGroupID,omitempty"`
+	OSDiskCaching                     *CachingType      `json:"osDiskCaching,omitempty"`
 }
+
+// CachingType determines the HostCache mode for an Azure VM Disk. Read more here:
+// https://docs.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching
+type CachingType string
+
+const (
+	CachingTypesReadOnly  CachingType = "ReadOnly"
+	CachingTypesReadWrite CachingType = "ReadWrite"
+)
 
 // AgentPoolProfileRole represents an agent role
 type AgentPoolProfileRole string

--- a/pkg/api/vlabs/types_test.go
+++ b/pkg/api/vlabs/types_test.go
@@ -33,7 +33,6 @@ func TestOrchestratorProfile(t *testing.T) {
 
 	if !op.IsSwarmMode() {
 		t.Fatalf("unexpectedly detected OrchestratorProfile.Type != DockerCE after unmarshal")
-
 	}
 
 	OrchestratorProfileText = `{ "orchestratorType": "DCOS" }`
@@ -46,7 +45,6 @@ func TestOrchestratorProfile(t *testing.T) {
 	op = &OrchestratorProfile{}
 	if e := json.Unmarshal([]byte(OrchestratorProfileText), op); e != nil {
 		t.Fatalf("unexpectedly detected unmarshal failure for OrchestratorProfile, %+v", e)
-
 	}
 }
 
@@ -201,7 +199,7 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be true after unmarshal")
 	}
 
-	if ap.OSDiskCaching == nil || *ap.OSDiskCaching != CachingTypesReadOnly {
+	if ap.OSDiskCaching == nil || *ap.OSDiskCaching != DiskCachingTypesReadOnly {
 		t.Fatalf("AgentPoolProfile.OSDiskCaching should be ReadOnly after unmarshal")
 	}
 
@@ -238,7 +236,7 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.DiskEncryptionSetID is empty after unmarshal")
 	}
 
-	if ap.OSDiskCaching == nil || *ap.OSDiskCaching != CachingTypesReadWrite {
+	if ap.OSDiskCaching == nil || *ap.OSDiskCaching != DiskCachingTypesReadWrite {
 		t.Fatalf("AgentPoolProfile.OSDiskCaching should be ReadWrite after unmarshal")
 	}
 
@@ -766,7 +764,7 @@ func GetMockPropertiesWithCustomCloudProfile(name string, hasCustomCloudProfile,
 			}
 		}
 		if hasAzureEnvironmentSpecConfig {
-			//azureStackCloudSpec is the default configurations for azure stack with public Azure.
+			// azureStackCloudSpec is the default configurations for azure stack with public Azure.
 			azureStackCloudSpec := AzureEnvironmentSpecConfig{
 				CloudName: AzureStackCloud,
 			}

--- a/pkg/api/vlabs/types_test.go
+++ b/pkg/api/vlabs/types_test.go
@@ -165,8 +165,12 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.StorageProfile != ManagedDisks after unmarshal")
 	}
 
+	if ap.OSDiskCaching != nil {
+		t.Fatalf("AgentPoolProfile.OSDiskCaching should be nil after unmarshal")
+	}
+
 	// With osType Windows and Ephemeral disks
-	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Windows", "count": 1, "vmSize": "Standard_D2_v2",
+	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Windows", "count": 1, "vmSize": "Standard_D2_v2", "osDiskCaching": "ReadOnly",
 "availabilityProfile": "AvailabilitySet", "storageProfile" : "Ephemeral", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID", "encryptionAtHost": true }`
 	ap = &AgentPoolProfile{}
 	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
@@ -196,9 +200,15 @@ func TestAgentPoolProfile(t *testing.T) {
 	if !to.Bool(ap.EncryptionAtHost) {
 		t.Fatalf("AgentPoolProfile.EncryptionAtHost should be true after unmarshal")
 	}
+
+	if ap.OSDiskCaching == nil || *ap.OSDiskCaching != CachingTypesReadOnly {
+		t.Fatalf("AgentPoolProfile.OSDiskCaching should be ReadOnly after unmarshal")
+	}
+
 	// With osType Linux and RHEL distro
-	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Linux", "distro" : "rhel", "count": 1, "vmSize": "Standard_D2_v2",
-"availabilityProfile": "AvailabilitySet", "storageProfile" : "ManagedDisks", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID" }`
+	AgentPoolProfileText = `{ "name": "linuxpool1", "osType" : "Linux", "distro" : "rhel", "count": 1, "vmSize": "Standard_D2_v2", 
+"availabilityProfile": "AvailabilitySet", "storageProfile" : "ManagedDisks", "vnetSubnetID" : "12345", "diskEncryptionSetID": "diskEncryptionSetID",
+"osDiskCaching": "ReadWrite", }`
 	ap = &AgentPoolProfile{}
 	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
 		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
@@ -226,6 +236,10 @@ func TestAgentPoolProfile(t *testing.T) {
 
 	if ap.DiskEncryptionSetID == "" {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.DiskEncryptionSetID is empty after unmarshal")
+	}
+
+	if ap.OSDiskCaching == nil || *ap.OSDiskCaching != CachingTypesReadWrite {
+		t.Fatalf("AgentPoolProfile.OSDiskCaching should be ReadWrite after unmarshal")
 	}
 
 	// With VMSS and Spot VMs

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -15,7 +15,6 @@ import (
 )
 
 func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
-
 	masterProfile := cs.Properties.MasterProfile
 	orchProfile := cs.Properties.OrchestratorProfile
 	k8sConfig := orchProfile.KubernetesConfig
@@ -592,7 +591,6 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 	vmssVMProfile.NetworkProfile = &vmssNetworkProfile
 
 	t, err := InitializeTemplateGenerator(Context{})
-
 	if err != nil {
 		panic(err)
 	}
@@ -739,7 +737,7 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 	}
 
 	if profile.OSDiskCaching != nil {
-		if *profile.OSDiskCaching == api.CachingTypesReadOnly {
+		if *profile.OSDiskCaching == api.DiskCachingTypesReadOnly {
 			osDisk.Caching = compute.CachingTypesReadOnly
 		}
 	}

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -738,6 +738,12 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 		Caching:      compute.CachingTypesReadWrite,
 	}
 
+	if profile.OSDiskCaching != nil {
+		if *profile.OSDiskCaching == api.CachingTypesReadOnly {
+			osDisk.Caching = compute.CachingTypesReadOnly
+		}
+	}
+
 	if profile.OSDiskSizeGB > 0 {
 		osDisk.DiskSizeGB = to.Int32Ptr(int32(profile.OSDiskSizeGB))
 	}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
allow setting read only cache

we've observed several issues with the performance of write caching on azure, including stalls on the whole disk when fsync'ing a single file, and allowing the cache to accept IO requests in excess of what the the device can handle. the former directly degrades performance and the latter indirectly degrades it by decreasing the ability of the linux kernel to counteract using e.g. io request merging (since everything passes through to azure as if there were no traffic). 

we're working with storage on mitigating those issues but in the meantime we'd like to allow changing this value to ReadOnly for OS disk. This is the only other allowed value (None for OS Disk will be overridden internally, refer to the doc link on the API type).

**Issue Fixed**:


**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes


---
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

