### PR TITLE
ci: removing flaky log rotation test for Windows nodes

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2529,36 +2529,6 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
-		// verifies that the pod logs continue to flow even during rotation
-		// https://github.com/Azure/aks-engine/issues/3573
-		It("should be able to rotate docker logs", func() {
-			if !eng.HasWindowsAgents() {
-				Skip("No windows agent was provisioned for this Cluster Definition")
-			}
-
-			if !eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.RequiresDocker() {
-				Skip("Skip docker validations on non-docker-backed clusters")
-			}
-
-			windowsImages, err := eng.GetWindowsTestImages()
-			loggingPodFile, err := pod.ReplaceContainerImageFromFile(filepath.Join(WorkloadDir, "validate-windows-logging.yaml"), windowsImages.ServerCore)
-			Expect(err).NotTo(HaveOccurred())
-			defer os.Remove(loggingPodFile)
-
-			By("launching a pod that logs too much")
-			podName := "validate-windows-logging" // should be the same as in iis-azurefile.yaml
-			loggingPod, err := pod.CreatePodFromFileWithRetry(loggingPodFile, podName, "default", 1*time.Second, cfg.Timeout)
-			Expect(err).NotTo(HaveOccurred())
-			ready, err := loggingPod.WaitOnReady(false, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ready).To(Equal(true))
-
-			By("validating the logs continue to flow")
-			logsRotated, err := loggingPod.ValidateLogsRotate(20*time.Second, 2*time.Minute)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(logsRotated).To(Equal(true))
-		})
-
 		// metrics endpoints failing in 1.18+
 		// https://github.com/kubernetes/kubernetes/issues/95735
 		It("windows should be able to get node metrics when high cpu", func() {


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
This test case was added to validate issues with log rotation in Moby (https://github.com/Azure/aks-engine/issues/3573)
The test has become flakey and this is not the proper place to do validation, so we'll remove it.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
