### PR TITLE
Revert "use Standard_B2s as baseline SKU for test clusters (#5083)"

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
@@ -20,7 +20,7 @@
         "masterProfile": {
             "count": 3,
             "dnsPrefix": "",
-            "vmSize": "Standard_B2s",
+            "vmSize": "Standard_D2_v3",
             "OSDiskSizeGB": 200,
             "availabilityZones": [
                 "1",
@@ -31,7 +31,7 @@
             {
                 "name": "poollinux",
                 "count": 1,
-                "vmSize": "Standard_B2s",
+                "vmSize": "Standard_D2_v3",
                 "OSDiskSizeGB": 200,
                 "storageProfile": "ManagedDisks",
                 "diskSizesGB": [
@@ -60,7 +60,7 @@
             {
                 "name": "pool1804",
                 "count": 1,
-                "vmSize": "Standard_B2s",
+                "vmSize": "Standard_D2_v3",
                 "distro": "ubuntu-18.04",
                 "availabilityProfile": "VirtualMachineScaleSets",
                 "availabilityZones": [

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -21,7 +21,7 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "",
-      "vmSize": "Standard_B2s",
+      "vmSize": "Standard_D2_v3",
       "OSDiskSizeGB": 200,
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
       "firstConsecutiveStaticIP": "10.239.255.239",
@@ -35,7 +35,7 @@
       {
         "name": "poollinux",
         "count": 1,
-        "vmSize": "Standard_B2s",
+        "vmSize": "Standard_D2_v3",
         "OSDiskSizeGB": 200,
         "storageProfile": "ManagedDisks",
         "diskSizesGB": [
@@ -66,7 +66,7 @@
       {
         "name": "pool1804",
         "count": 1,
-        "vmSize": "Standard_B2s",
+        "vmSize": "Standard_D2_v3",
         "distro": "ubuntu-18.04",
         "availabilityProfile": "VirtualMachineScaleSets",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",

--- a/examples/kubernetes-gpu/kubernetes.json
+++ b/examples/kubernetes-gpu/kubernetes.json
@@ -4,13 +4,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_B2s"
+      "vmSize": "Standard_D2_v3"
     },
     "agentPoolProfiles": [
       {
         "name": "pool1",
         "count": 1,
-        "vmSize": "Standard_B2s"
+        "vmSize": "Standard_D2_v3"
       },
       {
         "name": "poolgpu",


### PR DESCRIPTION
This reverts commit 3b039911c52918fdeacb3241977331bfdfe46f28.

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->

Have a theory that this is causing some of test failures we're seeing, trying this out.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
