### PR TITLE
chore: use storage.k8s.io/v1 apiVersion for 1.22+

### DIFF
--- a/parts/k8s/addons/azure-cloud-provider.yaml
+++ b/parts/k8s/addons/azure-cloud-provider.yaml
@@ -168,7 +168,7 @@ volumeBindingMode: Immediate
 {{else}}
   {{- if NeedsStorageAccountStorageClasses}}
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: default
@@ -180,7 +180,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: unmanaged-premium
@@ -193,7 +193,7 @@ parameters:
   storageaccounttype: Premium_LRS
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: unmanaged-standard
@@ -221,7 +221,7 @@ parameters:
   {{- end}}
   {{- if NeedsManagedDiskStorageClasses}}
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: default
@@ -235,7 +235,7 @@ parameters:
   storageaccounttype: Standard_LRS
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: managed-premium
@@ -248,7 +248,7 @@ parameters:
   storageaccounttype: Premium_LRS
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: managed-standard

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -1864,7 +1864,7 @@ volumeBindingMode: Immediate
 {{else}}
   {{- if NeedsStorageAccountStorageClasses}}
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: default
@@ -1876,7 +1876,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: unmanaged-premium
@@ -1889,7 +1889,7 @@ parameters:
   storageaccounttype: Premium_LRS
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: unmanaged-standard
@@ -1917,7 +1917,7 @@ parameters:
   {{- end}}
   {{- if NeedsManagedDiskStorageClasses}}
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: default
@@ -1931,7 +1931,7 @@ parameters:
   storageaccounttype: Standard_LRS
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: managed-premium
@@ -1944,7 +1944,7 @@ parameters:
   storageaccounttype: Premium_LRS
   cachingmode: ReadOnly
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1{{- if not (IsKubernetesVersionGe "1.22.0-alpha.2")}}beta1{{end}}
 kind: StorageClass
 metadata:
   name: managed-standard


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR changes the StorageClass api version to `storage.k8s.io/v1` for versions of Kubernetes >= 1.22.0

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
