### PR TITLE
fix: Azure CNI IP address allocation for win nodes

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -628,7 +628,11 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 				// Allocate IP addresses for pods if VNET integration is enabled.
 				if cs.Properties.OrchestratorProfile.IsAzureCNI() {
 					agentPoolMaxPods, _ := strconv.Atoi(profile.KubernetesConfig.KubeletConfig["--max-pods"])
-					profile.IPAddressCount = getPodIPAddressCountForAzureCNI(agentPoolMaxPods, o.KubernetesConfig)
+					if profile.IsWindows() {
+						profile.IPAddressCount += agentPoolMaxPods
+					} else {
+						profile.IPAddressCount = getPodIPAddressCountForAzureCNI(agentPoolMaxPods, o.KubernetesConfig)
+					}
 				}
 			}
 		}

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -5762,14 +5762,15 @@ func TestDefaultIPAddressCount(t *testing.T) {
 							Name: "pool1",
 						},
 						{
-							Name: "pool2",
+							Name:   "pool2",
+							OSType: Windows,
 						},
 					},
 				},
 			},
 			expectedMaster: DefaultKubernetesMaxPodsVNETIntegrated + 1,
 			expectedPool0:  DefaultKubernetesMaxPodsVNETIntegrated + 1 - numHostNetworkAddonsEnabledByDefault,
-			expectedPool1:  DefaultKubernetesMaxPodsVNETIntegrated + 1 - numHostNetworkAddonsEnabledByDefault,
+			expectedPool1:  DefaultKubernetesMaxPodsVNETIntegrated + 1,
 		},
 		{
 			name: "Azure CNI + custom IPAddressCount",


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR addresses an edge case from #4689: Windows nodes do not run hostNetwork pods from any of the available addons, and so those nodes may pre-allocate IPs according to the complete max-pods configuration for a ~accurate estimate of always having enough IP addresses as there will be pods running.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
