### PR TITLE
Remove api-server --insecure-port for versions greater than 1.20

### DIFF
--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -20,7 +20,6 @@ func (cs *ContainerService) setAPIServerConfig() {
 		"--advertise-address":           "<advertiseAddr>",
 		"--allow-privileged":            "true",
 		"--audit-log-path":              "/var/log/kubeaudit/audit.log",
-		"--insecure-port":               "0",
 		"--secure-port":                 "443",
 		"--service-account-lookup":      "true",
 		"--etcd-certfile":               "/etc/kubernetes/certs/etcdclient.crt",
@@ -103,6 +102,10 @@ func (cs *ContainerService) setAPIServerConfig() {
 	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.20.0-alpha.1") {
 		defaultAPIServerConfig["--service-account-issuer"] = "https://kubernetes.default.svc.cluster.local"
 		defaultAPIServerConfig["--service-account-signing-key-file"] = "/etc/kubernetes/certs/apiserver.key"
+	}
+
+	if !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.20.0-alpha.0") {
+		defaultAPIServerConfig["--insecure-port"] = "0"
 	}
 
 	// Set default admission controllers

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -495,6 +495,65 @@ func TestAPIServerFeatureGates(t *testing.T) {
 	}
 }
 
+func TestAPIServerInsecureFlag(t *testing.T) {
+	type apiServerTest struct {
+		version string
+		found   bool
+	}
+
+	apiTests := []apiServerTest{
+		{
+			version: "1.19.16",
+			found:   true,
+		},
+		{
+			version: "1.20.0",
+			found:   false,
+		},
+		{
+			version: "1.21.0",
+			found:   false,
+		},
+		{
+			version: "1.22.0",
+			found:   false,
+		},
+		{
+			version: "1.23.0",
+			found:   false,
+		},
+		{
+			version: "1.24.0",
+			found:   false,
+		},
+		{
+			version: "1.24.0-alpha.0",
+			found:   false,
+		},
+		{
+			version: "1.24.0-alpha.1-24",
+			found:   false,
+		},
+	}
+
+	for _, tt := range apiTests {
+		cs := CreateMockContainerService("testcluster", tt.version, 3, 2, false)
+		cs.setAPIServerConfig()
+		a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+
+		v, found := a["--insecure-port"]
+		if found != tt.found {
+			t.Fatalf("got found %t want %t", found, tt.found)
+		}
+
+		if tt.found && v != "0" {
+			t.Fatalf("got unexpected '--insecure-port' API server config value for k8s v%s: %s",
+				defaultTestClusterVer, a["--insecure-port"])
+		}
+	}
+
+}
+
 func TestAPIServerIPv6Only(t *testing.T) {
 	cs := CreateMockContainerService("testcluster", "", 3, 2, false)
 	cs.Properties.FeatureFlags = &FeatureFlags{EnableIPv6Only: true}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
This flag was removed in 1.24+  https://github.com/kubernetes/kubernetes/commit/9573b4a6b993aaa2238d347419ffe7c4b8005c94 and windows jobs are failing: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd/1469025482350530560

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
