### PR TITLE
fix: ensure iovisor is not present in apt config

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 ERR_FILE_WATCH_TIMEOUT=6 {{/* Timeout waiting for a file */}}
 
+{{/* delete non-working iovisor definition to ensure apt operations work */}}
+rm -Rf /etc/apt/sources.list.d/iovisor.list
+
 set -x
 if [ -f /opt/azure/containers/provision.complete ]; then
   exit 0

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17718,6 +17718,9 @@ func k8sCloudInitArtifactsCse_installSh() (*asset, error) {
 var _k8sCloudInitArtifactsCse_mainSh = []byte(`#!/bin/bash
 ERR_FILE_WATCH_TIMEOUT=6 {{/* Timeout waiting for a file */}}
 
+{{/* delete non-working iovisor definition to ensure apt operations work */}}
+rm -Rf /etc/apt/sources.list.d/iovisor.list
+
 set -x
 if [ -f /opt/azure/containers/provision.complete ]; then
   exit 0


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This is a follow-up from #4744, to ensure that if we are using a VHD built w/ the iovisor apt configuration, we delete that configuration at the beginning of our bootstrap scripts.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
