### PR TITLE
test: exclude uksouth from test infra regions list

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -1,4 +1,4 @@
-//go:build test
+//+build test
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -1,4 +1,6 @@
-//+build test
+//go:build test
+// +build test
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
@@ -337,7 +339,7 @@ func (c *Config) SetSSHKeyPermissions() error {
 func (c *Config) SetRandomRegion() {
 	var regions []string
 	if c.Regions == nil || len(c.Regions) == 0 {
-		regions = []string{"eastus", "uksouth", "southeastasia", "westus2", "westeurope"}
+		regions = []string{"eastus", "southeastasia", "westus2", "westeurope"}
 	} else {
 		regions = c.Regions
 	}

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR removes the uksouth region from the list of regions to build Azure infra in for our E2E test runner after observing failures in that region.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
