### PR TITLE
chore: remove iovisor apt dependencies

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -118,15 +118,6 @@ installMoby() {
     apt_get_install 20 30 120 ${install_pkgs} --allow-downgrades || exit 27
   fi
 }
-installBcc() {
-  local key=/tmp/iovisor-release.key url=https://repo.iovisor.org/GPG-KEY
-  retrycmd_no_stats 120 5 25 curl -fsSL $url >$key || exit 166
-  wait_for_apt_locks
-  retrycmd 30 5 30 apt-key add $key || exit 167
-  echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" >/etc/apt/sources.list.d/iovisor.list
-  apt_get_update || exit 99
-  apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit 168
-}
 downloadCNI() {
   mkdir -p $CNI_DOWNLOADS_DIR
   CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}

--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -81,9 +81,6 @@ if [[ $OS == $UBUNTU_OS_NAME || $OS == $DEBIAN_OS_NAME ]] && [ "$FULL_INSTALL_RE
   if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
     overrideNetworkConfig
   fi
-  if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    time_metric "InstallBcc" installBcc
-  fi
   {{- if not IsDockerContainerRuntime}}
   time_metric "InstallImg" installImg
   {{end}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -13485,15 +13485,6 @@ installMoby() {
     apt_get_install 20 30 120 ${install_pkgs} --allow-downgrades || exit 27
   fi
 }
-installBcc() {
-  local key=/tmp/iovisor-release.key url=https://repo.iovisor.org/GPG-KEY
-  retrycmd_no_stats 120 5 25 curl -fsSL $url >$key || exit 166
-  wait_for_apt_locks
-  retrycmd 30 5 30 apt-key add $key || exit 167
-  echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" >/etc/apt/sources.list.d/iovisor.list
-  apt_get_update || exit 99
-  apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit 168
-}
 downloadCNI() {
   mkdir -p $CNI_DOWNLOADS_DIR
   CNI_TGZ_TMP=${CNI_PLUGINS_URL##*/}
@@ -13714,9 +13705,6 @@ if [[ $OS == $UBUNTU_OS_NAME || $OS == $DEBIAN_OS_NAME ]] && [ "$FULL_INSTALL_RE
   time_metric "InstallDeps" installDeps
   if [[ ${UBUNTU_RELEASE} == "18.04" ]]; then
     overrideNetworkConfig
-  fi
-  if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    time_metric "InstallBcc" installBcc
   fi
   {{- if not IsDockerContainerRuntime}}
   time_metric "InstallImg" installImg

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -45,7 +45,6 @@ apt packages:
   - jq
   - libpam-pwquality
   - libpwquality-tools
-  - linux-headers-$(uname -r)
   - make
   - mount
   - nfs-common
@@ -95,12 +94,6 @@ ETCD_VERSION="3.3.25"
 ETCD_DOWNLOAD_URL="mcr.microsoft.com/oss/etcd-io/"
 installEtcd "docker"
 echo "  - etcd v${ETCD_VERSION}" >> ${VHD_LOGS_FILEPATH}
-
-installBcc
-cat << EOF >> ${VHD_LOGS_FILEPATH}
-  - bcc-tools
-  - libbcc-examples
-EOF
 
 VNET_CNI_VERSIONS="
 1.4.14


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR removes the installation of apt packages that depend upon https://repo.iovisor.org in reponse to intermittent unavailability of that endpoint. These packages were implemented on behalf of AKS, which no longer uses aks-engine to maintain that requirement.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
