### PR TITLE
fix: Graceful coredns shutdown

### DIFF
--- a/parts/k8s/addons/coredns.yaml
+++ b/parts/k8s/addons/coredns.yaml
@@ -62,7 +62,10 @@ data:
     import conf.d/Corefile*
     .:53 {
         errors
-        health
+        health {
+          # this should be > readiness probe failure time
+          lameduck 35s
+        }
         ready
         kubernetes {{ContainerConfig "domain"}} in-addr.arpa ip6.arpa {
             pods insecure
@@ -200,6 +203,10 @@ spec:
             path: /ready
             port: 8181
             scheme: HTTP
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -8536,7 +8536,10 @@ data:
     import conf.d/Corefile*
     .:53 {
         errors
-        health
+        health {
+          # this should be > readiness probe failure time
+          lameduck 35s
+        }
         ready
         kubernetes {{ContainerConfig "domain"}} in-addr.arpa ip6.arpa {
             pods insecure
@@ -8674,6 +8677,10 @@ spec:
             path: /ready
             port: 8181
             scheme: HTTP
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
**Reason for Change**:
This PR adds graceful shutdown configurations to coredns. 

Currently, if a coredns pod is deleted (due to eviction for example), the container shuts down immediately. This has negative side effects:
1. Some in-flight requests may fail.
2. A transient race where some requests may still be sent to the shutdown instance until this pod's IP address have been removed from the service.
If any of the two happens, we end up with the dreadful 5s timeout/retry latency.

The PR adds [`lameduck` configuration](https://github.com/coredns/coredns/blob/master/plugin/health/README.md) to the `health` plugin such that it would delay shutting down the service until 5 seconds after the readiness probes had failed. This guarantees that both in-flight queries are completed and enough time for this instance IP address to be discarded from the service.

Note: Since original readiness probe parameters were left at defaults, the PR also explicitly sets the default to make it clearer.

**Credit Where Due**:
technicianted

**Does this change contain code from or inspired by another project?**

- [X] No
- [ ] Yes


**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:

The issue can be reproduced by running `dig` in a loop (100ms delay) then deleting/evicting a coredns pod.