### PR TITLE
feat: get-logs from VMs unable to join the cluster

### DIFF
--- a/cmd/get_logs.go
+++ b/cmd/get_logs.go
@@ -52,6 +52,7 @@ type getLogsCmd struct {
 	outputDirectory        string
 	controlPlaneOnly       bool
 	uploadSASURL           string
+	nodeNames              []string
 	// computed
 	cs                  *api.ContainerService
 	locale              *gotext.Locale
@@ -91,8 +92,9 @@ func newGetLogsCmd() *cobra.Command {
 	command.Flags().StringVar(&glc.linuxScriptPath, "linux-script", "", "path to the log collection script to execute on the cluster's Linux nodes (required if distro is not aks-ubuntu)")
 	command.Flags().StringVar(&glc.windowsScriptPath, "windows-script", "", "path to the log collection script to execute on the cluster's Windows nodes (required if distro is not aks-windows)")
 	command.Flags().StringVarP(&glc.outputDirectory, "output-directory", "o", "", "collected logs destination directory, derived from --api-model if missing")
-	command.Flags().BoolVarP(&glc.controlPlaneOnly, "control-plane-only", "", false, "get logs from control plane VMs only")
+	command.Flags().BoolVarP(&glc.controlPlaneOnly, "control-plane-only", "", false, "get logs from control plane VMs only (unless --vm-names is set)")
 	command.Flags().StringVarP(&glc.uploadSASURL, "upload-sas-url", "", "", "Azure Storage Account SAS URL to upload the collected logs")
+	command.Flags().StringSliceVar(&glc.nodeNames, "vm-names", nil, "get logs from the VM name list only (comma-separated names)")
 	_ = command.MarkFlagRequired("location")
 	_ = command.MarkFlagRequired("api-model")
 	_ = command.MarkFlagRequired("ssh-host")
@@ -149,6 +151,9 @@ func (glc *getLogsCmd) validateArgs() (err error) {
 		if !exp.MatchString(sasURL.Path) {
 			return errors.New("invalid upload SAS URL format, expected 'https://{blob-service-uri}/{container-name}?{sas-token}'")
 		}
+	}
+	if glc.nodeNames != nil && len(glc.nodeNames) == 0 {
+		return errors.New("--vm-names cannot be empty")
 	}
 	return nil
 }
@@ -248,6 +253,24 @@ func (glc *getLogsCmd) run() error {
 
 // getClusterNodes returns the target node list
 func getClusterNodes(glc *getLogsCmd, kubeClient kubernetes.NodeLister) (nodes []*ssh.RemoteHost) {
+	if glc.nodeNames != nil {
+		for _, nodeName := range glc.nodeNames {
+			if strings.HasPrefix(nodeName, api.DefaultOrchestratorName) {
+				log.Infof("Treating node %s as a Linux agent node", nodeName)
+				nodes = append(nodes, &ssh.RemoteHost{
+					URI: nodeName, Port: 22, OperatingSystem: api.Linux, AuthConfig: glc.linuxAuthConfig, Jumpbox: glc.jumpbox})
+			} else {
+				log.Infof("Treating node %s as a Windows agent node", nodeName)
+				if glc.windowsAuthConfig != nil {
+					nodes = append(nodes, &ssh.RemoteHost{
+						URI: nodeName, Port: 22, OperatingSystem: api.Windows, AuthConfig: glc.windowsAuthConfig, Jumpbox: glc.jumpbox})
+				} else {
+					log.Infof("Skipping node %s, WindowsProfile was not provided", nodeName)
+				}
+			}
+		}
+		return nodes
+	}
 	nodeList, err := kubeClient.ListNodes()
 	if err != nil {
 		log.Warnf("Error retrieving node list from apiserver: %s", err)
@@ -326,21 +349,24 @@ func getClusterNodeScripts(glc *getLogsCmd, nodes []*ssh.RemoteHost) map[*ssh.Re
 
 // collectLogs uploads the log collection script (if needed), executes the script and downloads the collected logs
 func collectLogs(glc *getLogsCmd, node *ssh.RemoteHost, script *ssh.RemoteFile) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	log.Infof("Processing node: %s", node.URI)
 	if script.Content != nil {
-		stdout, err := ssh.CopyToRemote(node, script)
+		stdout, err := ssh.CopyToRemote(ctx, node, script)
 		if err != nil {
 			return errors.Wrap(err, stdout)
 		}
 	}
 	isAzureStack := glc.cs.Properties.IsAzureStackCloud()
-	stdout, err := ssh.ExecuteRemote(node, collectLogsScript(script, node.OperatingSystem, isAzureStack))
+	stdout, err := ssh.ExecuteRemote(ctx, node, collectLogsScript(script, node.OperatingSystem, isAzureStack))
 	if err != nil {
 		return errors.Wrap(err, stdout)
 	}
 	src := fileToDownload(node.OperatingSystem, node.URI)
 	dst := path.Join(glc.outputDirectory, fmt.Sprintf("%s.zip", node.URI))
-	stdout, err = ssh.CopyFromRemote(node, src, dst)
+	stdout, err = ssh.CopyFromRemote(ctx, node, src, dst)
 	if err != nil {
 		return errors.Wrap(err, stdout)
 	}

--- a/cmd/get_logs_test.go
+++ b/cmd/get_logs_test.go
@@ -147,7 +147,7 @@ func TestGetLogsCmdValidateArgs(t *testing.T) {
 				location:               "southcentralus",
 				uploadSASURL:           "https://blob-service-uri/?sas-token",
 			},
-			expectedErr: errors.Errorf("invalid upload SAS URL format, expected 'https://{blob-service-uri}/{container-name}?{sas-token}'"),
+			expectedErr: errors.New("invalid upload SAS URL format, expected 'https://{blob-service-uri}/{container-name}?{sas-token}'"),
 			name:        "InvalidSASURLNoPath",
 		},
 		{
@@ -160,7 +160,7 @@ func TestGetLogsCmdValidateArgs(t *testing.T) {
 				location:               "southcentralus",
 				uploadSASURL:           "https://blob-service-uri//?sas-token",
 			},
-			expectedErr: errors.Errorf("invalid upload SAS URL format, expected 'https://{blob-service-uri}/{container-name}?{sas-token}'"),
+			expectedErr: errors.New("invalid upload SAS URL format, expected 'https://{blob-service-uri}/{container-name}?{sas-token}'"),
 			name:        "InvalidSASURLEmptyPath",
 		},
 		{
@@ -173,7 +173,7 @@ func TestGetLogsCmdValidateArgs(t *testing.T) {
 				location:               "southcentralus",
 				uploadSASURL:           "https://blob-service-uri//folder-name?sas-token",
 			},
-			expectedErr: errors.Errorf("invalid upload SAS URL format, expected 'https://{blob-service-uri}/{container-name}?{sas-token}'"),
+			expectedErr: errors.New("invalid upload SAS URL format, expected 'https://{blob-service-uri}/{container-name}?{sas-token}'"),
 			name:        "InvalidSASURLNoContainerName",
 		},
 		{
@@ -197,7 +197,21 @@ func TestGetLogsCmdValidateArgs(t *testing.T) {
 				windowsScriptPath:      existingFile,
 				sshHostURI:             "server.example.com",
 				location:               "southcentralus",
+				nodeNames:              []string{},
+			},
+			expectedErr: errors.New("--vm-names cannot be empty"),
+			name:        "EmptyVMList",
+		},
+		{
+			glc: &getLogsCmd{
+				apiModelPath:           existingFile,
+				linuxSSHPrivateKeyPath: existingFile,
+				linuxScriptPath:        existingFile,
+				windowsScriptPath:      existingFile,
+				sshHostURI:             "server.example.com",
+				location:               "southcentralus",
 				uploadSASURL:           "https://blob-service-uri/container-name?sas-token",
+				nodeNames:              []string{"vm1,vm2"},
 			},
 			expectedErr: nil,
 			name:        "IsValid",

--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -370,7 +371,7 @@ func (rcc *rotateCertsCmd) distributeCerts() (err error) {
 	upload := func(files fileMap, node *ssh.RemoteHost) error {
 		for _, file := range files {
 			var co string
-			if co, err = ssh.CopyToRemote(node, file); err != nil {
+			if co, err = ssh.CopyToRemote(context.Background(), node, file); err != nil {
 				log.Debugf("Remote command output: %s", co)
 				return errors.Wrap(err, "uploading certificate")
 			}
@@ -554,7 +555,7 @@ func execStepsSequence(cond nodeCondition, node *ssh.RemoteHost, steps ...func(n
 
 func execRemoteFunc(script string) func(node *ssh.RemoteHost) error {
 	return func(node *ssh.RemoteHost) error {
-		out, err := ssh.ExecuteRemote(node, script)
+		out, err := ssh.ExecuteRemote(context.Background(), node, script)
 		if err != nil {
 			log.Debugf("Remote command output: %s", out)
 		}

--- a/docs/topics/get-logs.md
+++ b/docs/topics/get-logs.md
@@ -30,6 +30,14 @@ Once the cluster logs were successfully retrieved, AKS Engine can persist them t
 
 *Note: storage accounts on custom clouds using the `AD FS` identity provider are not yet supported*
 
+### Nodes unable to join the cluster
+
+By default, `aks-engine get-logs` collects logs from nodes that succesfully joined the cluster. To collect logs from VMs that were not able to join the cluster, set flag `--vm-names`:
+
+```console
+--vm-name k8s-pool-01,k8s-pool-02
+```
+
 ## Usage
 
 Assuming that you have a cluster deployed and the API model originally used to deploy that cluster is stored at `_output/<dnsPrefix>/apimodel.json`, then you can collect logs running a command like:
@@ -55,5 +63,6 @@ $ aks-engine get-logs \
 |--linux-script|no|Custom log collection bash script. Required only when the Linux node distro is not `aks-ubuntu`. The script should produce file `/tmp/logs.zip`.|
 |--windows-script|no|Custom log collection powershell script. Required only when the Windows node distro is not `aks-windows`. The script should produce file `%TEMP%\{NodeName}.zip`.|
 |--output-directory|no|Output directory, derived from `--api-model` if missing.|
-|--control-plane-only|no|Only collect logs from master nodes.|
+|--control-plane-only|no|Only collect logs from master nodes (unless --vm-names is set).|
+|--vm-names|no|Only collect logs from the specified VMs (comma-separated names).|
 |--upload-sas-url|no|Azure Storage Account SAS URL to upload the collected logs.|

--- a/pkg/helpers/ssh/scp.go
+++ b/pkg/helpers/ssh/scp.go
@@ -5,6 +5,7 @@ package ssh
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -13,9 +14,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CopyToRemote copies a file to a remote host
-func CopyToRemote(host *RemoteHost, file *RemoteFile) (combinedOutput string, err error) {
-	c, err := clientWithRetry(host)
+// CopyToRemote copies a file to a remote host.
+//
+// Context ctx is only enforced during the process that stablishes
+// the SSH connection and creates the SSH client.
+func CopyToRemote(ctx context.Context, host *RemoteHost, file *RemoteFile) (combinedOutput string, err error) {
+	c, err := clientWithRetry(ctx, host)
 	if err != nil {
 		return "", errors.Wrap(err, "creating SSH client")
 	}
@@ -34,14 +38,17 @@ func CopyToRemote(host *RemoteHost, file *RemoteFile) (combinedOutput string, er
 	return "", nil
 }
 
-// CopyFromRemote copies a remote file to the local host
-func CopyFromRemote(host *RemoteHost, remoteFile *RemoteFile, destinationPath string) (stderr string, err error) {
+// CopyFromRemote copies a remote file to the local host.
+//
+// Context ctx is only enforced during the process that stablishes
+// the SSH connection and creates the SSH client.
+func CopyFromRemote(ctx context.Context, host *RemoteHost, remoteFile *RemoteFile, destinationPath string) (stderr string, err error) {
 	f, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return "", errors.Wrap(err, "opening destination file")
 	}
 	defer f.Close()
-	c, err := clientWithRetry(host)
+	c, err := clientWithRetry(ctx, host)
 	if err != nil {
 		return "", errors.Wrap(err, "creating SSH client")
 	}

--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -50,6 +50,7 @@ collectDaemonLogs() {
     local DIR=${OUTDIR}/daemons
     mkdir -p ${DIR}
     if systemctl list-units --no-pager | grep -q ${1}; then
+        timeout 15 systemctl status ${1} &> ${DIR}/${1}.status
         timeout 15 journalctl --utc -o short-iso --no-pager -r -u ${1} &> /tmp/${1}.log
         tac /tmp/${1}.log > ${DIR}/${1}.log
     fi


### PR DESCRIPTION
**Reason for Change**:

Added extra flag `--vm-names` to `aks-engine get-logs` to enable log collection from nodes that are not able to join the cluster.

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
