### PR TITLE
fix: front-proxy certs updated by rotate-certs

### DIFF
--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -492,6 +492,7 @@ func (rcc *rotateCertsCmd) rotateMasters() error {
 	}
 	log.Info("Rotating proxy certificates")
 	step = "cp_proxy"
+	// cp_proxy execution has to remain serial, otherwise it will break the front-proxy PKI rotation
 	for _, node := range rcc.nodes {
 		log.Debugf("Node: %s. Step: %s", node.URI, step)
 		if err := execStepsSequence(isMaster, node, execRemoteFunc(remoteBashScript(step))); err != nil {

--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -490,7 +490,7 @@ func (rcc *rotateCertsCmd) rotateMasters() error {
 	if err := rcc.waitForNodesReady(keys(rcc.nodes)); err != nil {
 		return err
 	}
-	log.Info("Rotating proxy certificates")
+	log.Info("Rotating front-proxy certificates")
 	step = "cp_proxy"
 	// cp_proxy execution has to remain serial, otherwise it will break the front-proxy PKI rotation
 	for _, node := range rcc.nodes {

--- a/parts/k8s/cloud-init/artifacts/generateproxycerts.sh
+++ b/parts/k8s/cloud-init/artifacts/generateproxycerts.sh
@@ -62,13 +62,13 @@ ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} lock ${PROXY_CERTS_LOCK_NAME} >"${PROXY_
 
 pid=$!
 if read -r lockthis <"${PROXY_CERT_LOCK_FILE}"; then
-  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
+  if [[ "${OVERRIDE_PROXY_CERTS}" == "true" ]] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_REQUESTHEADER_CLIENT_CA " $(cat ${PROXY_CRT})" >/dev/null 2>&1
   fi
-  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
+  if [[ "${OVERRIDE_PROXY_CERTS}" == "true" ]] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_KEY " $(cat ${PROXY_CLIENT_KEY})" >/dev/null 2>&1
   fi
-  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
+  if [[ "${OVERRIDE_PROXY_CERTS}" == "true" ]] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_CERT " $(cat ${PROXY_CLIENT_CRT})" >/dev/null 2>&1
   fi
 fi

--- a/parts/k8s/cloud-init/artifacts/generateproxycerts.sh
+++ b/parts/k8s/cloud-init/artifacts/generateproxycerts.sh
@@ -31,10 +31,10 @@ RANDFILE=$(mktemp)
 export RANDFILE
 
 openssl genrsa -out $PROXY_CA_KEY 2048
-openssl req -new -x509 -days 1826 -key $PROXY_CA_KEY -out $PROXY_CRT -subj '/CN=proxyClientCA'
+openssl req -new -x509 -days 262824 -key $PROXY_CA_KEY -out $PROXY_CRT -subj '/CN=proxyClientCA'
 openssl genrsa -out $PROXY_CLIENT_KEY 2048
 openssl req -new -key $PROXY_CLIENT_KEY -out $PROXY_CLIENT_CSR -subj '/CN=aggregator/O=system:masters'
-openssl x509 -req -days 730 -in $PROXY_CLIENT_CSR -CA $PROXY_CRT -CAkey $PROXY_CA_KEY -set_serial 02 -out $PROXY_CLIENT_CRT
+openssl x509 -req -days 262824 -in $PROXY_CLIENT_CSR -CA $PROXY_CRT -CAkey $PROXY_CA_KEY -set_serial 02 -out $PROXY_CLIENT_CRT
 
 write_certs_to_disk() {
   ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only >$K8S_PROXY_CA_CRT_FILEPATH
@@ -62,13 +62,13 @@ ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} lock ${PROXY_CERTS_LOCK_NAME} >"${PROXY_
 
 pid=$!
 if read -r lockthis <"${PROXY_CERT_LOCK_FILE}"; then
-  if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
+  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_REQUESTHEADER_CLIENT_CA " $(cat ${PROXY_CRT})" >/dev/null 2>&1
   fi
-  if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
+  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_KEY " $(cat ${PROXY_CLIENT_KEY})" >/dev/null 2>&1
   fi
-  if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
+  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_CERT " $(cat ${PROXY_CLIENT_CRT})" >/dev/null 2>&1
   fi
 fi

--- a/parts/k8s/rotate-certs.sh
+++ b/parts/k8s/rotate-certs.sh
@@ -37,6 +37,11 @@ cp_certs() {
 
 cp_proxy() {
   source /etc/environment
+  local NODE_INDEX
+  NODE_INDEX=$(hostname | tail -c 2)
+  if [[ $NODE_INDEX == 0 ]]; then
+    export OVERRIDE_PROXY_CERTS="true"
+  fi
   /etc/kubernetes/generate-proxy-certs.sh
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -894,7 +894,7 @@ func (p *Properties) AnyAgentIsLinux() bool {
 	return false
 }
 
-// GetMasterVMNameList returns the control plane VM name list
+// GetMasterVMNameList returns the ordered control plane VM name list
 func (p *Properties) GetMasterVMNameList() []string {
 	masters := []string{}
 	for i := 0; i < p.MasterProfile.Count; i++ {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13951,13 +13951,13 @@ ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} lock ${PROXY_CERTS_LOCK_NAME} >"${PROXY_
 
 pid=$!
 if read -r lockthis <"${PROXY_CERT_LOCK_FILE}"; then
-  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
+  if [[ "${OVERRIDE_PROXY_CERTS}" == "true" ]] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_REQUESTHEADER_CLIENT_CA " $(cat ${PROXY_CRT})" >/dev/null 2>&1
   fi
-  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
+  if [[ "${OVERRIDE_PROXY_CERTS}" == "true" ]] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_KEY " $(cat ${PROXY_CLIENT_KEY})" >/dev/null 2>&1
   fi
-  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
+  if [[ "${OVERRIDE_PROXY_CERTS}" == "true" ]] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_CERT " $(cat ${PROXY_CLIENT_CRT})" >/dev/null 2>&1
   fi
 fi

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13920,10 +13920,10 @@ RANDFILE=$(mktemp)
 export RANDFILE
 
 openssl genrsa -out $PROXY_CA_KEY 2048
-openssl req -new -x509 -days 1826 -key $PROXY_CA_KEY -out $PROXY_CRT -subj '/CN=proxyClientCA'
+openssl req -new -x509 -days 262824 -key $PROXY_CA_KEY -out $PROXY_CRT -subj '/CN=proxyClientCA'
 openssl genrsa -out $PROXY_CLIENT_KEY 2048
 openssl req -new -key $PROXY_CLIENT_KEY -out $PROXY_CLIENT_CSR -subj '/CN=aggregator/O=system:masters'
-openssl x509 -req -days 730 -in $PROXY_CLIENT_CSR -CA $PROXY_CRT -CAkey $PROXY_CA_KEY -set_serial 02 -out $PROXY_CLIENT_CRT
+openssl x509 -req -days 262824 -in $PROXY_CLIENT_CSR -CA $PROXY_CRT -CAkey $PROXY_CA_KEY -set_serial 02 -out $PROXY_CLIENT_CRT
 
 write_certs_to_disk() {
   ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only >$K8S_PROXY_CA_CRT_FILEPATH
@@ -13951,13 +13951,13 @@ ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} lock ${PROXY_CERTS_LOCK_NAME} >"${PROXY_
 
 pid=$!
 if read -r lockthis <"${PROXY_CERT_LOCK_FILE}"; then
-  if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
+  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_REQUESTHEADER_CLIENT_CA --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_REQUESTHEADER_CLIENT_CA " $(cat ${PROXY_CRT})" >/dev/null 2>&1
   fi
-  if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
+  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_KEY --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_KEY " $(cat ${PROXY_CLIENT_KEY})" >/dev/null 2>&1
   fi
-  if [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
+  if [ "${OVERRIDE_PROXY_CERTS}" = "true" ] || [[ "" == "$(ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} get $ETCD_PROXY_CERT --print-value-only)" ]]; then
     ETCDCTL_API=3 etcdctl ${ETCDCTL_PARAMS} put $ETCD_PROXY_CERT " $(cat ${PROXY_CLIENT_CRT})" >/dev/null 2>&1
   fi
 fi
@@ -18149,6 +18149,11 @@ cp_certs() {
 
 cp_proxy() {
   source /etc/environment
+  local NODE_INDEX
+  NODE_INDEX=$(hostname | tail -c 2)
+  if [[ $NODE_INDEX == 0 ]]; then
+    export OVERRIDE_PROXY_CERTS="true"
+  fi
   /etc/kubernetes/generate-proxy-certs.sh
 }
 


### PR DESCRIPTION
**Reason for Change**:

`aks-engine rotate-certs` is not rotating the front-proxy certs.

AKS Engine creates a separate PKI for the front-proxy as part of node bootstrapping process and delivers them to all nodes  through etcd. To effectively reuse this functionality, `rotate-certs` has to replace the certs stored in etcd.

Also, front-proxy certs now expire after 30 years.

**Issue Fixed**:

Fixes #4463

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
