### PR TITLE
fix: fetch releases via the GitHub API optionally using GH Token

### DIFF
--- a/scripts/get-akse.sh
+++ b/scripts/get-akse.sh
@@ -67,19 +67,47 @@ verifySupported() {
     echo "Either curl or wget is required"
     exit 1
   fi
+
+  if ! type "jq" > /dev/null; then
+    echo "jq is required"
+    exit 1
+  fi
 }
 
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
-  # Use the GitHub releases webpage for the project to find the desired version for this project.
-  local release_url="https://github.com/Azure/aks-engine/releases/${DESIRED_VERSION:-latest}"
-  # shellcheck disable=SC2086
-  if type "curl" > /dev/null; then
-    TAG=$(curl -SsL $release_url | awk '/\/tag\//' | grep -v no-underline | grep "href=\"/Azure/aks-engine/releases" | head -n 1 | cut -d '"' -f 8 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
-  elif type "wget" > /dev/null; then
-    TAG=$(wget -q -O - $release_url | awk '/\/tag\//' | grep -v no-underline | grep "href=\"/Azure/aks-engine/releases" | head -n 1 | cut -d '"' -f 8 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+  # Use the GitHub releases API for the project to find the desired version for this project.
+  local release_url
+  if [[ -z "${DESIRED_VERSION}" ]]; then
+    release_url="https://api.github.com/repos/Azure/aks-engine/releases/latest"
+  else
+    release_url="https://api.github.com/repos/Azure/aks-engine/releases/tags/${DESIRED_VERSION}"
   fi
-  if [ "$TAG" == "" ]; then
+
+  # shellcheck disable=SC2086
+  local requestCmd
+  if type "curl" > /dev/null; then
+    requestCmd="curl -Ssl "
+    if [[ -n "${GITHUB_TOKEN}" ]]; then
+      requestCmd+="-H 'Authorization: token ${GITHUB_TOKEN}'"
+    fi
+    requestCmd+=" --fail ${release_url}"
+  elif type "wget" > /dev/null; then
+    requestCmd="wget -nv "
+    if [[ -n "${GITHUB_TOKEN}" ]]; then
+      requestCmd+="--header='Authorization: token ${GITHUB_TOKEN}'"
+    fi
+    requestCmd+=" -O - ${release_url}"
+  fi
+
+  local response
+  if ! response=$(eval "${requestCmd}") ; then
+    echo "Failed requesting release for ${DESIRED_VERSION} tag from GitHub API."
+    exit 1
+  fi
+
+  TAG=$(jq -r '.name | values' <<< "${response}")
+  if [[ -z "${TAG}" ]]; then
     echo "Cannot determine ${DESIRED_VERSION} tag."
     exit 1
   fi
@@ -164,7 +192,8 @@ help () {
   echo -e "\t[--help|-h ] ->> prints this help"
   echo -e "\t[--version|-v <desired_version>] . When not defined it defaults to latest"
   echo -e "\te.g. --version v0.32.3  or -v latest"
-  echo -e "\t[--no-sudo]  ->> install without sudo"
+  echo -e "\t[--no-sudo]  ->> install without sudo\n"
+  echo -e "\tIf GITHUB_TOKEN env var is set, it will be used to fetch releases via the GitHub API.\n"
 }
 
 # cleanup temporary files


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Scraping the GitHub release HTML is brittle. This change uses the GitHub API to determine the release tag rather than scraping HTML.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #4708

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
