### PR TITLE
fix: rotate certs script breaks on Ubuntu 20.04

### DIFF
--- a/parts/k8s/rotate-certs.sh
+++ b/parts/k8s/rotate-certs.sh
@@ -30,7 +30,7 @@ cp_certs() {
   cp -p ${NEW_CERTS_DIR}/ca.* /etc/kubernetes/certs/
   cp -p ${NEW_CERTS_DIR}/client.* /etc/kubernetes/certs/
   cp -p ${NEW_CERTS_DIR}/apiserver.* /etc/kubernetes/certs/
-  cp -p ${NEW_CERTS_DIR}/kubeconfig ~/.kube/config
+  cp -p ${NEW_CERTS_DIR}/kubeconfig /home/$(logname)/.kube/config
 
   rm -f /var/lib/kubelet/pki/kubelet-client-current.pem
 }

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -22816,7 +22816,7 @@ cp_certs() {
   cp -p ${NEW_CERTS_DIR}/ca.* /etc/kubernetes/certs/
   cp -p ${NEW_CERTS_DIR}/client.* /etc/kubernetes/certs/
   cp -p ${NEW_CERTS_DIR}/apiserver.* /etc/kubernetes/certs/
-  cp -p ${NEW_CERTS_DIR}/kubeconfig ~/.kube/config
+  cp -p ${NEW_CERTS_DIR}/kubeconfig /home/$(logname)/.kube/config
 
   rm -f /var/lib/kubelet/pki/kubelet-client-current.pem
 }


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
The rotate certs command was failing on 20.04 environments, Output:
```
cp -p /etc/kubernetes/rotate-certs/certs/kubeconfig /root/.kube/config 
cp: cannot create regular file '/root/.kube/config': No such file or directory
```
The fix specifies the user instead of using ~, works on both 20.04 and 18.04

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
