### PR TITLE
Update pipeline image to Ubuntu 20.04

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -13,7 +13,7 @@ jobs:
   strategy:
     maxParallel: 0
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   container: dev1
 

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -26,7 +26,7 @@ jobs:
   strategy:
     maxParallel: 0
   pool:
-      vmImage: 'Ubuntu 18.04'
+      vmImage: 'Ubuntu 20.04'
 
   container: dev1
 

--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -11,7 +11,7 @@ jobs:
   variables:
     CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.7'
   pool:
-    vmImage: 'Ubuntu 18.04'
+    vmImage: 'Ubuntu 20.04'
   steps:
   - script: |
       docker run --rm \


### PR DESCRIPTION
**Reason for Change**:

Updates the `vmImage` used in aks-engine Azure DevOps jobs to Ubuntu 20.04, to avoid warnings (and brownout errors) about 18.04 EOL.

**Issue Fixed**:

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

**Requirements**:


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
