### PR TITLE
feat: Updating script used to run kubelet to not set docker-specific kubelet args when using containerd

### DIFF
--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -318,7 +318,16 @@ func removeKubeletFlags(k map[string]string, v string) {
 
 	// Remove dockershim related flags in v1.24 and up
 	if common.IsKubernetesVersionGe(v, "1.24.0-alpha") {
-		for _, key := range []string{"--image-pull-progress-deadline", "--network-plugin"} {
+		for _, key := range []string{
+			"--cni-conf-dir",
+			"--cni-bin-dir",
+			"--cni-cache-dir",
+			"--docker-endpoint",
+			"--experimental-dockershim-root-directory",
+			"--image-pull-progress-deadline",
+			"--network-plugin",
+			"--network-plugin-mtu",
+		} {
 			delete(k, key)
 		}
 	}

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -2423,9 +2423,15 @@ func TestRemoveKubeletFlags(t *testing.T) {
 		{
 			name: "v1.24.0",
 			kubeletConfig: map[string]string{
-				"--image-pull-progress-deadline": "30m",
-				"--network-plugin":               "cni",
-				"--pod-max-pids":                 "100",
+				"--cni-conf-dir":    "/opt/cni/conf",
+				"--cni-bin-dir":     "/opt/cni/bin",
+				"--cni-cache-dir":   "/opt/cni/cache",
+				"--docker-endpoint": "/docker.sock",
+				"--experimental-dockershim-root-directory": "/some/dir",
+				"--image-pull-progress-deadline":           "30m",
+				"--network-plugin":                         "cni",
+				"--network-plugin-mtu":                     "2000",
+				"--pod-max-pids":                           "100",
 			},
 			expected: map[string]string{
 				"--pod-max-pids": "100",

--- a/staging/provisioning/windows/kubeletstart.ps1
+++ b/staging/provisioning/windows/kubeletstart.ps1
@@ -39,17 +39,21 @@ $KubeletArgList += "--volume-plugin-dir=$global:VolumePluginDir"
 # If you are thinking about adding another arg here, you should be considering pkg/engine/defaults-kubelet.go first
 # Only args that need to be calculated or combined with other ones on the Windows agent should be added here.
 
-# Configure kubelet to use CNI plugins if enabled.
-if ($NetworkPlugin -eq "azure") {
-    $KubeletArgList += @("--cni-bin-dir=$AzureCNIBinDir", "--cni-conf-dir=$AzureCNIConfDir")
-}
-elseif ($NetworkPlugin -eq "kubenet") {
-    $KubeletArgList += @("--cni-bin-dir=$CNIPath", "--cni-conf-dir=$CNIConfigPath")
-    # handle difference in naming between Linux & Windows reference plugin
-    $KubeletArgList = $KubeletArgList -replace "kubenet", "cni"
-}
-else {
-    throw "Unknown network type $NetworkPlugin, can't configure kubelet"
+
+if ($global:ContainerRuntime -eq "docker") {
+    # Configure kubelet to use CNI plugins if enabled.
+    # Note: --cni-bin-dir and --cni-conf-dir kubelet args are only used with dockershim and have been removed in v1.24
+    if ($NetworkPlugin -eq "azure") {
+        $KubeletArgList += @("--cni-bin-dir=$AzureCNIBinDir", "--cni-conf-dir=$AzureCNIConfDir")
+    }
+    elseif ($NetworkPlugin -eq "kubenet") {
+        $KubeletArgList += @("--cni-bin-dir=$CNIPath", "--cni-conf-dir=$CNIConfigPath")
+        # handle difference in naming between Linux & Windows reference plugin
+        $KubeletArgList = $KubeletArgList -replace "kubenet", "cni"
+    }
+    else {
+        throw "Unknown network type $NetworkPlugin, can't configure kubelet"
+    }
 }
 
 # Update args to use ContainerD if needed


### PR DESCRIPTION

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Some of the recently deprecated kubelet flags were getting set by the powershell script that starts/runs kubelet.exe on Windows nodes.
This PR updates that logic to only set dockershim specific kubelet flags if usinig dockershim.

Note: We'll need to sign these scripts and create another signed provisioning scripts package

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
