### PR TITLE
fix: Enable ipforwarding on agent nic for Azure CNI dualstack scenario

### DIFF
--- a/pkg/engine/networkinterfaces.go
+++ b/pkg/engine/networkinterfaces.go
@@ -200,6 +200,13 @@ func createPrivateClusterMasterVMNetworkInterface(cs *api.ContainerService) Netw
 		nicProperties.EnableIPForwarding = to.BoolPtr(true)
 	}
 
+	// Enable IPForwarding on NetworkInterface for azurecni dualstack
+	if isAzureCNI {
+		if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
+			nicProperties.EnableIPForwarding = to.BoolPtr(true)
+		}
+	}
+
 	linuxProfile := cs.Properties.LinuxProfile
 	if linuxProfile != nil && linuxProfile.HasCustomNodesDNS() {
 		nicProperties.DNSSettings = &network.InterfaceDNSSettings{
@@ -408,6 +415,13 @@ func createAgentVMASNetworkInterface(cs *api.ContainerService, profile *api.Agen
 
 	if !isAzureCNI && !cs.Properties.IsAzureStackCloud() {
 		networkInterface.EnableIPForwarding = to.BoolPtr(true)
+	}
+
+	// Enable IPForwarding on NetworkInterface for azurecni dualstack
+	if isAzureCNI {
+		if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
+			networkInterface.EnableIPForwarding = to.BoolPtr(true)
+		}
 	}
 
 	return NetworkInterfaceARM{

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -188,6 +188,13 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 		netintconfig.EnableIPForwarding = to.BoolPtr(true)
 	}
 
+	// Enable IPForwarding on NetworkInterface for azurecni dualstack
+	if isAzureCNI {
+		if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
+			netintconfig.EnableIPForwarding = to.BoolPtr(true)
+		}
+	}
+
 	networkProfile := compute.VirtualMachineScaleSetNetworkProfile{
 		NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 			netintconfig,
@@ -572,8 +579,16 @@ func CreateAgentVMSS(cs *api.ContainerService, profile *api.AgentPoolProfile) Vi
 		}
 	}
 
-	if !orchProfile.IsAzureCNI() && !cs.Properties.IsAzureStackCloud() {
+	isAzureCNI := orchProfile.IsAzureCNI()
+	if !isAzureCNI && !cs.Properties.IsAzureStackCloud() {
 		vmssNICConfig.EnableIPForwarding = to.BoolPtr(true)
+	}
+
+	// Enable IPForwarding on NetworkInterface for azurecni dualstack
+	if isAzureCNI {
+		if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
+			vmssNICConfig.EnableIPForwarding = to.BoolPtr(true)
+		}
 	}
 
 	vmssNetworkProfile := compute.VirtualMachineScaleSetNetworkProfile{

--- a/pkg/engine/virtualmachinescalesets_test.go
+++ b/pkg/engine/virtualmachinescalesets_test.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
-
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
-
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -620,6 +618,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					Primary:                     to.BoolPtr(true),
 					EnableAcceleratedNetworking: to.BoolPtr(true),
+					EnableIPForwarding:          to.BoolPtr(true),
 					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), false, true),
 				},
 			},
@@ -642,6 +641,7 @@ func TestCreateAgentVMSS(t *testing.T) {
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					Primary:                     to.BoolPtr(true),
 					EnableAcceleratedNetworking: to.BoolPtr(true),
+					EnableIPForwarding:          to.BoolPtr(true),
 					IPConfigurations:            getIPConfigs(to.StringPtr("/subscriptions/123/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/mySLB/backendAddressPools/mySLBBEPool"), true, true),
 				},
 			},


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Enable ipforwarding on agent nic for Azure CNI dualstack scenario. In dualstack, azure cni assigns overlay ipv6 addresses to pod and rely on udr for routing. Enabling ipforwarding is required to route traffic between pods. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
