### PR TITLE
docs: print deprecation message to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,15 @@ import (
 
 func main() {
 	log.SetFormatter(&log.TextFormatter{ForceColors: true})
+	log.SetOutput(colorable.NewColorableStderr())
+	msg := `
+aks-engine is deprecated for Azure public cloud customers.
+Please consider using Azure Kubernetes Service (AKS) for managed Kubernetes:
+    https://azure.microsoft.com/en-us/services/kubernetes-service/#overview
+or Cluster API Provider Azure (CAPZ) for self-managed Kubernetes:
+    https://capz.sigs.k8s.io/
+`
+	log.Warningf("\u001b[33m%s\u001b[0m", msg)
 	log.SetOutput(colorable.NewColorableStdout())
 	if err := cmd.NewRootCmd().Execute(); err != nil {
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -15,7 +15,9 @@ func main() {
 	log.SetFormatter(&log.TextFormatter{ForceColors: true})
 	log.SetOutput(colorable.NewColorableStderr())
 	msg := `
-aks-engine is deprecated for Azure public cloud customers.
+aks-engine is deprecated for Azure public cloud customers. Learn more at:
+    https://github.com/Azure/aks-engine#project-status
+
 Please consider using Azure Kubernetes Service (AKS) for managed Kubernetes:
     https://azure.microsoft.com/en-us/services/kubernetes-service/#overview
 or Cluster API Provider Azure (CAPZ) for self-managed Kubernetes:

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ aks-engine is deprecated for Azure public cloud customers. Learn more at:
     https://github.com/Azure/aks-engine#project-status
 
 Please consider using Azure Kubernetes Service (AKS) for managed Kubernetes:
-    https://azure.microsoft.com/en-us/services/kubernetes-service/#overview
+    https://azure.microsoft.com/services/kubernetes-service/
 or Cluster API Provider Azure (CAPZ) for self-managed Kubernetes:
     https://capz.sigs.k8s.io/
 `


### PR DESCRIPTION
**Reason for Change**:

AKS Engine [is deprecated](https://github.com/Azure/aks-engine#project-status) and will not support Kubernetes 1.25 or later. This prints a yellow warning to stderr reminding users of that whenever `aks-engine` is run:

![Untitled 3](https://user-images.githubusercontent.com/73019/172433694-480dc29d-3dc2-4b9e-abc4-9fb9e1dd1e30.png)

**Issue Fixed**:

Fixes #4342

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
