### PR TITLE
feat: enable new clusters w/ 1000 count node pools

### DIFF
--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -14,7 +14,7 @@ const (
 	// MinAgentCount are the minimum number of agents per agent pool
 	MinAgentCount = 1
 	// MaxAgentCount are the maximum number of agents per agent pool
-	MaxAgentCount = 100
+	MaxAgentCount = 1000
 	// MinPort specifies the minimum tcp port to open
 	MinPort = 1
 	// MaxPort specifies the maximum tcp port to open

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -43,7 +43,7 @@ const (
 	// MinAgentCount are the minimum number of agents per agent pool
 	MinAgentCount = 1
 	// MaxAgentCount are the maximum number of agents per agent pool
-	MaxAgentCount = 100
+	MaxAgentCount = 1000
 	// MinPort specifies the minimum tcp port to open
 	MinPort = 1
 	// MaxPort specifies the maximum tcp port to open

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -39,7 +39,7 @@ const (
 	// MinAgentCount are the minimum number of agents per agent pool
 	MinAgentCount = 1
 	// MaxAgentCount are the maximum number of agents per agent pool
-	MaxAgentCount = 100
+	MaxAgentCount = 1000
 	// MinPort specifies the minimum tcp port to open
 	MinPort = 1
 	// MaxPort specifies the maximum tcp port to open

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -497,7 +497,7 @@ type Extension struct {
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
 	Name                                string               `json:"name" validate:"required"`
-	Count                               int                  `json:"count" validate:"required,min=1,max=100"`
+	Count                               int                  `json:"count" validate:"required,min=1,max=1000"`
 	VMSize                              string               `json:"vmSize" validate:"required"`
 	OSDiskSizeGB                        int                  `json:"osDiskSizeGB,omitempty" validate:"min=0,max=2048"`
 	DNSPrefix                           string               `json:"dnsPrefix,omitempty"`


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR enables node pools to be up to 1000 at cluster creation time, matching the VMSS instance count maximum.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
