### PR TITLE
chore: upgrade container runtimes

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -107,8 +107,8 @@ mobyPkgVersion() {
 installRunc() {
   local v
   v=$(runc --version | head -n 1 | cut -d" " -f3)
-  if [[ $v != "1.0.3" ]]; then
-    apt_get_install 20 30 120 moby-runc=1.0.3* --allow-downgrades || exit 27
+  if [[ $v != "1.1.2" ]]; then
+    apt_get_install 20 30 120 moby-runc=1.1.2* --allow-downgrades || exit 27
   fi
 }
 installMoby() {

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -112,8 +112,8 @@ installRunc() {
     url=${MS_APT_REPO}/ubuntu/${UBUNTU_RELEASE}/multiarch/prod/pool/main/m/moby-runc/moby-runc_1.1.2%2Bazure-ubuntu${UBUNTU_RELEASE}u1_amd64.deb
     if [[ -n "${url:-}" ]]; then
       DEB="${url##*/}"
-      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
-      dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit 184
+      dpkg_install 20 30 /tmp/${DEB} || exit 184
     fi
   fi
 }

--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -106,9 +106,15 @@ mobyPkgVersion() {
 }
 installRunc() {
   local v
+  local url
   v=$(runc --version | head -n 1 | cut -d" " -f3)
   if [[ $v != "1.1.2" ]]; then
-    apt_get_install 20 30 120 moby-runc=1.1.2* --allow-downgrades || exit 27
+    url=${MS_APT_REPO}/ubuntu/${UBUNTU_RELEASE}/multiarch/prod/pool/main/m/moby-runc/moby-runc_1.1.2%2Bazure-ubuntu${UBUNTU_RELEASE}u1_amd64.deb
+    if [[ -n "${url:-}" ]]; then
+      DEB="${url##*/}"
+      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
+      dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+    fi
   fi
 }
 installMoby() {

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -207,7 +207,7 @@
       }
     },
     "mobyVersion": {
-      "defaultValue": "20.10.11",
+      "defaultValue": "20.10.14",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -233,12 +233,13 @@
          "20.10.8",
          "20.10.9",
          "20.10.10",
-         "20.10.11"
+         "20.10.11",
+         "20.10.14"
        ],
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.5.11",
+      "defaultValue": "1.5.13",
       "metadata": {
         "description": "The Azure containerd build version"
       },
@@ -257,7 +258,8 @@
          "1.4.8",
          "1.4.9",
          "1.4.11",
-         "1.5.11"
+         "1.5.11",
+         "1.5.13"
        ],
       "type": "string"
     },

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -446,9 +446,9 @@ const (
 	// DefaultKubernetesDNSServiceIPv6 specifies the IPv6 address that kube-dns listens on by default. must by in the default Service CIDR range.
 	DefaultKubernetesDNSServiceIPv6 = "fd00::10"
 	// DefaultMobyVersion specifies the default Azure build version of Moby to install.
-	DefaultMobyVersion = "20.10.11"
+	DefaultMobyVersion = "20.10.14"
 	// DefaultContainerdVersion specifies the default containerd version to install.
-	DefaultContainerdVersion = "1.5.11"
+	DefaultContainerdVersion = "1.5.13"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
 	DefaultDockerBridgeSubnet = "172.17.0.1/16"
 	// DefaultKubernetesMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -1275,7 +1275,7 @@ func TestAzureStackKubernetesConfigDefaults(t *testing.T) {
 
 func TestContainerRuntime(t *testing.T) {
 
-	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10", "19.03.11", "19.03.12", "19.03.13", "19.03.14", "20.10.5", "20.10.7", "20.10.8", "20.10.9", "20.10.10", "20.10.11"} {
+	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10", "19.03.11", "19.03.12", "19.03.13", "19.03.14", "20.10.5", "20.10.7", "20.10.8", "20.10.9", "20.10.10", "20.10.11", "20.10.14"} {
 		mockCS := getMockBaseContainerService("1.10.13")
 		properties := mockCS.Properties
 		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
@@ -6115,10 +6115,10 @@ func ExampleContainerService_setOrchestratorDefaults() {
 	mockCS.setOrchestratorDefaults(false, false)
 
 	// Output:
-	// level=warning msg="Moby will be upgraded to version 20.10.11\n"
-	// level=warning msg="containerd will be upgraded to version 1.5.11\n"
-	// level=warning msg="Any new nodes will have Moby version 20.10.11\n"
-	// level=warning msg="Any new nodes will have containerd version 1.5.11\n"
+	// level=warning msg="Moby will be upgraded to version 20.10.14\n"
+	// level=warning msg="containerd will be upgraded to version 1.5.13\n"
+	// level=warning msg="Any new nodes will have Moby version 20.10.14\n"
+	// level=warning msg="Any new nodes will have containerd version 1.5.13\n"
 }
 
 func TestCombineValues(t *testing.T) {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -38,7 +38,7 @@ var (
 		"3.1.0", "3.1.1", "3.1.2", "3.1.2", "3.1.3", "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8", "3.1.9", "3.1.10",
 		"3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.8", "3.2.9", "3.2.11", "3.2.12",
 		"3.2.13", "3.2.14", "3.2.15", "3.2.16", "3.2.23", "3.2.24", "3.2.25", "3.2.26", "3.3.0", "3.3.1", "3.3.8", "3.3.9", "3.3.10", "3.3.13", "3.3.15", "3.3.18", "3.3.19", "3.3.22", "3.3.25"}
-	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6", "1.4.7", "1.4.8", "1.4.9", "1.4.11", "1.5.11"}
+	containerdValidVersions              = [...]string{"1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.8", "1.3.9", "1.4.4", "1.4.6", "1.4.7", "1.4.8", "1.4.9", "1.4.11", "1.5.11", "1.5.13"}
 	kubernetesImageBaseTypeValidVersions = [...]string{"", common.KubernetesImageBaseTypeGCR, common.KubernetesImageBaseTypeMCR}
 	cachingTypesValidValues              = [...]string{"", string(compute.CachingTypesNone), string(compute.CachingTypesReadWrite), string(compute.CachingTypesReadOnly)}
 	linuxEth0MTUAllowedValues            = [...]int{1500, 3900}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -64,7 +64,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6 1.4.7 1.4.8 1.4.9 1.4.11 1.5.11]",
+			expectedError: "Invalid containerd version \"1.0.0\", please use one of the following versions: [1.3.2 1.3.3 1.3.4 1.3.5 1.3.6 1.3.7 1.3.8 1.3.9 1.4.4 1.4.6 1.4.7 1.4.8 1.4.9 1.4.11 1.5.11 1.5.13]",
 		},
 		"should error when KubernetesConfig has containerdVersion value for docker container runtime": {
 			properties: &Properties{

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17626,8 +17626,8 @@ installRunc() {
     url=${MS_APT_REPO}/ubuntu/${UBUNTU_RELEASE}/multiarch/prod/pool/main/m/moby-runc/moby-runc_1.1.2%2Bazure-ubuntu${UBUNTU_RELEASE}u1_amd64.deb
     if [[ -n "${url:-}" ]]; then
       DEB="${url##*/}"
-      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
-      dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit 184
+      dpkg_install 20 30 /tmp/${DEB} || exit 184
     fi
   fi
 }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17621,8 +17621,8 @@ mobyPkgVersion() {
 installRunc() {
   local v
   v=$(runc --version | head -n 1 | cut -d" " -f3)
-  if [[ $v != "1.0.3" ]]; then
-    apt_get_install 20 30 120 moby-runc=1.0.3* --allow-downgrades || exit 27
+  if [[ $v != "1.1.2" ]]; then
+    apt_get_install 20 30 120 moby-runc=1.1.2* --allow-downgrades || exit 27
   fi
 }
 installMoby() {
@@ -21041,7 +21041,7 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
       }
     },
     "mobyVersion": {
-      "defaultValue": "20.10.11",
+      "defaultValue": "20.10.14",
       "metadata": {
         "description": "The Azure Moby build version"
       },
@@ -21067,12 +21067,13 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
          "20.10.8",
          "20.10.9",
          "20.10.10",
-         "20.10.11"
+         "20.10.11",
+         "20.10.14"
        ],
       "type": "string"
     },
     "containerdVersion": {
-      "defaultValue": "1.5.11",
+      "defaultValue": "1.5.13",
       "metadata": {
         "description": "The Azure containerd build version"
       },
@@ -21091,7 +21092,8 @@ var _k8sKubernetesparamsT = []byte(`    "etcdServerCertificate": {
          "1.4.8",
          "1.4.9",
          "1.4.11",
-         "1.5.11"
+         "1.5.11",
+         "1.5.13"
        ],
       "type": "string"
     },

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17620,9 +17620,15 @@ mobyPkgVersion() {
 }
 installRunc() {
   local v
+  local url
   v=$(runc --version | head -n 1 | cut -d" " -f3)
   if [[ $v != "1.1.2" ]]; then
-    apt_get_install 20 30 120 moby-runc=1.1.2* --allow-downgrades || exit 27
+    url=${MS_APT_REPO}/ubuntu/${UBUNTU_RELEASE}/multiarch/prod/pool/main/m/moby-runc/moby-runc_1.1.2%2Bazure-ubuntu${UBUNTU_RELEASE}u1_amd64.deb
+    if [[ -n "${url:-}" ]]; then
+      DEB="${url##*/}"
+      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_DOWNLOAD_TIMEOUT"}}
+      dpkg_install 20 30 /tmp/${DEB} || exit {{GetCSEErrorCode "ERR_DEB_PKG_ADD_FAIL"}}
+    fi
   fi
 }
 installMoby() {

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -81,8 +81,8 @@ echo "  - apmz $apmz_version" >> ${VHD_LOGS_FILEPATH}
 installBpftrace
 echo "  - bpftrace" >> ${VHD_LOGS_FILEPATH}
 
-MOBY_VERSION="20.10.11"
-CONTAINERD_VERSION="1.5.11"
+MOBY_VERSION="20.10.14"
+CONTAINERD_VERSION="1.5.13"
 installMoby
 installRunc
 systemctl_restart 100 5 30 docker || exit 1


### PR DESCRIPTION
**Reason for Change**:

Upgraded `runc` to address CVE-2022-29162. While on it, upgraded `moby` and `containerd` to the latest v1.5 patch.

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
