### PR TITLE
test: delete failed vmss extensions, wait longer

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -3085,8 +3085,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						numNodesExpected := numAgentNodes + newKaminoNodes + numControlPlaneNodes
 						numLargeContainerPodsExpected := numAgentNodes + newKaminoNodes
 						By(fmt.Sprintf("Waiting for the %d new nodes created from prototype(s) to become Ready; waiting for %d total nodes", newKaminoNodes, numNodesExpected))
+						timeToWaitForLargeCluster := time.Duration(newKaminoNodes/1000) * time.Hour
+						timeToWaitForNewNodes := timeToWaitForLargeCluster
+						if cfg.Timeout > timeToWaitForLargeCluster {
+							timeToWaitForNewNodes = cfg.Timeout
+						}
 						start := time.Now()
-						ready := node.WaitOnReadyMin(numNodesExpected, 30*time.Second, false, 2*time.Hour)
+						ready := node.WaitOnReadyMin(numNodesExpected, 30*time.Second, false, timeToWaitForNewNodes)
 						Expect(ready).To(BeTrue())
 						elapsed = time.Since(start)
 						log.Printf("Took %s to add %d nodes derived from peer node prototype(s)\n", elapsed, newKaminoNodes)

--- a/test/e2e/kubernetes/scripts/vmss-health-check.sh
+++ b/test/e2e/kubernetes/scripts/vmss-health-check.sh
@@ -20,44 +20,56 @@ while true; do
   for VMSS in $(az vmss list -g $RESOURCE_GROUP | jq -r '.[] | .name'); do
     ((NUM_VMSS++))
     NUM_DELETED_INSTANCES=0
+    VMSS_PROVISIONING_STATE=$(az vmss show -g $RESOURCE_GROUP -n $VMSS | jq -r '.provisioningState')
+    echo $(date)    VMSS $VMSS has a ProvisioningState of $VMSS_PROVISIONING_STATE
     VMSS_CAPACITY=$(az vmss list -g $RESOURCE_GROUP | jq -r --arg VMSS "$VMSS" '.[] | select(.name == $VMSS) | .sku.capacity')
     echo $(date)    VMSS $VMSS has a current capacity of $VMSS_CAPACITY
-    for TERMINAL_VMSS in $(az vmss show -g $RESOURCE_GROUP -n $VMSS | jq -r '. | select(.provisioningState == "Succeeded" or .provisioningState == "Failed") | .name'); do
+    if [ "$VMSS_PROVISIONING_STATE" == "Succeeded" ] || [ "$VMSS_PROVISIONING_STATE" == "Failed" ]; then
       ((NUM_TERMINAL_VMSS++))
-      echo $(date)    VMSS $TERMINAL_VMSS is in a terminal state!
       HAS_FAILED_STATE_INSTANCE="false"
-      for TARGET_VMSS_INSTANCE in $(az vmss list-instances -g $RESOURCE_GROUP -n $TERMINAL_VMSS | jq -r '.[] | select(.provisioningState == "Failed") | .name'); do
+      for TARGET_VMSS_INSTANCE in $(az vmss list-instances -g $RESOURCE_GROUP -n $VMSS | jq -r '.[] | select(.provisioningState == "Failed") | .name'); do
         HAS_FAILED_STATE_INSTANCE="true"
-        echo $(date)    Deleting VMSS $TERMINAL_VMSS instance $TARGET_VMSS_INSTANCE
-        if ! az vmss delete-instances -n $TERMINAL_VMSS -g $RESOURCE_GROUP --instance-id ${TARGET_VMSS_INSTANCE##*_} --no-wait; then
+        echo $(date)    Deleting VMSS $VMSS instance $TARGET_VMSS_INSTANCE
+        if ! az vmss delete-instances -n $VMSS -g $RESOURCE_GROUP --instance-id ${TARGET_VMSS_INSTANCE##*_} --no-wait; then
           sleep 30
         else
           sleep 1
           ((NUM_DELETED_INSTANCES++))
         fi
       done
-      for TARGET_VMSS_INSTANCE in $(az vmss list-instances -g $RESOURCE_GROUP -n $TERMINAL_VMSS | jq -r '.[].resources[] | select(.name == "vmssCSE" and .provisioningState == "Failed") | .id' | awk -F'/' '{print $9}'); do
-        echo $(date)    Deleting VMSS $TERMINAL_VMSS instance $TARGET_VMSS_INSTANCE
-        if ! az vmss delete-instances -n $TERMINAL_VMSS -g $RESOURCE_GROUP --instance-id ${TARGET_VMSS_INSTANCE##*_}; then
+      for TARGET_VMSS_INSTANCE in $(az vmss list-instances -g $RESOURCE_GROUP -n $VMSS | jq -r '.[].resources[] | select(.name == "vmssCSE" and .provisioningState == "Failed") | .id' | awk -F'/' '{print $9}'); do
+        HAS_FAILED_STATE_INSTANCE="true"
+        echo $(date)    Deleting VMSS $VMSS instance $TARGET_VMSS_INSTANCE
+        if ! az vmss delete-instances -n $VMSS -g $RESOURCE_GROUP --instance-id ${TARGET_VMSS_INSTANCE##*_}; then
            sleep 30
         else
            sleep 1
            ((NUM_DELETED_INSTANCES++))
         fi
       done
+      for TARGET_VMSS_INSTANCE in $(az vmss list-instances -g $RESOURCE_GROUP -n $VMSS | jq -r '.[].resources[] | select(.publisher == "Microsoft.AKS" and .provisioningState != "Succeeded" and .provisioningState != "Creating" and .provisioningState != "Deleting") | .id' | awk -F'/' '{print $9}'); do
+        HAS_FAILED_STATE_INSTANCE="true"
+        echo $(date)    Deleting VMSS $VMSS instance $TARGET_VMSS_INSTANCE
+        if ! az vmss delete-instances -n $VMSS -g $RESOURCE_GROUP --instance-id ${TARGET_VMSS_INSTANCE##*_}; then
+          sleep 30
+        else
+          sleep 1
+          ((NUM_DELETED_INSTANCES++))
+        fi
+      done
       if [ "$HAS_FAILED_STATE_INSTANCE" == "true" ]; then
-        echo $(date)    Waiting for $TERMINAL_VMSS to reach a terminal ProvisioningState after failed instances were deleted...
+        echo $(date)    Waiting for $VMSS to reach a terminal ProvisioningState after failed instances were deleted...
         sleep 30
         until [[ $(az vmss show -g $RESOURCE_GROUP -n $VMSS | jq -r '. | select(.provisioningState == "Succeeded" or .provisioningState == "Failed") | .name') ]]; do
-          for STILL_FAILED_VMSS_INSTANCE in $(az vmss list-instances -g $RESOURCE_GROUP -n $TERMINAL_VMSS | jq -r '.[] | select(.provisioningState == "Failed") | .name'); do
-            echo $(date)    Instance $STILL_FAILED_VMSS_INSTANCE is still in a failed state, will attempt to delete again in the next loop
-          done
+          echo $(date)    Waiting for $VMSS to reach a terminal ProvisioningState after failed instances were deleted...
+          sleep 30
         done
+        echo $(date)    VMSS $VMSS is in a terminal state after failed instances were deleted!
       fi
-    done
+    fi
     if [ "$NUM_DELETED_INSTANCES" -gt "0" ]; then
       echo $(date)    Instances were deleted from VMSS $VMSS, ensuring that capacity is set to $VMSS_CAPACITY
-      if ! az vmss scale --new-capacity $VMSS_CAPACITY -n $VMSS -g $RESOURCE_GROUP; then
+      if ! az vmss scale --new-capacity $VMSS_CAPACITY -n $VMSS -g $RESOURCE_GROUP --no-wait; then
           exit 1
       fi
     fi


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR adds instance extension checks to the VMSS health check script, as well as waiting longer overall for new nodes to join during large cluster tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
