### PR TITLE
fix: Update Windows dynamic port range

### DIFF
--- a/parts/k8s/windowsconfigfunc.ps1
+++ b/parts/k8s/windowsconfigfunc.ps1
@@ -141,8 +141,12 @@ function Adjust-DynamicPortRange()
     # to ~225 services if default port reservations are used.
     # https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#load-balancers-are-plumbed-inconsistently-across-the-cluster-nodes
     # Kube-proxy load balancing should be set to DSR mode when it releases with future versions of the OS
+    #
+    # The fix which reduces dynamic port usage for non-DSR load balancers is shiped with KB4550969 in April 2020
+    # Update the range to [33000, 65535] to avoid that it conflicts with NodePort range (30000 - 32767)
+    # Will remove this after WinDSR is enabled by default
 
-    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "16385", "49151")
+    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "33000", "32536")
 }
 
 # TODO: should this be in this PR?

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -23417,8 +23417,12 @@ function Adjust-DynamicPortRange()
     # to ~225 services if default port reservations are used.
     # https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#load-balancers-are-plumbed-inconsistently-across-the-cluster-nodes
     # Kube-proxy load balancing should be set to DSR mode when it releases with future versions of the OS
+    #
+    # The fix which reduces dynamic port usage for non-DSR load balancers is shiped with KB4550969 in April 2020
+    # Update the range to [33000, 65535] to avoid that it conflicts with NodePort range (30000 - 32767)
+    # Will remove this after WinDSR is enabled by default
 
-    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "16385", "49151")
+    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "33000", "32536")
 }
 
 # TODO: should this be in this PR?


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
The fix which reduces dynamic port usage for non-DSR load balancers is shiped with KB4550969 in April 2020
Update the range to [33000, 65535] to avoid that it conflicts with NodePort range (30000 - 32767)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
