### PR TITLE
 fix: don't start kubelet if reboot is imminent

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -397,7 +397,7 @@ ensureKubelet() {
 {{- if not RunUnattendedUpgrades}}
     systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
 {{else}}
-    retrycmd 120 5 25 systemctl enable kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+    systemctl_enable 100 5 30 kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
 {{- end}}
   fi
 {{- if HasKubeletHealthZPort}}
@@ -408,7 +408,7 @@ ensureKubelet() {
   {{- if not RunUnattendedUpgrades}}
     systemctlEnableAndStart kubelet-monitor || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
   {{else}}
-    retrycmd 120 5 25 systemctl enable kubelet-monitor || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+    systemctl_enable 100 5 30 kubelet-monitor || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
   {{- end}}
   fi
 {{- end}}

--- a/parts/k8s/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_helpers.sh
@@ -233,6 +233,18 @@ systemctl_restart() {
       fi
   done
 }
+systemctl_enable() {
+  retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
+  for i in $(seq 1 $retries); do
+    timeout $timeout systemctl daemon-reload
+    timeout $timeout systemctl enable $svcname && break ||
+      if [ $i -eq $retries ]; then
+        return 1
+      else
+        sleep $wait_sleep
+      fi
+  done
+}
 systemctl_stop() {
   retries=$1; wait_sleep=$2; timeout=$3 svcname=$4
   for i in $(seq 1 $retries); do

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -294,10 +294,12 @@ if [ -f /var/run/reboot-required ]; then
     aptmarkWALinuxAgent unhold &
   fi
 else
+{{- if RunUnattendedUpgrades}}
   if [[ -z ${MASTER_NODE} ]]; then
     systemctl_restart 100 5 30 kubelet
     systemctl_restart 100 5 30 kubelet-monitor
   fi
+{{- end}}
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
     /usr/lib/apt/apt.systemd.daily &
     aptmarkWALinuxAgent unhold &

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -254,11 +254,7 @@ if [[ -n ${MASTER_NODE} ]]; then
     time_metric "EnsureEtcd" ensureEtcd
   fi
   time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
-  if [ -f /var/run/reboot-required ]; then
-    time_metric "ReplaceAddonsInit" replaceAddonsInit
-  else
-    time_metric "EnsureAddons" ensureAddons
-  fi
+  time_metric "EnsureAddons" ensureAddons
   {{- if HasClusterInitComponent}}
   if [[ $NODE_INDEX == 0 ]]; then
     retrycmd 120 5 30 $KUBECTL apply -f /opt/azure/containers/cluster-init.yaml || exit {{GetCSEErrorCode "ERR_CLUSTER_INIT_FAIL"}}
@@ -298,6 +294,10 @@ if [ -f /var/run/reboot-required ]; then
     aptmarkWALinuxAgent unhold &
   fi
 else
+  if [[ -z ${MASTER_NODE} ]]; then
+    systemctl_restart 100 5 30 kubelet
+    systemctl_restart 100 5 30 kubelet-monitor
+  fi
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
     /usr/lib/apt/apt.systemd.daily &
     aptmarkWALinuxAgent unhold &

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12207,14 +12207,30 @@ ensureKubelet() {
     sed -i "s|<advertiseAddr>|$PRIVATE_IP|g" $f
   fi
   wait_for_file 1200 1 /opt/azure/containers/kubelet.sh || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  {{- if HasKubeReservedCgroup}}
+{{- if HasKubeReservedCgroup}}
   wait_for_file 1200 1 /etc/systemd/system/{{- GetKubeReservedCgroup -}}.slice || exit {{GetCSEErrorCode "ERR_KUBERESERVED_SLICE_SETUP_FAIL"}}
   wait_for_file 1200 1 /etc/systemd/system/kubelet.service.d/kubereserved-slice.conf || exit {{GetCSEErrorCode "ERR_KUBELET_SLICE_SETUP_FAIL"}}
-  {{- end}}
-  systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+{{- end}}
+  if [[ -n ${MASTER_NODE} ]]; then
+    systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+  else
+{{- if not RunUnattendedUpgrades}}
+    systemctlEnableAndStart kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+{{else}}
+    retrycmd 120 5 25 systemctl enable kubelet || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+{{- end}}
+  fi
 {{- if HasKubeletHealthZPort}}
   wait_for_file 1200 1 /etc/systemd/system/kubelet-monitor.service || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  systemctlEnableAndStart kubelet-monitor || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+  if [[ -n ${MASTER_NODE} ]]; then
+    systemctlEnableAndStart kubelet-monitor || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+  else
+  {{- if not RunUnattendedUpgrades}}
+    systemctlEnableAndStart kubelet-monitor || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+  {{else}}
+    retrycmd 120 5 25 systemctl enable kubelet-monitor || exit {{GetCSEErrorCode "ERR_KUBELET_START_FAIL"}}
+  {{- end}}
+  fi
 {{- end}}
 }
 
@@ -12227,8 +12243,8 @@ ensureAddons() {
 {{- end}}
 {{- if not HasCustomPodSecurityPolicy}}
   retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
-  rm -Rf ${ADDONS_DIR}/init
 {{- end}}
+  rm -Rf ${ADDONS_DIR}/init
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
@@ -12303,7 +12319,7 @@ installKubeletAndKubectl() {
   rm -rf ${binPath}/kubelet-* ${binPath}/kubectl-* /home/hyperkube-downloads &
 }
 ensureK8sControlPlane() {
-  if [ -f /var/run/reboot-required ] || [ "$NO_OUTBOUND" = "true" ]; then
+  if [ "$NO_OUTBOUND" = "true" ]; then
     return
   fi
   retrycmd 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit_cse {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}} $GET_KUBELET_LOGS
@@ -13563,11 +13579,7 @@ if [[ -n ${MASTER_NODE} ]]; then
     time_metric "EnsureEtcd" ensureEtcd
   fi
   time_metric "EnsureK8sControlPlane" ensureK8sControlPlane
-  if [ -f /var/run/reboot-required ]; then
-    time_metric "ReplaceAddonsInit" replaceAddonsInit
-  else
-    time_metric "EnsureAddons" ensureAddons
-  fi
+  time_metric "EnsureAddons" ensureAddons
   {{- if HasClusterInitComponent}}
   if [[ $NODE_INDEX == 0 ]]; then
     retrycmd 120 5 30 $KUBECTL apply -f /opt/azure/containers/cluster-init.yaml || exit {{GetCSEErrorCode "ERR_CLUSTER_INIT_FAIL"}}
@@ -13607,6 +13619,10 @@ if [ -f /var/run/reboot-required ]; then
     aptmarkWALinuxAgent unhold &
   fi
 else
+  if [[ -z ${MASTER_NODE} ]]; then
+    systemctl_restart 100 5 30 kubelet
+    systemctl_restart 100 5 30 kubelet-monitor
+  fi
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
     /usr/lib/apt/apt.systemd.daily &
     aptmarkWALinuxAgent unhold &

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13619,10 +13619,12 @@ if [ -f /var/run/reboot-required ]; then
     aptmarkWALinuxAgent unhold &
   fi
 else
+{{- if RunUnattendedUpgrades}}
   if [[ -z ${MASTER_NODE} ]]; then
     systemctl_restart 100 5 30 kubelet
     systemctl_restart 100 5 30 kubelet-monitor
   fi
+{{- end}}
   if [[ $OS == $UBUNTU_OS_NAME ]]; then
     /usr/lib/apt/apt.systemd.daily &
     aptmarkWALinuxAgent unhold &


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR ensures that worker nodes do not start the kubelet systemd service if they are going to be rebooted by CSE.

Additionally, we clean things up so that control plane node *do* always fully start up, even if they are going to be rebooted. This is because we may need to do one-time (delivered via aks-engine api model) resource bootstrapping, and for that we need a working cluster, which each control plane node during cluster creation essentially represents. This will result in a bit more control plane node readiness thrashing during cluster creation (kubelet may come online and then be rebooted a minute later), but this is not a big problem.

This solves the problem of new nodes coming online after cluster creation (for example, node scale out operations) causing workload thrashing due to new nodes coming online as Ready, accepting new work, and then rebooting a minute later (thus force-killing any scheduled containers scheduled onto that new node).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
