### PR TITLE
feat: allow setting apiserver verbosity and change default from 4 to 2

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -614,6 +614,7 @@ Below is a list of apiserver options that AKS Engine will configure by default:
 | "--oidc-issuer-url"             | _calculated value that represents OID issuer URL_ (_if has AADProfile_)                                                                                                                                                         |
 | "--service-account-issuer"             | "https://kubernetes.default.svc.cluster.local" (Kubernetes v1.20.0 and greater only) |
 | "--service-account-signing-key-file"             | "/etc/kubernetes/certs/apiserver.key" (Kubernetes v1.20.0 and greater only) |
+| "--v"                           | "2" |
 
 `*` In Kubernetes versions 1.10.0 and later the `--admission-control` flag is deprecated and `--enable-admission-plugins` is used instead.
 
@@ -642,7 +643,6 @@ Below is a list of apiserver options that are _not_ currently user-configurable,
 | "--kubelet-client-key"                 | "/etc/kubernetes/certs/client.key"                                                      |
 | "--service-cluster-ip-range"           | _see serviceCIDR_                                                                       |
 | "--storage-backend"                    | _calculated value that represents etcd version_                                         |
-| "--v"                                  | "4"                                                                                     |
 | "--encryption-provider-config"         | "/etc/kubernetes/encryption-config.yaml" (_if enableDataEncryptionAtRest is true_)      |
 | "--encryption-provider-config"         | "/etc/kubernetes/encryption-config.yaml" (_if enableEncryptionWithExternalKms is true_) |
 | "--requestheader-client-ca-file"       | "/etc/kubernetes/certs/proxy-ca.crt" (_if enableAggregatedAPIs is true_)                |

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -453,6 +453,8 @@ const (
 	DefaultKubernetesMaxPodsAzureCNI = "30"
 	// DefaultKubernetesAPIServerEnableProfiling is the config that enables profiling via web interface host:port/debug/pprof/
 	DefaultKubernetesAPIServerEnableProfiling = "false"
+	// DefaultKubernetesAPIServerVerbosity is the default verbosity setting for the apiserver
+	DefaultKubernetesAPIServerVerbosity = "2"
 	// DefaultKubernetesCtrMgrEnableProfiling is the config that enables profiling via web interface host:port/debug/pprof/
 	DefaultKubernetesCtrMgrEnableProfiling = "false"
 	// DefaultKubernetesSchedulerEnableProfiling is the config that enables profiling via web interface host:port/debug/pprof/

--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -34,7 +34,6 @@ func (cs *ContainerService) setAPIServerConfig() {
 		"--service-cluster-ip-range":    o.KubernetesConfig.ServiceCIDR,
 		"--storage-backend":             o.GetAPIServerEtcdAPIVersion(),
 		"--enable-bootstrap-token-auth": "true",
-		"--v":                           "4",
 	}
 
 	if cs.Properties.MasterProfile != nil {
@@ -56,6 +55,7 @@ func (cs *ContainerService) setAPIServerConfig() {
 		"--audit-log-maxsize":   "100",
 		"--profiling":           DefaultKubernetesAPIServerEnableProfiling,
 		"--tls-cipher-suites":   TLSStrongCipherSuitesAPIServer,
+		"--v":                   DefaultKubernetesAPIServerVerbosity,
 	}
 
 	// Data Encryption at REST configuration conditions

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -536,3 +536,29 @@ func TestAPIServerAnonymousAuth(t *testing.T) {
 			a["--anonymous-auth"])
 	}
 }
+
+func TestAPIServerConfigChangeVerbosity(t *testing.T) {
+	// Test
+	// "apiServerConfig": {
+	// 	"--v": "4"
+	// },
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
+		"--v": "4",
+	}
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--v"] != "4" {
+		t.Fatalf("got unexpected '--v' API server config value for \"--v\": \"4\": %s",
+			a["--v"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--v"] != DefaultKubernetesAPIServerVerbosity {
+		t.Fatalf("got unexpected default value for '--v' API server config: %s",
+			a["--v"])
+	}
+}


### PR DESCRIPTION
**Reason for Change**:
I think not all users need verbosity level 4 for the apiserver. This logs all requests sent to it and is really quite verbose.

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
BREAKING CHANGE: the default apiServer verbosity changes from 4 to 2.