### PR TITLE
chore: force containerd runtime for Kubernetes v1.24+ on Azure Stack Hub

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -228,6 +228,12 @@ func (uc *upgradeCmd) loadCluster() error {
 		uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
 	}
 
+	// Only containerd runtime is allowed for Kubernetes 1.24+ on Azure Stack cloud
+	if uc.containerService.Properties.IsAzureStackCloud() && strings.EqualFold(uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, "docker") && common.IsKubernetesVersionGe(uc.upgradeVersion, "1.24.0") {
+		log.Infoln("The docker runtime is no longer supported for v1.24+ clusters, overwriting ContainerRuntime to 'containerd'")
+		uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = "containerd"
+	}
+
 	// The cluster-init component is a cluster create-only feature, temporarily disable if enabled
 	if i := api.GetComponentsIndexByName(uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.Components, common.ClusterInitComponentName); i > -1 {
 		if uc.containerService.Properties.OrchestratorProfile.KubernetesConfig.Components[i].IsEnabled() {

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -206,6 +206,10 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 		}
 		if o.KubernetesConfig.ContainerRuntime == "" {
 			o.KubernetesConfig.ContainerRuntime = DefaultContainerRuntime
+			if a.IsAzureStackCloud() && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.24.0") {
+				log.Warnf("The docker runtime is no longer supported for v1.24+ clusters, setting ContainerRuntime to 'containerd'")
+				o.KubernetesConfig.ContainerRuntime = Containerd
+			}
 		}
 		switch o.KubernetesConfig.ContainerRuntime {
 		case Docker:

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -304,6 +304,10 @@ func (a *Properties) ValidateOrchestratorProfile(isUpdate bool) error {
 					return errors.New("useCloudControllerManager should be set to true for Kubernetes v1.21+ clusters on Azure Stack Hub")
 				}
 
+				if common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.24.0") && o.KubernetesConfig.ContainerRuntime == Docker {
+					return errors.Errorf("Docker runtime is no longer supported for v1.24+ clusters, use %s containerRuntime value instead", Containerd)
+				}
+
 				if to.Bool(o.KubernetesConfig.UseInstanceMetadata) {
 					return errors.New("useInstanceMetadata shouldn't be set to true as feature not yet supported on Azure Stack")
 				}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -4768,6 +4768,28 @@ func TestValidateLocation(t *testing.T) {
 			expectedErr: errors.New("useInstanceMetadata shouldn't be set to true as feature not yet supported on Azure Stack"),
 		},
 		{
+			name:          "AzureStack ContainerRuntime is docker",
+			location:      "local",
+			propertiesnil: false,
+			cs: &ContainerService{
+				Location: "local",
+				Properties: &Properties{
+					CustomCloudProfile: &CustomCloudProfile{
+						PortalURL: "https://portal.local.cotoso.com",
+					},
+					OrchestratorProfile: &OrchestratorProfile{
+						OrchestratorType:    Kubernetes,
+						OrchestratorVersion: common.RationalizeReleaseAndVersion(Kubernetes, "1.24", "", false, false, true),
+						KubernetesConfig: &KubernetesConfig{
+							UseCloudControllerManager: to.BoolPtr(trueVal),
+							ContainerRuntime:          "docker",
+						},
+					},
+				},
+			},
+			expectedErr: errors.Errorf("Docker runtime is no longer supported for v1.24+ clusters, use %s containerRuntime value instead", Containerd),
+		},
+		{
 			name:          "AzureStack EtcdDiskSizeGB is 1024",
 			location:      "local",
 			propertiesnil: false,

--- a/pkg/armhelpers/httpMockClient.go
+++ b/pkg/armhelpers/httpMockClient.go
@@ -703,6 +703,15 @@ func (mc *HTTPMockClient) RegisterVMImageFetcherInterface() {
 		}
 	})
 
+	pattern = fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/artifacttypes/vmimage/offers/%s/skus/%s/versions/%s", mc.SubscriptionID, mc.Location, api.AKSWindowsServer2019ContainerDOSImageConfig.ImagePublisher, api.AKSWindowsServer2019ContainerDOSImageConfig.ImageOffer, api.AKSWindowsServer2019ContainerDOSImageConfig.ImageSku, api.AKSWindowsServer2019ContainerDOSImageConfig.ImageVersion)
+	mc.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("api-version") != mc.ComputeAPIVersion {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			_, _ = fmt.Fprint(w, mc.ResponseGetVirtualMachineImage)
+		}
+	})
+
 	pattern = fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/artifacttypes/vmimage/offers/%s/skus/%s/versions/%s", mc.SubscriptionID, mc.Location, api.AKSUbuntu1604OSImageConfig.ImagePublisher, api.AKSUbuntu1604OSImageConfig.ImageOffer, api.AKSUbuntu1604OSImageConfig.ImageSku, api.AKSUbuntu1604OSImageConfig.ImageVersion)
 	mc.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("api-version") != mc.ComputeAPIVersion {

--- a/pkg/armhelpers/support_validator.go
+++ b/pkg/armhelpers/support_validator.go
@@ -5,6 +5,7 @@ package armhelpers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/pkg/errors"
@@ -22,6 +23,7 @@ func ValidateRequiredImages(ctx context.Context, location string, p *api.Propert
 	if fetcher, ok := client.(VMImageFetcher); ok {
 		missingImages := make(map[api.Distro]validationResult)
 		for distro, i := range requiredImages(p) {
+			log.Infoln(fmt.Sprintf("ValidateRequiredImage: %s, %s, %s, %s", i.ImagePublisher, i.ImageOffer, i.ImageSku, i.ImageVersion))
 			if i.ImageVersion == "latest" {
 				list, err := fetcher.ListVirtualMachineImages(ctx, location, i.ImagePublisher, i.ImageOffer, i.ImageSku)
 				if err != nil || len(*list.Value) == 0 {
@@ -100,7 +102,7 @@ func toImageConfig(distro api.Distro) api.AzureOSImageConfig {
 }
 
 func toImageConfigWindows(profile *api.WindowsProfile) api.AzureOSImageConfig {
-	if profile != nil && profile.WindowsPublisher != api.AKSWindowsServer2019OSImageConfig.ImagePublisher {
+	if profile != nil {
 		return api.AzureOSImageConfig{
 			ImageOffer:     profile.WindowsOffer,
 			ImageSku:       profile.WindowsSku,
@@ -108,5 +110,5 @@ func toImageConfigWindows(profile *api.WindowsProfile) api.AzureOSImageConfig {
 			ImageVersion:   profile.ImageVersion,
 		}
 	}
-	return api.AKSWindowsServer2019OSImageConfig
+	return api.AKSWindowsServer2019ContainerDOSImageConfig
 }

--- a/pkg/armhelpers/support_validator.go
+++ b/pkg/armhelpers/support_validator.go
@@ -23,7 +23,7 @@ func ValidateRequiredImages(ctx context.Context, location string, p *api.Propert
 	if fetcher, ok := client.(VMImageFetcher); ok {
 		missingImages := make(map[api.Distro]validationResult)
 		for distro, i := range requiredImages(p) {
-			log.Infoln(fmt.Sprintf("ValidateRequiredImage: %s, %s, %s, %s", i.ImagePublisher, i.ImageOffer, i.ImageSku, i.ImageVersion))
+			log.Debugln(fmt.Sprintf("Validate OS image is available on the target cloud: %s, %s, %s, %s", i.ImagePublisher, i.ImageOffer, i.ImageSku, i.ImageVersion))
 			if i.ImageVersion == "latest" {
 				list, err := fetcher.ListVirtualMachineImages(ctx, location, i.ImagePublisher, i.ImageOffer, i.ImageSku)
 				if err != nil || len(*list.Value) == 0 {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Only impacts Azure Stack Hub
- force overwrite from docker to containerd for upgrade
- set containerd as default container runtime for deploy/generate
- add unit test
- fix validate windows image on ash stamps

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Notes**:
