### PR TITLE
fix: Fix installer for custom package URL's.

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -114,7 +114,7 @@ time_metric "installMoby" installMoby
   if [[ -n "${LINUX_MOBY_URL:-}" ]]; then
     DEB="${LINUX_MOBY_URL##*/}"
     retrycmd_no_stats 120 5 25 curl -fsSL ${LINUX_MOBY_URL} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
-    retrycmd 20 30 120 dpkg -i /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+    dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
   fi
 {{end}}
 {{- if HasLinuxContainerdURL}}
@@ -122,7 +122,7 @@ time_metric "installMoby" installMoby
   if [[ -n "${LINUX_CONTAINERD_URL:-}" ]]; then
     DEB="${LINUX_CONTAINERD_URL##*/}"
     retrycmd_no_stats 120 5 25 curl -fsSL ${LINUX_CONTAINERD_URL} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
-    retrycmd 20 30 120 dpkg -i /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+    dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
   fi
 {{end}}
 fi

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12927,13 +12927,21 @@ apt_get_update() {
   done
   echo Executed apt-get update $i times
 }
+dpkg_install() {
+  retries=$1; wait_sleep=$2; shift && shift;
+  for i in $(seq 1 $retries); do
+    wait_for_apt_locks; dpkg -i "${1}" && break; apt-get update --fix-missing; do_apt_get_install -f && break
+    if [ $i -eq $retries ]; then return 1; fi; sleep $wait_sleep
+  done
+}
+do_apt_get_install() {
+  dpkg --configure -a --force-confdef; DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y ${@}
+}
 apt_get_install() {
   retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
   for i in $(seq 1 $retries); do
     wait_for_apt_locks
-    export DEBIAN_FRONTEND=noninteractive
-    dpkg --configure -a --force-confdef
-    apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y ${@} && break ||
+    do_apt_get_install ${@} && break ||
       if [ $i -eq $retries ]; then
         return 1
       else
@@ -13431,7 +13439,7 @@ time_metric "installMoby" installMoby
   if [[ -n "${LINUX_MOBY_URL:-}" ]]; then
     DEB="${LINUX_MOBY_URL##*/}"
     retrycmd_no_stats 120 5 25 curl -fsSL ${LINUX_MOBY_URL} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
-    retrycmd 20 30 120 dpkg -i /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+    dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
   fi
 {{end}}
 {{- if HasLinuxContainerdURL}}
@@ -13439,7 +13447,7 @@ time_metric "installMoby" installMoby
   if [[ -n "${LINUX_CONTAINERD_URL:-}" ]]; then
     DEB="${LINUX_CONTAINERD_URL##*/}"
     retrycmd_no_stats 120 5 25 curl -fsSL ${LINUX_CONTAINERD_URL} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
-    retrycmd 20 30 120 dpkg -i /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+    dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
   fi
 {{end}}
 fi


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Ran into this in CI where I'm trying to test new packages.
runc that's already installed in the vm image is older than the minimum
version of the new package, as such the package installation fails and
cluster provisioning errors out.

apt has functionality to fix dependency problems found while using
`dpkg`.

This adds a helper function to replace `dpkg install` with one that
basically calls `apt-get update && apt-get install -f` after a failed
install (update is required as well, otherwise the package list is out
of date).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
