### PR TITLE
fix: always install GPU drivers during bootstrapping

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -150,9 +150,7 @@ time_metric "InstallNetworkPlugin" installNetworkPlugin
 
 {{- if and HasNSeriesSKU IsNvidiaDevicePluginAddonEnabled}}
 if [[ ${GPU_NODE} == true ]]; then
-  if $FULL_INSTALL_REQUIRED; then
-    time_metric "DownloadGPUDrivers" downloadGPUDrivers
-  fi
+  time_metric "DownloadGPUDrivers" downloadGPUDrivers
   time_metric "EnsureGPUDrivers" ensureGPUDrivers
 fi
 {{end}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13487,9 +13487,7 @@ time_metric "InstallNetworkPlugin" installNetworkPlugin
 
 {{- if and HasNSeriesSKU IsNvidiaDevicePluginAddonEnabled}}
 if [[ ${GPU_NODE} == true ]]; then
-  if $FULL_INSTALL_REQUIRED; then
-    time_metric "DownloadGPUDrivers" downloadGPUDrivers
-  fi
+  time_metric "DownloadGPUDrivers" downloadGPUDrivers
   time_metric "EnsureGPUDrivers" ensureGPUDrivers
 fi
 {{end}}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR restores the previous behavior of always installing GPU drivers during bootstrapping. This has the side-effect of no longer supporting "airgap" scenarios, but it appears that simply `apt-get download`'ing the packages during VHD creation is not sufficient for providing that solution. I am speculating that files in `/var/cache/apt/archives/` are regularly cleaned up based on the age of the files, which means that pre-downloaded apt packages in the VHD are only viable for a temporary period of time.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #4631

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
