### PR TITLE
fix: distinguish ctrd and smalldisk windows image in upgrade scenario

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -32,11 +32,11 @@ import (
 )
 
 const (
-	upgradeName             		= "upgrade"
-	upgradeShortDescription 		= "Upgrade an existing AKS Engine-created Kubernetes cluster"
-	upgradeLongDescription  		= "Upgrade an existing AKS Engine-created Kubernetes cluster, one node at a time"
-	smalldiskWindowsImageIdentifier	= "smalldisk"
-	ctrdWindowsImageIdentifier		= "ctrd"
+	upgradeName                     = "upgrade"
+	upgradeShortDescription         = "Upgrade an existing AKS Engine-created Kubernetes cluster"
+	upgradeLongDescription          = "Upgrade an existing AKS Engine-created Kubernetes cluster, one node at a time"
+	smalldiskWindowsImageIdentifier = "smalldisk"
+	ctrdWindowsImageIdentifier      = "ctrd"
 )
 
 type upgradeCmd struct {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Azure/aks-engine/pkg/api"
@@ -31,9 +32,11 @@ import (
 )
 
 const (
-	upgradeName             = "upgrade"
-	upgradeShortDescription = "Upgrade an existing AKS Engine-created Kubernetes cluster"
-	upgradeLongDescription  = "Upgrade an existing AKS Engine-created Kubernetes cluster, one node at a time"
+	upgradeName             		= "upgrade"
+	upgradeShortDescription 		= "Upgrade an existing AKS Engine-created Kubernetes cluster"
+	upgradeLongDescription  		= "Upgrade an existing AKS Engine-created Kubernetes cluster, one node at a time"
+	smalldiskWindowsImageIdentifier	= "smalldisk"
+	ctrdWindowsImageIdentifier		= "ctrd"
 )
 
 type upgradeCmd struct {
@@ -192,10 +195,10 @@ func (uc *upgradeCmd) loadCluster() error {
 	// Use the Windows VHD associated with the aks-engine version if upgradeWindowsVHD is set to "true"
 	if uc.upgradeWindowsVHD && uc.containerService.Properties.WindowsProfile != nil {
 		windowsProfile := uc.containerService.Properties.WindowsProfile
-		if api.ImagePublisherAndOfferMatch(windowsProfile, api.AKSWindowsServer2019ContainerDOSImageConfig) {
+		if api.ImagePublisherAndOfferMatch(windowsProfile, api.AKSWindowsServer2019ContainerDOSImageConfig) && strings.Contains(windowsProfile.WindowsSku, ctrdWindowsImageIdentifier) {
 			windowsProfile.ImageVersion = api.AKSWindowsServer2019ContainerDOSImageConfig.ImageVersion
 			windowsProfile.WindowsSku = api.AKSWindowsServer2019ContainerDOSImageConfig.ImageSku
-		} else if api.ImagePublisherAndOfferMatch(windowsProfile, api.AKSWindowsServer2019OSImageConfig) {
+		} else if api.ImagePublisherAndOfferMatch(windowsProfile, api.AKSWindowsServer2019OSImageConfig) && strings.Contains(windowsProfile.WindowsSku, smalldiskWindowsImageIdentifier) {
 			windowsProfile.ImageVersion = api.AKSWindowsServer2019OSImageConfig.ImageVersion
 			windowsProfile.WindowsSku = api.AKSWindowsServer2019OSImageConfig.ImageSku
 		} else if api.ImagePublisherAndOfferMatch(windowsProfile, api.WindowsServer2019OSImageConfig) {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
During upgrade, the ImagePublisherAndOfferMatch function itself is not able to distinguish smalldisk and ctrd image, since they have the same ImageOffer and ImagePublisher. This is causing mixed cluster previously using smalldisk image to always try to upgrade to use ctrd image, since it's the first condition. Adding the identifier for ImageSku to help distinguish these two cases.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
