### PR TITLE
chore: update CRI builds

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -96,6 +96,9 @@ removeContainerd() {
 mobyPkgVersion() {
   dpkg -s "${1}" | grep "Version:" | awk '{ print $2 }' | cut -d '+' -f 1
 }
+installRunc() {
+  apt_get_install 20 30 120 moby-runc=1.0.0~rc92* --allow-downgrades || exit 27
+}
 installMoby() {
   local install_pkgs="" v cli_ver="${MOBY_VERSION}"
   v="$(mobyPkgVersion moby-containerd)"

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -97,7 +97,11 @@ mobyPkgVersion() {
   dpkg -s "${1}" | grep "Version:" | awk '{ print $2 }' | cut -d '+' -f 1
 }
 installRunc() {
-  apt_get_install 20 30 120 moby-runc=1.0.0~rc92* --allow-downgrades || exit 27
+  local v
+  v=$(runc --version | head -n 1 | cut -d" " -f3)
+  if [[ $v != "1.0.0-rc92" ]]; then
+    apt_get_install 20 30 120 moby-runc=1.0.0~rc92* --allow-downgrades || exit 27
+  fi
 }
 installMoby() {
   local install_pkgs="" v cli_ver="${MOBY_VERSION}"

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -109,6 +109,7 @@ time_metric "InstallContainerd" installContainerd
 {{else}}
 time_metric "installMoby" installMoby
 {{end}}
+time_metric "installRunc" installRunc
 {{- if HasLinuxMobyURL}}
   LINUX_MOBY_URL={{GetLinuxMobyURL}}
   if [[ -n "${LINUX_MOBY_URL:-}" ]]; then

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -207,7 +207,7 @@
       }
     },
     "mobyVersion": {
-      "defaultValue": "19.03.14",
+      "defaultValue": "20.10.5",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -227,12 +227,13 @@
          "19.03.11",
          "19.03.12",
          "19.03.13",
-         "19.03.14"
+         "19.03.14",
+         "20.10.5"
        ],
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.3.9",
+      "defaultValue": "1.4.4",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -244,7 +245,8 @@
          "1.3.6",
          "1.3.7",
          "1.3.8",
-         "1.3.9"
+         "1.3.9",
+         "1.4.4"
        ],
       "type": "string"
     },

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -207,7 +207,7 @@
       }
     },
     "mobyVersion": {
-      "defaultValue": "20.10.5",
+      "defaultValue": "19.03.14",
       "metadata": {
         "description": "The Azure Moby build version"
       },

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -442,9 +442,9 @@ const (
 	// DefaultKubernetesDNSServiceIPv6 specifies the IPv6 address that kube-dns listens on by default. must by in the default Service CIDR range.
 	DefaultKubernetesDNSServiceIPv6 = "fd00::10"
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
-	DefaultMobyVersion = "19.03.14"
+	DefaultMobyVersion = "20.10.5"
 	// DefaultContainerdVersion specifies the default containerd version to install.
-	DefaultContainerdVersion = "1.3.9"
+	DefaultContainerdVersion = "1.4.4"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
 	DefaultDockerBridgeSubnet = "172.17.0.1/16"
 	// DefaultKubernetesMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -442,7 +442,7 @@ const (
 	// DefaultKubernetesDNSServiceIPv6 specifies the IPv6 address that kube-dns listens on by default. must by in the default Service CIDR range.
 	DefaultKubernetesDNSServiceIPv6 = "fd00::10"
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
-	DefaultMobyVersion = "20.10.5"
+	DefaultMobyVersion = "19.03.14"
 	// DefaultContainerdVersion specifies the default containerd version to install.
 	DefaultContainerdVersion = "1.4.4"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1275,7 +1275,7 @@ func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 
 func TestContainerRuntime(t *testing.T) {
 
-	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10", "19.03.11", "19.03.12", "19.03.13", "19.03.14"} {
+	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10", "19.03.11", "19.03.12", "19.03.13", "19.03.14", "20.10.5"} {
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
 		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
@@ -6052,10 +6052,10 @@ func ExampleContainerService_setOrchestratorDefaults() {
 	mockCS.setOrchestratorDefaults(false, false)
 
 	// Output:
-	// level=warning msg="Moby will be upgraded to version 19.03.14\n"
-	// level=warning msg="containerd will be upgraded to version 1.3.9\n"
-	// level=warning msg="Any new nodes will have Moby version 19.03.14\n"
-	// level=warning msg="Any new nodes will have containerd version 1.3.9\n"
+	// level=warning msg="Moby will be upgraded to version 20.10.5\n"
+	// level=warning msg="containerd will be upgraded to version 1.4.4\n"
+	// level=warning msg="Any new nodes will have Moby version 20.10.5\n"
+	// level=warning msg="Any new nodes will have containerd version 1.4.4\n"
 }
 
 func TestCombineValues(t *testing.T) {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -6052,9 +6052,9 @@ func ExampleContainerService_setOrchestratorDefaults() {
 	mockCS.setOrchestratorDefaults(false, false)
 
 	// Output:
-	// level=warning msg="Moby will be upgraded to version 20.10.5\n"
+	// level=warning msg="Moby will be upgraded to version 19.03.14\n"
 	// level=warning msg="containerd will be upgraded to version 1.4.4\n"
-	// level=warning msg="Any new nodes will have Moby version 20.10.5\n"
+	// level=warning msg="Any new nodes will have Moby version 19.03.14\n"
 	// level=warning msg="Any new nodes will have containerd version 1.4.4\n"
 }
 

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -38,7 +38,7 @@ var (
 		"3.1.0", "3.1.1", "3.1.2", "3.1.2", "3.1.3", "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8", "3.1.9", "3.1.10",
 		"3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.8", "3.2.9", "3.2.11", "3.2.12",
 		"3.2.13", "3.2.14", "3.2.15", "3.2.16", "3.2.23", "3.2.24", "3.2.25", "3.2.26", "3.3.0", "3.3.1", "3.3.8", "3.3.9", "3.3.10", "3.3.13", "3.3.15", "3.3.18", "3.3.19", "3.3.22"}
-	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9"}
+	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4"}
 	kubernetesImageBaseTypeValidVersions = [...]string{"", common.KubernetesImageBaseTypeGCR, common.KubernetesImageBaseTypeMCR}
 	cachingTypesValidValues              = [...]string{"", string(compute.CachingTypesNone), string(compute.CachingTypesReadWrite), string(compute.CachingTypesReadOnly)}
 	linuxEth0MTUAllowedValues            = [...]int{1500, 3900}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -64,7 +64,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9]",
+			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4]",
 		},
 		"should error when KubernetesConfig has containerdVersion value for docker container runtime": {
 			properties: &Properties{

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13059,7 +13059,11 @@ mobyPkgVersion() {
   dpkg -s "${1}" | grep "Version:" | awk '{ print $2 }' | cut -d '+' -f 1
 }
 installRunc() {
-  apt_get_install 20 30 120 moby-runc=1.0.0~rc92* --allow-downgrades || exit 27
+  local v
+  v=$(runc --version | head -n 1 | cut -d" " -f3)
+  if [[ $v != "1.0.0-rc92" ]]; then
+    apt_get_install 20 30 120 moby-runc=1.0.0~rc92* --allow-downgrades || exit 27
+  fi
 }
 installMoby() {
   local install_pkgs="" v cli_ver="${MOBY_VERSION}"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13058,6 +13058,9 @@ removeContainerd() {
 mobyPkgVersion() {
   dpkg -s "${1}" | grep "Version:" | awk '{ print $2 }' | cut -d '+' -f 1
 }
+installRunc() {
+  apt_get_install 20 30 120 moby-runc=1.0.0~rc92* --allow-downgrades || exit 27
+}
 installMoby() {
   local install_pkgs="" v cli_ver="${MOBY_VERSION}"
   v="$(mobyPkgVersion moby-containerd)"
@@ -13337,6 +13340,7 @@ time_metric "InstallContainerd" installContainerd
 {{else}}
 time_metric "installMoby" installMoby
 {{end}}
+time_metric "installRunc" installRunc
 {{- if HasLinuxMobyURL}}
   LINUX_MOBY_URL={{GetLinuxMobyURL}}
   if [[ -n "${LINUX_MOBY_URL:-}" ]]; then
@@ -16410,7 +16414,7 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
       }
     },
     "mobyVersion": {
-      "defaultValue": "19.03.14",
+      "defaultValue": "20.10.5",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -16430,12 +16434,13 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
          "19.03.11",
          "19.03.12",
          "19.03.13",
-         "19.03.14"
+         "19.03.14",
+         "20.10.5"
        ],
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.3.9",
+      "defaultValue": "1.4.4",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -16447,7 +16452,8 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
          "1.3.6",
          "1.3.7",
          "1.3.8",
-         "1.3.9"
+         "1.3.9",
+         "1.4.4"
        ],
       "type": "string"
     },

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -16418,7 +16418,7 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
       }
     },
     "mobyVersion": {
-      "defaultValue": "20.10.5",
+      "defaultValue": "19.03.14",
       "metadata": {
         "description": "The Azure Moby build version"
       },

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -82,7 +82,7 @@ echo "  - apmz $apmz_version" >> ${VHD_LOGS_FILEPATH}
 installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
-MOBY_VERSION="20.10.5"
+MOBY_VERSION="19.03.14"
 CONTAINERD_VERSION="1.4.4"
 installMoby
 installRunc

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -82,8 +82,8 @@ echo "  - apmz $apmz_version" >> ${VHD_LOGS_FILEPATH}
 installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
-MOBY_VERSION="19.03.14"
-CONTAINERD_VERSION="1.3.9"
+MOBY_VERSION="20.10.5"
+CONTAINERD_VERSION="1.4.4"
 installMoby
 systemctl_restart 100 5 30 docker || exit 1
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -85,6 +85,7 @@ echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 MOBY_VERSION="20.10.5"
 CONTAINERD_VERSION="1.4.4"
 installMoby
+installRunc
 systemctl_restart 100 5 30 docker || exit 1
 echo "  - moby v${MOBY_VERSION}" >> ${VHD_LOGS_FILEPATH}
 downloadGPUDrivers


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR updates the default versions for both moby and containerd to the current latest builds, and standardizes runc to rc92.

The reason for pinning to runc rc92 is to address this issue which was introduced in rc93:

https://github.com/opencontainers/runc/issues/2865

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
