### PR TITLE
fix: use mcr.microsoft.com for nvidia in mooncake

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -268,7 +268,7 @@ var (
 		KubernetesSpecConfig: KubernetesSpecConfig{
 			KubernetesImageBase:    "gcr.azk8s.cn/google_containers/",
 			TillerImageBase:        "mcr.microsoft.com/",
-			NVIDIAImageBase:        "dockerhub.azk8s.cn/nvidia/",
+			NVIDIAImageBase:        "mcr.microsoft.com/",
 			AzureCNIImageBase:      "mcr.azk8s.cn/containernetworking/",
 			MCRKubernetesImageBase: "mcr.microsoft.com/",
 			CalicoImageBase:        "dockerhub.azk8s.cn/calico/",

--- a/pkg/api/azenvtypes_test.go
+++ b/pkg/api/azenvtypes_test.go
@@ -11,10 +11,11 @@ import (
 
 func TestURLForAzureChinaCloud(t *testing.T) {
 	var azureChinaCloudMirror = "azk8s.cn"
+	var publicCloudMCR = "mcr.microsoft.com"
 	g := NewGomegaWithT(t)
 
 	g.Expect(AzureChinaCloudSpec.KubernetesSpecConfig.KubernetesImageBase).To(ContainSubstring(azureChinaCloudMirror))
-	g.Expect(AzureChinaCloudSpec.KubernetesSpecConfig.NVIDIAImageBase).To(ContainSubstring(azureChinaCloudMirror))
+	g.Expect(AzureChinaCloudSpec.KubernetesSpecConfig.NVIDIAImageBase).To(ContainSubstring(publicCloudMCR))
 	g.Expect(AzureChinaCloudSpec.KubernetesSpecConfig.AzureCNIImageBase).To(ContainSubstring(azureChinaCloudMirror))
 	g.Expect(AzureChinaCloudSpec.KubernetesSpecConfig.CalicoImageBase).To(ContainSubstring(azureChinaCloudMirror))
 	g.Expect(AzureChinaCloudSpec.KubernetesSpecConfig.CNIPluginsDownloadURL).To(ContainSubstring(azureChinaCloudMirror))


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

This PR updates the mooncake configuration for nvidia driver image pull downloads to use the default `mcr.microsoft.com` container image registry.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #5034 

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
