### PR TITLE
fix: resumeClusterAutoscaler nil dereference in rotate-certs

### DIFF
--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -255,11 +255,13 @@ func (rcc *rotateCertsCmd) run() (err error) {
 	if !rcc.force {
 		var resumeClusterAutoscaler func() error
 		resumeClusterAutoscaler, err = ops.PauseClusterAutoscaler(rcc.kubeClient)
-		defer func() {
-			if e := resumeClusterAutoscaler(); e != nil {
-				log.Warn(e)
-			}
-		}()
+		if resumeClusterAutoscaler != nil {
+			defer func() {
+				if e := resumeClusterAutoscaler(); e != nil {
+					log.Warn(e)
+				}
+			}()
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR addresses one nil pointer dereference opportunity in the rotate-certs flow.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
