### PR TITLE
fix: update APIVersion for Kubernetes resources

### DIFF
--- a/parts/k8s/addons/aad-pod-identity.yaml
+++ b/parts/k8s/addons/aad-pod-identity.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureassignedidentities.aadpodidentity.k8s.io
@@ -22,7 +22,7 @@ spec:
     plural: azureassignedidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentitybindings.aadpodidentity.k8s.io
@@ -37,7 +37,7 @@ spec:
     plural: azureidentitybindings
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentities.aadpodidentity.k8s.io
@@ -53,7 +53,7 @@ spec:
     plural: azureidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azurepodidentityexceptions.aadpodidentity.k8s.io
@@ -93,7 +93,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-nmi-binding
@@ -236,7 +236,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-mic-binding

--- a/parts/k8s/addons/aad-pod-identity.yaml
+++ b/parts/k8s/addons/aad-pod-identity.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureassignedidentities.aadpodidentity.k8s.io
@@ -22,7 +22,7 @@ spec:
     plural: azureassignedidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentitybindings.aadpodidentity.k8s.io
@@ -37,7 +37,7 @@ spec:
     plural: azureidentitybindings
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentities.aadpodidentity.k8s.io
@@ -53,7 +53,7 @@ spec:
     plural: azureidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azurepodidentityexceptions.aadpodidentity.k8s.io
@@ -93,7 +93,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-nmi-binding
@@ -236,7 +236,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-mic-binding

--- a/parts/k8s/addons/azure-network-policy.yaml
+++ b/parts/k8s/addons/azure-network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: {{GetMode}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRole
 metadata:
   name: azure-npm
@@ -33,7 +33,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: azure-npm-binding

--- a/parts/k8s/addons/azure-network-policy.yaml
+++ b/parts/k8s/addons/azure-network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: {{GetMode}}
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRole
 metadata:
   name: azure-npm
@@ -33,7 +33,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: azure-npm-binding

--- a/parts/k8s/addons/azure-policy-deployment.yaml
+++ b/parts/k8s/addons/azure-policy-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: gatekeeper-system
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -122,7 +122,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -199,7 +199,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -275,7 +275,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -836,7 +836,7 @@ spec:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
 ---
-apiVersion: admissionregistration.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetWebhookAPIVersion}}
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null

--- a/parts/k8s/addons/azure-policy-deployment.yaml
+++ b/parts/k8s/addons/azure-policy-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: gatekeeper-system
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -122,7 +122,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -199,7 +199,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -275,7 +275,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -836,7 +836,7 @@ spec:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/{{GetAPIVersion}}
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null

--- a/parts/k8s/addons/calico.yaml
+++ b/parts/k8s/addons/calico.yaml
@@ -46,7 +46,7 @@ data:
 
 ---
 {{- /* Source: calico/templates/kdd-crds.yaml */}}
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
@@ -62,7 +62,7 @@ spec:
     singular: felixconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -78,7 +78,7 @@ spec:
     singular: bgpconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -94,7 +94,7 @@ spec:
     singular: ippool
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -110,7 +110,7 @@ spec:
     singular: hostendpoint
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -126,7 +126,7 @@ spec:
     singular: clusterinformation
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -142,7 +142,7 @@ spec:
     singular: globalnetworkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -158,7 +158,7 @@ spec:
     singular: globalnetworkset
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
@@ -174,7 +174,7 @@ spec:
     singular: networkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
@@ -193,7 +193,7 @@ spec:
 Include a clusterrole for the calico-node DaemonSet,
 and bind it to the calico-node serviceaccount. */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 metadata:
   name: calico-node
   labels:
@@ -294,7 +294,7 @@ be removed after upgrade or on fresh installations. */}}
   - create
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: calico-node

--- a/parts/k8s/addons/calico.yaml
+++ b/parts/k8s/addons/calico.yaml
@@ -46,7 +46,7 @@ data:
 
 ---
 {{- /* Source: calico/templates/kdd-crds.yaml */}}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
@@ -62,7 +62,7 @@ spec:
     singular: felixconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -78,7 +78,7 @@ spec:
     singular: bgpconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -94,7 +94,7 @@ spec:
     singular: ippool
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -110,7 +110,7 @@ spec:
     singular: hostendpoint
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -126,7 +126,7 @@ spec:
     singular: clusterinformation
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -142,7 +142,7 @@ spec:
     singular: globalnetworkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -158,7 +158,7 @@ spec:
     singular: globalnetworkset
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
@@ -174,7 +174,7 @@ spec:
     singular: networkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
@@ -193,7 +193,7 @@ spec:
 Include a clusterrole for the calico-node DaemonSet,
 and bind it to the calico-node serviceaccount. */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 metadata:
   name: calico-node
   labels:
@@ -294,7 +294,7 @@ be removed after upgrade or on fresh installations. */}}
   - create
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: calico-node

--- a/parts/k8s/addons/container-monitoring.yaml
+++ b/parts/k8s/addons/container-monitoring.yaml
@@ -876,7 +876,7 @@ spec:
     plural: healthstates
     kind: HealthState
 {{- else }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: healthstates.azmon.container.insights

--- a/parts/k8s/addons/container-monitoring.yaml
+++ b/parts/k8s/addons/container-monitoring.yaml
@@ -876,7 +876,7 @@ spec:
     plural: healthstates
     kind: HealthState
 {{- else }}
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: healthstates.azmon.container.insights

--- a/parts/k8s/addons/flannel.yaml
+++ b/parts/k8s/addons/flannel.yaml
@@ -120,7 +120,7 @@ spec:
 {{- /* This file was pulled from:
 https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378) */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 metadata:
   name: flannel
   labels:
@@ -147,7 +147,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 metadata:
   name: flannel
   labels:

--- a/parts/k8s/addons/flannel.yaml
+++ b/parts/k8s/addons/flannel.yaml
@@ -120,7 +120,7 @@ spec:
 {{- /* This file was pulled from:
 https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378) */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 metadata:
   name: flannel
   labels:
@@ -147,7 +147,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 metadata:
   name: flannel
   labels:

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/{{GetAPIVersion}}
 kind: CSIDriver
 metadata:
   name: secrets-store.csi.k8s.io

--- a/parts/k8s/addons/secrets-store-csi-driver.yaml
+++ b/parts/k8s/addons/secrets-store-csi-driver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetStorageAPIVersion}}
 kind: CSIDriver
 metadata:
   name: secrets-store.csi.k8s.io

--- a/parts/k8s/addons/tiller.yaml
+++ b/parts/k8s/addons/tiller.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: tiller

--- a/parts/k8s/addons/tiller.yaml
+++ b/parts/k8s/addons/tiller.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: tiller

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -655,11 +655,29 @@ func getAddonFuncMap(addon api.KubernetesAddon, cs *api.ContainerService) templa
 		"IsAzureCNI": func() bool {
 			return cs.Properties.OrchestratorProfile.IsAzureCNI()
 		},
-		"GetAPIVersion": func() string {
+		"GetCRDAPIVersion": func() string {
 			if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.22.0") {
-				return "v1"
+				return "apiextensions.k8s.io/v1"
 			}
-			return "v1beta1"
+			return "apiextensions.k8s.io/v1beta1"
+		},
+		"GetRBACAPIVersion": func() string {
+			if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.22.0") {
+				return "rbac.authorization.k8s.io/v1"
+			}
+			return "rbac.authorization.k8s.io/v1beta1"
+		},
+		"GetStorageAPIVersion": func() string {
+			if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.22.0") {
+				return "storage.k8s.io/v1"
+			}
+			return "storage.k8s.io/v1beta1"
+		},
+		"GetWebhookAPIVersion": func() string {
+			if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.22.0") {
+				return "admissionregistration.k8s.io/v1"
+			}
+			return "admissionregistration.k8s.io/v1beta1"
 		},
 	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -655,6 +655,12 @@ func getAddonFuncMap(addon api.KubernetesAddon, cs *api.ContainerService) templa
 		"IsAzureCNI": func() bool {
 			return cs.Properties.OrchestratorProfile.IsAzureCNI()
 		},
+		"GetAPIVersion": func() string {
+			if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.22.0") {
+				return "v1"
+			}
+			return "v1beta1"
+		},
 	}
 }
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -460,7 +460,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureassignedidentities.aadpodidentity.k8s.io
@@ -475,7 +475,7 @@ spec:
     plural: azureassignedidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentitybindings.aadpodidentity.k8s.io
@@ -490,7 +490,7 @@ spec:
     plural: azureidentitybindings
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentities.aadpodidentity.k8s.io
@@ -506,7 +506,7 @@ spec:
     plural: azureidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azurepodidentityexceptions.aadpodidentity.k8s.io
@@ -546,7 +546,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-nmi-binding
@@ -689,7 +689,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-mic-binding
@@ -6102,7 +6102,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: {{GetMode}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRole
 metadata:
   name: azure-npm
@@ -6129,7 +6129,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: azure-npm-binding
@@ -6245,7 +6245,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: gatekeeper-system
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6358,7 +6358,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6435,7 +6435,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6511,7 +6511,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -7072,7 +7072,7 @@ spec:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/{{GetAPIVersion}}
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -9811,7 +9811,7 @@ data:
 
 ---
 {{- /* Source: calico/templates/kdd-crds.yaml */}}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
@@ -9827,7 +9827,7 @@ spec:
     singular: felixconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -9843,7 +9843,7 @@ spec:
     singular: bgpconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -9859,7 +9859,7 @@ spec:
     singular: ippool
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -9875,7 +9875,7 @@ spec:
     singular: hostendpoint
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -9891,7 +9891,7 @@ spec:
     singular: clusterinformation
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -9907,7 +9907,7 @@ spec:
     singular: globalnetworkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -9923,7 +9923,7 @@ spec:
     singular: globalnetworkset
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
@@ -9939,7 +9939,7 @@ spec:
     singular: networkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
@@ -9958,7 +9958,7 @@ spec:
 Include a clusterrole for the calico-node DaemonSet,
 and bind it to the calico-node serviceaccount. */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 metadata:
   name: calico-node
   labels:
@@ -10059,7 +10059,7 @@ be removed after upgrade or on fresh installations. */}}
   - create
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
@@ -12825,7 +12825,7 @@ spec:
     plural: healthstates
     kind: HealthState
 {{- else }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: healthstates.azmon.container.insights
@@ -13361,7 +13361,7 @@ spec:
 {{- /* This file was pulled from:
 https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378) */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 metadata:
   name: flannel
   labels:
@@ -13388,7 +13388,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 metadata:
   name: flannel
   labels:
@@ -15229,7 +15229,7 @@ func k8sAddonsScheduledMaintenanceDeploymentYaml() (*asset, error) {
 	return a, nil
 }
 
-var _k8sAddonsSecretsStoreCsiDriverYaml = []byte(`apiVersion: storage.k8s.io/v1beta1
+var _k8sAddonsSecretsStoreCsiDriverYaml = []byte(`apiVersion: storage.k8s.io/{{GetAPIVersion}}
 kind: CSIDriver
 metadata:
   name: secrets-store.csi.k8s.io
@@ -15840,7 +15840,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: tiller

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -460,7 +460,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureassignedidentities.aadpodidentity.k8s.io
@@ -475,7 +475,7 @@ spec:
     plural: azureassignedidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentitybindings.aadpodidentity.k8s.io
@@ -490,7 +490,7 @@ spec:
     plural: azureidentitybindings
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentities.aadpodidentity.k8s.io
@@ -506,7 +506,7 @@ spec:
     plural: azureidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: azurepodidentityexceptions.aadpodidentity.k8s.io
@@ -546,7 +546,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-nmi-binding
@@ -689,7 +689,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-mic-binding
@@ -6102,7 +6102,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: {{GetMode}}
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRole
 metadata:
   name: azure-npm
@@ -6129,7 +6129,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: azure-npm-binding
@@ -6245,7 +6245,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: gatekeeper-system
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6358,7 +6358,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6435,7 +6435,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6511,7 +6511,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -7072,7 +7072,7 @@ spec:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
 ---
-apiVersion: admissionregistration.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetWebhookAPIVersion}}
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -9811,7 +9811,7 @@ data:
 
 ---
 {{- /* Source: calico/templates/kdd-crds.yaml */}}
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
@@ -9827,7 +9827,7 @@ spec:
     singular: felixconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -9843,7 +9843,7 @@ spec:
     singular: bgpconfiguration
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -9859,7 +9859,7 @@ spec:
     singular: ippool
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -9875,7 +9875,7 @@ spec:
     singular: hostendpoint
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -9891,7 +9891,7 @@ spec:
     singular: clusterinformation
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -9907,7 +9907,7 @@ spec:
     singular: globalnetworkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -9923,7 +9923,7 @@ spec:
     singular: globalnetworkset
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
@@ -9939,7 +9939,7 @@ spec:
     singular: networkpolicy
 ---
 
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
@@ -9958,7 +9958,7 @@ spec:
 Include a clusterrole for the calico-node DaemonSet,
 and bind it to the calico-node serviceaccount. */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 metadata:
   name: calico-node
   labels:
@@ -10059,7 +10059,7 @@ be removed after upgrade or on fresh installations. */}}
   - create
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
@@ -12825,7 +12825,7 @@ spec:
     plural: healthstates
     kind: HealthState
 {{- else }}
-apiVersion: apiextensions.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetCRDAPIVersion}}
 kind: CustomResourceDefinition
 metadata:
   name: healthstates.azmon.container.insights
@@ -13361,7 +13361,7 @@ spec:
 {{- /* This file was pulled from:
 https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378) */}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 metadata:
   name: flannel
   labels:
@@ -13388,7 +13388,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 metadata:
   name: flannel
   labels:
@@ -15229,7 +15229,7 @@ func k8sAddonsScheduledMaintenanceDeploymentYaml() (*asset, error) {
 	return a, nil
 }
 
-var _k8sAddonsSecretsStoreCsiDriverYaml = []byte(`apiVersion: storage.k8s.io/{{GetAPIVersion}}
+var _k8sAddonsSecretsStoreCsiDriverYaml = []byte(`apiVersion: {{GetStorageAPIVersion}}
 kind: CSIDriver
 metadata:
   name: secrets-store.csi.k8s.io
@@ -15840,7 +15840,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: rbac.authorization.k8s.io/{{GetAPIVersion}}
+apiVersion: {{GetRBACAPIVersion}}
 kind: ClusterRoleBinding
 metadata:
   name: tiller


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Update API Versions for Kubernetes resources. This is due to the deprecation of multiple `v1beta1` API versions for Kubernetes version 1.22+ as describe in this doc (https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) .


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
