### PR TITLE
docs: fix addon name in Calico `logSeverityScreen` example

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -247,7 +247,7 @@ The `calico` addon includes configurable verbosity via the `logSeverityScreen` c
     "addons": [
         ...
         {
-          "name": "calico",
+          "name": "calico-daemonset",
           "enabled": true,
           "config": {
             "logSeverityScreen": "error"


### PR DESCRIPTION
I think there's a bug in the example for the Calico `logSeverityScreen`. The addon name should be `calico-daemonset` as defined by `common.CalicoAddonName`.
Only with this name I could convince aks-engine to include my customized log level into the ARM template.