### PR TITLE
ci: remove goveralls references

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -4,7 +4,7 @@ LOCALBIN		= $(shell pwd)/bin
 all: install
 
 .PHONY: install
-install: $(LOCALBIN)/go-bindata $(LOCALBIN)/gox $(LOCALBIN)/ginkgo $(LOCALBIN)/golangci-lint $(LOCALBIN)/pub $(LOCALBIN)/goveralls $(LOCALBIN)/mockgen
+install: $(LOCALBIN)/go-bindata $(LOCALBIN)/gox $(LOCALBIN)/ginkgo $(LOCALBIN)/golangci-lint $(LOCALBIN)/pub $(LOCALBIN)/mockgen
 	@echo > /dev/null
 
 $(LOCALBIN)/go-bindata:

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -22,9 +22,6 @@ $(LOCALBIN)/golangci-lint:
 $(LOCALBIN)/pub:
 	GOBIN=$(LOCALBIN) $(GO) get github.com/devigned/pub/...@v0.2.6
 
-$(LOCALBIN)/goveralls:
-	GOBIN=$(LOCALBIN) $(GO) get github.com/mattn/goveralls
-
 $(LOCALBIN)/mockgen:
 	GOBIN=$(LOCALBIN) $(GO) get github.com/golang/mock/mockgen@v1.2.0
 

--- a/scripts/ginkgo.coverage.sh
+++ b/scripts/ginkgo.coverage.sh
@@ -30,10 +30,6 @@ generate_cover_data() {
   grep -h -v "^mode:" "$coverdir"/*.coverprofile >>"$profile"
 }
 
-push_to_coveralls() {
-  goveralls -coverprofile="${profile}" -service=circle-ci -repotoken "$COVERALLS_REPO_TOKEN" || echo "push to coveralls failed"
-}
-
 push_to_codecov() {
   bash <(curl -s https://codecov.io/bash) || echo "push to codecov failed"
 }
@@ -44,14 +40,6 @@ go tool cover -func "${profile}"
 case "${1-}" in
   --html)
     go tool cover -html "${profile}"
-    ;;
-  --coveralls)
-		if [ -z "$COVERALLS_REPO_TOKEN" ]; then
-			# shellcheck disable=SC2016
-			echo '$COVERALLS_REPO_TOKEN not set. Skipping pushing coverage report to coveralls.io'
-			exit
-		fi
-    push_to_coveralls
     ;;
   --codecov)
     push_to_codecov


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR removes various CI references to the goveralls endpoint for publishing ginkgo coverage data, as we aren't actively using that endpoint anymore.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
