### PR TITLE
chore: update docker EE to 20.10.9 for Windows

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -31,7 +31,7 @@ const (
 
 const (
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
-	KubernetesWindowsDockerVersion = "20.10.6"
+	KubernetesWindowsDockerVersion = "20.10.9"
 	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
 	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 	// KubernetesDefaultWindowsRuntimeHandler is the default containerd handler for windows pods

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -173,7 +173,7 @@ function Install-ContainerD {
 }
 
 function Install-Docker {
-    $defaultDockerVersion = "20.10.6"
+    $defaultDockerVersion = "20.10.9"
 
     Write-Log "Attempting to install Docker version $defaultDockerVersion"
     Install-PackageProvider -Name DockerMsftProvider -Force -ForceBootstrap | Out-Null


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews --> Windows: Fix a situation where containers were not stopped if HcsShutdownComputeSystem returned an ERROR_PROC_NOT_FOUND error moby/moby#42613

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Docker 20.10.8 contains a fix where windows containers can stay around after they get deleted (aka 'zombie pods') which continue to consume host resources.

https://docs.docker.com/engine/release-notes/#20108 -> Windows: Fix a situation where containers were not stopped if HcsShutdownComputeSystem returned an ERROR_PROC_NOT_FOUND error moby/moby#42613

/cc @AbelHu 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
