### PR TITLE
chore: force external cloud provider for Kubernetes v1.21+ on Azure Stack Hub

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -224,7 +224,7 @@ func (uc *upgradeCmd) loadCluster() error {
 
 	// Enforce UseCloudControllerManager for Kubernetes 1.21+ on Azure Stack cloud
 	if uc.containerService.Properties.IsAzureStackCloud() && common.IsKubernetesVersionGe(uc.upgradeVersion, "1.21.0") {
-		log.Infoln("Updating UseCloudControllerManager to 'true' on Azure Stack cloud...")
+		log.Infoln("The in-tree cloud provider is not longer supported on Azure Stack Hub for v1.21+ clusters, overwriting UseCloudControllerManager to 'true'...")
 		uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
 	}
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -224,7 +224,7 @@ func (uc *upgradeCmd) loadCluster() error {
 
 	// Enforce UseCloudControllerManager for Kubernetes 1.21+ on Azure Stack cloud
 	if uc.containerService.Properties.IsAzureStackCloud() && common.IsKubernetesVersionGe(uc.upgradeVersion, "1.21.0") {
-		log.Infoln("The in-tree cloud provider is not longer supported on Azure Stack Hub for v1.21+ clusters, overwriting UseCloudControllerManager to 'true'...")
+		log.Infoln("The in-tree cloud provider is not longer supported on Azure Stack Hub for v1.21+ clusters, overwriting UseCloudControllerManager to 'true'")
 		uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
 	}
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -222,6 +222,12 @@ func (uc *upgradeCmd) loadCluster() error {
 		}
 	}
 
+	// Enforce UseCloudControllerManager for Kubernetes 1.21+ on Azure Stack cloud
+	if uc.containerService.Properties.IsAzureStackCloud() && common.IsKubernetesVersionGe(uc.upgradeVersion, "1.21.0") {
+		log.Infoln("Updating UseCloudControllerManager to 'true' on Azure Stack cloud...\n")
+		uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
+	}
+
 	// The cluster-init component is a cluster create-only feature, temporarily disable if enabled
 	if i := api.GetComponentsIndexByName(uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.Components, common.ClusterInitComponentName); i > -1 {
 		if uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.Components[i].IsEnabled() {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -224,7 +224,7 @@ func (uc *upgradeCmd) loadCluster() error {
 
 	// Enforce UseCloudControllerManager for Kubernetes 1.21+ on Azure Stack cloud
 	if uc.containerService.Properties.IsAzureStackCloud() && common.IsKubernetesVersionGe(uc.upgradeVersion, "1.21.0") {
-		log.Infoln("Updating UseCloudControllerManager to 'true' on Azure Stack cloud...\n")
+		log.Infoln("Updating UseCloudControllerManager to 'true' on Azure Stack cloud...")
 		uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
 	}
 

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -926,6 +926,18 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		}
 	}
 
+	// Ensure cloud-node-manager is enabled on appropriate upgrades for Azure Stack cloud
+	if isUpgrade &&
+		cs.Properties.IsAzureStackCloud() &&
+		to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) &&
+		common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.21.0") {
+		// Force enabling cloud-node-manager addon
+		log.Infoln("Updating cloud-node-manager addon to 'true' on Azure Stack cloud...\n")
+		if i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.CloudNodeManagerAddonName); i > -1 {
+			o.KubernetesConfig.Addons[i] = defaultCloudNodeManagerAddonsConfig
+		}
+	}
+
 	// Back-compat for older addon specs of cluster-autoscaler
 	if isUpgrade {
 		i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.ClusterAutoscalerAddonName)

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -929,10 +929,8 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 	// Ensure cloud-node-manager is enabled on appropriate upgrades for Azure Stack cloud
 	if isUpgrade &&
 		cs.Properties.IsAzureStackCloud() &&
-		to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) &&
-		common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.21.0") {
+		to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) {
 		// Force enabling cloud-node-manager addon
-		log.Infoln("Updating cloud-node-manager addon to 'true' on Azure Stack cloud...")
 		if i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.CloudNodeManagerAddonName); i > -1 {
 			o.KubernetesConfig.Addons[i] = defaultCloudNodeManagerAddonsConfig
 		}

--- a/pkg/api/addons.go
+++ b/pkg/api/addons.go
@@ -932,7 +932,7 @@ func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
 		to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) &&
 		common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.21.0") {
 		// Force enabling cloud-node-manager addon
-		log.Infoln("Updating cloud-node-manager addon to 'true' on Azure Stack cloud...\n")
+		log.Infoln("Updating cloud-node-manager addon to 'true' on Azure Stack cloud...")
 		if i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.CloudNodeManagerAddonName); i > -1 {
 			o.KubernetesConfig.Addons[i] = defaultCloudNodeManagerAddonsConfig
 		}

--- a/pkg/api/components.go
+++ b/pkg/api/components.go
@@ -155,7 +155,7 @@ func (cs *ContainerService) setComponentsConfig(isUpgrade bool) {
 		to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) &&
 		common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.21.0") {
 		// Force enabling cloud-controller-manager
-		log.Infoln("Updating cloud-controller-manager component to 'true' on Azure Stack cloud...\n")
+		log.Infoln("Updating cloud-controller-manager component to 'true' on Azure Stack cloud...")
 		if i := GetComponentsIndexByName(kubernetesConfig.Components, common.CloudControllerManagerComponentName); i > -1 {
 			kubernetesConfig.Components[i] = defaultCloudControllerManagerComponentConfig
 		}

--- a/pkg/api/components.go
+++ b/pkg/api/components.go
@@ -6,8 +6,6 @@ package api
 import (
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/go-autorest/autorest/to"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func (cs *ContainerService) setComponentsConfig(isUpgrade bool) {
@@ -152,10 +150,8 @@ func (cs *ContainerService) setComponentsConfig(isUpgrade bool) {
 	// Ensure cloud-controller-manager is enabled on appropriate upgrades for Azure Stack cloud
 	if isUpgrade &&
 		cs.Properties.IsAzureStackCloud() &&
-		to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) &&
-		common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.21.0") {
+		to.Bool(cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) {
 		// Force enabling cloud-controller-manager
-		log.Infoln("Updating cloud-controller-manager component to 'true' on Azure Stack cloud...")
 		if i := GetComponentsIndexByName(kubernetesConfig.Components, common.CloudControllerManagerComponentName); i > -1 {
 			kubernetesConfig.Components[i] = defaultCloudControllerManagerComponentConfig
 		}

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -77,9 +77,6 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	staticWindowsKubeletConfig["--image-pull-progress-deadline"] = "20m"
 	staticWindowsKubeletConfig["--resolv-conf"] = "\"\"\"\""
 	staticWindowsKubeletConfig["--eviction-hard"] = "\"\"\"\""
-	if to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
-		staticWindowsKubeletConfig["--cloud-provider"] = "external"
-	}
 
 	nodeStatusUpdateFrequency := GetK8sComponentsByVersionMap(o.KubernetesConfig)[o.OrchestratorVersion]["nodestatusfreq"]
 	if cs.Properties.IsAzureStackCloud() {

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -77,6 +77,9 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 	staticWindowsKubeletConfig["--image-pull-progress-deadline"] = "20m"
 	staticWindowsKubeletConfig["--resolv-conf"] = "\"\"\"\""
 	staticWindowsKubeletConfig["--eviction-hard"] = "\"\"\"\""
+	if to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
+		staticWindowsKubeletConfig["--cloud-provider"] = "external"
+	}
 
 	nodeStatusUpdateFrequency := GetK8sComponentsByVersionMap(o.KubernetesConfig)[o.OrchestratorVersion]["nodestatusfreq"]
 	if cs.Properties.IsAzureStackCloud() {
@@ -190,6 +193,10 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		if isUpgrade {
 			// if upgrade, force default "--pod-infra-container-image" value
 			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--pod-infra-container-image"] = o.KubernetesConfig.KubeletConfig["--pod-infra-container-image"]
+		}
+		//Ensure cloud-provider setting
+		if to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
+			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--cloud-provider"] = "external"
 		}
 		setMissingKubeletValues(cs.Properties.MasterProfile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 		addDefaultFeatureGates(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "", "")

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -301,7 +301,7 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 
 			if a.IsAzureStackCloud() {
 				if common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.21.0") && !to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
-					return errors.New("useCloudControllerManager should be set to true for Kubernetes 1.21+ cluster on Azure Stack")
+					return errors.New("useCloudControllerManager should be set to true for Kubernetes v1.21+ cluster on Azure Stack Hub")
 				}
 
 				if to.Bool(o.KubernetesConfig.UseInstanceMetadata) {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -300,6 +300,10 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 			}
 
 			if a.IsAzureStackCloud() {
+				if common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.21.0") && !to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
+					return errors.New("useCloudControllerManager should be set to true for Kubernetes 1.21+ cluster on Azure Stack")
+				}
+
 				if to.Bool(o.KubernetesConfig.UseInstanceMetadata) {
 					return errors.New("useInstanceMetadata shouldn't be set to true as feature not yet supported on Azure Stack")
 				}
@@ -809,7 +813,7 @@ func (a *Properties) validateAddons(isUpdate bool) error {
 				// Validation for addons if they are disabled
 				switch addon.Name {
 				case "cloud-node-manager":
-					if a.ShouldEnableAzureCloudAddon(addon.Name) {
+					if a.ShouldEnableAzureCloudAddon(addon.Name) && !a.IsAzureStackCloud() {
 						minVersion := "1.16.0"
 						if a.HasWindows() {
 							minVersion = "1.18.0"

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -301,7 +301,7 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 
 			if a.IsAzureStackCloud() {
 				if common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.21.0") && !to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
-					return errors.New("useCloudControllerManager should be set to true for Kubernetes v1.21+ cluster on Azure Stack Hub")
+					return errors.New("useCloudControllerManager should be set to true for Kubernetes v1.21+ clusters on Azure Stack Hub")
 				}
 
 				if to.Bool(o.KubernetesConfig.UseInstanceMetadata) {

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -4720,6 +4720,27 @@ func TestValidateLocation(t *testing.T) {
 			expectedErr: errors.New("missing ContainerService Location"),
 		},
 		{
+			name:          "AzureStack UseCloudControllerManager is false",
+			location:      "local",
+			propertiesnil: false,
+			cs: &ContainerService{
+				Location: "local",
+				Properties: &Properties{
+					CustomCloudProfile: &CustomCloudProfile{
+						PortalURL: "https://portal.local.cotoso.com",
+					},
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: common.RationalizeReleaseAndVersion(Kubernetes, "", "", false, false, true),
+						KubernetesConfig: &KubernetesConfig{
+							UseCloudControllerManager: to.BoolPtr(falseVal),
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("useCloudControllerManager should be set to true for Kubernetes v1.21+ cluster on Azure Stack Hub"),
+		},
+		{
 			name:          "AzureStack UseInstanceMetadata is true",
 			location:      "local",
 			propertiesnil: false,
@@ -4733,7 +4754,8 @@ func TestValidateLocation(t *testing.T) {
 						OrchestratorType:    Kubernetes,
 						OrchestratorVersion: common.RationalizeReleaseAndVersion(Kubernetes, "", "", false, false, true),
 						KubernetesConfig: &KubernetesConfig{
-							UseInstanceMetadata: to.BoolPtr(trueVal),
+							UseCloudControllerManager: to.BoolPtr(trueVal),
+							UseInstanceMetadata:       to.BoolPtr(trueVal),
 						},
 					},
 				},
@@ -4754,7 +4776,8 @@ func TestValidateLocation(t *testing.T) {
 						OrchestratorType:    Kubernetes,
 						OrchestratorVersion: common.RationalizeReleaseAndVersion(Kubernetes, "", "", false, false, true),
 						KubernetesConfig: &KubernetesConfig{
-							EtcdDiskSizeGB: "1024",
+							UseCloudControllerManager: to.BoolPtr(trueVal),
+							EtcdDiskSizeGB:            "1024",
 						},
 					},
 				},
@@ -4775,7 +4798,8 @@ func TestValidateLocation(t *testing.T) {
 						OrchestratorType:    Kubernetes,
 						OrchestratorVersion: common.RationalizeReleaseAndVersion(Kubernetes, "", "", false, false, true),
 						KubernetesConfig: &KubernetesConfig{
-							EtcdDiskSizeGB: "1024GB",
+							UseCloudControllerManager: to.BoolPtr(trueVal),
+							EtcdDiskSizeGB:            "1024GB",
 						},
 					},
 				},

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -4738,7 +4738,7 @@ func TestValidateLocation(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: errors.New("useCloudControllerManager should be set to true for Kubernetes v1.21+ cluster on Azure Stack Hub"),
+			expectedErr: errors.New("useCloudControllerManager should be set to true for Kubernetes v1.21+ clusters on Azure Stack Hub"),
 		},
 		{
 			name:          "AzureStack UseInstanceMetadata is true",

--- a/pkg/engine/testdata/azurestack/kubernetes-ubuntu16.json
+++ b/pkg/engine/testdata/azurestack/kubernetes-ubuntu16.json
@@ -6,6 +6,7 @@
             "kubernetesConfig": {
                 "kubernetesImageBase": "k8s.gcr.io/",
                 "useInstanceMetadata": false,
+                "useCloudControllerManager":  true,
                 "networkPolicy": "none"
             }
         },

--- a/pkg/engine/testdata/azurestack/kubernetes.json
+++ b/pkg/engine/testdata/azurestack/kubernetes.json
@@ -6,6 +6,7 @@
             "kubernetesConfig": {
                 "kubernetesImageBase": "k8s.gcr.io/",
                 "useInstanceMetadata": false,
+                "useCloudControllerManager":  true,
                 "networkPolicy": "none"
             }
         },


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Start Kubernetes 1.21, only external cloud provider is supported on Azure Stack cloud. Adding the logic to enforce that for deploy and upgrade operations.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
