### PR TITLE
fix: bypass systemd-resolved but use the resolv.conf it generates

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -115,13 +115,9 @@ ensureChrony() {
   systemctlEnableAndStart chrony || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 disable1804SystemdResolved() {
-  ls -ltr /etc/resolv.conf
-  cat /etc/resolv.conf
   {{/* Ignoring systemd-resolved query service but using its resolv.conf file */}}
   {{/* This is the simplest approach to workaround resolved issues without completely uninstall it */}}
   [ -f /run/systemd/resolve/resolv.conf ] && sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-  ls -ltr /etc/resolv.conf
-  cat /etc/resolv.conf
 }
 ensureRPC() {
   systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -114,7 +114,15 @@ configureChrony() {
 ensureChrony() {
   systemctlEnableAndStart chrony || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
-
+disable1804SystemdResolved() {
+  ls -ltr /etc/resolv.conf
+  cat /etc/resolv.conf
+  {{/* Ingorings systemd-resolved query service but using its resolv.conf file */}}
+  {{/* This is the simplest approach to workaround resolved issues without completely uninstall it */}}
+  [ -f /run/systemd/resolve/resolv.conf ] && sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+  ls -ltr /etc/resolv.conf
+  cat /etc/resolv.conf
+}
 ensureRPC() {
   systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
   systemctlEnableAndStart rpc-statd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -117,7 +117,7 @@ ensureChrony() {
 disable1804SystemdResolved() {
   ls -ltr /etc/resolv.conf
   cat /etc/resolv.conf
-  {{/* Ingorings systemd-resolved query service but using its resolv.conf file */}}
+  {{/* Ignoring systemd-resolved query service but using its resolv.conf file */}}
   {{/* This is the simplest approach to workaround resolved issues without completely uninstall it */}}
   [ -f /run/systemd/resolve/resolv.conf ] && sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
   ls -ltr /etc/resolv.conf

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -40,6 +40,10 @@ wait_for_file 3600 1 {{GetCustomCloudConfigCSEScriptFilepath}} || exit {{GetCSEE
 source {{GetCustomCloudConfigCSEScriptFilepath }}
 {{end}}
 
+if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
+  disable1804SystemdResolved
+fi
+
 set +x
 ETCD_PEER_CERT=$(echo ${ETCD_PEER_CERTIFICATES} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))
 ETCD_PEER_KEY=$(echo ${ETCD_PEER_PRIVATE_KEYS} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12227,7 +12227,15 @@ configureChrony() {
 ensureChrony() {
   systemctlEnableAndStart chrony || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
-
+disable1804SystemdResolved() {
+  ls -ltr /etc/resolv.conf
+  cat /etc/resolv.conf
+  {{/* Ingorings systemd-resolved query service but using its resolv.conf file */}}
+  {{/* This is the simplest approach to workaround resolved issues without completely uninstall it */}}
+  [ -f /run/systemd/resolve/resolv.conf ] && sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+  ls -ltr /etc/resolv.conf
+  cat /etc/resolv.conf
+}
 ensureRPC() {
   systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
   systemctlEnableAndStart rpc-statd || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
@@ -13669,6 +13677,10 @@ source {{GetCSEConfigScriptFilepath}}
 wait_for_file 3600 1 {{GetCustomCloudConfigCSEScriptFilepath}} || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
 source {{GetCustomCloudConfigCSEScriptFilepath }}
 {{end}}
+
+if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
+  disable1804SystemdResolved
+fi
 
 set +x
 ETCD_PEER_CERT=$(echo ${ETCD_PEER_CERTIFICATES} | cut -d'[' -f 2 | cut -d']' -f 1 | cut -d',' -f $((NODE_INDEX + 1)))

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12228,13 +12228,9 @@ ensureChrony() {
   systemctlEnableAndStart chrony || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}
 }
 disable1804SystemdResolved() {
-  ls -ltr /etc/resolv.conf
-  cat /etc/resolv.conf
   {{/* Ignoring systemd-resolved query service but using its resolv.conf file */}}
   {{/* This is the simplest approach to workaround resolved issues without completely uninstall it */}}
   [ -f /run/systemd/resolve/resolv.conf ] && sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-  ls -ltr /etc/resolv.conf
-  cat /etc/resolv.conf
 }
 ensureRPC() {
   systemctlEnableAndStart rpcbind || exit {{GetCSEErrorCode "ERR_SYSTEMCTL_START_FAIL"}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12230,7 +12230,7 @@ ensureChrony() {
 disable1804SystemdResolved() {
   ls -ltr /etc/resolv.conf
   cat /etc/resolv.conf
-  {{/* Ingorings systemd-resolved query service but using its resolv.conf file */}}
+  {{/* Ignoring systemd-resolved query service but using its resolv.conf file */}}
   {{/* This is the simplest approach to workaround resolved issues without completely uninstall it */}}
   [ -f /run/systemd/resolve/resolv.conf ] && sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
   ls -ltr /etc/resolv.conf


### PR DESCRIPTION
**Reason for Change**:

Name resolution fails on Ubuntu 18.04 hosts because `/etc/resolv.conf` is not pointing to the correct name server.

Borrowing this fix: https://github.com/Azure/AgentBaker/blob/5018e82018f31f3b1fb9a26332f4c706b2d9f011/parts/linux/cloud-init/artifacts/cse_config.sh#L238-L253

**Issue Fixed**:

Related to https://github.com/Azure/AKS/issues/2052

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [x] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [x] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
