### PR TITLE
feat: allow windows custom images per agent pool

### DIFF
--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -102,13 +102,14 @@ func getParameters(cs *api.ContainerService, generatorCode string, aksEngineVers
 			addValue(parametersMap, fmt.Sprintf("%sScaleSetEvictionPolicy", agentProfile.Name), agentProfile.ScaleSetEvictionPolicy)
 		}
 
+		if agentProfile.ImageRef != nil {
+			addValue(parametersMap, fmt.Sprintf("%sosImageName", agentProfile.Name), agentProfile.ImageRef.Name)
+			addValue(parametersMap, fmt.Sprintf("%sosImageResourceGroup", agentProfile.Name), agentProfile.ImageRef.ResourceGroup)
+		}
+
 		// Unless distro is defined, default distro is configured by defaults#setAgentProfileDefaults
 		//   Ignores Windows OS
 		if !(agentProfile.OSType == api.Windows) {
-			if agentProfile.ImageRef != nil {
-				addValue(parametersMap, fmt.Sprintf("%sosImageName", agentProfile.Name), agentProfile.ImageRef.Name)
-				addValue(parametersMap, fmt.Sprintf("%sosImageResourceGroup", agentProfile.Name), agentProfile.ImageRef.ResourceGroup)
-			}
 			addValue(parametersMap, fmt.Sprintf("%sosImageOffer", agentProfile.Name), cloudSpecConfig.OSImageConfig[agentProfile.Distro].ImageOffer)
 			addValue(parametersMap, fmt.Sprintf("%sosImageSKU", agentProfile.Name), cloudSpecConfig.OSImageConfig[agentProfile.Distro].ImageSku)
 			addValue(parametersMap, fmt.Sprintf("%sosImagePublisher", agentProfile.Name), cloudSpecConfig.OSImageConfig[agentProfile.Distro].ImagePublisher)

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -657,22 +657,22 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 
 	vmssStorageProfile := compute.VirtualMachineScaleSetStorageProfile{}
 
-	if profile.IsWindows() {
-		vmssStorageProfile.ImageReference = createWindowsImageReference(profile.Name, cs.Properties.WindowsProfile)
-		vmssStorageProfile.DataDisks = getVMSSDataDisks(profile)
-	} else {
-		if profile.HasImageRef() {
-			imageRef := profile.ImageRef
-			if profile.HasImageGallery() {
-				v := fmt.Sprintf("[concat('/subscriptions/', '%s', '/resourceGroups/', variables('%sosImageResourceGroup'), '/providers/Microsoft.Compute/galleries/', '%s', '/images/', variables('%sosImageName'), '/versions/', '%s')]", imageRef.SubscriptionID, profile.Name, imageRef.Gallery, profile.Name, imageRef.Version)
-				vmssStorageProfile.ImageReference = &compute.ImageReference{
-					ID: to.StringPtr(v),
-				}
-			} else {
-				vmssStorageProfile.ImageReference = &compute.ImageReference{
-					ID: to.StringPtr(fmt.Sprintf("[resourceId(variables('%[1]sosImageResourceGroup'), 'Microsoft.Compute/images', variables('%[1]sosImageName'))]", profile.Name)),
-				}
+	if profile.HasImageRef() {
+		imageRef := profile.ImageRef
+		if profile.HasImageGallery() {
+			v := fmt.Sprintf("[concat('/subscriptions/', '%s', '/resourceGroups/', variables('%sosImageResourceGroup'), '/providers/Microsoft.Compute/galleries/', '%s', '/images/', variables('%sosImageName'), '/versions/', '%s')]", imageRef.SubscriptionID, profile.Name, imageRef.Gallery, profile.Name, imageRef.Version)
+			vmssStorageProfile.ImageReference = &compute.ImageReference{
+				ID: to.StringPtr(v),
 			}
+		} else {
+			vmssStorageProfile.ImageReference = &compute.ImageReference{
+				ID: to.StringPtr(fmt.Sprintf("[resourceId(variables('%[1]sosImageResourceGroup'), 'Microsoft.Compute/images', variables('%[1]sosImageName'))]", profile.Name)),
+			}
+		}
+	} else {
+		if profile.IsWindows() {
+			vmssStorageProfile.ImageReference = createWindowsImageReference(profile.Name, cs.Properties.WindowsProfile)
+			vmssStorageProfile.DataDisks = getVMSSDataDisks(profile)
 		} else {
 			vmssStorageProfile.ImageReference = &compute.ImageReference{
 				Offer:     to.StringPtr(fmt.Sprintf("[variables('%sosImageOffer')]", profile.Name)),


### PR DESCRIPTION
**Reason for Change**:
Allows a different windows image per agent pool. This brings the windows agent image support on par with what linux pools support. 

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
I'm not sure if this is a PR you'd accept so I just added the functionality without fixing/adding tests. Will do so as soon as you give it a go :) 

This would allow e.g. the [custom shared gallery image](https://github.com/Azure/aks-engine/blob/master/examples/custom-shared-image.json) example to also work for windows:
```json
{
    "apiVersion": "vlabs",
    "properties": {
      "masterProfile": {
        "imageReference": {
          "name": "linuxvm",
          "resourceGroup": "sig",
          "subscriptionID": "00000000-0000-0000-0000-000000000000",
          "gallery": "siggallery",
          "version": "0.0.1"
        },
        "count": 1,
        "dnsPrefix": "",
        "vmSize": "Standard_D2_v3"
      },
      "agentPoolProfiles": [
        {
          "name": "agentpool1",
          "count": 3,
          "osType": "Windows",
          "imageReference": {
            "name": "windowsvm",
            "resourceGroup": "sig",
            "subscriptionID": "00000000-0000-0000-0000-000000000000",
            "gallery": "siggallery",
            "version": "0.0.1"
          },
          "vmSize": "Standard_D2_v3",
          "availabilityProfile": "AvailabilitySet"
        }
      ],
      "linuxProfile": {
        "adminUsername": "azureuser",
        "ssh": {
          "publicKeys": [
            {
              "keyData": ""
            }
          ]
        }
      }
    }
  }
```