### PR TITLE
fix: Use Invoke-WebRequest instead of curl.exe to download files

### DIFF
--- a/parts/k8s/rotate-certs.ps1
+++ b/parts/k8s/rotate-certs.ps1
@@ -53,9 +53,10 @@ function Force-Kubelet-CertRotation {
     Remove-Item "/var/lib/kubelet/pki/kubelet.crt" -Force -ErrorAction Ignore
     Remove-Item "/var/lib/kubelet/pki/kubelet.key" -Force -ErrorAction Ignore
 
-    $err = Retry-Command -Command "c:\k\windowsnodereset.ps1" -Args @{Foo="Bar"} -Retries 3 -RetryDelaySeconds 10
-    if(!$err) {
-        Write-Error 'Error reseting Windows node'
+    try {
+        $err = Retry-Command -Command "c:\k\windowsnodereset.ps1" -Args @{Foo="Bar"} -Retries 3 -RetryDelaySeconds 10
+    } catch {
+        Write-Error "Error reseting Windows node. Error: $_"
         throw $_
     }
 }

--- a/parts/k8s/windowsazurecnifunc.ps1
+++ b/parts/k8s/windowsazurecnifunc.ps1
@@ -206,10 +206,10 @@ function GetSubnetPrefix
     $uri = "$($ResourceManagerEndpoint)$($SubnetId)?api-version=$NetworkAPIVersion"
     $headers = @{Authorization="Bearer $Token"}
 
-    $response = Retry-Command -Command "Invoke-RestMethod" -Args @{Uri=$uri; Method="Get"; ContentType="application/json"; Headers=$headers} -Retries 5 -RetryDelaySeconds 10
-
-    if(!$response) {
-        throw 'Error getting subnet prefix'
+    try {
+        $response = Retry-Command -Command "Invoke-RestMethod" -Args @{Uri=$uri; Method="Get"; ContentType="application/json"; Headers=$headers} -Retries 5 -RetryDelaySeconds 10
+    } catch {
+        throw "Error getting subnet prefix. Error: $_"
     }
 
     $response.properties.addressPrefix
@@ -267,10 +267,10 @@ function GenerateAzureStackCNIConfig
 
     $body = "grant_type=client_credentials&client_id=$AADClientId&client_secret=$encodedSecret&resource=$($azureEnvironment.serviceManagementEndpoint)"
     $args = @{Uri=$tokenURL; Method="Post"; Body=$body; ContentType='application/x-www-form-urlencoded'}
-    $tokenResponse = Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
-
-    if(!$tokenResponse) {
-        throw 'Error generating token for Azure Resource Manager'
+    try {
+        $tokenResponse = Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
+    } catch {
+        throw "Error generating token for Azure Resource Manager. Error: $_"
     }
 
     $token = $tokenResponse | Select-Object -ExpandProperty access_token
@@ -280,10 +280,10 @@ function GenerateAzureStackCNIConfig
     $interfacesUri = "$($azureEnvironment.resourceManagerEndpoint)subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Network/networkInterfaces?api-version=$NetworkAPIVersion"
     $headers = @{Authorization="Bearer $token"}
     $args = @{Uri=$interfacesUri; Method="Get"; ContentType="application/json"; Headers=$headers; OutFile=$networkInterfacesFile}
-    Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
-
-    if(!$(Test-Path $networkInterfacesFile)) {
-        throw 'Error fetching network interface configuration for node'
+    try {
+        Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
+    } catch {
+        throw "Error fetching network interface configuration for node. Error: $_"
     }
 
     Write-Log "Generating Azure CNI interface file"

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17108,9 +17108,11 @@ function DownloadFileOverHttp {
         $ProgressPreference = 'SilentlyContinue'
 
         $downloadTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        curl.exe -f --retry 5 --retry-delay 0 -L $Url -o $DestinationPath
-        if ($LASTEXITCODE) {
-            throw "Curl exited with '$LASTEXITCODE' while attemping to downlaod '$Url'"
+        try {
+            $args = @{Uri=$Url; Method="Get"; OutFile=$DestinationPath}
+            Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
+        } catch {
+            throw "Fail in downloading $Url. Error: $_"
         }
         $downloadTimer.Stop()
 
@@ -17206,11 +17208,15 @@ function Retry-Command {
         $RetryDelaySeconds
     )
 
-    for ($i = 0; $i -lt $Retries; $i++) {
+    for ($i = 0; ; ) {
         try {
             return & $Command @Args
         }
         catch {
+            $i++
+            if ($i -ge $Retries) {
+                throw $_
+            }
             Start-Sleep $RetryDelaySeconds
         }
     }
@@ -18381,9 +18387,10 @@ function Force-Kubelet-CertRotation {
     Remove-Item "/var/lib/kubelet/pki/kubelet.crt" -Force -ErrorAction Ignore
     Remove-Item "/var/lib/kubelet/pki/kubelet.key" -Force -ErrorAction Ignore
 
-    $err = Retry-Command -Command "c:\k\windowsnodereset.ps1" -Args @{Foo="Bar"} -Retries 3 -RetryDelaySeconds 10
-    if(!$err) {
-        Write-Error 'Error reseting Windows node'
+    try {
+        $err = Retry-Command -Command "c:\k\windowsnodereset.ps1" -Args @{Foo="Bar"} -Retries 3 -RetryDelaySeconds 10
+    } catch {
+        Write-Error "Error reseting Windows node. Error: $_"
         throw $_
     }
 }
@@ -18717,10 +18724,10 @@ function GetSubnetPrefix
     $uri = "$($ResourceManagerEndpoint)$($SubnetId)?api-version=$NetworkAPIVersion"
     $headers = @{Authorization="Bearer $Token"}
 
-    $response = Retry-Command -Command "Invoke-RestMethod" -Args @{Uri=$uri; Method="Get"; ContentType="application/json"; Headers=$headers} -Retries 5 -RetryDelaySeconds 10
-
-    if(!$response) {
-        throw 'Error getting subnet prefix'
+    try {
+        $response = Retry-Command -Command "Invoke-RestMethod" -Args @{Uri=$uri; Method="Get"; ContentType="application/json"; Headers=$headers} -Retries 5 -RetryDelaySeconds 10
+    } catch {
+        throw "Error getting subnet prefix. Error: $_"
     }
 
     $response.properties.addressPrefix
@@ -18778,10 +18785,10 @@ function GenerateAzureStackCNIConfig
 
     $body = "grant_type=client_credentials&client_id=$AADClientId&client_secret=$encodedSecret&resource=$($azureEnvironment.serviceManagementEndpoint)"
     $args = @{Uri=$tokenURL; Method="Post"; Body=$body; ContentType='application/x-www-form-urlencoded'}
-    $tokenResponse = Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
-
-    if(!$tokenResponse) {
-        throw 'Error generating token for Azure Resource Manager'
+    try {
+        $tokenResponse = Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
+    } catch {
+        throw "Error generating token for Azure Resource Manager. Error: $_"
     }
 
     $token = $tokenResponse | Select-Object -ExpandProperty access_token
@@ -18791,10 +18798,10 @@ function GenerateAzureStackCNIConfig
     $interfacesUri = "$($azureEnvironment.resourceManagerEndpoint)subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Network/networkInterfaces?api-version=$NetworkAPIVersion"
     $headers = @{Authorization="Bearer $token"}
     $args = @{Uri=$interfacesUri; Method="Get"; ContentType="application/json"; Headers=$headers; OutFile=$networkInterfacesFile}
-    Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
-
-    if(!$(Test-Path $networkInterfacesFile)) {
-        throw 'Error fetching network interface configuration for node'
+    try {
+        Retry-Command -Command "Invoke-RestMethod" -Args $args -Retries 5 -RetryDelaySeconds 10
+    } catch {
+        throw "Error fetching network interface configuration for node. Error: $_"
     }
 
     Write-Log "Generating Azure CNI interface file"


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Use Invoke-WebRequest instead of curl.exe to download files
curl.exe does not retry when failed in handshake.

```
2021-09-08T01:12:44.6532522+00:00: Download kubelet binaries and unzip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:21 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:21 --:--:--     0
curl: (35) schannel: failed to receive handshake, SSL/TLS connection failed

```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
