### PR TITLE
Deprecation of AKS Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,11 @@
-# AKS Engine - Units of Kubernetes on Azure!
-
-[![Build Status](https://msazure.visualstudio.com/One/_apis/build/status/Custom/Compute/ContainerService/AKS%20Engine%20CI%20E2E?branchName=master)](https://msazure.visualstudio.com/One/_build/latest?definitionId=50661&branchName=master)
-[![GoDoc](https://godoc.org/github.com/Azure/aks-engine?status.svg)](https://godoc.org/github.com/Azure/aks-engine)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Azure/aks-engine)](https://goreportcard.com/report/github.com/Azure/aks-engine)
+# AKS Engine - Deprecated tool for self-managed Kubernetes on Azure
 
 ## Project status
 
-This project is deprecated for Azure public cloud customers. Please consider using [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/services/kubernetes-service/#overview) for managed Kubernetes or [Cluster API Provider Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure) for self-managed Kubernetes. There are no new features planned; this project will only be updated for CVEs & similar, with Kubernetes 1.24 as the final version to receive updates.
+This project is deprecated for Azure public cloud customers. Please use [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/services/kubernetes-service/#overview) for managed Kubernetes or [Cluster API Provider Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure) for self-managed Kubernetes. There are no further releases planned; Kubernetes 1.24 was the final version to receive updates.
 
 For use on the [Azure Stack Hub product](https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-kubernetes-aks-engine-overview) this project is fully supported and will continue to be supported by the Hub team throughout the lifespan of Azure Stack Hub. Development is already moved to a new Azure Stack Hub specific repository ([Azure/aks-engine-azurestack](https://github.com/Azure/aks-engine-azurestack)). This new repository is where new [releases](https://github.com/Azure/aks-engine-azurestack/releases) for Azure Stack Hub clouds, starting at v0.75.3, will be published and where [issues](https://github.com/Azure/aks-engine-azurestack/issues/new) concerning Azure Stack Hub should be created.
 
-## Overview
-
-AKS Engine is an ARM template-driven way to provision a self-managed Kubernetes cluster on Azure. By leveraging [ARM (Azure Resource Manager)][ARM], AKS Engine helps you create, destroy and maintain clusters provisioned with basic IaaS resources in Azure. AKS Engine has limited support for ongoing operational capabilities such as scaling, in-place upgrade, and extensions. The [Cluster API Provider for Azure a.k.a. CAPZ](https://capz.sigs.k8s.io/) provides more complete operational capabilities. AKS Engine remains the tool for managing Kubernetes clusters on Azure Stack Hub as CAPZ does not yet work there.
-
-## Getting started
-
-- Read the [CLI Overview](docs/tutorials/cli-overview.md) for a list of features provided by the `aks-engine` command line tool.
-
-- The [Quickstart Guide](docs/tutorials/quickstart.md) describes how to download the latest release of `aks-engine` for your environment, and demonstrates how to use `aks-engine` to create a Kubernetes cluster on Azure that you will manage and customize.
-
-- The [complete body of documentation can be found here][docs].
-
-Please see the [FAQ][] for answers about AKS Engine and its progenitor ACS-Engine.
-
-## Join the community
-
-We encourage AKS Engine users to evaluate moving to AKS or to CAPZ, per the [project status](#project-status).
-
-For existing users of AKS Engine, the [community guide][community] and [developer guide][developer-guide] are available, as is the [#aks-engine-dev Slack channel](https://kubernetes.slack.com/archives/CU1CXUHN0).
 
 ## Support
 
@@ -43,12 +20,6 @@ The software may collect information about you and your use of the software and 
 
 For more information, please see the [telemetry documentation][telemetry].
 
-[ARM]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview
-[community]: docs/community/README.md
-[developer-guide]: docs/community/developer-guide.md
-[docs]: docs/README.md
-[FAQ]: docs/faq.md
 [support-policy]: SUPPORT.md
-[tutorials]: docs/tutorials/README.md
 [telemetry]: docs/topics/telemetry.md
 [telemetry-config]: docs/topics/telemetry.md#configuration

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,47 +1,7 @@
 # Support
-## How to file issues and get help
-
-This project uses GitHub Issues to track bugs and feature requests. Please search the [existing issues][github-issues] before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new Issue.
-
-The AKS Engine project maintainers will respond to the best of their abilities.
-
-## Support FAQ
 
 ### Is AKS Engine currently maintained?
 
-See the [AKS Engine project status][project-status] for updates on the maintenance of AKS Engine.
+No; AKS Engine is deprecated and no support is available. See the [AKS Engine project status][project-status] for more details.
 
-### How often are new AKS Engine releases published?
-
-There is no definite release cadence. Project maintainers use the following as guidance to prioritize testing, validating, and publishing a new release:
-
-- Are there new, validated versions of Kubernetes that haven't yet been included in an AKS Engine release?
-- Are there improvements to the "default" Kubernetes configuration surface area?
-- Is there a remediated Kubernetes CVE?
-- Has a significant amount of time (say, more than 2 months) transpired since the last released VHD (Ubuntu OS image)?
-- Has a bug with broad impact been fixed?
-- Is there any new Kubernetes + Azure integration present and validated in the main branch, but not yet released?
-- Is the community asking for a new release, for any of the above reasons?
-
-If the answer to one or more of the above is true, then we may consider a release. In the past, the real-world release cadence was approximately once every 3-5 weeks. The community will determine the release cadence going forward.
-
-### Does AKS Engine support OS patching for security vulnerabilities?
-
-No. In general, the most recent release of AKS Engine will include a VHD derived from a build of Canonical Ubuntu about a week before the release is published. In other words, the maintainers will build a VHD from the "latest" tag of the supported Ubuntu releases, and then run about a week's worth of testing and validation prior to release. In practice, this means that on the day of a new AKS Engine release, OS security patches will be roughly a week behind of "latest", which may or may not have any practical effect (the Canonical Ubuntu "latest" tag isn't necessarily changed every week). As time progresses beyond that initial release, the most recent version of AKS Engine will eventually be several weeks behind "latest" when building a new cluster. If this does not meet your OS security requirements, we recommend curating your own Shared Image Gallery with OS images running one of the AKS Engine supported Ubuntu releases, with your desired OS patches already applied. See [the `imageReference` documentation here for more information](docs/topics/clusterdefinitions.md).
-
-## More information
-
-For help and questions about using this project, please:
-
-  - Check out [Frequently Asked Questions][faq] about the AKS Engine project and tool
-  - Read the [documentation][docs]
-  - Join us on the [#aks-engine-users][aks-engine-users-slack] Slack channel
-## Microsoft Support Policy
-
-Support for this project is limited to the resources listed above.
-
-[aks-engine-users-slack]: https://kubernetes.slack.com/archives/CU3N85WJK
-[docs]: https://github.com/Azure/aks-engine/tree/master/docs
-[faq]: https://github.com/Azure/aks-engine/blob/master/docs/faq.md
-[github-issues]: https://github.com/Azure/aks-engine/issues
 [project-status]: https://github.com/Azure/aks-engine/#project-status


### PR DESCRIPTION
This clarifies the deprecated status of AKS Engine as a prelude to repo archiving.