### PR TITLE
test: check vmssCSE resource w/ VMSS health check

### DIFF
--- a/test/e2e/kubernetes/scripts/vmss-health-check.sh
+++ b/test/e2e/kubernetes/scripts/vmss-health-check.sh
@@ -36,6 +36,15 @@ while true; do
           ((NUM_DELETED_INSTANCES++))
         fi
       done
+      for TARGET_VMSS_INSTANCE in $(az vmss list-instances -g $RESOURCE_GROUP -n $TERMINAL_VMSS | jq -r '.[].resources[] | select(.name == "vmssCSE" and .provisioningState == "Failed") | .id' | awk -F'/' '{print $9}'); do
+        echo $(date)    Deleting VMSS $TERMINAL_VMSS instance $TARGET_VMSS_INSTANCE
+        if ! az vmss delete-instances -n $TERMINAL_VMSS -g $RESOURCE_GROUP --instance-id ${TARGET_VMSS_INSTANCE##*_}; then
+           sleep 30
+        else
+           sleep 1
+           ((NUM_DELETED_INSTANCES++))
+        fi
+      done
       if [ "$HAS_FAILED_STATE_INSTANCE" == "true" ]; then
         echo $(date)    Waiting for $TERMINAL_VMSS to reach a terminal ProvisioningState after failed instances were deleted...
         sleep 30


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR adds the `vmssCSE` resource to our list of `provisioningState` things to validate when running vmss-health-check during E2E.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
