### PR TITLE
chore: retain LegacyServiceAccountTokenNoAutoGeneration=false behavior

### DIFF
--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -87,6 +87,10 @@ func (cs *ContainerService) setControllerManagerConfig() {
 		addDefaultFeatureGates(o.KubernetesConfig.ControllerManagerConfig, o.OrchestratorVersion, "1.9.0", "ServiceNodeExclusion=true")
 	}
 
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.24.0-alpha.4") {
+		addDefaultFeatureGates(o.KubernetesConfig.ControllerManagerConfig, o.OrchestratorVersion, "1.9.0", "LegacyServiceAccountTokenNoAutoGeneration=false")
+	}
+
 	// Enable the consumption of local ephemeral storage and also the sizeLimit property of an emptyDir volume.
 	addDefaultFeatureGates(o.KubernetesConfig.ControllerManagerConfig, o.OrchestratorVersion, "1.10.0", "LocalStorageCapacityIsolation=true")
 

--- a/pkg/api/defaults-controller-manager_test.go
+++ b/pkg/api/defaults-controller-manager_test.go
@@ -99,6 +99,17 @@ func TestControllerManagerConfigDefaultFeatureGates(t *testing.T) {
 			cm["--feature-gates"])
 	}
 
+	// test 1.24.0
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.24.0"
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	expected := "LegacyServiceAccountTokenNoAutoGeneration=false,LocalStorageCapacityIsolation=true"
+	if cm["--feature-gates"] != expected {
+		t.Fatalf("got unexpected '--feature-gates' Controller Manager config value, expected %s, got %s",
+			expected, cm["--feature-gates"])
+	}
+
 	// test user-overrides
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
 	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR sets the `LegacyServiceAccountTokenNoAutoGeneration=false` feature flag config to preserve pre-existing service account token generation functionality for legacy AKS Engine customers.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
