### PR TITLE
test: only validate MTU if Eth0MTU is present

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -475,11 +475,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						if n.HasSubstring(largeSKUPrefixes) && n.IsUbuntu() {
 							gt8CoreSKU = "true"
 						}
-						expectedEth0MTU := 1500
+						var netConfigValidationCommand string
 						if eng.ExpandedDefinition.Properties.OrchestratorProfile.IsAzureCNI() && eng.ExpandedDefinition.Properties.LinuxProfile.Eth0MTU != 0 {
-							expectedEth0MTU = eng.ExpandedDefinition.Properties.LinuxProfile.Eth0MTU
+							expectedEth0MTU := eng.ExpandedDefinition.Properties.LinuxProfile.Eth0MTU
+							netConfigValidationCommand = fmt.Sprintf("\"GT_8_CORE_SKU=%s ETH0_MTU=%d /tmp/%s\"", gt8CoreSKU, expectedEth0MTU, netConfigValidateScript)
+						} else {
+							netConfigValidationCommand = fmt.Sprintf("\"GT_8_CORE_SKU=%s /tmp/%s\"", gt8CoreSKU, netConfigValidateScript)
 						}
-						netConfigValidationCommand := fmt.Sprintf("\"GT_8_CORE_SKU=%s ETH0_MTU=%d /tmp/%s\"", gt8CoreSKU, expectedEth0MTU, netConfigValidateScript)
 						if n.IsUbuntu() && !firstMasterRegexp.MatchString(n.Metadata.Name) {
 							err := sshConn.CopyToRemoteWithRetry(n.Metadata.Name, "/tmp/"+netConfigValidateScript, sleepBetweenRetriesRemoteSSHCommand, cfg.Timeout)
 							Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR tweaks the E2E test implementation so that `/sys/class/net/eth0/mtu` is not validated unless the `LinuxProfile.Eth0MTU` property is present (e.g., kubenet).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
