### PR TITLE
fix: ensure we delete init kube-addon-manager

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -432,10 +432,10 @@ ensureAddons() {
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
-  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
-  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
-  retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
-  exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  retrycmd 120 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s -l app=kube-addon-manager po -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  for initPod in $(${KUBECTL} get pod -l app=kube-addon-manager -n kube-system -o json | jq -r '.items[] | select(.spec.containers[0].env[] | select(.value=="/etc/kubernetes/addons/init")) | select(.status.phase=="Running") .metadata.name'); do
+    retrycmd 120 5 30 ${KUBECTL} delete pod $initPod -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  done
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
     sleep 3

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -434,8 +434,7 @@ ensureAddons() {
   while [ ! $(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --template={{.status.phase}}) == "Running"]; do
     sleep 3
   done
-    retrycmd 3 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
-    retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
+  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -432,7 +432,7 @@ ensureAddons() {
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
-  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po
+  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -431,7 +431,9 @@ ensureAddons() {
   rm -Rf ${ADDONS_DIR}/init
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
-  ADDON_POD_NAME=$(k get pods -l app=kube-addon-manager -n kube-system --no-headers -o custom-columns=":metadata.name")
+  {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
+  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po
+  ADDON_POD_NAME=$(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --no-headers -o custom-columns=":metadata.name")
   retrycmd 10 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system || \
   retrycmd 120 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -431,8 +431,11 @@ ensureAddons() {
   rm -Rf ${ADDONS_DIR}/init
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
-  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
-  retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
+  while [ ! $(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --template={{.status.phase}}) == "Running"]; do
+    sleep 3
+  done
+    retrycmd 3 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
+    retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -433,9 +433,8 @@ ensureAddons() {
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
   ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po
-  ADDON_POD_NAME=$(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --no-headers -o custom-columns=":metadata.name")
-  retrycmd 10 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system || \
-  retrycmd 120 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system --force --grace-period 0 || \
+  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
+  retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -432,7 +432,7 @@ ensureAddons() {
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
-  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS

--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -431,10 +431,9 @@ ensureAddons() {
   rm -Rf ${ADDONS_DIR}/init
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
-  while [ ! $(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --template={{.status.phase}}) == "Running"]; do
-    sleep 3
-  done
-  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
+  ADDON_POD_NAME=$(k get pods -l app=kube-addon-manager -n kube-system --no-headers -o custom-columns=":metadata.name")
+  retrycmd 10 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system || \
+  retrycmd 120 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12544,10 +12544,9 @@ ensureAddons() {
   rm -Rf ${ADDONS_DIR}/init
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
-  while [ ! $(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --template={{.status.phase}}) == "Running"]; do
-    sleep 3
-  done
-  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
+  ADDON_POD_NAME=$(k get pods -l app=kube-addon-manager -n kube-system --no-headers -o custom-columns=":metadata.name")
+  retrycmd 10 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system || \
+  retrycmd 120 5 30 ${KUBECTL} delete pod $ADDON_POD_NAME -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12545,7 +12545,7 @@ ensureAddons() {
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
-  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po
+  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12544,8 +12544,11 @@ ensureAddons() {
   rm -Rf ${ADDONS_DIR}/init
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
-  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
-  retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
+  while [ ! $(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --template={{.status.phase}}) == "Running"]; do
+    sleep 3
+  done
+    retrycmd 3 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
+    retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12547,8 +12547,7 @@ ensureAddons() {
   while [ ! $(${KUBECTL} get pods -l app=kube-addon-manager -n kube-system --template={{.status.phase}}) == "Running"]; do
     sleep 3
   done
-    retrycmd 3 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
-    retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
+  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12545,7 +12545,7 @@ ensureAddons() {
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
-  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
   retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
   exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12545,10 +12545,10 @@ ensureAddons() {
   replaceAddonsInit
   {{/* Force re-load all addons because we have changed the source location for addon specs */}}
   {{/* Wait for the kube-addon manager to be running see pr 4743  */}}
-  ${KUBECTL} wait --for=condition=Ready --timeout=5m -l app=kube-addon-manager po -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
-  retrycmd 10 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system || \
-  retrycmd 120 5 30 ${KUBECTL} delete pods -l app=kube-addon-manager -n kube-system --force --grace-period 0 || \
-  exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  retrycmd 120 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s -l app=kube-addon-manager po -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  for initPod in $(${KUBECTL} get pod -l app=kube-addon-manager -n kube-system -o json | jq -r '.items[] | select(.spec.containers[0].env[] | select(.value=="/etc/kubernetes/addons/init")) | select(.status.phase=="Running") .metadata.name'); do
+    retrycmd 120 5 30 ${KUBECTL} delete pod $initPod -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  done
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
     sleep 3


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR addresses the fact that we can't get valid error responses from kubectl get or delete using the --label argument.

Instead we now get the actual pod name of the init'ed kube-addon-manager, and delete it.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
