### PR TITLE
fix: rotate-certs recreates all service account tokens

### DIFF
--- a/cmd/rotate_certs.go
+++ b/cmd/rotate_certs.go
@@ -79,7 +79,6 @@ type rotateCertsCmd struct {
 	newCertsProfile   *api.CertificateProfile
 	kubeClient        *kubernetes.CompositeClientSet
 	armClient         *ops.ARMClientWrapper
-	saTokenNamespaces []string
 	nodes             nodeMap
 	generateCerts     bool
 	linuxAuthConfig   *ssh.AuthConfig
@@ -216,7 +215,6 @@ func (rcc *rotateCertsCmd) loadAPIModel() (err error) {
 }
 
 func (rcc *rotateCertsCmd) init() (err error) {
-	rcc.saTokenNamespaces = rcc.getNamespacesWithSATokensToRotate()
 	rcc.backupDirectory = path.Join(filepath.Dir(rcc.apiModelPath), "_rotate_certs_backup")
 
 	rcc.linuxAuthConfig = &ssh.AuthConfig{
@@ -451,7 +449,7 @@ func (rcc *rotateCertsCmd) rotateAgentCerts() (err error) {
 		return err
 	}
 	log.Info("Recreating service account tokens")
-	if err = ops.RotateServiceAccountTokens(rcc.kubeClient, rcc.saTokenNamespaces); err != nil {
+	if err = ops.RotateServiceAccountTokens(rcc.kubeClient); err != nil {
 		return err
 	}
 	if err = rcc.waitForKubeSystemReadiness(); err != nil {
@@ -769,25 +767,6 @@ func isMaster(node *ssh.RemoteHost) bool {
 func isLinux(node *ssh.RemoteHost) bool        { return node.OperatingSystem == api.Linux }
 func isWindowsAgent(node *ssh.RemoteHost) bool { return node.OperatingSystem == api.Windows }
 func isLinuxAgent(node *ssh.RemoteHost) bool   { return isLinux(node) && !isMaster(node) }
-
-func (rcc *rotateCertsCmd) getNamespacesWithSATokensToRotate() []string {
-	// TODO parametize addons namespace so hard-coding their names is not required.
-	// TODO maybe add an extra cli param so user can add extra namespaces
-	namespaces := []string{metav1.NamespaceSystem}
-	if rcc.cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.DashboardAddonName) {
-		namespaces = append(namespaces, "kubernetes-dashboard")
-	}
-	if rcc.cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.AzureArcOnboardingAddonName) {
-		namespaces = append(namespaces, "azure-arc")
-	}
-	if rcc.cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.AzurePolicyAddonName) {
-		namespaces = append(namespaces, "gatekeeper-system")
-	}
-	if rcc.cs.Properties.OrchestratorProfile.KubernetesConfig.IsAddonEnabled(common.ScheduledMaintenanceAddonName) {
-		namespaces = append(namespaces, "drainsafe-system")
-	}
-	return namespaces
-}
 
 func keys(nodes nodeMap) []string {
 	n := make([]string, 0)

--- a/cmd/rotatecerts/operations.go
+++ b/cmd/rotatecerts/operations.go
@@ -61,109 +61,79 @@ func PauseClusterAutoscaler(client internal.KubeClient) (func() error, error) {
 	}, nil
 }
 
-// RotateServiceAccountTokens deletes service account tokens referenced by daemonsets and deployments
-// from the namespaces of interest and triggers a rollout once the tokens are deleted.
+// RotateServiceAccountTokens deletes all service account tokens and
+// triggers a forced rollout of all daemonsets and deployments.
 //
 // Service account tokens are signed by the cluster CA,
 // deleting them after the CA is rotated ensures that KCM will regenerate tokens signed by the new CA.
-func RotateServiceAccountTokens(client internal.KubeClient, namespaces []string) error {
-	for _, ns := range namespaces {
-		deleteSATokens, err := deleteSATokensFunc(client, ns)
-		if err != nil {
-			return err
-		}
-		if deleteSATokens == nil {
-			// no tokens to rotate in this namespace
-			continue
-		}
-		if err = deleteDeploymentSATokensAndForceRollout(client, ns, deleteSATokens); err != nil {
-			return err
-		}
-		if err = deleteDaemonSetSATokensAndForceRollout(client, ns, deleteSATokens); err != nil {
-			return err
-		}
+func RotateServiceAccountTokens(client internal.KubeClient) error {
+	if err := deleteSATokens(client); err != nil {
+		return err
 	}
+	if err := rolloutDeployments(client); err != nil {
+		return err
+	}
+	if err := rolloutDaemonSets(client); err != nil {
+		return err
+	}
+	// TODO rolloutStatefulSets
 	return nil
 }
 
-func deleteDeploymentSATokensAndForceRollout(client internal.KubeClient, ns string, deleteSATokens func(string) error) error {
+func rolloutDeployments(client internal.KubeClient) error {
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"ca-rotation":"%d"}}}}}`, random.Int31())
 
-	deployList, err := client.ListDeployments(ns, metav1.ListOptions{})
+	deployList, err := client.ListDeployments(metav1.NamespaceAll, metav1.ListOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "listing %s deployments", ns)
+		return errors.Wrapf(err, "listing cluster deployments")
 	}
 	for _, deploy := range deployList.Items {
-		if deploy.Spec.Template.Spec.ServiceAccountName != "" {
-			// delete SA tokens
-			if err = deleteSATokens(deploy.Spec.Template.Spec.ServiceAccountName); err != nil {
-				return err
-			}
-		}
 		// trigger rollout so the deploy replicas mount the newly generated sa token
-		if _, err := client.PatchDeployment(ns, deploy.Name, patch); err != nil {
-			return errors.Wrapf(err, "patching %s deployment %s", ns, deploy.Name)
+		if _, err := client.PatchDeployment(deploy.Namespace, deploy.Name, patch); err != nil {
+			return errors.Wrapf(err, "patching %s deployment %s", deploy.Namespace, deploy.Name)
 		}
 	}
 	return nil
 }
 
-func deleteDaemonSetSATokensAndForceRollout(client internal.KubeClient, ns string, deleteSATokens func(string) error) error {
+func rolloutDaemonSets(client internal.KubeClient) error {
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"ca-rotation":"%d"}}}}}`, random.Int31())
 
-	dsList, err := client.ListDaemonSets(ns, metav1.ListOptions{})
+	dsList, err := client.ListDaemonSets(metav1.NamespaceAll, metav1.ListOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "listing %s daemonsets", ns)
+		return errors.Wrapf(err, "listing cluster daemonsets")
 	}
 	for _, ds := range dsList.Items {
-		if ds.Spec.Template.Spec.ServiceAccountName != "" {
-			// delete SA tokens
-			if err = deleteSATokens(ds.Spec.Template.Spec.ServiceAccountName); err != nil {
-				return err
-			}
-		}
 		// trigger rollout so the ds replicas mount the newly generated sa token
-		if _, err = client.PatchDaemonSet(ns, ds.Name, patch); err != nil {
-			return errors.Wrapf(err, "patching %s daemonset %s", ns, ds.Name)
+		if _, err = client.PatchDaemonSet(ds.Namespace, ds.Name, patch); err != nil {
+			return errors.Wrapf(err, "patching %s daemonset %s", ds.Namespace, ds.Name)
 		}
 	}
 	return nil
 }
 
-func deleteSATokensFunc(client internal.KubeClient, ns string) (func(string) error, error) {
-	saList, err := client.ListServiceAccounts(ns, metav1.ListOptions{})
+func deleteSATokens(client internal.KubeClient) error {
+	saList, err := client.ListServiceAccounts(metav1.NamespaceAll, metav1.ListOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "listing %s service accounts", ns)
+		return errors.Wrapf(err, "listing cluster service accounts")
 	}
 	if len(saList.Items) == 0 {
-		return nil, nil
+		return nil
 	}
-	saMap := make(map[string]v1.ServiceAccount)
 	for _, sa := range saList.Items {
-		saMap[sa.Name] = sa
-	}
-	return func(name string) error {
-		sa, ok := saMap[name]
-		if !ok {
-			return nil
-		}
 		for _, s := range sa.Secrets {
 			err := client.DeleteSecret(&v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns,
+					Namespace: sa.Namespace,
 					Name:      s.Name,
 				},
 			})
 			if err != nil && !apierrors.IsNotFound(err) {
-				return errors.Wrapf(err, "deleting %s secret %s", ns, s.Name)
+				return errors.Wrapf(err, "deleting %s secret %s", s.Namespace, s.Name)
 			}
 		}
-		if err := client.DeleteServiceAccount(&sa); err != nil && !apierrors.IsNotFound(err) {
-			return errors.Wrapf(err, "deleting %s service account %s", ns, sa.Name)
-		}
-		delete(saMap, name)
-		return nil
-	}, nil
+	}
+	return nil
 }


### PR DESCRIPTION
**Reason for Change**:

`rotate-certs` command rotates all SA tokens, even those created by workloads.

**Issue Fixed**:

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
