### PR TITLE
chore: update Go toolchain to v1.15.11

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go for aks-engine",
-	"image": "mcr.microsoft.com/oss/azcu/go-dev:v1.29.2",
+	"image": "mcr.microsoft.com/oss/azcu/go-dev:v1.30.0",
 	"extensions": [
 		"ms-vscode.go"
 	],

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -21,7 +21,7 @@ jobs:
           docker run --rm \
           -v ${GITHUB_WORKSPACE}:/go/src/github.com/Azure/aks-engine \
           -w /go/src/github.com/Azure/aks-engine \
-          mcr.microsoft.com/oss/azcu/go-dev:v1.29.2 make dist
+          mcr.microsoft.com/oss/azcu/go-dev:v1.30.0 make dist
 
       - name: Rename outputs
         run: |

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -17,7 +17,7 @@ pr:
 resources:
   containers:
   - container: dev1
-    image: mcr.microsoft.com/oss/azcu/go-dev:v1.29.2
+    image: mcr.microsoft.com/oss/azcu/go-dev:v1.30.0
 
 jobs:
 - job: unit_tests

--- a/.pipelines/vhd-builder-ubuntu-gen2.yaml
+++ b/.pipelines/vhd-builder-ubuntu-gen2.yaml
@@ -7,7 +7,7 @@ trigger: none
 # - POST a new SKU to azure marketplace
 
 variables:
-  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.29.2'
+  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.30.0'
 
 phases:
 - phase: build_vhd

--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -7,7 +7,7 @@ trigger: none
 # - POST a new SKU to azure marketplace
 
 variables:
-  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.29.2'
+  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.30.0'
 
 phases:
 - phase: build_vhd

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(GITTAG),)
 GITTAG := $(VERSION_SHORT)
 endif
 
-DEV_ENV_IMAGE := mcr.microsoft.com/oss/azcu/go-dev:v1.29.2
+DEV_ENV_IMAGE := mcr.microsoft.com/oss/azcu/go-dev:v1.30.0
 DEV_ENV_WORK_DIR := /aks-engine
 DEV_ENV_OPTS := --rm -v $(GOPATH)/pkg/mod:/go/pkg/mod -v $(CURDIR):$(DEV_ENV_WORK_DIR) -w $(DEV_ENV_WORK_DIR) $(DEV_ENV_VARS)
 DEV_ENV_CMD := docker run $(DEV_ENV_OPTS) $(DEV_ENV_IMAGE)

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -17,7 +17,7 @@ $(LOCALBIN)/ginkgo:
 	GOBIN=$(LOCALBIN) $(GO) get github.com/onsi/ginkgo/ginkgo/...@v1.15.0
 
 $(LOCALBIN)/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) v1.31.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) v1.38.0
 
 $(LOCALBIN)/pub:
 	GOBIN=$(LOCALBIN) $(GO) get github.com/devigned/pub/...@v0.2.6

--- a/makedev.ps1
+++ b/makedev.ps1
@@ -1,4 +1,4 @@
-$DEV_ENV_IMAGE = "mcr.microsoft.com/oss/azcu/go-dev:v1.29.2"
+$DEV_ENV_IMAGE = "mcr.microsoft.com/oss/azcu/go-dev:v1.30.0"
 $DEV_ENV_WORK_DIR = "/aks-engine"
 
 # Ensure docker is configured for linux containers

--- a/test/e2e/kubernetes/workloads/large-container-daemonset.yaml
+++ b/test/e2e/kubernetes/workloads/large-container-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
                 - linux
       containers:
       - name: large-container
-        image: mcr.microsoft.com/oss/azcu/go-dev:v1.29.2
+        image: mcr.microsoft.com/oss/azcu/go-dev:v1.30.0
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "while true; do sleep 1000; done"]


### PR DESCRIPTION
**Reason for Change**:

See https://github.com/deis/docker-go-dev/releases/tag/v1.30.0
and https://github.com/golang/go/issues?q=milestone%3AGo1.15.11+label%3ACherryPickApproved

**Issue Fixed**:

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
