### PR TITLE
fix: ensure correct agent pool selection in scale operations

### DIFF
--- a/cmd/scale_test.go
+++ b/cmd/scale_test.go
@@ -152,7 +152,7 @@ func TestVmInVMASAgentPool(t *testing.T) {
 				agentPoolIndex:   0,
 				agentPoolToScale: "linuxpool",
 				agentPool: &api.AgentPoolProfile{
-					Name:                "linuxpool2",
+					Name:                "linuxpool",
 					OSType:              "Linux",
 					AvailabilityProfile: "AvailabilitySet",
 				},
@@ -192,7 +192,7 @@ func TestVmInVMASAgentPool(t *testing.T) {
 				agentPoolIndex:   2,
 				agentPoolToScale: "windowspool",
 				agentPool: &api.AgentPoolProfile{
-					Name:                "windowspool2",
+					Name:                "windowspool",
 					OSType:              "Windows",
 					AvailabilityProfile: "AvailabilitySet",
 				},

--- a/cmd/scale_test.go
+++ b/cmd/scale_test.go
@@ -163,7 +163,7 @@ func TestVmInVMASAgentPool(t *testing.T) {
 				},
 			},
 			expected: false,
-			name:     "linux agentpool mismatch scale pool",
+			name:     "linux VM is not in linux pool to scale",
 			vmName:   "k8s-linuxpool2-39573225-0",
 		},
 		{
@@ -183,7 +183,7 @@ func TestVmInVMASAgentPool(t *testing.T) {
 				},
 			},
 			expected: true,
-			name:     "linux agentpool matches scale pool",
+			name:     "linux VM is in linux pool to scale",
 			vmName:   "k8s-linuxpool2-39573225-1",
 		},
 		{
@@ -203,7 +203,7 @@ func TestVmInVMASAgentPool(t *testing.T) {
 				},
 			},
 			expected: false,
-			name:     "windows agentpool mismatch scale pool",
+			name:     "windows VM is not in windows pool to scale",
 			vmName:   "3957k8s030",
 		},
 		{
@@ -223,7 +223,7 @@ func TestVmInVMASAgentPool(t *testing.T) {
 				},
 			},
 			expected: true,
-			name:     "windows agentpool matches scale pool",
+			name:     "windows VM is in windows pool to scale",
 			vmName:   "3957k8s031",
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
When there are multiple Windows / Linux agent pools, the scale operation is not selecting the correct agent pool.

For Windows agent pools, the code `vmName[:9] == sc.containerService.Properties.GetAgentVMPrefix(sc.agentPool, winPoolIndex)[:9]` will always be true and thus all Windows agent pools will be mixed in scaling and indexing.

For Linux agent pools, for example if one agentpool is named `linuxpool` and the other agentpool is named `linxpool2`, and scale operation targets `linuxpool`, then code `strings.Contains(vmName, sc.agentPoolToScale)` will also consider VMs from `linuxpool2` are in agentpool `linuxpool`.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://github.com/Azure/aks-engine/issues/1065

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
