### PR TITLE
Revert "chore: add qatarcentral region"

### DIFF
--- a/cmd/get_locations.go
+++ b/cmd/get_locations.go
@@ -46,8 +46,6 @@ var (
 	germanyCentralName          = "germanycentral"
 	germanyNortheastDisplayName = "Germany Northeast"
 	germanyNortheastName        = "germanynortheast"
-	qatarCentralDisplayName     = "(Middle East) Qatar Central"
-	qatarCentralName            = "qatarcentral"
 	usDodCentralDisplayName     = "US DoD Central"
 	usDodCentralName            = "usdodcentral"
 	usDodEastDisplayName        = "US Dod East"
@@ -246,14 +244,6 @@ func (glc *LocationsCmd) run(cmd *cobra.Command, args []string) error {
 			ID:          &notAvailable,
 			Name:        &germanyNortheastName,
 			DisplayName: &germanyNortheastDisplayName,
-			Latitude:    &notAvailable,
-			Longitude:   &notAvailable,
-		},
-		// Pre-release locations
-		{
-			ID:          &notAvailable,
-			Name:        &qatarCentralName,
-			DisplayName: &qatarCentralDisplayName,
 			Latitude:    &notAvailable,
 			Longitude:   &notAvailable,
 		},

--- a/cmd/get_locations_test.go
+++ b/cmd/get_locations_test.go
@@ -97,24 +97,23 @@ func ExampleLocationsCmd_run_humanOutput() {
 	}
 
 	// Output:
-	// Location          Name                         Latitude  Longitude
-	// centraluseuap     Central US EUAP (Canary)     N/A       N/A
-	// chinaeast         China East                   N/A       N/A
-	// chinaeast2        China East 2                 N/A       N/A
-	// chinaeast3        China East 3                 N/A       N/A
-	// chinanorth        China North                  N/A       N/A
-	// chinanorth2       China North 2                N/A       N/A
-	// chinanorth3       China North 3                N/A       N/A
-	// eastus2euap       East US 2 EUAP (Canary)      N/A       N/A
-	// germanycentral    Germany Central              N/A       N/A
-	// germanynortheast  Germany Northeast            N/A       N/A
-	// qatarcentral      (Middle East) Qatar Central  N/A       N/A
-	// usdodcentral      US DoD Central               N/A       N/A
-	// usdodeast         US Dod East                  N/A       N/A
-	// usgovarizona      US Gov Arizona               N/A       N/A
-	// usgoviowa         US Gov Iowa                  N/A       N/A
-	// usgovtexas        US Gov Texas                 N/A       N/A
-	// usgovvirginia     US Gov Virginia              N/A       N/A
+	// Location          Name                      Latitude  Longitude
+	// centraluseuap     Central US EUAP (Canary)  N/A       N/A
+	// chinaeast         China East                N/A       N/A
+	// chinaeast2        China East 2              N/A       N/A
+	// chinaeast3        China East 3              N/A       N/A
+	// chinanorth        China North               N/A       N/A
+	// chinanorth2       China North 2             N/A       N/A
+	// chinanorth3       China North 3             N/A       N/A
+	// eastus2euap       East US 2 EUAP (Canary)   N/A       N/A
+	// germanycentral    Germany Central           N/A       N/A
+	// germanynortheast  Germany Northeast         N/A       N/A
+	// usdodcentral      US DoD Central            N/A       N/A
+	// usdodeast         US Dod East               N/A       N/A
+	// usgovarizona      US Gov Arizona            N/A       N/A
+	// usgoviowa         US Gov Iowa               N/A       N/A
+	// usgovtexas        US Gov Texas              N/A       N/A
+	// usgovvirginia     US Gov Virginia           N/A       N/A
 }
 
 func ExampleLocationsCmd_run_jsonOutput() {
@@ -217,13 +216,6 @@ func ExampleLocationsCmd_run_jsonOutput() {
 	//     "id": "N/A",
 	//     "name": "germanynortheast",
 	//     "displayName": "Germany Northeast",
-	//     "latitude": "N/A",
-	//     "longitude": "N/A"
-	//   },
-	//   {
-	//     "id": "N/A",
-	//     "name": "qatarcentral",
-	//     "displayName": "(Middle East) Qatar Central",
 	//     "latitude": "N/A",
 	//     "longitude": "N/A"
 	//   },

--- a/pkg/helpers/azure_locations.go
+++ b/pkg/helpers/azure_locations.go
@@ -48,7 +48,6 @@ func GetAzureLocations() []string {
 		"northeurope",
 		"norwayeast",
 		"norwaywest",
-		"qatarcentral",
 		"southafricanorth",
 		"southafricawest",
 		"southcentralus",


### PR DESCRIPTION
Reverts Azure/aks-engine#4919

It looks like `qatarcentral` is now enabled on the subscription that manages Azure locations, so we no longer need to be manually curating it!