### PR TITLE
test: retry create pod from file if not exist

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -916,7 +916,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 
 			By("Ensuring that we have stable and responsive DNS resolution")
-			p, err := pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "dns-loop.yaml"), "dns-loop", "default", 1*time.Second, cfg.Timeout)
+			p, err := pod.CreatePodFromFileIfNotExistWithRetry(filepath.Join(WorkloadDir, "dns-loop.yaml"), "dns-loop", "default", 1*time.Second, 1*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 			running, err := p.WaitOnReady(true, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
@@ -980,7 +980,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should be able to launch a long-running container networking DNS liveness pod", func() {
-			p, err := pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "dns-liveness.yaml"), "dns-liveness", "default", 1*time.Second, cfg.Timeout)
+			p, err := pod.CreatePodFromFileIfNotExistWithRetry(filepath.Join(WorkloadDir, "dns-liveness.yaml"), "dns-liveness", "default", 1*time.Second, 1*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 			running, err := p.WaitOnReady(true, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
@@ -988,7 +988,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should be able to restart a pod due to an exec livenessProbe failure", func() {
-			_, err := pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "exec-liveness.yaml"), "exec-liveness", "default", 1*time.Second, 2*time.Minute)
+			_, err := pod.CreatePodFromFileIfNotExistWithRetry(filepath.Join(WorkloadDir, "exec-liveness.yaml"), "exec-liveness", "default", 1*time.Second, 1*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(30 * time.Second) // Wait for probe to take effect
 			p, err := pod.Get("exec-liveness", "default", podLookupRetries)
@@ -998,7 +998,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			p.Describe()
 			Expect(restarts > 0).To(BeTrue())
 			Expect(p.Delete(util.DefaultDeleteRetries)).To(Succeed())
-			_, err = pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "exec-liveness-assume-1-second-default-timeout.yaml"), "exec-liveness-assume-1-second-default-timeout", "default", 1*time.Second, 2*time.Minute)
+			_, err = pod.CreatePodFromFileIfNotExistWithRetry(filepath.Join(WorkloadDir, "exec-liveness-assume-1-second-default-timeout.yaml"), "exec-liveness-assume-1-second-default-timeout", "default", 1*time.Second, 1*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(30 * time.Second) // Wait for probe to take effect
 			p, err = pod.Get("exec-liveness-assume-1-second-default-timeout", "default", podLookupRetries)
@@ -1014,7 +1014,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(restarts > 0).To(BeTrue())
 			}
 			Expect(p.Delete(util.DefaultDeleteRetries)).To(Succeed())
-			_, err = pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "exec-liveness-always-fail.yaml"), "exec-liveness-always-fail", "default", 1*time.Second, 2*time.Minute)
+			_, err = pod.CreatePodFromFileIfNotExistWithRetry(filepath.Join(WorkloadDir, "exec-liveness-always-fail.yaml"), "exec-liveness-always-fail", "default", 1*time.Second, 1*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(30 * time.Second) // Wait for probe to take effect
 			p, err = pod.Get("exec-liveness-always-fail", "default", podLookupRetries)
@@ -1027,7 +1027,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			// exec probe timeout is broken entirely for containerd prior to 1.20, and/or if ExecProbeTimeout=false, so we can't test it
 			if !(eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.NeedsContainerd() &&
 				(!common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.20.0") || strings.Contains(eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--feature-gates"], "ExecProbeTimeout=false"))) {
-				_, err = pod.CreatePodFromFileIfNotExist(filepath.Join(WorkloadDir, "exec-liveness-timeout-always-fail.yaml"), "exec-liveness-timeout-always-fail", "default", 1*time.Second, 2*time.Minute)
+				_, err = pod.CreatePodFromFileIfNotExistWithRetry(filepath.Join(WorkloadDir, "exec-liveness-timeout-always-fail.yaml"), "exec-liveness-timeout-always-fail", "default", 1*time.Second, 1*time.Minute)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(30 * time.Second) // Wait for probe to take effect
 				p, err = pod.Get("exec-liveness-timeout-always-fail", "default", podLookupRetries)

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -228,6 +228,49 @@ func CreatePodFromFileIfNotExist(filename, name, namespace string, sleep, timeou
 	return p, nil
 }
 
+// CreatePodFromFileIfNotExistAsync wraps CreatePodFromFileIfNotExist with a struct response for goroutine + channel usage
+func CreatePodFromFileIfNotExistAsync(filename, name, namespace string, sleep, timeout time.Duration) GetResult {
+	p, err := CreatePodFromFileIfNotExist(filename, name, namespace, sleep, timeout)
+	return GetResult{
+		pod: p,
+		err: err,
+	}
+}
+
+// CreatePodFromFileIfNotExistWithRetry will kubectl apply a Pod from file (if it doesn't exist already) with a name with retry toleration
+func CreatePodFromFileIfNotExistWithRetry(filename, name, namespace string, sleep, timeout time.Duration) (*Pod, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ch := make(chan GetResult)
+	var mostRecentCreatePodFromFileIfNotExistWithRetryWithRetryError error
+	var p *Pod
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				ch <- CreatePodFromFileIfNotExistAsync(filename, name, namespace, sleep, timeout)
+				time.Sleep(sleep)
+			}
+		}
+	}()
+	for {
+		select {
+		case result := <-ch:
+			mostRecentCreatePodFromFileIfNotExistWithRetryWithRetryError = result.err
+			p = result.pod
+			if mostRecentCreatePodFromFileIfNotExistWithRetryWithRetryError == nil {
+				if p != nil {
+					return p, nil
+				}
+			}
+		case <-ctx.Done():
+			return p, errors.Errorf("CreatePodFromFileIfNotExistWithRetry timed out: %s\n", mostRecentCreatePodFromFileIfNotExistWithRetryWithRetryError)
+		}
+	}
+}
+
 // RunLinuxPod will create a pod that runs a bash command
 // --overrides := `"spec": {"nodeSelector":{"kubernetes.io/os":"linux"}}}`
 func RunLinuxPod(image, name, namespace, command string, printOutput bool, sleep, commandTimeout, podGetTimeout time.Duration) (*Pod, error) {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

In response to recent flakes, this change adds retry tolerance to the "create pod from file if not exist" instances in the E2E test runner.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
