### PR TITLE
ci: standardize go mod vendor

### DIFF
--- a/.github/workflows/update-go-mod-vendor.yaml
+++ b/.github/workflows/update-go-mod-vendor.yaml
@@ -1,10 +1,10 @@
-name: Update Tools
+name: Update Go Mod Vendor
 on:
   schedule:
     - cron: '0 9 * * *' # Every day at 9:00 a.m.
   workflow_dispatch:
 jobs:
-  generate-azure-consts:
+  udpate-go-mod-vendor:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,16 +12,16 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.16'
-      - name: update hack/tools
-        run: make tools-reload
+      - name: run go mod vendor
+        run: make vendor
       - name: validate no changes
-        run: git diff-index --quiet HEAD --
+        run: git diff-index --quiet HEAD -- || echo "MAKE_PR=true" >> $GITHUB_ENV
       - name: create pull request
-        if: ${{ failure() }}
+        if: ${{ env.MAKE_PR == 'true' }}
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: 'chore: Update hack/tools dependencies'
-          title: 'chore: Update hack/tools dependencies'
-          body: Automated update of hack/tools dependencies
+          commit-message: 'chore: Update go mod vendor directories'
+          title: 'chore: Update go mod vendor directories'
+          body: Automated update of go mod vendor directories
           branch: apply-hack-tools-updates
           base: master

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ tidy:
 .PHONY: vendor
 vendor: tidy
 	$(GO) mod vendor
+	make -C ./test/e2e vendor
 
 build-binary: generate
 	go build $(GOFLAGS) -v -ldflags "$(LDFLAGS)" -o $(BINARY_DEST_DIR)/aks-engine .

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -25,3 +25,7 @@ clean:
 .PHONY: tidy
 tidy:
 	$(GO) mod tidy
+
+.PHONY: vendor
+vendor:
+	$(GO) mod vendor


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR standardizes our usage of the vendor directory so that both the aks-engine code itself _and_ the E2E go module store local dependencies in `vendor/`.

Also ships a GitHub Action to regularly maintain go mod vendor, and it replaces the (now no longer needed) hack/tools GitHub Action.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
