### PR TITLE
fix: correctly handle multiple root certificates on Azure Stack Hub windows nodes

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -462,7 +462,7 @@ try
             $azsARMUri = [System.Uri]$azsJson.resourceManagerEndpoint
             $webRequest = [Net.WebRequest]::Create($azsARMUri.AbsoluteUri)
             try { $webRequest.GetResponse() } catch {}
-            if ($null -eq $webRequest.ServicePoint.Certificate) {
+            if (($null -eq $webRequest.ServicePoint) -Or ($null -eq $webRequest.ServicePoint.Certificate)) {
                 throw "SSL Certificate of ARM endpoint is null"
             }
             $sslCert = $webRequest.ServicePoint.Certificate

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -450,20 +450,33 @@ try
 
         {{if IsAzureStackCloud}}
             {{if UseCloudControllerManager}}
-            # Export the Azure Stack root cert for use in cloud node manager container setup.
+            # Retrieve SSL cert of ARM Endpoint and find unique Azure Stack root cert
             $azsConfigFile = [io.path]::Combine($global:KubeDir, "azurestackcloud.json")
             if (-not (Test-Path -Path $azsConfigFile)) {
-                throw "$azsConfigFile does not exist, cannot export Azure Stack root cert"
+                throw "$azsConfigFile does not exist"
             }
             $azsJson = Get-Content -Raw -Path $azsConfigFile | ConvertFrom-Json
-            if ([string]::IsNullOrEmpty($azsJson.managementPortalURL)) {
-                throw "managementPortalURL is empty, cannot get Azure Stack ARM uri"
+            if ([string]::IsNullOrEmpty($azsJson.resourceManagerEndpoint)) {
+                throw "resourceManagerEndpoint is empty, cannot get Azure Stack ARM uri"
             }
-            $azsARMUri = [System.Uri]$azsJson.managementPortalURL
-            $azsRootCert = Get-ChildItem -Path Cert:\LocalMachine\Root | Where-Object {$_.DnsNameList.Unicode -contains $azsARMUri.Host.Substring($azsARMUri.Host.IndexOf(".")).TrimStart(".")}
+            $azsARMUri = [System.Uri]$azsJson.resourceManagerEndpoint
+            $webRequest = [Net.WebRequest]::Create($azsARMUri.AbsoluteUri)
+            try { $webRequest.GetResponse() } catch {}
+            if ($null -eq $webRequest.ServicePoint.Certificate) {
+                throw "SSL Certificate of ARM endpoint is null"
+            }
+            $sslCert = $webRequest.ServicePoint.Certificate
+            $sslCertChain = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Chain
+            $sslCertChain.build($sslCert)
+            $sslRootCert = @($sslCertChain.ChainElements.Certificate)[-1]
+            $azsRootCert = Get-ChildItem -Path Cert:\LocalMachine\Root | Where-Object {$_.Thumbprint -eq $sslRootCert.Thumbprint}
             if ($null -eq $azsRootCert) {
-                throw "$azsRootCert is null, cannot export Azure Stack root cert"
+                throw "azsRootCert is null, cannot find Azure Stack root cert"
+            } elseif ($azsRootCert.Count -ne 1) {
+                throw "azsRootCert is not unique, cannot find Azure Stack root cert"
             }
+
+            # Export the Azure Stack root cert for use in cloud node manager container setup.
             $azsRootCertFilePath =  [io.path]::Combine($global:KubeDir, "azsroot.cer")
             Export-Certificate -Cert $azsRootCert -FilePath $azsRootCertFilePath -Type CERT
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -22158,7 +22158,7 @@ try
             $azsARMUri = [System.Uri]$azsJson.resourceManagerEndpoint
             $webRequest = [Net.WebRequest]::Create($azsARMUri.AbsoluteUri)
             try { $webRequest.GetResponse() } catch {}
-            if ($null -eq $webRequest.ServicePoint.Certificate) {
+            if (($null -eq $webRequest.ServicePoint) -Or ($null -eq $webRequest.ServicePoint.Certificate)) {
                 throw "SSL Certificate of ARM endpoint is null"
             }
             $sslCert = $webRequest.ServicePoint.Certificate


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Update external cloud provider logic for windows node to retrieve root certificate from SSL certificate of ARM endpoint

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
