### PR TITLE
chore: only label nodes with kubernetes.io/role if they need it

### DIFF
--- a/parts/k8s/cloud-init/artifacts/label-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/label-nodes.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-# Applies missing master and agent labels to Kubernetes nodes.
+# This script looks for nodes that don't have the required kubernetes.io/role label,
+# and then labels them appropriately
 #
-# Kubelet 1.16+ rejects the `kubernetes.io/role` and `node-role.kubernetes.io`
-# labels in its `--node-labels` argument, but they need to be present for
-# backward compatibility.
+# Because nodes can't self-label their role in this way,
+# we need control plane nodes to do this continually
+# to ensure that new nodes get the role labels quickly
 
 set -euo pipefail
 

--- a/parts/k8s/cloud-init/artifacts/label-nodes.sh
+++ b/parts/k8s/cloud-init/artifacts/label-nodes.sh
@@ -12,10 +12,10 @@ set -euo pipefail
 KUBECONFIG="$(find /home/*/.kube/config)"
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
 
-MASTER_SELECTOR="kubernetes.azure.com/role!=agent,kubernetes.io/role!=agent"
-MASTER_LABELS="kubernetes.azure.com/role=master kubernetes.io/role=master node-role.kubernetes.io/master="
-AGENT_SELECTOR="kubernetes.azure.com/role!=master,kubernetes.io/role!=master"
-AGENT_LABELS="kubernetes.azure.com/role=agent kubernetes.io/role=agent node-role.kubernetes.io/agent="
+MASTER_SELECTOR="kubernetes.azure.com/role=master,kubernetes.io/role!=master,node-role.kubernetes.io/master!="
+MASTER_LABELS="kubernetes.io/role=master node-role.kubernetes.io/master="
+AGENT_SELECTOR="kubernetes.azure.com/role=agent,kubernetes.io/role!=agent,node-role.kubernetes.io/agent!="
+AGENT_LABELS="kubernetes.io/role=agent node-role.kubernetes.io/agent="
 
 ${KUBECTL} label nodes --overwrite -l $MASTER_SELECTOR $MASTER_LABELS
 ${KUBECTL} label nodes --overwrite -l $AGENT_SELECTOR $AGENT_LABELS

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18871,11 +18871,12 @@ func k8sCloudInitArtifactsLabelNodesService() (*asset, error) {
 
 var _k8sCloudInitArtifactsLabelNodesSh = []byte(`#!/usr/bin/env bash
 
-# Applies missing master and agent labels to Kubernetes nodes.
+# This script looks for nodes that don't have the required kubernetes.io/role label,
+# and then labels them appropriately
 #
-# Kubelet 1.16+ rejects the ` + "`" + `kubernetes.io/role` + "`" + ` and ` + "`" + `node-role.kubernetes.io` + "`" + `
-# labels in its ` + "`" + `--node-labels` + "`" + ` argument, but they need to be present for
-# backward compatibility.
+# Because nodes can't self-label their role in this way,
+# we need control plane nodes to do this continually
+# to ensure that new nodes get the role labels quickly
 
 set -euo pipefail
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -18883,10 +18883,10 @@ set -euo pipefail
 KUBECONFIG="$(find /home/*/.kube/config)"
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
 
-MASTER_SELECTOR="kubernetes.azure.com/role!=agent,kubernetes.io/role!=agent"
-MASTER_LABELS="kubernetes.azure.com/role=master kubernetes.io/role=master node-role.kubernetes.io/master="
-AGENT_SELECTOR="kubernetes.azure.com/role!=master,kubernetes.io/role!=master"
-AGENT_LABELS="kubernetes.azure.com/role=agent kubernetes.io/role=agent node-role.kubernetes.io/agent="
+MASTER_SELECTOR="kubernetes.azure.com/role=master,kubernetes.io/role!=master,node-role.kubernetes.io/master!="
+MASTER_LABELS="kubernetes.io/role=master node-role.kubernetes.io/master="
+AGENT_SELECTOR="kubernetes.azure.com/role=agent,kubernetes.io/role!=agent,node-role.kubernetes.io/agent!="
+AGENT_LABELS="kubernetes.io/role=agent node-role.kubernetes.io/agent="
 
 ${KUBECTL} label nodes --overwrite -l $MASTER_SELECTOR $MASTER_LABELS
 ${KUBECTL} label nodes --overwrite -l $AGENT_SELECTOR $AGENT_LABELS

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2802,6 +2802,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 				labels := n.Metadata.Labels
 				Expect(labels).To(HaveKeyWithValue("kubernetes.io/role", role))
+				Expect(labels).To(HaveKeyWithValue(fmt.Sprintf("node-role.kubernetes.io/%s", role), ""))
 				Expect(labels).To(HaveKey(fmt.Sprintf("node-role.kubernetes.io/%s", role)))
 				if role == "master" && common.IsKubernetesVersionGe(
 					eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.17.1") {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR updates the way we idempotently enforce `kubernetes.io/role` node labels. Instead of redoing it blindly every minute forever, we only do it if the required labels aren't present.

The key part of the change is the way we filter out nodes (by label) for labeling. As an example:

Was:

- Filter by nodes with label `kubernetes.azure.com/role!=master,kubernetes.io/role!=master`
  - This filter will *always* return a set of non-control-plane-labeled nodes.

Now:

- Filter by nodes with label `kubernetes.azure.com/role=agent,kubernetes.io/role!=agent,node-role.kubernetes.io/agent!=`
  - This filter returns nodes that have the `kubernetes.azure.com/role=agent` label (delivered via kubelet config args when node joins cluster), but have the missing or incorrect `kubernetes.io/role` and `node-role.kubernetes.io/agent` labels.

The key point above is when we have a set of nodes using the new filters, we apply the desired labels such that the next time we query for nodes those recently labeled nodes are not included in the next query. This results in far fewer, actual `kubectl label nodes` write operations, as the label selector we use to label nodes will only be non-empty when a new node has recently come online.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
