### PR TITLE
chore: enable latest k8s v1.22 and v1.23 on Azure Stack Hub

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -378,8 +378,10 @@ var AllKubernetesSupportedVersionsAzureStack = map[string]bool{
 	"1.20.6":  false,
 	"1.20.11": false,
 	"1.21.10": false,
-	"1.22.7":  true,
-	"1.23.6":  true,
+	"1.22.7":  false,
+	"1.22.15": true,
+	"1.23.6":  false,
+	"1.23.12": true,
 }
 
 // AllKubernetesWindowsSupportedVersionsAzureStack maintain a set of available k8s Windows versions in aks-engine on Azure Stack
@@ -408,8 +410,10 @@ var AllKubernetesWindowsSupportedVersionsAzureStack = map[string]bool{
 	"1.20.6":  false,
 	"1.20.11": false,
 	"1.21.10": false,
-	"1.22.7":  true,
-	"1.23.6":  true,
+	"1.22.7":  false,
+	"1.22.15": true,
+	"1.23.6":  false,
+	"1.23.12": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**Reason for Change**:

Enable Kubernetes v1.22 and v1.23 on Azure Stack Hub.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
