### PR TITLE
WIP: feat: upgrade to Windows Containerd config to v2 and enable hostprocess annotations

### DIFF
--- a/parts/k8s/containerdtemplate.toml
+++ b/parts/k8s/containerdtemplate.toml
@@ -1,3 +1,4 @@
+version = 2
 root = "C:\\ProgramData\\containerd\\root"
 state = "C:\\ProgramData\\containerd\\state"
 
@@ -21,7 +22,7 @@ state = "C:\\ProgramData\\containerd\\state"
   path = ""
 
 [plugins]
-  [plugins.cri]
+  [plugins."io.containerd.grpc.v1.cri"]
     stream_server_address = "127.0.0.1"
     stream_server_port = "0"
     enable_selinux = false
@@ -30,37 +31,41 @@ state = "C:\\ProgramData\\containerd\\state"
     systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
-    [plugins.cri.containerd]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "windows"
       discard_unpacked_layers = true
       no_pivot = false
-      [plugins.cri.containerd.default_runtime]
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
         runtime_type = "io.containerd.runhcs.v1"
-        [plugins.cri.containerd.default_runtime.options]
+        container_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user" ]
+        pod_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user"]
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
           Debug = true
           DebugType = 2
           SandboxImage = "{{pauseImage}}-windows-{{currentversion}}-amd64"
           SandboxPlatform = "windows/amd64"
           SandboxIsolation = {{sandboxIsolation}}
-      [plugins.cri.containerd.runtimes]
-        [plugins.cri.containerd.runtimes.runhcs-wcow-process]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process]
           runtime_type = "io.containerd.runhcs.v1"
-          [plugins.cri.containerd.runtimes.runhcs-wcow-process.options]
+          container_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user" ]
+          pod_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user"]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process.options]
             Debug = true
             DebugType = 2
             SandboxImage = "{{pauseImage}}-windows-{{currentversion}}-amd64"
             SandboxPlatform = "windows/amd64"
 {{hypervisors}}
-    [plugins.cri.cni]
+    [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "{{cnibin}}"
       conf_dir = "{{cniconf}}"
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
-  [plugins.diff-service]
+  [plugins."io.containerd.service.v1.diff-service"]
     default = ["windows"]
-  [plugins.scheduler]
+  [plugins."io.containerd.gc.v1.scheduler"]
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100

--- a/parts/k8s/windowscontainerdfunc.ps1
+++ b/parts/k8s/windowscontainerdfunc.ps1
@@ -50,9 +50,9 @@ function CreateHypervisorRuntime {
   )
 
   return @"
-        [plugins.cri.containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber]
           runtime_type = "io.containerd.runhcs.v1"
-          [plugins.cri.containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber.options]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber.options]
             Debug = true
             DebugType = 2
             SandboxImage = "$image-windows-$version-amd64"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -16165,7 +16165,8 @@ func k8sCloudInitNodecustomdataYml() (*asset, error) {
 	return a, nil
 }
 
-var _k8sContainerdtemplateToml = []byte(`root = "C:\\ProgramData\\containerd\\root"
+var _k8sContainerdtemplateToml = []byte(`version = 2
+root = "C:\\ProgramData\\containerd\\root"
 state = "C:\\ProgramData\\containerd\\state"
 
 [grpc]
@@ -16188,7 +16189,7 @@ state = "C:\\ProgramData\\containerd\\state"
   path = ""
 
 [plugins]
-  [plugins.cri]
+  [plugins."io.containerd.grpc.v1.cri"]
     stream_server_address = "127.0.0.1"
     stream_server_port = "0"
     enable_selinux = false
@@ -16197,37 +16198,41 @@ state = "C:\\ProgramData\\containerd\\state"
     systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
-    [plugins.cri.containerd]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "windows"
       discard_unpacked_layers = true
       no_pivot = false
-      [plugins.cri.containerd.default_runtime]
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
         runtime_type = "io.containerd.runhcs.v1"
-        [plugins.cri.containerd.default_runtime.options]
+        container_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user" ]
+        pod_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user"]
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
           Debug = true
           DebugType = 2
           SandboxImage = "{{pauseImage}}-windows-{{currentversion}}-amd64"
           SandboxPlatform = "windows/amd64"
           SandboxIsolation = {{sandboxIsolation}}
-      [plugins.cri.containerd.runtimes]
-        [plugins.cri.containerd.runtimes.runhcs-wcow-process]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process]
           runtime_type = "io.containerd.runhcs.v1"
-          [plugins.cri.containerd.runtimes.runhcs-wcow-process.options]
+          container_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user" ]
+          pod_annotations = ["microsoft.com/hostprocess-container","microsoft.com/hostprocess-inherit-user"]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process.options]
             Debug = true
             DebugType = 2
             SandboxImage = "{{pauseImage}}-windows-{{currentversion}}-amd64"
             SandboxPlatform = "windows/amd64"
 {{hypervisors}}
-    [plugins.cri.cni]
+    [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "{{cnibin}}"
       conf_dir = "{{cniconf}}"
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
-  [plugins.diff-service]
+  [plugins."io.containerd.service.v1.diff-service"]
     default = ["windows"]
-  [plugins.scheduler]
+  [plugins."io.containerd.gc.v1.scheduler"]
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100
@@ -18911,9 +18916,9 @@ function CreateHypervisorRuntime {
   )
 
   return @"
-        [plugins.cri.containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber]
           runtime_type = "io.containerd.runhcs.v1"
-          [plugins.cri.containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber.options]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber.options]
             Debug = true
             DebugType = 2
             SandboxImage = "$image-windows-$version-amd64"


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Enables alpha host process feature in Containerd.

Currently, To use hostprocess you need k8s 1.22.0-alpha.2+ and the following flags:

```
          "kubeletConfig": {
              "-v": "5",
              "--feature-gates": "WindowsHostProcessContainers=true"
          },
          "apiServerConfig": {
            "--feature-gates": "WindowsHostProcessContainers=true"
          },
```

Also need the containerd-shim binary built from https://github.com/microsoft/hcsshim/pull/962

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
