### PR TITLE
chore: update containerd versions

### DIFF
--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -238,9 +238,9 @@
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.4.11",
+      "defaultValue": "1.5.8",
       "metadata": {
-        "description": "The Azure Moby build version"
+        "description": "The Azure containerd build version"
       },
       "allowedValues": [
          "1.3.2",
@@ -256,7 +256,8 @@
          "1.4.7",
          "1.4.8",
          "1.4.9",
-         "1.4.11"
+         "1.4.11",
+         "1.5.8"
        ],
       "type": "string"
     },

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -238,7 +238,7 @@
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.4.6",
+      "defaultValue": "1.4.11",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -252,7 +252,11 @@
          "1.3.8",
          "1.3.9",
          "1.4.4",
-         "1.4.6"
+         "1.4.6",
+         "1.4.7",
+         "1.4.8",
+         "1.4.9",
+         "1.4.11"
        ],
       "type": "string"
     },

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -238,7 +238,7 @@
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.5.8",
+      "defaultValue": "1.4.11",
       "metadata": {
         "description": "The Azure containerd build version"
       },
@@ -256,8 +256,7 @@
          "1.4.7",
          "1.4.8",
          "1.4.9",
-         "1.4.11",
-         "1.5.8"
+         "1.4.11"
        ],
       "type": "string"
     },

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -448,7 +448,7 @@ const (
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
 	DefaultMobyVersion = "20.10.11"
 	// DefaultContainerdVersion specifies the default containerd version to install.
-	DefaultContainerdVersion = "1.4.11"
+	DefaultContainerdVersion = "1.5.8"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
 	DefaultDockerBridgeSubnet = "172.17.0.1/16"
 	// DefaultKubernetesMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.
@@ -470,7 +470,7 @@ const (
 	// DefaultWindowsSSHEnabled is the default windowsProfile.sshEnabled value
 	DefaultWindowsSSHEnabled = true
 	// DefaultWindowsContainerdURL is the URL for the default containerd package on Windows
-	DefaultWindowsContainerdURL = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.11+azure/windows/windows_amd64/moby-containerd-1.4.11+azure-1.amd64.zip"
+	DefaultWindowsContainerdURL = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.5.8+azure/windows/windows_amd64/moby-containerd-1.5.8+azure-1.amd64.zip"
 )
 
 // WindowsProfile defaults

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -448,7 +448,7 @@ const (
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
 	DefaultMobyVersion = "20.10.11"
 	// DefaultContainerdVersion specifies the default containerd version to install.
-	DefaultContainerdVersion = "1.5.8"
+	DefaultContainerdVersion = "1.4.11"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
 	DefaultDockerBridgeSubnet = "172.17.0.1/16"
 	// DefaultKubernetesMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -448,7 +448,7 @@ const (
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
 	DefaultMobyVersion = "20.10.11"
 	// DefaultContainerdVersion specifies the default containerd version to install.
-	DefaultContainerdVersion = "1.4.6"
+	DefaultContainerdVersion = "1.4.11"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
 	DefaultDockerBridgeSubnet = "172.17.0.1/16"
 	// DefaultKubernetesMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.
@@ -470,7 +470,7 @@ const (
 	// DefaultWindowsSSHEnabled is the default windowsProfile.sshEnabled value
 	DefaultWindowsSSHEnabled = true
 	// DefaultWindowsContainerdURL is the URL for the default containerd package on Windows
-	DefaultWindowsContainerdURL = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.6+azure/windows/windows_amd64/moby-containerd-1.4.6+azure-1.amd64.zip"
+	DefaultWindowsContainerdURL = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.11+azure/windows/windows_amd64/moby-containerd-1.4.11+azure-1.amd64.zip"
 )
 
 // WindowsProfile defaults

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -6115,9 +6115,9 @@ func ExampleContainerService_setOrchestratorDefaults() {
 
 	// Output:
 	// level=warning msg="Moby will be upgraded to version 20.10.11\n"
-	// level=warning msg="containerd will be upgraded to version 1.4.11\n"
+	// level=warning msg="containerd will be upgraded to version 1.5.8\n"
 	// level=warning msg="Any new nodes will have Moby version 20.10.11\n"
-	// level=warning msg="Any new nodes will have containerd version 1.4.11\n"
+	// level=warning msg="Any new nodes will have containerd version 1.5.8\n"
 }
 
 func TestCombineValues(t *testing.T) {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -6115,9 +6115,9 @@ func ExampleContainerService_setOrchestratorDefaults() {
 
 	// Output:
 	// level=warning msg="Moby will be upgraded to version 20.10.11\n"
-	// level=warning msg="containerd will be upgraded to version 1.4.6\n"
+	// level=warning msg="containerd will be upgraded to version 1.4.11\n"
 	// level=warning msg="Any new nodes will have Moby version 20.10.11\n"
-	// level=warning msg="Any new nodes will have containerd version 1.4.6\n"
+	// level=warning msg="Any new nodes will have containerd version 1.4.11\n"
 }
 
 func TestCombineValues(t *testing.T) {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -6115,9 +6115,9 @@ func ExampleContainerService_setOrchestratorDefaults() {
 
 	// Output:
 	// level=warning msg="Moby will be upgraded to version 20.10.11\n"
-	// level=warning msg="containerd will be upgraded to version 1.5.8\n"
+	// level=warning msg="containerd will be upgraded to version 1.4.11\n"
 	// level=warning msg="Any new nodes will have Moby version 20.10.11\n"
-	// level=warning msg="Any new nodes will have containerd version 1.5.8\n"
+	// level=warning msg="Any new nodes will have containerd version 1.4.11\n"
 }
 
 func TestCombineValues(t *testing.T) {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -38,7 +38,7 @@ var (
 		"3.1.0", "3.1.1", "3.1.2", "3.1.2", "3.1.3", "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8", "3.1.9", "3.1.10",
 		"3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.8", "3.2.9", "3.2.11", "3.2.12",
 		"3.2.13", "3.2.14", "3.2.15", "3.2.16", "3.2.23", "3.2.24", "3.2.25", "3.2.26", "3.3.0", "3.3.1", "3.3.8", "3.3.9", "3.3.10", "3.3.13", "3.3.15", "3.3.18", "3.3.19", "3.3.22", "3.3.25"}
-	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6", "1.4.7", "1.4.8", "1.4.9", "1.4.11", "1.5.8"}
+	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6", "1.4.7", "1.4.8", "1.4.9", "1.4.11"}
 	kubernetesImageBaseTypeValidVersions = [...]string{"", common.KubernetesImageBaseTypeGCR, common.KubernetesImageBaseTypeMCR}
 	cachingTypesValidValues              = [...]string{"", string(compute.CachingTypesNone), string(compute.CachingTypesReadWrite), string(compute.CachingTypesReadOnly)}
 	linuxEth0MTUAllowedValues            = [...]int{1500, 3900}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -38,7 +38,7 @@ var (
 		"3.1.0", "3.1.1", "3.1.2", "3.1.2", "3.1.3", "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8", "3.1.9", "3.1.10",
 		"3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.8", "3.2.9", "3.2.11", "3.2.12",
 		"3.2.13", "3.2.14", "3.2.15", "3.2.16", "3.2.23", "3.2.24", "3.2.25", "3.2.26", "3.3.0", "3.3.1", "3.3.8", "3.3.9", "3.3.10", "3.3.13", "3.3.15", "3.3.18", "3.3.19", "3.3.22", "3.3.25"}
-	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6", "1.4.7", "1.4.8", "1.4.9", "1.4.11"}
+	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6", "1.4.7", "1.4.8", "1.4.9", "1.4.11", "1.5.8"}
 	kubernetesImageBaseTypeValidVersions = [...]string{"", common.KubernetesImageBaseTypeGCR, common.KubernetesImageBaseTypeMCR}
 	cachingTypesValidValues              = [...]string{"", string(compute.CachingTypesNone), string(compute.CachingTypesReadWrite), string(compute.CachingTypesReadOnly)}
 	linuxEth0MTUAllowedValues            = [...]int{1500, 3900}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -38,7 +38,7 @@ var (
 		"3.1.0", "3.1.1", "3.1.2", "3.1.2", "3.1.3", "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8", "3.1.9", "3.1.10",
 		"3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.8", "3.2.9", "3.2.11", "3.2.12",
 		"3.2.13", "3.2.14", "3.2.15", "3.2.16", "3.2.23", "3.2.24", "3.2.25", "3.2.26", "3.3.0", "3.3.1", "3.3.8", "3.3.9", "3.3.10", "3.3.13", "3.3.15", "3.3.18", "3.3.19", "3.3.22", "3.3.25"}
-	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6"}
+	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6", "1.4.7", "1.4.8", "1.4.9", "1.4.11"}
 	kubernetesImageBaseTypeValidVersions = [...]string{"", common.KubernetesImageBaseTypeGCR, common.KubernetesImageBaseTypeMCR}
 	cachingTypesValidValues              = [...]string{"", string(compute.CachingTypesNone), string(compute.CachingTypesReadWrite), string(compute.CachingTypesReadOnly)}
 	linuxEth0MTUAllowedValues            = [...]int{1500, 3900}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -64,7 +64,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6 1.4.7 1.4.8 1.4.9 1.4.11 1.5.8]",
+			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6 1.4.7 1.4.8 1.4.9 1.4.11]",
 		},
 		"should error when KubernetesConfig has containerdVersion value for docker container runtime": {
 			properties: &Properties{

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -64,7 +64,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6]",
+			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6 1.4.7 1.4.8 1.4.9 1.4.11]",
 		},
 		"should error when KubernetesConfig has containerdVersion value for docker container runtime": {
 			properties: &Properties{

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -64,7 +64,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6 1.4.7 1.4.8 1.4.9 1.4.11]",
+			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6 1.4.7 1.4.8 1.4.9 1.4.11 1.5.8]",
 		},
 		"should error when KubernetesConfig has containerdVersion value for docker container runtime": {
 			properties: &Properties{

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -21048,9 +21048,9 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.4.11",
+      "defaultValue": "1.5.8",
       "metadata": {
-        "description": "The Azure Moby build version"
+        "description": "The Azure containerd build version"
       },
       "allowedValues": [
          "1.3.2",
@@ -21066,7 +21066,8 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
          "1.4.7",
          "1.4.8",
          "1.4.9",
-         "1.4.11"
+         "1.4.11",
+         "1.5.8"
        ],
       "type": "string"
     },

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -21048,7 +21048,7 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.4.6",
+      "defaultValue": "1.4.11",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -21062,7 +21062,11 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
          "1.3.8",
          "1.3.9",
          "1.4.4",
-         "1.4.6"
+         "1.4.6",
+         "1.4.7",
+         "1.4.8",
+         "1.4.9",
+         "1.4.11"
        ],
       "type": "string"
     },

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -21048,7 +21048,7 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.5.8",
+      "defaultValue": "1.4.11",
       "metadata": {
         "description": "The Azure containerd build version"
       },
@@ -21066,8 +21066,7 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
          "1.4.7",
          "1.4.8",
          "1.4.9",
-         "1.4.11",
-         "1.5.8"
+         "1.4.11"
        ],
       "type": "string"
     },

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 
 filter Timestamp { "$(Get-Date -Format o): $_" }
 
-$global:containerdPackageUrl = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.11+azure/windows/windows_amd64/moby-containerd-1.4.11+azure-1.amd64.zip"
+$global:containerdPackageUrl = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.5.8+azure/windows/windows_amd64/moby-containerd-1.5.8+azure-1.amd64.zip"
 
 function Write-Log($Message) {
     $msg = $message | Timestamp

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 
 filter Timestamp { "$(Get-Date -Format o): $_" }
 
-$global:containerdPackageUrl = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.6+azure/windows/windows_amd64/moby-containerd-1.4.6+azure-1.amd64.zip"
+$global:containerdPackageUrl = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.11+azure/windows/windows_amd64/moby-containerd-1.4.11+azure-1.amd64.zip"
 
 function Write-Log($Message) {
     $msg = $message | Timestamp

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -82,7 +82,7 @@ installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
 MOBY_VERSION="20.10.11"
-CONTAINERD_VERSION="1.4.11"
+CONTAINERD_VERSION="1.5.8"
 installMoby
 installRunc
 systemctl_restart 100 5 30 docker || exit 1

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -82,7 +82,7 @@ installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
 MOBY_VERSION="20.10.11"
-CONTAINERD_VERSION="1.5.8"
+CONTAINERD_VERSION="1.4.11"
 installMoby
 installRunc
 systemctl_restart 100 5 30 docker || exit 1

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -82,7 +82,7 @@ installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
 MOBY_VERSION="20.10.11"
-CONTAINERD_VERSION="1.4.6"
+CONTAINERD_VERSION="1.4.11"
 installMoby
 installRunc
 systemctl_restart 100 5 30 docker || exit 1


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR updates the default version of containerd delivered to containerd-enabled clusters to 1.5.8 for Windows nodes and 1.4.11 for Linux nodes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
