### PR TITLE
test: fix prior k8s minor version in mocks and upgrade test

### DIFF
--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -45,7 +45,7 @@ func init() {
 	versionSplit := strings.Split(defaultVersion, ".")
 	minorVersion, _ := strconv.Atoi(versionSplit[1])
 	minorVersionLessOne := minorVersion - 1
-	priorVersion := versionSplit[0] + "." + strconv.Itoa(minorVersionLessOne) + "." + versionSplit[2]
+	priorVersion := common.RationalizeReleaseAndVersion(common.Kubernetes, versionSplit[0]+"."+strconv.Itoa(minorVersionLessOne), "", false, false, false)
 	defaultK8sVersionForFakeVMs = fmt.Sprintf("Kubernetes:%s", priorVersion)
 }
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	versionSplit := strings.Split(defaultVersion, ".")
 	minorVersion, _ := strconv.Atoi(versionSplit[1])
 	minorVersionLessOne := minorVersion - 1
-	priorVersion := versionSplit[0] + "." + strconv.Itoa(minorVersionLessOne) + "." + versionSplit[2]
+	priorVersion := common.RationalizeReleaseAndVersion(common.Kubernetes, versionSplit[0]+"."+strconv.Itoa(minorVersionLessOne), "", false, false, false)
 	mockK8sVersionOneLessThanDefault := fmt.Sprintf("Kubernetes:%s", priorVersion)
 	AfterEach(func() {
 		// delete temp template directory


### PR DESCRIPTION
**Reason for Change**:

Some unit test code was naively calculating the prior Kubernetes version by decrementing the minor but leaving the major and patch versions intact. This will fail when Kubernetes 1.18.18 comes out next week, since it will supply "1.17.18" which doesn't and won't exist.

Instead let's reuse the `RationalizeReleaseAndVersion` func to get the latest patch for the previous minor release correctly.

**Issue Fixed**:

Prevents a test bug that will arise next Wednesday [when v1.18.18 drops](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#118).

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
