### PR TITLE
feat: add Standard_HB120rs_v3 support

### DIFF
--- a/pkg/armhelpers/httpMockClientData/listResourceSkus.json
+++ b/pkg/armhelpers/httpMockClientData/listResourceSkus.json
@@ -1037,6 +1037,11 @@
       "AcceleratedNetworking": false
     },
     {
+      "Name": "Standard_HB120rs_v3",
+      "StorageAccountType": "Premium_LRS",
+      "AcceleratedNetworking": false
+    },
+    {
       "Name": "Standard_HB60rs",
       "StorageAccountType": "Premium_LRS",
       "AcceleratedNetworking": false

--- a/pkg/helpers/azure_skus_const.go
+++ b/pkg/helpers/azure_skus_const.go
@@ -1365,6 +1365,10 @@ var VMSkus = []VMSku{
 		AcceleratedNetworking: false,
 	},
 	{
+		Name:                  "Standard_HB120rs_v3",
+		AcceleratedNetworking: false,
+	},
+	{
 		Name:                  "Standard_HB60rs",
 		AcceleratedNetworking: false,
 	},


### PR DESCRIPTION
**Reason for Change**:
Add missing VM type. This type is only available in some availability zones (e.g. westeurope zone 3). 

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
