### PR TITLE
fix: Update calico-3.3.1-cleanup-after-upgrade.yaml

### DIFF
--- a/docs/topics/calico-3.3.1-cleanup-after-upgrade.yaml
+++ b/docs/topics/calico-3.3.1-cleanup-after-upgrade.yaml
@@ -168,7 +168,7 @@ spec:
 
 # This manifest creates a Deployment of Typha to back the above service.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha
@@ -314,7 +314,7 @@ data:
 ---
 
 # Typha Horizontal Autoscaler Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha-horizontal-autoscaler
@@ -409,7 +409,7 @@ metadata:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system


### PR DESCRIPTION
**Reason for Change**:

Updates the API version of Deployments and Daemonsets in the calico-3.3.1-cleanup-after-upgrade.yaml resource.

**Issue Fixed**:
Refs: #3839

**Credit Where Due**:

This is @jovieir's change from #3839 that somehow was overlooked. Then, when I went to update the commit message and merge it, somehow I managed to overwrite the branch and close that PR.

Apologies @jovieir! And thanks for your contribution, which I've resurrected here.

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
